### PR TITLE
Add stream.append RPC call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,6 +3444,7 @@ dependencies = [
  "schemars_derive 1.2.0",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -3800,11 +3801,14 @@ dependencies = [
  "http-body-util",
  "jiff",
  "reqwest 0.13.1",
+ "rmp-serde",
+ "schemars 1.2.0",
  "serde",
  "serde_json",
  "static_assertions",
  "url",
  "uuid",
+ "validator",
 ]
 
 [[package]]
@@ -4371,6 +4375,7 @@ checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ regex = "1.5.5"
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "hickory-dns"] }
 rmp-serde = "1.3.0"
 rustls = "0.23.31"
-schemars = { version = "1.2.0", features = ["jiff02"] }
+schemars = { version = "1.2.0", features = ["jiff02", "uuid1"] }
 serde = { version = "1.0.184", features = ["derive", "rc"] }
 serde_json = { version = "1.0.74", features = ["arbitrary_precision", "raw_value"] }
 serde_path_to_error = "0.1.7"
@@ -165,7 +165,7 @@ tracing = "0.1.35"
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "local-time", "fmt", "registry", "std"] }
 url = { version = "2.2.2", features = ["serde"] }
-uuid = { version = "1.19.0", features = ["v7"] }
+uuid = { version = "1.19.0", features = ["v7", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 
 [workspace.lints.rust]

--- a/crates/kv/Cargo.toml
+++ b/crates/kv/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+coyote-error.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true
 format-bytes = "0.3.0"
@@ -16,7 +17,6 @@ schemars.workspace = true
 serde.workspace = true
 static_assertions.workspace = true
 tokio.workspace = true
-coyote-error.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/stream/Cargo.toml
+++ b/crates/stream/Cargo.toml
@@ -15,11 +15,14 @@ http.workspace = true
 http-body-util.workspace = true
 jiff.workspace = true
 reqwest.workspace = true
+rmp-serde.workspace = true
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 static_assertions.workspace = true
 url.workspace = true
 uuid.workspace = true
+validator.workspace = true
 
 [lints]
 workspace = true

--- a/crates/stream/src/entities.rs
+++ b/crates/stream/src/entities.rs
@@ -1,4 +1,9 @@
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
 // FIXME(@svix-gabriel) - I opted for type aliases here just for expediency.
 // We absolutely can (and should) use more robust types.
-pub type StreamId = String;
+pub type StreamId = Uuid;
 pub type MsgId = u64;
+pub type MsgHeaders = HashMap<String, String>;

--- a/crates/stream/src/lib.rs
+++ b/crates/stream/src/lib.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use coyote_error::Error;
-use fjall::KeyspaceCreateOptions;
+use fjall::{KeyspaceCreateOptions, compaction::Fifo};
 
 /// User facing resources/types.
 pub mod entities;
@@ -15,13 +17,20 @@ mod tables;
 /// Tracks all internal state for Streams.
 pub struct State {
     pub(crate) db: fjall::Database,
+
     /// Where metadata for streams (created_at, stream names, offsets, acks, etc.) are stored.
     pub(crate) metadata_tables: fjall::Keyspace,
+
+    /// Where all messages are stored.
+    /// We're opting for a separate keyspace here as the access patterns for msgs are very different,
+    /// so there's likely room for optimizations.
+    pub(crate) msg_table: fjall::Keyspace,
 }
 
 impl State {
     pub fn init(db: fjall::Database) -> Result<Self, Error> {
         const METADATA_KEYSPACE: &str = "_coyote_stream_metadata";
+        const MSG_TABLE_KEYSPACE: &str = "_coyote_stream_msgs";
 
         // There's probably more tweaking we can do for each of these tables, but for now,
         // this should suffice.
@@ -31,9 +40,25 @@ impl State {
             db.keyspace(METADATA_KEYSPACE, || opts)?
         };
 
+        let msg_table = {
+            // NOTE(@svix-gabriel) I'm not 100% certain Fifo compaction strategy is the right call, but
+            // here's the thinking:
+            // - msgs are append and delete only. No updates.
+            // - the keyspace only grows monotonically.
+            //
+            // However, we'll have to manually delete data for expired streams, so it might end up being
+            // the case that Fifo is suboptimal here. 🤷
+            let opts = KeyspaceCreateOptions::default().compaction_strategy(Arc::new(Fifo {
+                limit: u64::MAX,
+                ttl_seconds: None, // we have to manually expire data.
+            }));
+            db.keyspace(MSG_TABLE_KEYSPACE, || opts)?
+        };
+
         Ok(Self {
             db,
             metadata_tables,
+            msg_table,
         })
     }
 }

--- a/crates/stream/src/operations/append_to_stream.rs
+++ b/crates/stream/src/operations/append_to_stream.rs
@@ -1,0 +1,74 @@
+use crate::{
+    State,
+    entities::{MsgId, StreamId},
+    tables::{MsgRow, msg_row_key},
+};
+use coyote_error::Result;
+use jiff::Timestamp;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use validator::Validate;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+pub struct MsgIn {
+    pub payload: Vec<u8>,
+    pub headers: HashMap<String, String>,
+}
+
+pub struct AppendToStream {
+    stream_id: StreamId,
+    msgs: Vec<(MsgId, MsgRow)>,
+}
+
+pub struct AppendToStreamOutput {
+    pub msg_ids: Vec<MsgId>,
+}
+
+impl AppendToStream {
+    pub fn new(state: &State, stream_id: StreamId, msgs: Vec<MsgIn>) -> Result<Self> {
+        let offset = MsgRow::get_next_msg_id_in_stream(state, stream_id)?;
+        let created_at = Timestamp::now();
+
+        let msgs: Vec<_> = msgs
+            .into_iter()
+            .enumerate()
+            .map(|(i, msg)| {
+                let i =
+                    MsgId::try_from(i).expect("usize should trivially be convertable to a msg-id");
+                let msg_id = offset + i;
+                (msg_id, msg)
+            })
+            .map(|(id, msg)| {
+                let msg = MsgRow {
+                    payload: msg.payload,
+                    headers: msg.headers,
+                    created_at,
+                };
+
+                (id, msg)
+            })
+            .collect();
+
+        Ok(Self { stream_id, msgs })
+    }
+
+    // FIXME(@svix-gabriel) - I'm trying to adhere mostly to the API mentioned in the HA rfc (https://github.com/svix/rfc/pull/30/files#diff-1f8e708b840474d3072b1c965eb090a3e30b26e8b7036c6e0ae47ef36ffb09abR54)
+    // However for expediency, I don't want to wait for the relevant traits to be added in order to have something working.
+    // It should be straightforward (famous last words) to translate this method to the Operations trait once it's in place.
+    pub fn apply_operation(self, state: &State) -> Result<AppendToStreamOutput> {
+        let mut batch = state.db.batch();
+
+        let msg_ids = self.msgs.iter().map(|(id, _msg)| *id).collect();
+
+        for (id, msg) in self.msgs {
+            let key = msg_row_key(self.stream_id, id);
+            let val = msg.to_fjall_value()?;
+            batch.insert(&state.msg_table, key, val);
+        }
+
+        batch.commit()?;
+
+        Ok(AppendToStreamOutput { msg_ids })
+    }
+}

--- a/crates/stream/src/operations/create_stream.rs
+++ b/crates/stream/src/operations/create_stream.rs
@@ -35,7 +35,7 @@ impl CreateStream {
             .and_then(|row| StreamRow::fetch(&state.metadata_tables, &row.id).transpose())
             .transpose()?
             .unwrap_or_else(|| {
-                let id = Uuid::new_v4().to_string();
+                let id = Uuid::new_v4();
                 StreamRow {
                     id,
                     name,

--- a/crates/stream/src/operations/mod.rs
+++ b/crates/stream/src/operations/mod.rs
@@ -1,3 +1,5 @@
+pub mod append_to_stream;
 pub mod create_stream;
 
+pub use append_to_stream::*;
 pub use create_stream::*;

--- a/crates/stream/src/tables.rs
+++ b/crates/stream/src/tables.rs
@@ -1,7 +1,11 @@
-use std::num::NonZeroU64;
+use std::{num::NonZeroU64, ops::RangeInclusive};
 
-use crate::entities::StreamId;
+use crate::{
+    State,
+    entities::{MsgHeaders, MsgId, StreamId},
+};
 
+use coyote_error::{Error, Result};
 use fjall_utils::TableRow;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -46,5 +50,133 @@ impl TableRow for StreamRow {
 
     fn get_key(&self) -> &Self::Key {
         &self.id
+    }
+}
+
+/// MsgRow is slightly different from the other models in that:
+///
+/// * Its in its own keyspace (so need for a unique TABLE_PREFIX)
+/// * The keys need to support iterating through all msgs for a stream in order of msg-id.
+///
+/// This necessitates rolling a slightly boutique key format, so we don't implement [TableRow] for this
+/// struct.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct MsgRow {
+    pub payload: Vec<u8>,
+    #[serde(skip_serializing_if = "MsgHeaders::is_empty")]
+    pub headers: MsgHeaders,
+    pub created_at: Timestamp,
+}
+
+const MSG_KEY_LEN: usize = size_of::<StreamId>() + size_of::<MsgId>();
+
+/// The MsgRowKey is effectively a (stream_id, msg_id), serialized so that they
+/// are ordered by msg_id in fjall, and grouped by stream_ids.
+type MsgRowKey = [u8; MSG_KEY_LEN];
+
+pub(crate) fn msg_row_key(s_id: StreamId, m_id: MsgId) -> MsgRowKey {
+    let mut key: [u8; _] = Default::default();
+    {
+        let (prefix, suffix) = key.split_at_mut(size_of::<StreamId>());
+
+        let stream_id = s_id.as_u128().to_be_bytes();
+        prefix.copy_from_slice(&stream_id);
+
+        let msg_id = m_id.to_be_bytes();
+        suffix.copy_from_slice(&msg_id);
+    }
+    key
+}
+
+fn parse_msg_id(key: MsgRowKey) -> Result<MsgId> {
+    let bytes = (&key[size_of::<StreamId>()..])
+        .try_into()
+        .map_err(Error::generic)?;
+    Ok(MsgId::from_be_bytes(bytes))
+}
+
+fn msg_row_key_range(s_id: StreamId, range: RangeInclusive<MsgId>) -> RangeInclusive<MsgRowKey> {
+    msg_row_key(s_id, *range.start())..=msg_row_key(s_id, *range.end())
+}
+
+impl MsgRow {
+    /// Returns the *next* id for a msg in the stream.
+    pub(crate) fn get_next_msg_id_in_stream(state: &State, stream_id: StreamId) -> Result<MsgId> {
+        let range = msg_row_key_range(stream_id, MsgId::MIN..=MsgId::MAX);
+
+        let Some(max_entry) = state.msg_table.range(range).next_back() else {
+            return Ok(MsgId::MIN);
+        };
+
+        let key: MsgRowKey = max_entry
+            .key()?
+            .as_ref()
+            .try_into()
+            .map_err(Error::generic)?;
+
+        let msg_id = parse_msg_id(key)?;
+
+        Ok(msg_id + 1)
+    }
+
+    pub(crate) fn to_fjall_value(&self) -> Result<fjall::UserValue> {
+        rmp_serde::to_vec(&self)
+            .map(fjall::UserValue::from)
+            .map_err(Error::generic)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn msg_row_keys_are_sorted_correctly() {
+        let db = fjall::Database::builder("msg_row_keys_are_sorted_correctly_test")
+            .temporary(true)
+            .open()
+            .unwrap();
+        let ks = db
+            .keyspace("test", fjall::KeyspaceCreateOptions::default)
+            .unwrap();
+
+        let s1 = StreamId::new_v4();
+        let s2 = StreamId::new_v4();
+
+        // Insert IDs in an arbitrary order.
+        let ids = [100, 2, 1, MsgId::MAX, MsgId::MAX - 1, 999];
+        for id in ids {
+            ks.insert(msg_row_key(s1, id), []).unwrap();
+            ks.insert(msg_row_key(s2, id), []).unwrap();
+        }
+        ks.insert(msg_row_key(s1, 1234), []).unwrap();
+        ks.insert(msg_row_key(s2, 5678), []).unwrap();
+
+        // We should be able to do range queries for all messages within a single stream.
+        // AND msgs should be returned, ordered by ID.
+
+        let mut s1_msgs = ks
+            .range(msg_row_key_range(s1, MsgId::MIN..=MsgId::MAX))
+            .map(|g| g.key().unwrap());
+        assert_eq!(s1_msgs.next().unwrap(), msg_row_key(s1, 1));
+        assert_eq!(s1_msgs.next().unwrap(), msg_row_key(s1, 2));
+        assert_eq!(s1_msgs.next().unwrap(), msg_row_key(s1, 100));
+        assert_eq!(s1_msgs.next().unwrap(), msg_row_key(s1, 999));
+        assert_eq!(s1_msgs.next().unwrap(), msg_row_key(s1, 1234));
+        assert_eq!(s1_msgs.next().unwrap(), msg_row_key(s1, MsgId::MAX - 1));
+        assert_eq!(s1_msgs.next().unwrap(), msg_row_key(s1, MsgId::MAX));
+        assert_eq!(s1_msgs.next(), None);
+
+        let mut s2_msgs = ks
+            .range(msg_row_key_range(s2, MsgId::MIN..=MsgId::MAX))
+            .map(|g| g.key().unwrap());
+        assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, 1));
+        assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, 2));
+        assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, 100));
+        assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, 999));
+        assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, 5678));
+        assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, MsgId::MAX - 1));
+        assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, MsgId::MAX));
+        assert_eq!(s2_msgs.next(), None);
     }
 }

