### PR TITLE
Hash kv store keys before using them in fjall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +990,7 @@ dependencies = [
 name = "coyote-kv"
 version = "1.76.1"
 dependencies = [
+ "blake2",
  "coyote-error",
  "fjall",
  "fjall-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ assert_matches = "1.5.0"
 axum = "0.8.8"
 axum-extra = { version = "0.12.5", features = ["typed-header"] }
 base64 = "0.22"
+blake2 = "0.10"
 byteorder = "1.5.0"
 bytes = "1.1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/kv/Cargo.toml
+++ b/crates/kv/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+blake2.workspace = true
 coyote-error.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -9,7 +9,7 @@ use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::tables::{ExpirationRow, KvPairRow};
+use crate::tables::{ExpirationRow, HashedKey, KvPairRow};
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct KvModel {
@@ -38,7 +38,7 @@ pub struct KvStore {
     db: fjall::Database,
     tables: fjall::Keyspace,
     policy: EvictionPolicy,
-    lru: LinkedHashMap<String, Option<Timestamp>>,
+    lru: LinkedHashMap<HashedKey, Option<Timestamp>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -103,14 +103,14 @@ impl KvStore {
         }
     }
 
-    fn update_lru(&mut self, key: &str, expires_at: Option<Timestamp>) {
+    fn update_lru(&mut self, key: &HashedKey, expires_at: Option<Timestamp>) {
         match self.lru.raw_entry_mut().from_key(key) {
             RawEntryMut::Occupied(mut occupied) => {
                 occupied.to_back();
                 *occupied.get_mut() = expires_at;
             }
             RawEntryMut::Vacant(vacant) => {
-                vacant.insert(key.to_string(), expires_at);
+                vacant.insert(key.clone(), expires_at);
             }
         }
     }
@@ -120,7 +120,8 @@ impl KvStore {
     }
 
     fn fetch_non_expired(&mut self, key: &str) -> Result<Option<KvModel>> {
-        let Some(data) = KvPairRow::fetch(&self.tables, &key.to_string())? else {
+        let hashed_key = HashedKey::from(key.to_string());
+        let Some(data) = KvPairRow::fetch(&self.tables, &hashed_key)? else {
             return Ok(None);
         };
 
@@ -129,7 +130,7 @@ impl KvStore {
             return Ok(None);
         }
 
-        self.update_lru(key, data.expires_at);
+        self.update_lru(&hashed_key, data.expires_at);
 
         Ok(Some(data.into()))
     }
@@ -137,11 +138,8 @@ impl KvStore {
     fn insert_with_expiration(&mut self, key: &str, model: &KvModel) -> Result<()> {
         let mut batch = self.db.batch();
 
-        let row = KvPairRow {
-            key: key.to_string(),
-            value: model.value.clone(),
-            expires_at: model.expires_at,
-        };
+        let hashed_key = HashedKey::from(key.to_string());
+        let row = KvPairRow::new(key.to_string(), model.value.clone(), model.expires_at);
 
         batch.insert_row(&self.tables, &row)?;
 
@@ -152,7 +150,7 @@ impl KvStore {
 
         batch.commit()?;
 
-        self.update_lru(key, model.expires_at);
+        self.update_lru(&hashed_key, model.expires_at);
 
         Ok(())
     }
@@ -186,17 +184,20 @@ impl KvStore {
 
     pub fn delete(&mut self, key: &str) -> Result<()> {
         let mut batch = self.db.batch();
+        self.delete_key(&mut batch, &HashedKey::from(key.to_string()))?;
+        batch.commit()?;
+        Ok(())
+    }
 
-        if let Some(data) = KvPairRow::fetch(&self.tables, &key.to_string())? {
+    fn delete_key(&mut self, batch: &mut fjall::OwnedWriteBatch, key: &HashedKey) -> Result<()> {
+        if let Some(data) = KvPairRow::fetch(&self.tables, key)? {
             // Delete from the expiration keyspace
             if let Some(expires_at) = data.expires_at {
                 let r = ExpirationRow::new(expires_at, key.to_string());
                 batch.remove_row::<ExpirationRow>(&self.tables, r.get_key())?;
             }
-            batch.remove_row::<KvPairRow>(&self.tables, &key.to_string())?;
+            batch.remove_row::<KvPairRow>(&self.tables, key)?;
         }
-
-        batch.commit()?;
 
         self.lru.remove(key);
 
@@ -213,13 +214,14 @@ impl KvStore {
 
     pub fn evict_lru(&mut self, count: usize) -> Result<()> {
         let mut evicted = 0;
+        let mut batch = self.db.batch();
 
         while evicted < count {
             if let Some((key, _)) = self.lru.pop_front() {
                 // Check if key is still present. It could have been expired or the LRU map could be out of sync.
-                if self.fetch_non_expired(&key)?.is_some() {
+                if KvPairRow::fetch(&self.tables, &key)?.is_some() {
                     // FIXME(@svix-lucho): does this have to go through consensus?
-                    let _ = self.delete(&key);
+                    let _ = self.delete_key(&mut batch, &key);
                     evicted += 1;
                 }
             } else {
@@ -227,17 +229,19 @@ impl KvStore {
             }
         }
 
+        batch.commit()?;
+
         Ok(())
     }
 
     pub fn clear_expired(&mut self, now: Timestamp) -> Result<()> {
         let mut removed = 0;
         let now_ms = now.as_millisecond();
-        let mut expired_keys = Vec::new();
+        let mut expired_keys = Vec::<HashedKey>::new();
 
         for item in ExpirationRow::iter(&self.tables)? {
             if item.expiration_time.as_millisecond() < now_ms && removed < EXPIRATION_BATCH_SIZE {
-                expired_keys.push(item.key);
+                expired_keys.push(HashedKey::from(item.key));
                 removed += 1;
             } else if item.expiration_time.as_millisecond() >= now_ms {
                 // expiration rows are ordered, so we can break early
@@ -245,10 +249,11 @@ impl KvStore {
             }
         }
 
-        // FIXME(@svix-lucho): we can batch removes here to make this more efficient
+        let mut batch = self.db.batch();
         for key in expired_keys {
-            let _ = self.delete(&key);
+            let _ = self.delete_key(&mut batch, &key);
         }
+        batch.commit()?;
 
         Ok(())
     }

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use blake2::{Blake2b512, Digest};
 use fjall_utils::TableRow;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -15,14 +16,44 @@ pub struct KvPairRow {
     pub key: String,
     pub value: Vec<u8>,
     pub expires_at: Option<Timestamp>,
+    pub hashed_key: HashedKey,
 }
 
 impl TableRow for KvPairRow {
     const TABLE_PREFIX: &'static str = "_KV_PAIR_";
-    type Key = String;
+    type Key = HashedKey;
 
     fn get_key(&self) -> &Self::Key {
-        &self.key
+        &self.hashed_key
+    }
+}
+
+impl KvPairRow {
+    pub fn new(key: String, value: Vec<u8>, expires_at: Option<Timestamp>) -> Self {
+        Self {
+            hashed_key: HashedKey::from(key.clone()),
+            key,
+            value,
+            expires_at,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Clone)]
+pub struct HashedKey(String);
+
+impl HashedKey {
+    pub(crate) fn from(key: String) -> Self {
+        // FIXME(@svix-lucho): is this a good hashing method?
+        let mut hasher = Blake2b512::new();
+        hasher.update(key.as_bytes());
+        Self(hex::encode(hasher.finalize()))
+    }
+}
+
+impl Display for HashedKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
@@ -50,10 +81,11 @@ pub struct ExpirationKey(String);
 
 impl ExpirationKey {
     pub(crate) fn from(expiration_time: Timestamp, key: String) -> Self {
+        let hashed_key = HashedKey::from(key);
         let ts_ms = expiration_time.as_millisecond();
         let ts_bytes = ts_ms.to_be_bytes();
         let ts_hex = hex::encode(ts_bytes);
-        let computed_key = format!("{ts_hex}\0{key}");
+        let computed_key = format!("{ts_hex}\0{hashed_key}");
 
         Self(computed_key)
     }


### PR DESCRIPTION
Cache keys and Kv keys can potentially be very long, so it might be good to hash them before using them as fjall keys. 

Putting this PR out as a proposal. It might be a premature optimization that we don't need to do, given the (small) risk of collisions. I also don't know how big of a deal the long keys when it comes to performance. 

For the hashing algo/method, I just used the same one we use for idempotency keys in svix-webhooks-private. Not sure if there's a better option. 

I've also updated the worker to make it batch key expirations. It was easy to refactor in this same PR. 