### PR TITLE
add support for msgpack to axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,18 +759,22 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "jwt-simple",
+ "mime",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "regex",
+ "rmp-serde",
+ "rmpv",
  "schemars 1.2.0",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "serde_with",
  "stream",
+ "tap",
  "tempfile",
  "test-utils",
  "tokio",
@@ -3248,6 +3252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmpv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
+]
+
+[[package]]
 name = "ron"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,6 +3887,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,18 +40,21 @@ indexmap.workspace = true
 itertools.workspace = true
 jiff.workspace = true
 jwt-simple.workspace = true
+mime.workspace = true
 opentelemetry.workspace = true
 opentelemetry-http.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
 regex.workspace = true
+rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error.workspace = true
 serde_with.workspace = true
 stream.workspace = true
+tap.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower.workspace = true
@@ -66,6 +69,7 @@ validator.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 ctor.workspace = true
+rmpv.workspace = true
 tempfile.workspace = true
 test-utils.workspace = true
 
@@ -130,6 +134,7 @@ indexmap = "2.6.0"
 itertools = "0.14"
 jiff = { version = "0.2.18", features = ["serde"] }
 jwt-simple = "0.12"
+mime = "0.3"
 num_enum = "0.7.2"
 openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "ca08cda3aa7bf90f6577e1736806c8537144bfae" }
 opentelemetry = { version = "0.31.0", features = ["metrics"] }
@@ -144,7 +149,8 @@ quote = "1.0.15"
 rand = "0.9.2"
 regex = "1.5.5"
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "hickory-dns"] }
-rmp-serde = "1.3.0"
+rmp-serde = "1.3.1"
+rmpv = "1.3.1"
 rustls = "0.23.31"
 schemars = { version = "1.2.0", features = ["jiff02", "uuid1"] }
 serde = { version = "1.0.184", features = ["derive", "rc"] }
@@ -154,6 +160,7 @@ serde_with = "3.16.1"
 static_assertions = "1.1"
 stream.path = "crates/stream"
 syn = "2.0.48"
+tap = "1"
 tempfile = "3.24.0"
 test-utils.path = "crates/test-utils"
 tokio = { version = "1.24.2", features = ["rt", "signal"] }

--- a/src/v1/utils/mod.rs
+++ b/src/v1/utils/mod.rs
@@ -30,6 +30,7 @@ use validator::{Validate, ValidationError};
 use crate::error::{Error, HttpError, Result, ValidationErrorItem};
 
 pub mod patch;
