### PR TITLE
Fix CreateStream::apply_operation not being deterministic

### DIFF
--- a/crates/stream/src/operations/create_stream.rs
+++ b/crates/stream/src/operations/create_stream.rs
@@ -10,10 +10,7 @@ use std::num::NonZeroU64;
 use uuid::Uuid;
 
 pub struct CreateStream {
-    timestamp: Timestamp,
-    name: String,
-    retention_period_seconds: Option<NonZeroU64>,
-    max_byte_size: Option<NonZeroU64>,
+    stream: StreamRow,
 }
 
 pub struct CreateStreamOutput {
@@ -27,71 +24,63 @@ pub struct CreateStreamOutput {
 
 impl CreateStream {
     pub fn new(
+        state: &State,
         name: String,
         retention_period_seconds: Option<NonZeroU64>,
         max_byte_size: Option<NonZeroU64>,
-    ) -> Self {
-        Self {
-            timestamp: Timestamp::now(),
-            name,
-            retention_period_seconds,
-            max_byte_size,
-        }
+    ) -> Result<Self> {
+        let now = Timestamp::now();
+
+        let mut stream = NameToStreamRow::fetch(&state.metadata_tables, &name)?
+            .and_then(|row| StreamRow::fetch(&state.metadata_tables, &row.id).transpose())
+            .transpose()?
+            .unwrap_or_else(|| {
+                let id = Uuid::new_v4().to_string();
+                StreamRow {
+                    id,
+                    name,
+                    retention_period_seconds,
+                    max_byte_size,
+                    created_at: now,
+                    updated_at: now,
+                }
+            });
+
+        // If we're doing an update, this fields will have to change.
+        stream.retention_period_seconds = retention_period_seconds;
+        stream.max_byte_size = max_byte_size;
+        stream.updated_at = now;
+
+        Ok(Self { stream })
     }
 
     // FIXME(@svix-gabriel) - I'm trying to adhere mostly to the API mentioned in the HA rfc (https://github.com/svix/rfc/pull/30/files#diff-1f8e708b840474d3072b1c965eb090a3e30b26e8b7036c6e0ae47ef36ffb09abR54)
     // However for expediency, I don't want to wait for the relevant traits to be added in order to have something working.
     // It should be straightforward (famous last words) to translate this method to the Operations trait once it's in place.
     pub fn apply_operation(self, state: &State) -> Result<CreateStreamOutput> {
-        let mut stream = NameToStreamRow::fetch(&state.metadata_tables, &self.name)?
-            .and_then(|row| StreamRow::fetch(&state.metadata_tables, &row.id).transpose())
-            .transpose()?
-            .unwrap_or_else(|| {
-                let id = Uuid::new_v4();
-                StreamRow {
-                    id: id.to_string(),
-                    name: self.name,
-                    retention_period_seconds: self.retention_period_seconds,
-                    max_byte_size: self.max_byte_size,
-                    created_at: self.timestamp,
-                    updated_at: self.timestamp,
-                }
-            });
+        let (k1, v1) = self.stream.to_fjall_entry()?;
 
-        stream.retention_period_seconds = self.retention_period_seconds;
-        stream.max_byte_size = self.max_byte_size;
-        stream.updated_at = self.timestamp;
+        let name_entry = NameToStreamRow {
+            name: self.stream.name,
+            id: self.stream.id,
+        };
+
+        let (k2, v2) = name_entry.to_fjall_entry()?;
 
         {
-            let (k1, v1) = stream.to_fjall_entry()?;
-            let (k2, v2) = NameToStreamRow {
-                name: stream.name.clone(),
-                id: stream.id.clone(),
-            }
-            .to_fjall_entry()?;
-
             let mut batch = state.db.batch();
             batch.insert(&state.metadata_tables, k1, v1);
             batch.insert(&state.metadata_tables, k2, v2);
             batch.commit()?;
         }
 
-        let StreamRow {
-            id,
-            name,
-            retention_period_seconds,
-            max_byte_size,
-            created_at,
-            updated_at,
-        } = stream;
-
         Ok(CreateStreamOutput {
-            id,
-            name,
-            retention_period_seconds,
-            max_byte_size,
-            created_at,
-            updated_at,
+            id: name_entry.id,
+            name: name_entry.name,
+            retention_period_seconds: self.stream.retention_period_seconds,
+            max_byte_size: self.stream.max_byte_size,
+            created_at: self.stream.created_at,
+            updated_at: self.stream.updated_at,
         })
     }
 }

--- a/src/v1/endpoints/stream.rs
+++ b/src/v1/endpoints/stream.rs
@@ -56,13 +56,17 @@ async fn create_stream(
     so in practice the structure of this handler will look different once those two pieces are in place.
     */
 
-    let op = stream::operations::CreateStream::new(
-        data.name,
-        data.retention_period_seconds,
-        data.max_byte_size,
-    );
+    let out = tokio::task::spawn_blocking(move || {
+        let op = stream::operations::CreateStream::new(
+            &stream_state,
+            data.name,
+            data.retention_period_seconds,
+            data.max_byte_size,
+        )?;
 
-    let out = tokio::task::spawn_blocking(move || op.apply_operation(&stream_state)).await??;
+        op.apply_operation(&stream_state)
+    })
+    .await??;
 
     let CreateStreamOutput {
         id,


### PR DESCRIPTION
🤦 

I forgot that the "apply operation" step has to be perfectly deterministic for the HA/Raft/consensus stuff to work.

This means when I create the Operation struct, I need to know _exactly_ what I'm inserting into the DB.

Then the apply step actually does the inserts.

I guess this isn't broken _yet_, since none of the consensus stuff isn't in. But based on my understanding of how the Raft/consensus wrapper JB's working on, this is how things should be setup.