### PR TITLE
Use transaction in create_stream RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,6 +3193,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
+ "tracing",
  "url",
  "uuid",
 ]

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -1,6 +1,8 @@
 mod table_row;
+mod transaction_keyspace;
 
 pub use table_row::TableRow;
+pub use transaction_keyspace::*;
 
 /// Useful for verifying all table prefixes for a given keyspace are unique,
 /// at compile time.

--- a/crates/fjall-utils/src/transaction_keyspace.rs
+++ b/crates/fjall-utils/src/transaction_keyspace.rs
@@ -1,0 +1,88 @@
+//! Everything in this module is to make mirror the API for transactions in [fjall], except transactions are scoped to a single keyspace.
+//! This avoids the pain of having to manually carry around a OptimisticTxDatabase handle, or manually tying transaction inserts/reads to
+//! specific Keyspace.
+//! 
+//! Pros: much more ergonomic if you only need a transaction for a single keyspace.
+//! 
+//! Cons: doesn't support multikeyspace transaction ops.
+use fjall::{
+    Conflict, Keyspace, KeyspaceCreateOptions, OptimisticTxDatabase, OptimisticTxKeyspace,
+    OptimisticWriteTx, PersistMode, Result, UserKey, UserValue,
+};
+
+/// Wraps a [fjall::OptimisticTxKeyspace], except this makes it much more ergonomic to create transactions that are scoped to a single Keyspace. 
+pub struct ErgonomicOptimisticTxKeyspace {
+    db: OptimisticTxDatabase,
+    ks: OptimisticTxKeyspace,
+}
+
+impl ErgonomicOptimisticTxKeyspace {
+    pub fn new(db: OptimisticTxDatabase, name: &str, opts: KeyspaceCreateOptions) -> Result<Self> {
+        let ks = db.keyspace(name, || opts)?;
+        Ok(Self { db, ks })
+    }
+
+    pub fn write_tx(&self) -> Result<SingleKeyspaceOptimisticWriteTx<'_>> {
+        let tx = self.db.write_tx()?;
+        Ok(SingleKeyspaceOptimisticWriteTx { ks: &self.ks, tx })
+    }
+}
+
+impl AsRef<Keyspace> for ErgonomicOptimisticTxKeyspace {
+    fn as_ref(&self) -> &Keyspace {
+        self.ks.as_ref()
+    }
+}
+
+/// Wraps a [fjall::OptimisticWriteTx], except this is only associated with a single keyspace.
+///
+/// This makes method calls a bit more ergonomic, as you don't have to manually pass in the correct keyspace.
+pub struct SingleKeyspaceOptimisticWriteTx<'a> {
+    ks: &'a OptimisticTxKeyspace,
+    tx: OptimisticWriteTx,
+}
+
+impl<'a> SingleKeyspaceOptimisticWriteTx<'a> {
+    pub fn durability(self, mode: Option<PersistMode>) -> Self {
+        Self {
+            ks: self.ks,
+            tx: self.tx.durability(mode),
+        }
+    }
+
+    pub fn take<K: Into<UserKey>>(&mut self, key: K) -> Result<Option<UserValue>> {
+        self.tx.take(self.ks, key)
+    }
+
+    pub fn update_fetch<K: Into<UserKey>, F: FnMut(Option<&UserValue>) -> Option<UserValue>>(
+        &mut self,
+        key: K,
+        f: F,
+    ) -> Result<Option<UserValue>> {
+        self.tx.update_fetch(self.ks, key, f)
+    }
+
+    pub fn fetch_update<K: Into<UserKey>, F: FnMut(Option<&UserValue>) -> Option<UserValue>>(
+        &mut self,
+        key: K,
+        f: F,
+    ) -> Result<Option<UserValue>> {
+        self.tx.fetch_update(self.ks, key, f)
+    }
+
+    pub fn insert<K: Into<UserKey>, V: Into<UserValue>>(&mut self, key: K, value: V) {
+        self.tx.insert(self.ks, key, value)
+    }
+
+    pub fn remove<K: Into<UserKey>>(&mut self, key: K) {
+        self.tx.remove(self.ks, key)
+    }
+
+    pub fn commit(self) -> Result<std::result::Result<(), Conflict>> {
+        self.tx.commit()
+    }
+
+    pub fn rollback(self) {
+        self.tx.rollback()
+    }
+}

