### PR TITLE
Move Error module into separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "bytes",
  "config",
  "coyote-derive",
+ "coyote-error",
  "crossbeam",
  "crossbeam-skiplist",
  "ctor",
@@ -664,6 +665,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "coyote-error"
+version = "1.76.1"
+dependencies = [
+ "aide",
+ "axum",
+ "hyper",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ base64.workspace = true
 bytes.workspace = true
 config.workspace = true
 coyote-derive.workspace = true
+coyote-error.workspace = true
 crossbeam.workspace = true
 crossbeam-skiplist.workspace = true
 fjall.workspace = true
@@ -90,6 +91,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 config = { version = "0.15.19", default-features = false, features = ["toml"] }
 coyote.path = "."
 coyote-derive.path = "crates/coyote-derive"
+coyote-error.path = "crates/coyote-error"
 crossbeam = "0.8"
 crossbeam-skiplist = "0.1.3"
 ctor = "0.6.3"

--- a/crates/coyote-error/Cargo.toml
+++ b/crates/coyote-error/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "coyote-error"
+publish = false
+version.workspace = true
+license.workspace = true
+rust-version.workspace = true
+edition = "2024"
+
+[dependencies]
+aide.workspace = true
+axum.workspace = true
+hyper.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-FileCopyrightText: © 2022 Coyote Authors
 // SPDX-License-Identifier: MIT
 
 use std::{error, fmt, panic::Location};
@@ -14,10 +14,10 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;
 
-/// A short-hand version of a [`std::result::Result`] that defaults to Svix'es [Error].
+/// A short-hand version of a [`std::result::Result`] that defaults to Coyote'es [Error].
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// The error type returned from the Svix API
+/// The error type returned from the Coyote API
 #[derive(Debug)]
 pub struct Error {
     // the file name and line number of the error. Used for debugging non Http errors

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,2 @@
+cargo +nightly clippy --fix --allow-dirty
+cargo +nightly fmt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use crate::cfg::Configuration;
 
 pub mod cfg;
 pub mod core;
-pub mod error;
+pub use coyote_error as error;
 pub mod openapi;
 pub mod v1;
 


### PR DESCRIPTION
Drive by refactor.

I want to start _early_ with keeping small, module crates.

So I'm moving `error` into it's own crate. This way, other crates (e.g. stream, cache, etc.) can use it, and we're forced from the beginning to avoid having anything in `error` rely on anything in the main crate.