### PR TITLE
Add From<fjall::Error> for Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ version = "1.76.1"
 dependencies = [
  "aide",
  "axum",
+ "fjall",
  "hyper",
  "schemars",
  "serde",

--- a/crates/coyote-error/Cargo.toml
+++ b/crates/coyote-error/Cargo.toml
@@ -14,6 +14,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+fjall.workspace = true
 
 [lints]
 workspace = true

--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -315,3 +315,13 @@ impl From<ErrorType> for Error {
         Self { trace: vec![], typ }
     }
 }
+
+impl From<fjall::Error> for Error {
+    #[track_caller]
+    fn from(e: fjall::Error) -> Self {
+        Self {
+            trace: vec![Location::caller()],
+            typ: ErrorType::Generic(format!("{e:?}")),
+        }
+    }
+}


### PR DESCRIPTION
So we can use `?` when calling fjall methods easily.

AFAICT, any error we'd see from `fjall` is an internal servery error, so I just went with ErrorType::generic.

Maybe we can add a separate ErrorType variant if we think it'll be useful, but for now this was the most expedient.