### PR TITLE
implementation of openraft on top of fjall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
 dependencies = [
  "cfg-if",
- "cipher 0.5.0-rc.5",
+ "cipher 0.5.0-rc.6",
  "cpufeatures",
 ]
 
@@ -56,6 +62,17 @@ checksum = "10b6f24a1f796bc46415a1d0d18dc0a8203ccba088acf5def3291c4f61225522"
 dependencies = [
  "aes 0.9.0-rc.2",
  "byteorder",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -176,6 +193,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyerror"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71add24cc141a1e8326f249b74c41cfd217aeb2a67c9c6cf9134d175469afd49"
+dependencies = [
+ "anyhow",
+ "serde",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,9 +251,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -234,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
  "cc",
  "cmake",
@@ -376,6 +403,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,7 +422,7 @@ checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.4.2",
 ]
 
 [[package]]
@@ -397,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "boring"
-version = "4.21.0"
+version = "4.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7c065a1115b820c26020b3dba8e33592b1ddd9ff811819928b75a49d6c89e1"
+checksum = "9078ed42084a408d2a1c33bb9dde775721227f1673e4daa81e7f74017b412ce3"
 dependencies = [
  "bitflags 2.10.0",
  "boring-sys",
@@ -410,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "boring-sys"
-version = "4.21.0"
+version = "4.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf413a89e6c07a57fa74c047c78d1d54afe7a65aa33dab328554bca9ca431a28"
+checksum = "a4f033d6ba6dee8b5322f5504acf758c29317790883bac078e7949dd3d670269"
 dependencies = [
  "bindgen",
  "cmake",
@@ -421,10 +460,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.0",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -451,6 +547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dda4398f387cc6395a3e93b3867cd9abda914c97a0b344d1eefb2e5c51785fca"
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,9 +563,9 @@ checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -502,8 +607,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -519,11 +626,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.5"
+version = "0.5.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557bad79bc426785757001b5d732f323ae965363983d758295c1a1935496880"
+checksum = "eba4d87abf4032a6d927f84b71af5086128a3349b929b4501c51a0fe0981a937"
 dependencies = [
- "crypto-common 0.2.0-rc.11",
+ "crypto-common 0.2.0-rc.13",
  "inout 0.2.2",
 ]
 
@@ -702,6 +809,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
@@ -737,11 +850,13 @@ name = "coyote"
 version = "1.76.1"
 dependencies = [
  "aide 0.16.0-alpha.2",
+ "anyerror",
  "anyhow",
  "assert_matches",
  "axum",
  "axum-extra",
  "base64",
+ "byteorder",
  "bytes",
  "config",
  "coyote-derive",
@@ -760,11 +875,13 @@ dependencies = [
  "jiff",
  "jwt-simple",
  "mime",
+ "openraft",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "paste",
  "regex",
  "rmp-serde",
  "rmpv",
@@ -787,6 +904,7 @@ dependencies = [
  "url",
  "uuid",
  "validator",
+ "zip",
 ]
 
 [[package]]
@@ -898,6 +1016,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2bcc93d5cde6659e8649fc412894417ebc14dee54cfc6ee439c683a4a58342"
+checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
 dependencies = [
  "hybrid-array",
 ]
@@ -1123,6 +1265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deflate64"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1289,27 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1350,6 +1519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1639,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1638,6 +1824,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1759,24 +1948,24 @@ dependencies = [
 
 [[package]]
 name = "hmac-sha1-compact"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a4e188bd5d537801721276d1771f1cea235cd94961ddb2828eb76e16688356"
+checksum = "b0b3ba31f6dc772cc8221ce81dbbbd64fa1e668255a6737d95eeace59b5a8823"
 
 [[package]]
 name = "hmac-sha256"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6880c8d4a9ebf39c6e8b77007ce223f646a4d21ce29d99f70cb16420545425"
+checksum = "d0f0ae375a85536cac3a243e3a9cda80a47910348abdea7e2c22f8ec556d586d"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "hmac-sha512"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89e8d20b3799fa526152a5301a771eaaad80857f83e01b23216ceaafb2d9280"
+checksum = "e9c4d256181c136fe596b5e8cf23adf99c58f71bb54e98058cfa976caf8cc5c2"
 dependencies = [
  "digest",
 ]
@@ -1828,9 +2017,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
+checksum = "b41fb3dc24fe72c2e3a4685eed55917c2fb228851257f4a8f2d985da9443c3e5"
 dependencies = [
  "typenum",
 ]
@@ -1923,7 +2112,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2243,6 +2432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2333,6 +2528,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+dependencies = [
+ "crc",
+ "sha2",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2594,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2464,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -2550,6 +2771,43 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "openraft"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc22bb6823c606299be05f3cc0d2ac30216412e05352eaf192a481c12ea055fc"
+dependencies = [
+ "anyerror",
+ "anyhow",
+ "byte-unit",
+ "chrono",
+ "clap",
+ "derive_more",
+ "futures",
+ "maplit",
+ "openraft-macros",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "validit",
+]
+
+[[package]]
+name = "openraft-macros"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e5c7db6c8f2137b45a63096e09ac5a89177799b4bb0073915a5f41ee156651"
+dependencies = [
+ "chrono",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2738,10 +2996,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2851,6 +3125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +3146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2923,6 +3212,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick_cache"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,7 +3254,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2983,16 +3292,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -3002,6 +3311,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3132,6 +3447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,6 +3557,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,6 +3645,22 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3491,6 +3860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,6 +3920,12 @@ name = "self_cell"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -3745,6 +4126,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,9 +4161,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -3972,12 +4365,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -3989,15 +4383,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4029,7 +4423,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4109,6 +4503,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -4242,6 +4648,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4313,6 +4729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typed-path"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e43ffa54726cdc9ea78392023ffe9fe9cf9ac779e1c6fcb0d23f9862e3879d20"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,6 +4768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,6 +4803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4388,9 +4822,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -4426,6 +4860,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "validit"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efba0434d5a0a62d4f22070b44ce055dc18cb64d4fa98276aa523dadfaba0e7"
+dependencies = [
+ "anyerror",
 ]
 
 [[package]]
@@ -4993,6 +5436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5006,18 +5458,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5029,9 +5481,97 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "aes 0.8.4",
+ "bzip2",
+ "constant_time_eq 0.3.1",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "generic-array",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.13.0",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,12 @@ openapi = []
 
 [dependencies]
 aide.workspace = true
+anyerror.workspace = true
 anyhow.workspace = true
 axum.workspace = true
 axum-extra.workspace = true
 base64.workspace = true
+byteorder.workspace = true
 bytes.workspace = true
 config.workspace = true
 coyote-derive.workspace = true
@@ -41,11 +43,13 @@ itertools.workspace = true
 jiff.workspace = true
 jwt-simple.workspace = true
 mime.workspace = true
+openraft.workspace = true
 opentelemetry.workspace = true
 opentelemetry-http.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
+paste.workspace = true
 regex.workspace = true
 rmp-serde.workspace = true
 schemars.workspace = true
@@ -65,6 +69,7 @@ tracing-subscriber = { workspace = true, features = ["json"] }
 url.workspace = true
 uuid.workspace = true
 validator.workspace = true
+zip.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
@@ -96,11 +101,13 @@ rust-version = "1.91"
 
 [workspace.dependencies]
 aide = { version = "=0.16.0-alpha.2", features = ["axum", "axum-json", "axum-query", "macros"] }
+anyerror = { version = "0.1.13", features = ["anyhow"] }
 anyhow = "1.0.56"
 assert_matches = "1.5.0"
 axum = "0.8.8"
 axum-extra = { version = "0.12.5", features = ["typed-header"] }
 base64 = "0.22"
+byteorder = "1.5.0"
 bytes = "1.1.0"
 clap = { version = "4.1.8", features = ["derive"] }
 clap_complete = "4.5.38"
@@ -117,7 +124,7 @@ crossbeam-skiplist = "0.1.3"
 ctor = "0.6.3"
 dirs = "6.0.0"
 dotenvy = "0.15.7"
-fjall = "3.0.1"
+fjall = { version = "3.0.1", features = ["lz4", "metrics"] }
 fjall-utils.path = "crates/fjall-utils"
 hex = "0.4.3"
 hickory-resolver = "0.25.2"
@@ -137,12 +144,14 @@ jwt-simple = "0.12"
 mime = "0.3"
 num_enum = "0.7.2"
 openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "0a51d3898dab5943404890c31788f81e2f07f22e" }
+openraft = { version = "0.9.21", features = ["tracing-log", "anyhow", "serde", "storage-v2"] }
 opentelemetry = { version = "0.31.0", features = ["metrics"] }
 opentelemetry-http = "0.31.0"
 opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["internal-logs", "metrics", "grpc-tonic", "http-proto", "reqwest-client"] }
 opentelemetry-proto = { version = "0.31.0", default-features = false, features = ["internal-logs", "gen-tonic", "trace", "with-serde"] }
 opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["metrics", "rt-tokio", "rt-tokio-current-thread", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }
+paste = "1.0.15"
 percent-encoding = "2.3.2"
 proc-macro2 = "1.0.78"
 quote = "1.0.15"
@@ -163,7 +172,7 @@ syn = "2.0.48"
 tap = "1"
 tempfile = "3.24.0"
 test-utils.path = "crates/test-utils"
-tokio = { version = "1.24.2", features = ["rt", "signal"] }
+tokio = { version = "1.24.2", features = ["rt", "signal", "fs"] }
 tokio-util = "0.7"
 tower = "0.5.1"
 tower-http = { version = "0.6.1", features = ["trace", "cors", "normalize-path", "request-id"] }
@@ -174,6 +183,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["a
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.19.0", features = ["v7", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
+zip = "7"
 
 [workspace.lints.rust]
 # Can't forbid as we use at least one macro that expands to unsafe code

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -83,6 +83,9 @@ pub struct ConfigurationInner {
     /// The address to listen on
     pub listen_address: SocketAddr,
 
+    /// The address to listen on for replication/etc
+    pub interserver_listen_address: SocketAddr,
+
     #[serde(flatten, with = "management_db")]
     pub management_db_config: Arc<DatabaseConfig<Management>>,
 

--- a/src/core/cluster/errors.rs
+++ b/src/core/cluster/errors.rs
@@ -1,0 +1,32 @@
+use openraft::{AnyError, NodeId as RaftNodeId, StorageError, StorageIOError};
+
+macro_rules! build_openraft_storageio_error_helper {
+    ($name:ident) => {
+        paste::paste! {
+            pub(crate) fn [< $name _err >]<N: RaftNodeId>(e: impl Into<AnyError>) -> StorageError<N> {
+                StorageError::IO {
+                    source: StorageIOError::$name(e.into())
+                }
+            }
+        }
+    };
+}
+
+build_openraft_storageio_error_helper!(read);
+build_openraft_storageio_error_helper!(write);
+build_openraft_storageio_error_helper!(read_logs);
+build_openraft_storageio_error_helper!(write_logs);
+build_openraft_storageio_error_helper!(read_vote);
+build_openraft_storageio_error_helper!(write_vote);
+
+pub(crate) fn write_snapshot_err<N: RaftNodeId>(e: impl Into<AnyError>) -> StorageError<N> {
+    StorageError::IO {
+        source: StorageIOError::write_snapshot(None, e.into()),
+    }
+}
+
+pub(crate) fn read_snapshot_err<N: RaftNodeId>(e: impl Into<AnyError>) -> StorageError<N> {
+    StorageError::IO {
+        source: StorageIOError::read_snapshot(None, e.into()),
+    }
+}

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -1,0 +1,395 @@
+use byteorder::{BigEndian, ByteOrder};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable, Slice, UserKey};
+use openraft::storage::{LogFlushed, RaftLogStorage};
+use openraft::{
+    Entry, LogId, OptionalSend, RaftLogId, RaftLogReader, RaftTypeConfig, StorageError, Vote,
+};
+use std::fmt::Debug;
+use std::ops::{Bound, RangeBounds};
+use std::path::Path;
+use tap::{Tap, TapFallible};
+use tracing::{Instrument as _, Span};
+
+use super::errors::*;
+use super::raft::TypeConfig;
+
+type NodeId = <TypeConfig as RaftTypeConfig>::NodeId;
+
+// This is an implementation of an openraft Logs store backed by fjall
+
+#[derive(Debug, PartialEq, Clone)]
+enum LogError {
+    KeyDeserializationError,
+}
+
+impl std::error::Error for LogError {
+    fn description(&self) -> &str {
+        "Internal error processing logs"
+    }
+
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+impl std::fmt::Display for LogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: fix this
+        write!(f, "{self:?}")
+    }
+}
+
+type StorageResult<T> = Result<T, StorageError<NodeId>>;
+
+#[derive(Clone)]
+pub struct CoyoteLogs {
+    db: Database,
+    meta_keyspace: Keyspace,
+    log_keyspace: Keyspace,
+}
+
+type KeyType = [u8; 8];
+
+fn index_to_key(index: u64) -> KeyType {
+    let mut buf = [0u8; 8];
+    BigEndian::write_u64(&mut buf, index);
+    buf
+}
+
+fn key_to_index(key: Slice) -> Result<u64, LogError> {
+    if key.len() != 8 {
+        return Err(LogError::KeyDeserializationError);
+    }
+    Ok(BigEndian::read_u64(&key))
+}
+
+fn range_to_start<RB: RangeBounds<u64>>(range: RB) -> KeyType {
+    match range.start_bound() {
+        Bound::Included(i) => index_to_key(*i),
+        Bound::Excluded(i) => index_to_key(*i + 1),
+        Bound::Unbounded => index_to_key(0),
+    }
+}
+
+impl<C> RaftLogReader<C> for CoyoteLogs
+where
+    C: RaftTypeConfig,
+{
+    #[tracing::instrument(skip(self))]
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+        let output = self
+            .read_log_entries::<C, RB>(range.clone())
+            .await
+            .map_err(read_logs_err)?;
+        let output_keys = output.iter().map(|e| e.get_log_id());
+        tracing::trace!(?range, ?output_keys, "read log entries");
+        Ok(output)
+    }
+}
+
+impl RaftLogStorage<TypeConfig> for CoyoteLogs {
+    type LogReader = Self;
+
+    async fn get_log_reader(&mut self) -> Self::LogReader {
+        self.clone()
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn get_log_state(
+        &mut self,
+    ) -> Result<openraft::LogState<TypeConfig>, StorageError<NodeId>> {
+        self.get_log_state_().await.map_err(read_err)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<NodeId>> {
+        self.save_vote_(vote.to_owned())
+            .instrument(Span::current())
+            .await
+            .map_err(write_vote_err)?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<NodeId>> {
+        self.read_vote_()
+            .instrument(Span::current())
+            .await
+            .map_err(read_vote_err)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn append<I>(&mut self, entries: I, callback: LogFlushed<TypeConfig>) -> StorageResult<()>
+    where
+        I: IntoIterator<Item = Entry<TypeConfig>> + Send,
+        I::IntoIter: Send,
+    {
+        // TODO: figure out a way to do this without collecting into a vec here; the problem
+        // is that I is Send, but isn't 'static, so it can't be sent over with tokio::task::spawn_blocking...
+        let entries = entries.into_iter().collect();
+        self.append_entries_(entries, callback)
+            .instrument(Span::current())
+            .await
+            .map_err(write_logs_err)?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn truncate(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
+        self.truncate_entries_(log_id)
+            .instrument(Span::current())
+            .await
+            .map_err(write_logs_err)
+            .tap(|_| self.trace_logs())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn purge(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
+        self.purge_entries_(log_id)
+            .instrument(Span::current())
+            .await
+            .map_err(write_logs_err)
+            .tap(|_| self.trace_logs())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn save_committed(&mut self, committed: Option<LogId<NodeId>>) -> StorageResult<()> {
+        self.save_committed_(committed)
+            .instrument(Span::current())
+            .await
+            .map_err(write_err)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn read_committed(&mut self) -> Result<Option<LogId<NodeId>>, StorageError<NodeId>> {
+        self.read_committed_()
+            .instrument(Span::current())
+            .await
+            .map_err(write_err)
+    }
+}
+
+impl CoyoteLogs {
+    pub async fn new(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let db = Database::builder(path).worker_threads(1).open()?;
+        let log_keyspace = db.keyspace("cluster:logs", KeyspaceCreateOptions::default)?;
+        let meta_keyspace = db.keyspace("cluster:meta", KeyspaceCreateOptions::default)?;
+        Ok(Self {
+            db,
+            log_keyspace,
+            meta_keyspace,
+        })
+    }
+
+    async fn append_entries_(
+        &mut self,
+        entries: Vec<Entry<TypeConfig>>,
+        callback: LogFlushed<TypeConfig>,
+    ) -> anyhow::Result<()> {
+        let keyspace = self.log_keyspace.clone();
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let keys = entries.iter().map(|entry| entry.log_id).collect::<Vec<_>>();
+            tracing::trace!(?keys, "appending some entries");
+            let key_vs = entries
+                .into_iter()
+                .map(|entry| (index_to_key(entry.log_id.index), entry));
+            let mut ingest = keyspace.start_ingestion()?;
+            for (id, raw_value) in key_vs {
+                let value = rmp_serde::to_vec(&raw_value)?;
+                ingest.write(id, value)?;
+            }
+            ingest.finish()?;
+            Ok(())
+        })
+        .await??;
+
+        // callback should be called after writing the entries but before syncing them; ok
+        callback.log_io_completed(Ok(()));
+
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || db.persist(PersistMode::SyncAll)).await??;
+
+        Ok(())
+    }
+
+    /// Truncate logs since log_id, inclusive
+    async fn truncate_entries_(&self, log_id: LogId<NodeId>) -> anyhow::Result<()> {
+        let log_keyspace = self.log_keyspace.clone();
+        let mut tx = self.db.batch().durability(Some(PersistMode::SyncAll));
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let keys: Vec<UserKey> = log_keyspace
+                .range(index_to_key(log_id.index)..)
+                .map(|g| g.key())
+                .collect::<Result<Vec<_>, fjall::Error>>()?;
+            tracing::trace!(?keys, ?log_id, "deleting items after log_id (inclusive)");
+            for key in keys {
+                tx.remove(&log_keyspace, key);
+            }
+            tx.commit()?;
+            Ok(())
+        })
+        .await?
+    }
+
+    /// Purge logs upto log_id, inclusive
+    async fn purge_entries_(&self, log_id: LogId<NodeId>) -> anyhow::Result<()> {
+        let meta_keyspace = self.meta_keyspace.clone();
+        let log_keyspace = self.log_keyspace.clone();
+        let serialized_log_id = rmp_serde::encode::to_vec(&log_id)?;
+        let mut tx = self.db.batch().durability(Some(PersistMode::SyncAll));
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let keys: Vec<UserKey> = log_keyspace
+                .range(..=index_to_key(log_id.index))
+                .map(|g| g.key())
+                .collect::<Result<Vec<_>, fjall::Error>>()?;
+            tracing::trace!(?keys, ?log_id, "deleting items before log_id (inclusive)");
+            for key in keys {
+                tx.remove(&log_keyspace, key);
+            }
+            tx.insert(&meta_keyspace, "last_purged_log_id", serialized_log_id);
+            tx.commit()?;
+            Ok(())
+        })
+        .await?
+    }
+
+    fn trace_logs(&self) {
+        tracing::trace!("BEGINNING LOG TRACE");
+        let last_purged_log_id: Option<LogId<NodeId>> = self
+            .meta_keyspace
+            .get("last_purged_log_id")
+            .unwrap()
+            .map(|l| rmp_serde::from_slice(&l).unwrap());
+        let first_id = self
+            .log_keyspace
+            .first_key_value()
+            .map(|g| key_to_index(g.key().unwrap()).unwrap());
+        let last_id = self
+            .log_keyspace
+            .last_key_value()
+            .map(|g| key_to_index(g.key().unwrap()).unwrap());
+        tracing::trace!(?last_purged_log_id, first_id, last_id, "log metadata");
+        let tx = self.db.snapshot();
+        for guard in tx.iter(&self.log_keyspace) {
+            let (key, value) = guard.into_inner().unwrap();
+            let value: Entry<TypeConfig> = rmp_serde::from_slice(&value).unwrap();
+            let index = key_to_index(key).unwrap();
+            tracing::trace!(?value, ?index, "log");
+        }
+        tracing::trace!("END LOG TRACE");
+    }
+
+    async fn get_log_state_(&mut self) -> anyhow::Result<openraft::LogState<TypeConfig>> {
+        let db = self.db.clone();
+        let log_keyspace = self.log_keyspace.clone();
+        let meta_keyspace = self.meta_keyspace.clone();
+        tokio::task::spawn_blocking(move || {
+            let tx = db.snapshot();
+            let last_purged_log_id =
+                if let Some(value) = tx.get(&meta_keyspace, "last_purged_log_id")? {
+                    Some(rmp_serde::from_slice(&value)?)
+                } else {
+                    None
+                };
+            let last_log_id = if let Some(last_guard) = tx.last_key_value(&log_keyspace) {
+                let raw_entry = last_guard.value()?;
+                let value: <TypeConfig as RaftTypeConfig>::Entry =
+                    rmp_serde::from_slice(&raw_entry)?;
+                Some(value.log_id)
+            } else {
+                last_purged_log_id
+            };
+            Ok(openraft::LogState {
+                last_purged_log_id,
+                last_log_id,
+            })
+        })
+        .await?
+    }
+
+    async fn read_log_entries<C, RB>(&mut self, range: RB) -> anyhow::Result<Vec<C::Entry>>
+    where
+        C: RaftTypeConfig,
+        RB: RangeBounds<u64> + Clone + Debug + OptionalSend,
+    {
+        let db = self.db.clone();
+        let log_keyspace = self.log_keyspace.clone();
+        let iter_range = range_to_start(range.clone())..;
+        // why isn't RB always Send? it's a goddamn range...
+        let end = match range.end_bound() {
+            Bound::Unbounded => None,
+            Bound::Included(i) => Some(*i + 1),
+            Bound::Excluded(i) => Some(*i),
+        };
+        tokio::task::spawn_blocking(move || {
+            let mut output = vec![];
+            let tx = db.snapshot();
+            for guard in tx.range(&log_keyspace, iter_range) {
+                let (key, value) = guard
+                    .into_inner()
+                    .tap_err(|err| tracing::warn!(?err, "Error reading values from log"))?;
+                let index = key_to_index(key)
+                    .tap_err(|err| tracing::warn!(?err, "Error parsing key from log"))?;
+                if let Some(end) = end
+                    && index >= end
+                {
+                    break;
+                }
+                let value = rmp_serde::from_slice(&value)?;
+                output.push(value);
+            }
+            Ok(output)
+        })
+        .await?
+    }
+
+    async fn save_vote_(&self, vote: Vote<NodeId>) -> anyhow::Result<()> {
+        tracing::trace!(?vote, "saving a vote");
+        let db = self.db.clone();
+        let meta_keyspace = self.meta_keyspace.clone();
+        tokio::task::spawn_blocking(move || {
+            let serialized = rmp_serde::to_vec(&vote)?;
+            meta_keyspace.insert("vote", serialized)?;
+            db.persist(PersistMode::SyncAll)?;
+            Ok(())
+        })
+        .await?
+    }
+
+    async fn read_vote_(&self) -> anyhow::Result<Option<Vote<NodeId>>> {
+        let Some(raw) = self.meta_keyspace.get("vote")? else {
+            tracing::trace!("couldn't find a vote");
+            return Ok(None);
+        };
+        let vote = rmp_serde::from_slice(&raw)?;
+        tracing::trace!(?vote, "reading a vote");
+        Ok(Some(vote))
+    }
+
+    async fn save_committed_(&self, committed: Option<LogId<NodeId>>) -> anyhow::Result<()> {
+        let meta_keyspace = self.meta_keyspace.clone();
+        tracing::trace!(?committed, "saving committed state");
+        tokio::task::spawn_blocking(move || {
+            let serialized = rmp_serde::to_vec(&committed)?;
+            meta_keyspace.insert("committed", serialized)?;
+            Ok(())
+        })
+        .await?
+    }
+
+    async fn read_committed_(&self) -> anyhow::Result<Option<LogId<NodeId>>> {
+        let meta_keyspace = self.meta_keyspace.clone();
+        tokio::task::spawn_blocking(move || {
+            let committed = meta_keyspace
+                .get("committed")?
+                .map(|c| rmp_serde::from_slice(&c))
+                .transpose()?;
+            tracing::trace!(?committed, "read committed state");
+            Ok(committed)
+        })
+        .await?
+    }
+}

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -1,0 +1,8 @@
+mod errors;
+mod logs;
+mod raft;
+mod serialized_state_machine;
+mod state_machine;
+
+pub use logs::CoyoteLogs;
+pub use state_machine::Store;

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -1,0 +1,83 @@
+use openraft::BasicNode;
+use serde::{Deserialize, Serialize};
+
+use super::state_machine::StoredSnapshot;
+
+// TODO: this should actually be our Operation trait
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Request {
+    key: String,
+}
+
+// TODO: the value here needs to actually be the response from Operation
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Response {
+    value: Option<String>,
+}
+
+impl Response {
+    pub(crate) fn blank() -> Self {
+        Self { value: None }
+    }
+}
+
+// TODO: is BasicNode enough for us?
+pub(super) type Node = BasicNode;
+
+openraft::declare_raft_types!(
+    pub TypeConfig:
+        D = Request,
+        R = Response,
+        Node = Node,
+        SnapshotData = StoredSnapshot
+);
+
+#[cfg(test)]
+mod tests {
+    use fjall::Database;
+    use openraft::testing::StoreBuilder;
+    use openraft::{RaftTypeConfig, StorageIOError};
+    use tempfile::TempDir;
+
+    use super::super::logs::CoyoteLogs;
+    use super::super::state_machine::Store;
+    use super::TypeConfig;
+
+    type NodeId = <TypeConfig as RaftTypeConfig>::NodeId;
+
+    struct CoyoteStoreBuilder;
+
+    impl CoyoteStoreBuilder {
+        async fn setup() -> anyhow::Result<(TempDir, CoyoteLogs, Store)> {
+            let workdir = tempfile::tempdir()?;
+            let mut log_path = workdir.path().to_path_buf();
+            log_path.push("logs");
+            let logs = CoyoteLogs::new(log_path).await?;
+
+            let mut data_path = workdir.path().to_path_buf();
+            data_path.push("data");
+            let mut snapshot_path = workdir.path().to_path_buf();
+            snapshot_path.push("snapshots");
+            let db = Database::builder(data_path).open()?;
+            let store = Store::new(db, snapshot_path).await?;
+
+            Ok((workdir, logs, store))
+        }
+    }
+
+    impl StoreBuilder<TypeConfig, CoyoteLogs, Store, TempDir> for CoyoteStoreBuilder {
+        async fn build(
+            &self,
+        ) -> Result<(TempDir, CoyoteLogs, Store), openraft::StorageError<NodeId>> {
+            Self::setup().await.map_err(|e| openraft::StorageError::IO {
+                source: StorageIOError::write(e),
+            })
+        }
+    }
+
+    #[test]
+    fn test_storage() -> anyhow::Result<()> {
+        openraft::testing::Suite::test_all(CoyoteStoreBuilder)?;
+        Ok(())
+    }
+}

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -1,0 +1,283 @@
+use std::io::{Read, Seek, Write};
+
+use anyhow::Context;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, Readable};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use zip::{ZipArchive, write::SimpleFileOptions};
+
+// This file supports serializing a bunch of Fjall keyspaces to a file
+// to be sent as a Raft snapshot. In the future, when
+// https://github.com/fjall-rs/fjall/issues/52 is done, we should use that to just
+// take a backup and then tar it up, but for now we need to actually
+// separately serialize the whole thing.
+//
+// The format is as follows:
+//
+// - The magic data "COYOTE01"
+// - A zip snapshot
+//
+// Inside the zip snapshot is a file called "manifest.json" containing
+// the manifest structure below, and then a series of chunk files containing
+// sorted rows from each keyspace.
+//
+// Each chunk is serialized as
+//
+// [ key length ] [ data length ] [ key ] [ data ]
+//
+// Where `key length` is a 16-bit big-endian integer, `data length` is a
+// 32-bit big-endian integer, and key and data are untransformed bytes.
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Chunk {
+    num_records: u32,
+    name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Manifest {
+    keyspaces: BTreeMap<String, Vec<Chunk>>,
+}
+
+struct KeyspaceSerializer<'a, B: Write + Seek> {
+    file: &'a mut zip::ZipWriter<B>,
+    keyspace_name: &'a str,
+    current_buffer: Vec<u8>,
+    current_index: u32,
+    current_count: u32,
+    chunk_metadata: Vec<Chunk>,
+    total_written: usize,
+}
+
+impl<'a, B: Write + Seek> KeyspaceSerializer<'a, B> {
+    const MAX_BYTES_PER_CHUNK: usize = 10_000_000;
+
+    fn new(file: &'a mut zip::ZipWriter<B>, keyspace_name: &'a str) -> anyhow::Result<Self> {
+        let options = SimpleFileOptions::default().unix_permissions(0o755);
+        file.add_directory(keyspace_name, options)?;
+        Ok(Self {
+            file,
+            keyspace_name,
+            current_buffer: vec![],
+            chunk_metadata: vec![],
+            current_index: 0,
+            current_count: 0,
+            total_written: 0,
+        })
+    }
+
+    fn flush_current(&mut self) -> anyhow::Result<()> {
+        if self.current_buffer.is_empty() {
+            return Ok(());
+        }
+        let name = format!("{}/part{}", self.keyspace_name, self.current_index);
+        self.current_index += 1;
+        self.chunk_metadata.push(Chunk {
+            num_records: self.current_count,
+            name: name.clone(),
+        });
+        let options = SimpleFileOptions::default()
+            .large_file(true)
+            .unix_permissions(0o644);
+        self.file.start_file(name, options)?;
+        self.file.write_all(&self.current_buffer)?;
+        self.current_buffer.clear();
+        self.current_count = 0;
+        Ok(())
+    }
+
+    fn serialize_keyspace<R: Readable>(
+        mut self,
+        snapshot: &R,
+        keyspace: &Keyspace,
+    ) -> anyhow::Result<Vec<Chunk>> {
+        tracing::trace!(keyspace_name = self.keyspace_name, "serializing keyspace");
+        for guard in snapshot.iter(keyspace) {
+            let (k, v) = guard.into_inner()?;
+            if self.current_buffer.len() > Self::MAX_BYTES_PER_CHUNK {
+                self.flush_current()?;
+            }
+            self.current_count += 1;
+            self.current_buffer.write_u16::<BigEndian>(k.len() as u16)?;
+            self.current_buffer.write_u32::<BigEndian>(v.len() as u32)?;
+            self.current_buffer.write_all(&k)?;
+            self.current_buffer.write_all(&v)?;
+            self.total_written += 1;
+        }
+        self.flush_current()?;
+        tracing::trace!(
+            keyspace_name = self.keyspace_name,
+            total_written = self.total_written,
+            "finished serializing keyspace"
+        );
+        Ok(self.chunk_metadata)
+    }
+}
+
+fn deserialize_keyspace<R: Read + Seek>(
+    z: &mut ZipArchive<R>,
+    keyspace: &Keyspace,
+    chunks: Vec<Chunk>,
+) -> anyhow::Result<()> {
+    keyspace.clear()?;
+    let mut key_buf = vec![];
+    let mut value_buf = vec![];
+
+    for chunk in chunks {
+        tracing::trace!(?chunk, "deserializing chunk");
+        let mut entry = z.by_name(&chunk.name)?;
+        let mut i = keyspace.start_ingestion()?;
+        for _ in 0..chunk.num_records {
+            let key_len = entry.read_u16::<BigEndian>()?;
+            let value_len = entry.read_u32::<BigEndian>()?;
+            key_buf.resize(key_len as usize, 0u8);
+            entry.read_exact(&mut key_buf)?;
+            if value_len > 0 {
+                value_buf.resize(value_len as usize, 0u8);
+                entry.read_exact(&mut value_buf)?;
+            } else {
+                value_buf.clear();
+            }
+            i.write(&key_buf, &value_buf)?;
+        }
+        i.finish()?;
+    }
+    Ok(())
+}
+
+#[tracing::instrument(skip(db, snapshot, file))]
+pub(crate) fn serialize_to_file<F: Write + Seek>(
+    db: Database,
+    snapshot: fjall::Snapshot,
+    keyspaces: Vec<String>,
+    file: &mut F,
+) -> anyhow::Result<()> {
+    file.write_all(b"COYOTE01")?;
+
+    let mut zip = zip::write::ZipWriter::new(file);
+
+    let mut manifest = Manifest::default();
+
+    for keyspace_name in keyspaces {
+        tracing::debug!(keyspace=%keyspace_name, "serializing a keyspce");
+        let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
+        let serializer = KeyspaceSerializer::new(&mut zip, &keyspace_name)?;
+        let chunks = serializer.serialize_keyspace(&snapshot, &keyspace)?;
+        manifest.keyspaces.insert(keyspace_name, chunks);
+    }
+
+    let serialized_manifest = serde_json::to_vec(&manifest)?;
+
+    let options = SimpleFileOptions::default()
+        .large_file(false)
+        .unix_permissions(0o644);
+    zip.start_file("manifest.json", options)?;
+    zip.write_all(&serialized_manifest)?;
+
+    Ok(())
+}
+
+#[tracing::instrument(skip_all)]
+pub(crate) fn load_from_file<F: Read + Seek>(db: &Database, f: &mut F) -> anyhow::Result<()> {
+    let mut magic = [0u8; 8];
+    f.read_exact(&mut magic)?;
+    if &magic != b"COYOTE01" {
+        panic!("unhandled snapshot format {magic:?}");
+    }
+
+    let mut z = zip::read::ZipArchive::new(f)?;
+
+    let Ok(manifest) = z.by_name("manifest.json") else {
+        anyhow::bail!("no manifest.json in archive");
+    };
+
+    let manifest: Manifest = serde_json::from_reader(manifest).context("parsing manifest")?;
+
+    for (keyspace_name, chunks) in manifest.keyspaces {
+        tracing::debug!(
+            keyspace_name,
+            num_parts = chunks.len(),
+            "deserializing a keyspace"
+        );
+        let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
+        deserialize_keyspace(&mut z, &keyspace, chunks)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use fjall::{Database, KeyspaceCreateOptions, Slice};
+
+    use crate::core::cluster::serialized_state_machine::{load_from_file, serialize_to_file};
+
+    #[test]
+    fn test_serialize_to_file_round_trip() -> anyhow::Result<()> {
+        let workdir = tempfile::tempdir()?;
+        let mut db_path = workdir.path().to_path_buf();
+        db_path.push("db/");
+
+        let db = Database::builder(db_path).open()?;
+        let ks1 = db.keyspace("keyspace1", KeyspaceCreateOptions::default)?;
+        ks1.insert("key1", b"value1")?;
+        ks1.insert("key2", b"\x00\x00\x00")?;
+        ks1.insert("key3", b"")?;
+        let ks2 = db.keyspace("keyspace2", KeyspaceCreateOptions::default)?;
+        ks2.insert("key4", b"value4")?;
+        db.persist(fjall::PersistMode::SyncAll)?;
+
+        let snapshot = db.snapshot();
+
+        let mut cursor = Cursor::new(vec![]);
+
+        serialize_to_file(
+            db,
+            snapshot,
+            vec!["keyspace1".to_owned(), "keyspace2".to_owned()],
+            &mut cursor,
+        )?;
+
+        let out = cursor.into_inner();
+
+        assert_eq!(&out[..8], b"COYOTE01");
+
+        let mut db2_path = workdir.path().to_path_buf();
+        db2_path.push("db_loaded/");
+        let db2 = Database::builder(db2_path).open()?;
+
+        let mut cursor = Cursor::new(out);
+
+        load_from_file(&db2, &mut cursor)?;
+
+        let found_keyspaces = db2
+            .list_keyspace_names()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(&found_keyspaces, &["keyspace1", "keyspace2"]);
+
+        let keyspace1 = db2.keyspace("keyspace1", KeyspaceCreateOptions::default)?;
+        assert_eq!(
+            keyspace1.get("key1")?.as_ref(),
+            Some(&Slice::new(b"value1"))
+        );
+        assert_eq!(
+            keyspace1.get("key2")?.as_ref(),
+            Some(&Slice::new(b"\x00\x00\x00"))
+        );
+        assert_eq!(keyspace1.get("key3")?.as_ref(), Some(&Slice::new(b"")));
+        assert_eq!(keyspace1.get("key4")?.as_ref(), None);
+
+        let keyspace2 = db2.keyspace("keyspace2", KeyspaceCreateOptions::default)?;
+        assert_eq!(
+            keyspace2.get("key4")?.as_ref(),
+            Some(&Slice::new(b"value4"))
+        );
+
+        Ok(())
+    }
+}

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -1,0 +1,439 @@
+use std::io::{ErrorKind, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
+use openraft::storage::RaftStateMachine;
+use openraft::{
+    EntryPayload, LogId, RaftSnapshotBuilder, RaftTypeConfig, Snapshot, SnapshotMeta,
+    StoredMembership,
+};
+use serde::{Deserialize, Serialize};
+
+use super::errors::*;
+use crate::core::cluster::raft;
+
+use super::raft::{Node, TypeConfig};
+use super::serialized_state_machine;
+
+type NodeId = <TypeConfig as RaftTypeConfig>::NodeId;
+type StorageError = openraft::StorageError<NodeId>;
+type StorageResult<T> = Result<T, StorageError>;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct LastSnapshot {
+    meta: SnapshotMeta<NodeId, Node>,
+    path: PathBuf,
+}
+
+#[derive(Clone)]
+pub struct Store {
+    db: Database,
+    snapshot_directory: PathBuf,
+    meta_keyspace: Keyspace,
+    snapshot_idx: u64,
+    last_applied_log_id: Option<LogId<NodeId>>,
+    last_membership: StoredMembership<NodeId, Node>,
+    last_snapshot: Arc<RwLock<Option<LastSnapshot>>>,
+}
+
+trait SnapshotIdx {
+    fn snapshot_idx(&self) -> u64;
+}
+
+impl SnapshotIdx for SnapshotMeta<NodeId, Node> {
+    fn snapshot_idx(&self) -> u64 {
+        // TODO: fix these unwraps
+        self.snapshot_id
+            .split('-')
+            .next_back()
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+}
+
+const METADATA_KEYSPACE: &str = "_raft_metadata";
+
+impl Store {
+    pub async fn new(db: Database, snapshot_directory: PathBuf) -> anyhow::Result<Self> {
+        if let Err(e) = tokio::fs::create_dir_all(&snapshot_directory).await
+            && e.kind() != ErrorKind::AlreadyExists
+        {
+            return Err(e.into());
+        }
+        let meta_keyspace = db.keyspace(METADATA_KEYSPACE, KeyspaceCreateOptions::default)?;
+        let mut this = Self {
+            db,
+            snapshot_directory,
+            meta_keyspace,
+            last_snapshot: Arc::new(RwLock::new(None)),
+            snapshot_idx: 0,
+            last_applied_log_id: None,
+            last_membership: Default::default(),
+        };
+        this.load_information().await?;
+        Ok(this)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn load_information(&mut self) -> anyhow::Result<()> {
+        let db = self.db.clone();
+        let keyspace = self.meta_keyspace.clone();
+
+        let (last_applied_log_id, last_membership, last_snapshot) =
+            tokio::task::spawn_blocking(move || -> anyhow::Result<(_, _, _)> {
+                let snapshot = db.snapshot();
+                let last_applied_log_id = if let Some(raw_last_applied_log_id) =
+                    snapshot.get(&keyspace, "last_applied_log_id")?
+                {
+                    let last_applied_log_id = rmp_serde::from_slice(&raw_last_applied_log_id)?;
+                    Some(last_applied_log_id)
+                } else {
+                    None
+                };
+                let last_membership = if let Some(raw_last_membership) =
+                    snapshot.get(&keyspace, "last_membership")?
+                {
+                    rmp_serde::from_slice(&raw_last_membership)?
+                } else {
+                    tracing::trace!("found no last_membership in database!");
+                    Default::default()
+                };
+
+                let last_snapshot =
+                    if let Some(raw_snapshot_data) = snapshot.get(&keyspace, "last_snapshot")? {
+                        let s: LastSnapshot = rmp_serde::from_slice(&raw_snapshot_data)?;
+                        Some(s)
+                    } else {
+                        None
+                    };
+
+                Ok((last_applied_log_id, last_membership, last_snapshot))
+            })
+            .await??;
+        self.last_applied_log_id = last_applied_log_id;
+        self.last_membership = last_membership;
+        self.snapshot_idx = last_snapshot
+            .as_ref()
+            .map(|s| s.meta.snapshot_idx())
+            .unwrap_or(0);
+        *self.last_snapshot.write().unwrap() = last_snapshot;
+        Ok(())
+    }
+
+    async fn set_last_snapshot_(
+        &mut self,
+        meta: SnapshotMeta<NodeId, Node>,
+        snapshot_path: PathBuf,
+    ) -> anyhow::Result<()> {
+        let db = self.db.clone();
+        let keyspace = self.meta_keyspace.clone();
+        self.snapshot_idx = std::cmp::max(self.snapshot_idx + 1, meta.snapshot_idx());
+        let data = LastSnapshot {
+            meta,
+            path: snapshot_path,
+        };
+        tracing::trace!(last_snapshot=?data, "setting last_snapshot");
+        let serialized = rmp_serde::to_vec(&data)?;
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            keyspace.insert("last_snapshot", serialized)?;
+            db.persist(fjall::PersistMode::SyncAll)?;
+            Ok(())
+        })
+        .await??;
+        *self.last_snapshot.write().unwrap() = Some(data);
+        Ok(())
+    }
+
+    async fn record_ids_(&mut self) -> anyhow::Result<()> {
+        tracing::trace!(
+            last_applied_log_id=?self.last_applied_log_id,
+            last_membership=?self.last_membership,
+            "storing id values");
+        let mut tx = self.db.batch().durability(Some(PersistMode::Buffer));
+        let keyspace = self.meta_keyspace.clone();
+        let last_applied_log_id = rmp_serde::encode::to_vec(&self.last_applied_log_id)?;
+        let last_membership = rmp_serde::encode::to_vec(&self.last_membership)?;
+        tokio::task::spawn_blocking(move || {
+            tx.insert(&keyspace, "last_applied_log_id", last_applied_log_id);
+            tx.insert(&keyspace, "last_membership", last_membership);
+            tx.commit()?;
+            Ok(())
+        })
+        .await?
+    }
+
+    async fn delete_unused_snapshots(&self, keep_path: &Path) -> anyhow::Result<()> {
+        tracing::debug!("cleaning up unused snapshots");
+        let mut dents = tokio::fs::read_dir(&self.snapshot_directory).await?;
+        while let Some(dent) = dents.next_entry().await? {
+            if let Some(preserve_path) = keep_path.file_name() {
+                if dent.file_name() == preserve_path {
+                    tracing::trace!(filename=?dent.file_name(), "preserving used snapshot");
+                    continue;
+                }
+            } else {
+                tracing::warn!(path=?keep_path, "very weird snapshot path");
+            }
+            tracing::debug!(filename=?dent.file_name(), "deleting unused snapshot");
+            tokio::fs::remove_file(dent.path()).await?;
+        }
+        Ok(())
+    }
+
+    async fn install_snapshot_(
+        &mut self,
+        meta: &openraft::SnapshotMeta<NodeId, Node>,
+        snapshot: Box<StoredSnapshot>,
+    ) -> anyhow::Result<()> {
+        tracing::debug!("starting snapshot installation");
+        let mut f = snapshot.file.into_std().await;
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || serialized_state_machine::load_from_file(&db, &mut f))
+            .await??;
+        self.last_applied_log_id = meta.last_log_id;
+        self.last_membership = meta.last_membership.clone();
+        self.record_ids_().await?;
+        self.delete_unused_snapshots(snapshot.path.as_path())
+            .await?;
+        self.set_last_snapshot_(meta.clone(), snapshot.path).await?;
+        Ok(())
+    }
+}
+
+// Wrapper around a snapshot that has been written to disk and has both a filename
+// and a concrete File
+pub struct StoredSnapshot {
+    file: tokio::fs::File,
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for StoredSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "StoredSnapshot {{ path: {:?} }}", self.path)
+    }
+}
+
+impl tokio::io::AsyncWrite for StoredSnapshot {
+    fn is_write_vectored(&self) -> bool {
+        self.file.is_write_vectored()
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.file).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.file).poll_shutdown(cx)
+    }
+
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.file).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.file).poll_write_vectored(cx, bufs)
+    }
+}
+
+impl tokio::io::AsyncRead for StoredSnapshot {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.file).poll_read(cx, buf)
+    }
+}
+
+impl tokio::io::AsyncSeek for StoredSnapshot {
+    fn poll_complete(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<u64>> {
+        Pin::new(&mut self.file).poll_complete(cx)
+    }
+
+    fn start_seek(mut self: std::pin::Pin<&mut Self>, position: SeekFrom) -> std::io::Result<()> {
+        Pin::new(&mut self.file).start_seek(position)
+    }
+}
+
+impl StoredSnapshot {
+    async fn new(
+        metadata: &SnapshotMeta<NodeId, Node>,
+        directory: &Path,
+        database: Database,
+        keyspaces: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        let file_name = format!("coyote-{}", metadata.snapshot_id);
+        let path = directory.with_file_name(file_name);
+        let path_c = path.clone();
+        let file = tokio::task::spawn_blocking(move || -> anyhow::Result<std::fs::File> {
+            let snapshot = database.snapshot();
+            tracing::info!(path=%path_c.display(), "writing snapshot");
+            let mut f = std::fs::File::create(path_c)?;
+            serialized_state_machine::serialize_to_file(database, snapshot, keyspaces, &mut f)?;
+            f.seek(SeekFrom::Start(0))?;
+            Ok(f)
+        })
+        .await??;
+        let file = tokio::fs::File::from_std(file);
+        Ok(Self { file, path })
+    }
+}
+
+impl RaftSnapshotBuilder<TypeConfig> for Store {
+    async fn build_snapshot(&mut self) -> StorageResult<openraft::Snapshot<TypeConfig>> {
+        let last_log_id = self.last_applied_log_id;
+        let last_membership = self.last_membership.clone();
+
+        let snapshot_id = if let Some(last) = last_log_id {
+            format!("{}-{}-{}", last.leader_id, last.index, self.snapshot_idx)
+        } else {
+            format!("x-x-{}", self.snapshot_idx)
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id,
+            last_membership,
+            snapshot_id,
+        };
+
+        let keyspaces = self
+            .db
+            .list_keyspace_names()
+            .into_iter()
+            .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
+            .map(|s| s.to_string())
+            .collect();
+
+        let snapshot =
+            StoredSnapshot::new(&meta, &self.snapshot_directory, self.db.clone(), keyspaces)
+                .await
+                .map_err(write_snapshot_err)?;
+
+        self.set_last_snapshot_(meta.clone(), snapshot.path.clone())
+            .await
+            .map_err(write_snapshot_err)?;
+
+        let snapshot = Box::new(snapshot);
+
+        Ok(Snapshot { meta, snapshot })
+    }
+}
+
+impl RaftStateMachine<TypeConfig> for Store {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(
+        &mut self,
+    ) -> StorageResult<(Option<LogId<NodeId>>, StoredMembership<NodeId, Node>)> {
+        Ok((self.last_applied_log_id, self.last_membership.clone()))
+    }
+
+    async fn apply<I>(&mut self, entries: I) -> StorageResult<Vec<raft::Response>>
+    where
+        I: IntoIterator<Item = <TypeConfig as RaftTypeConfig>::Entry> + openraft::OptionalSend,
+        I::IntoIter: openraft::OptionalSend,
+    {
+        let mut replies = vec![];
+        let mut changed_log_id = false;
+        let mut changed_membership = false;
+        for item in entries {
+            self.last_applied_log_id = Some(item.log_id);
+            changed_log_id = true;
+
+            match item.payload {
+                EntryPayload::Blank => {
+                    tracing::trace!("heartbeat");
+                    replies.push(raft::Response::blank())
+                }
+                EntryPayload::Normal(req) => {
+                    // TODO actually apply something
+                    tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
+                }
+                EntryPayload::Membership(last_membership) => {
+                    tracing::trace!("changing cluster membership");
+                    self.last_membership =
+                        StoredMembership::new(Some(item.log_id), last_membership);
+                    changed_membership = true;
+                    replies.push(raft::Response::blank())
+                }
+            }
+        }
+        if changed_log_id || changed_membership {
+            self.record_ids_().await.map_err(write_err)?;
+        }
+        Ok(replies)
+    }
+
+    async fn begin_receiving_snapshot(
+        &mut self,
+    ) -> StorageResult<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>> {
+        let path = self
+            .snapshot_directory
+            .with_file_name(format!("coyote-incoming-snapshot-{}", self.snapshot_idx));
+        self.snapshot_idx += 1;
+        let f = tokio::fs::File::create_new(path.clone())
+            .await
+            .map_err(|e| write_snapshot_err(&e))?;
+        Ok(Box::new(StoredSnapshot { path, file: f }))
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.snapshot_idx += 1;
+        self.clone()
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> StorageResult<Option<openraft::Snapshot<TypeConfig>>> {
+        // clone to avoid holding a lock over an await point
+        let last_snapshot = self.last_snapshot.read().unwrap().clone();
+        if let Some(last_snapshot) = last_snapshot {
+            tracing::trace!(?last_snapshot, "found last_snapshot");
+            let f = tokio::fs::File::open(&last_snapshot.path)
+                .await
+                .map_err(|e| read_snapshot_err(&e))?;
+            Ok(Some(Snapshot {
+                meta: last_snapshot.meta.clone(),
+                snapshot: Box::new(StoredSnapshot {
+                    file: f,
+                    path: last_snapshot.path.clone(),
+                }),
+            }))
+        } else {
+            tracing::trace!("found no last_snapshot");
+            Ok(None)
+        }
+    }
+
+    #[tracing::instrument(skip(self, meta))]
+    async fn install_snapshot(
+        &mut self,
+        meta: &openraft::SnapshotMeta<NodeId, Node>,
+        snapshot: Box<StoredSnapshot>,
+    ) -> StorageResult<()> {
+        self.install_snapshot_(meta, snapshot)
+            .await
+            .map_err(read_snapshot_err)
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+pub mod cluster;
 pub mod otel_spans;
 pub mod retry;
 pub mod security;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -33,6 +33,9 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr: SocketAddr = listener.local_addr().unwrap();
 
+    let repl_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let repl_addr: SocketAddr = repl_listener.local_addr().unwrap();
+
     let jwt_key = HS256Key::generate();
     let token = "Stubbed token. Should probably be legit when we add auth.";
 
@@ -40,6 +43,7 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
 
     let cfg = Arc::new(ConfigurationInner {
         listen_address: addr,
+        interserver_listen_address: repl_addr,
         management_db_config: Arc::new(DatabaseConfig::<Management> {
             path: db_dir.path().to_string_lossy().to_string(),
             ..Default::default()


### PR DESCRIPTION
This implements an [openraft](https://crates.io/crates/openraft) backend using fjall. It doesn't implement any of the network parts yet (nothing is wired up to axum), nor any of the discovery parts. It also doesn't use the same fjall database for storage as the main system. But! It's a start and I wanted to check it in before embarking on the next multi-thousand-line PR.