+pub mod proto;
 use patch::UnrequiredField;
 
 const fn default_limit() -> PaginationLimit {

--- a/src/v1/utils/proto/mod.rs
+++ b/src/v1/utils/proto/mod.rs
@@ -1,0 +1,3 @@
+mod msgpack;
+
+pub use msgpack::MsgPack;

--- a/src/v1/utils/proto/msgpack.rs
+++ b/src/v1/utils/proto/msgpack.rs
@@ -1,0 +1,208 @@
+use axum::extract::rejection::BytesRejection;
+use axum::extract::{FromRequest, OptionalFromRequest, Request};
+use axum::response::{IntoResponse, Response};
+use bytes::{BufMut, Bytes, BytesMut};
+use http::{
+    StatusCode,
+    header::{self, HeaderMap, HeaderValue},
+};
+use serde::{Serialize, de::DeserializeOwned};
+
+#[derive(Debug, Clone)]
+pub struct MissingMsgPackContentType;
+
+impl axum::response::IntoResponse for MissingMsgPackContentType {
+    fn into_response(self) -> axum::response::Response {
+        let status = StatusCode::BAD_REQUEST;
+
+        tracing::warn!(status=?status, "missing content-type");
+
+        (
+            status,
+            "Expected request with `Content-Type: application/msgpack`",
+        )
+            .into_response()
+    }
+}
+
+#[derive(Debug)]
+pub struct MsgPackParseError(rmp_serde::decode::Error);
+
+impl axum::response::IntoResponse for MsgPackParseError {
+    fn into_response(self) -> axum::response::Response {
+        let status = StatusCode::BAD_REQUEST;
+
+        tracing::warn!(status=?status, error = ?self.0, "parse error");
+
+        (status, "Failed to parse the request body as msgpack").into_response()
+    }
+}
+
+#[derive(Debug)]
+pub enum MsgPackRejection {
+    MissingMsgPackContentType(MissingMsgPackContentType),
+    MsgPackParseError(MsgPackParseError),
+    BytesRejection(BytesRejection),
+}
+
+impl axum::response::IntoResponse for MsgPackRejection {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::MissingMsgPackContentType(r) => r.into_response(),
+            Self::MsgPackParseError(r) => r.into_response(),
+            Self::BytesRejection(r) => r.into_response(),
+        }
+    }
+}
+
+impl From<MissingMsgPackContentType> for MsgPackRejection {
+    fn from(value: MissingMsgPackContentType) -> Self {
+        Self::MissingMsgPackContentType(value)
+    }
+}
+
+impl From<MsgPackParseError> for MsgPackRejection {
+    fn from(value: MsgPackParseError) -> Self {
+        Self::MsgPackParseError(value)
+    }
+}
+
+impl From<axum::extract::rejection::BytesRejection> for MsgPackRejection {
+    fn from(value: BytesRejection) -> Self {
+        Self::BytesRejection(value)
+    }
+}
+
+/// MsgPack Extractor / Response.
+///
+/// When used as an extractor, it can deserialize request bodies into some type that
+/// implements [`serde::de::DeserializeOwned`]. The request will be rejected (and a [`MsgPackRejection`] will
+/// be returned) if:
+///
+/// - The request doesn't have a `Content-Type: application/MsgPack` (or similar) header.
+/// - The body doesn't contain syntactically valid MsgPack.
+/// - The body contains syntactically valid MsgPack, but it couldn't be deserialized into the target type.
+/// - Buffering the request body fails.
+///
+/// ⚠️ Since parsing MsgPack requires consuming the request body, the `MsgPack` extractor must be
+/// *last* if there are multiple extractors in a handler.
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+pub struct MsgPack<T>(pub T);
+
+impl<T, S> FromRequest<S> for MsgPack<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = MsgPackRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        if !msgpack_content_type(req.headers()) {
+            return Err(MissingMsgPackContentType.into());
+        }
+
+        let bytes = Bytes::from_request(req, state).await?;
+        Self::from_bytes(&bytes)
+    }
+}
+
+impl<T, S> OptionalFromRequest<S> for MsgPack<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = MsgPackRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Option<Self>, Self::Rejection> {
+        let headers = req.headers();
+        if headers.get(header::CONTENT_TYPE).is_some() {
+            if msgpack_content_type(headers) {
+                let bytes = Bytes::from_request(req, state).await?;
+                Ok(Some(Self::from_bytes(&bytes)?))
+            } else {
+                Err(MissingMsgPackContentType.into())
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn msgpack_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|content_type| content_type.to_str().ok())
+        .and_then(|content_type| content_type.parse::<mime::Mime>().ok())
+        .is_some_and(|mime| mime.type_() == "application" && mime.subtype() == "msgpack")
+}
+
+impl<T> std::ops::Deref for MsgPack<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for MsgPack<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for MsgPack<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T> MsgPack<T>
+where
+    T: DeserializeOwned,
+{
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, MsgPackRejection> {
+        rmp_serde::from_slice(bytes)
+            .map_err(|e| MsgPackRejection::MsgPackParseError(MsgPackParseError(e)))
+            .map(Self)
+    }
+}
+
+impl<T> IntoResponse for MsgPack<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        // Extracted into separate fn so it's only compiled once for all T.
+        fn make_response(
+            buf: BytesMut,
+            ser_result: Result<(), rmp_serde::encode::Error>,
+        ) -> Response {
+            match ser_result {
+                Ok(()) => (
+                    [(
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static(mime::APPLICATION_MSGPACK.as_ref()),
+                    )],
+                    buf.freeze(),
+                )
+                    .into_response(),
+                Err(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [(
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                    )],
+                    err.to_string(),
+                )
+                    .into_response(),
+            }
+        }
+
+        let mut buf = BytesMut::with_capacity(128).writer();
+        let res = rmp_serde::encode::write(&mut buf, &self.0);
+        make_response(buf.into_inner(), res)
+    }
+}

--- a/src/v1/utils/proto/msgpack.rs
+++ b/src/v1/utils/proto/msgpack.rs
@@ -15,7 +15,7 @@ impl axum::response::IntoResponse for MissingMsgPackContentType {
     fn into_response(self) -> axum::response::Response {
         let status = StatusCode::BAD_REQUEST;
 
-        tracing::warn!(status=?status, "missing content-type");
+        tracing::warn!(?status, "missing content-type");
 
         (
             status,
@@ -32,7 +32,7 @@ impl axum::response::IntoResponse for MsgPackParseError {
     fn into_response(self) -> axum::response::Response {
         let status = StatusCode::BAD_REQUEST;
 
-        tracing::warn!(status=?status, error = ?self.0, "parse error");
+        tracing::warn!(?status, error = ?self.0, "parse error");
 
         (status, "Failed to parse the request body as msgpack").into_response()
     }


### PR DESCRIPTION
This adds a really dumb `MsgPack<T>` wrapper that behaves like the `Json<T>` from axum (and, indeed, is largely copy-pasted from it).

I need this for replication.

Also runs `cargo sort` on `Cargo.toml`, guaranteeing merge conflicts for one and all.

No tests yet, just trying to get something in place