--- a/lint.sh
+++ b/lint.sh
@@ -1,3 +1,8 @@
-cargo +nightly clippy --fix --allow-dirty --all-features --all-targets
+cargo +nightly clippy \
+    --fix \
+    --allow-dirty \
+    --workspace \
+    --all-features \
+    --all-targets
 cargo +nightly fmt
 cargo sort --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace

--- a/src/v1/endpoints/stream.rs
+++ b/src/v1/endpoints/stream.rs
@@ -10,7 +10,10 @@ use coyote_error::Result;
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use stream::{entities::StreamId, operations::CreateStreamOutput};
+use stream::{
+    entities::{MsgId, StreamId},
+    operations::{CreateStreamOutput, MsgIn},
+};
 use validator::Validate;
 
 use crate::{
@@ -87,12 +90,59 @@ async fn create_stream(
     }))
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AppendToStreamIn {
+    pub stream_id: StreamId,
+    pub msgs: Vec<MsgIn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AppendToStreamOut {
+    pub msg_ids: Vec<MsgId>,
+}
+
+/// Appends messages to the stream.
+#[aide_annotate(op_id = "v1.stream.append")]
+async fn append_to_stream(
+    State(AppState { stream_state, .. }): State<AppState>,
+    ValidatedJson(data): ValidatedJson<AppendToStreamIn>,
+) -> Result<Json<AppendToStreamOut>> {
+    /*
+    FIXME(@svix-gabriel)
+
+    This is missing a few important things
+        1. We haven't setup thread-per-core, so this could go to any thread.
+        2. We haven't setup quorum/raft stuff yet, so there's no concensus.
+
+    I didn't want to let either of these things block developing stream,
+    so in practice the structure of this handler will look different once those two pieces are in place.
+    */
+
+    let out = tokio::task::spawn_blocking(move || {
+        let op = stream::operations::AppendToStream::new(&stream_state, data.stream_id, data.msgs)?;
+        op.apply_operation(&stream_state)
+    })
+    .await??;
+
+    Ok(Json(AppendToStreamOut {
+        msg_ids: out.msg_ids,
+    }))
+}
+
 pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Stream");
 
-    ApiRouter::new().api_route_with(
-        "/stream/create",
-        post_with(create_stream, create_stream_operation),
-        &tag,
-    )
+    ApiRouter::new()
+        .api_route_with(
+            "/stream/create",
+            post_with(create_stream, create_stream_operation),
+            &tag,
+        )
+        .api_route_with(
+            "/stream/append",
+            post_with(append_to_stream, append_to_stream_operation),
+            &tag,
+        )
 }

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+cargo test --workspace $@

--- a/tests/it/stream.rs
+++ b/tests/it/stream.rs
@@ -54,5 +54,28 @@ async fn test_create_stream() -> TestResult {
         })
     );
 
+    client
+        .post("stream/append")
+        .json(json!({
+            "streamId": id,
+            "msgs": [
+                {"payload": [1, 2, 3], "headers": {}},
+                {"payload": [4, 5, 6], "headers": {"key": "value"}}
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "streamId": id,
+            "msgs": [
+                {"payload": [7, 8, 9], "headers": {}}
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
     Ok(())
 }


### PR DESCRIPTION
This just adds the RPC call for writing messages to the stream. That's basically it.

Consuming messages is coming in the next commit.

The only thing really noteworthy here is how we store messages. We key on `(stream_id, msg_id)`, and the msg_id effectively an autoincrementing integer. The keys are deliberately serialized so that msgs are clustered by stream_id, and ordered by msg_id.