--- a/crates/fjall-utils/src/transaction_keyspace.rs
+++ b/crates/fjall-utils/src/transaction_keyspace.rs
@@ -1,16 +1,17 @@
 //! Everything in this module is to make mirror the API for transactions in [fjall], except transactions are scoped to a single keyspace.
 //! This avoids the pain of having to manually carry around a OptimisticTxDatabase handle, or manually tying transaction inserts/reads to
 //! specific Keyspace.
-//! 
+//!
 //! Pros: much more ergonomic if you only need a transaction for a single keyspace.
-//! 
+//!
 //! Cons: doesn't support multikeyspace transaction ops.
 use fjall::{
     Conflict, Keyspace, KeyspaceCreateOptions, OptimisticTxDatabase, OptimisticTxKeyspace,
     OptimisticWriteTx, PersistMode, Result, UserKey, UserValue,
 };
 
-/// Wraps a [fjall::OptimisticTxKeyspace], except this makes it much more ergonomic to create transactions that are scoped to a single Keyspace. 
+#[derive(Clone)]
+/// Wraps a [fjall::OptimisticTxKeyspace], except this makes it much more ergonomic to create transactions that are scoped to a single Keyspace.
 pub struct ErgonomicOptimisticTxKeyspace {
     db: OptimisticTxDatabase,
     ks: OptimisticTxKeyspace,

--- a/crates/stream/Cargo.toml
+++ b/crates/stream/Cargo.toml
@@ -18,6 +18,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 static_assertions.workspace = true
+tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
 

--- a/crates/stream/src/lib.rs
+++ b/crates/stream/src/lib.rs
@@ -1,5 +1,6 @@
 use coyote_error::Error;
 use fjall::KeyspaceCreateOptions;
+use fjall_utils::ErgonomicOptimisticTxKeyspace;
 
 /// User facing resources/types.
 pub mod entities;
@@ -15,11 +16,11 @@ mod tables;
 /// Tracks all internal state for Streams.
 pub struct State {
     /// Where metadata for streams (created_at, stream names, offsets, acks, etc.) are stored.
-    pub(crate) metadata_tables: fjall::Keyspace,
+    pub(crate) metadata_tables: ErgonomicOptimisticTxKeyspace,
 }
 
 impl State {
-    pub fn init(db: &fjall::Database) -> Result<Self, Error> {
+    pub fn init(db: fjall::OptimisticTxDatabase) -> Result<Self, Error> {
         const METADATA_KEYSPACE: &str = "_coyote_stream_metadata";
 
         // There's probably more tweaking we can do for each of these tables, but for now,
@@ -27,7 +28,7 @@ impl State {
 
         let metadata_tables = {
             let opts = KeyspaceCreateOptions::default();
-            db.keyspace(METADATA_KEYSPACE, || opts)?
+            ErgonomicOptimisticTxKeyspace::new(db, METADATA_KEYSPACE, opts)?
         };
 
         Ok(Self { metadata_tables })

--- a/crates/stream/src/operations/create_stream.rs
+++ b/crates/stream/src/operations/create_stream.rs
@@ -3,7 +3,7 @@ use crate::{
     entities::StreamId,
     tables::{NameToStreamRow, StreamRow},
 };
-use coyote_error::Result;
+use coyote_error::{Error, Result};
 use fjall_utils::TableRow as _;
 use jiff::Timestamp;
 use std::num::NonZeroU64;
@@ -43,8 +43,8 @@ impl CreateStream {
     // However for expediency, I don't want to wait for the relevant traits to be added in order to have something working.
     // It should be straightforward (famous last words) to translate this method to the Operations trait once it's in place.
     pub fn apply_operation(self, state: &State) -> Result<CreateStreamOutput> {
-        let mut stream = NameToStreamRow::fetch(&state.metadata_tables, &self.name)?
-            .and_then(|row| StreamRow::fetch(&state.metadata_tables, &row.id).transpose())
+        let mut stream = NameToStreamRow::fetch(state.metadata_tables.as_ref(), &self.name)?
+            .and_then(|row| StreamRow::fetch(state.metadata_tables.as_ref(), &row.id).transpose())
             .transpose()?
             .unwrap_or_else(|| {
                 let id = Uuid::new_v4();
@@ -62,8 +62,8 @@ impl CreateStream {
         stream.max_byte_size = self.max_byte_size;
         stream.updated_at = self.timestamp;
 
-        // FIXME(@svix-gabriel) do this atomically
         {
+            let mut tx = state.metadata_tables.write_tx()?;
             let (k1, v1) = stream.to_fjall_entry()?;
             let (k2, v2) = NameToStreamRow {
                 name: stream.name.clone(),
@@ -71,8 +71,13 @@ impl CreateStream {
             }
             .to_fjall_entry()?;
 
-            state.metadata_tables.insert(k1, v1)?;
-            state.metadata_tables.insert(k2, v2)?;
+            tx.insert(k1, v1);
+            tx.insert(k2, v2);
+
+            // FIXME(@svix-gabriel) - it's not clear to me what would actually cause a transaction to fail with a conflict.
+            // Maybe someone knows? I'm not sure what the best way to handle this would be. For now, just propogate the error
+            // since it means we failed to create the stream.
+            tx.commit()?.map_err(Error::generic)?;
         }
 
         let StreamRow {

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -21,6 +21,9 @@ pub struct ConfigurationInner {
     /// The directory for on-disk storage.
     pub db_directory: String,
 
+    /// The directory for the on-disk storage of the database for optimistic transactions.
+    pub optimistic_transaction_db_directory: String,
+
     /// Contains the secret and algorithm for signing JWTs
     #[serde(flatten)]
     pub jwt_signing_config: Arc<JwtSigningConfig>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::{sync::LazyLock, time::Duration};
 
 use aide::axum::ApiRouter;
 use cfg::ConfigurationInner;
-use fjall::Database;
+use fjall::{Database, OptimisticTxDatabase};
 use opentelemetry::{InstrumentationScope, trace::TracerProvider as _};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
@@ -112,8 +112,11 @@ pub async fn run_with_prefix(cfg: Configuration, listener: Option<TcpListener>) 
     let mut openapi = openapi::initialize_openapi();
 
     let db = Database::builder(&cfg.db_directory).open().unwrap();
+    let optimistic_db = OptimisticTxDatabase::builder(&cfg.optimistic_transaction_db_directory)
+        .open()
+        .unwrap();
 
-    let stream_state = stream::State::init(&db).expect("initialing stream state");
+    let stream_state = stream::State::init(optimistic_db).expect("initialing stream state");
 
     // build our application with a route
     let app_state = AppState {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -16,7 +16,8 @@ use tokio::{net::TcpListener, task::JoinHandle};
 ///
 /// Once it's DROPed, the server and it's resources are cleaned up automatically (or at least, that's the intent.)
 pub struct IsolatedServerHandle {
-    _db_dir: TempDir,
+    /// handles to the database we want to automatically clean up on deletion.
+    _db_dirs: Vec<TempDir>,
     server_handle: JoinHandle<()>,
 }
 
@@ -34,10 +35,15 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
     let token = "Stubbed token. Should probably be legit when we add auth.";
 
     let db_dir = tempfile::tempdir().unwrap();
+    let optimistic_db_dir = tempfile::tempdir().unwrap();
 
     let cfg = Arc::new(ConfigurationInner {
         listen_address: addr,
         db_directory: db_dir.path().to_string_lossy().into_owned(),
+        optimistic_transaction_db_directory: optimistic_db_dir
+            .path()
+            .to_string_lossy()
+            .into_owned(),
         jwt_signing_config: Arc::new(JwtSigningConfig::HS256(jwt_key)),
         log_level: LogLevel::Debug,
         log_format: LogFormat::Default,
@@ -57,7 +63,7 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
     });
 
     let handle = IsolatedServerHandle {
-        _db_dir: db_dir,
+        _db_dirs: vec![db_dir, optimistic_db_dir],
         server_handle,
     };
 


### PR DESCRIPTION
In the create_stream operation, we create two records in fjall

- a `stream.name -> stream.id` map (to maintain name uniqueness)
- a `stream.id -> stream` map (the actual "stream table")

Inserting both these records needs to happen atomically, so we need to use fjall transactions.

Fjall transactions are annoying AF, for two reasons

1. You declare transactions from the `*TxDatabase`, rather than the `*TxKeyspace`. Despite the fact that the `Keyspace` is where you typically insert/read records from.
2. When doing any operation on a `*WriteTx`, you have to pass in the Keyspace.

This API makes sense for supporting multi-keyspace transactions, but it's a massive PITA if you only need a "Single keyspace scoped transaction", like I do.

Because of this non-ergonomic API, there's a separate commit that adds a "single keyspace scoped optimistic transaction". 