### PR TITLE
raft: wire up the networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -343,6 +344,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -858,6 +870,7 @@ dependencies = [
  "base64",
  "byteorder",
  "bytes",
+ "clap",
  "config",
  "coyote-derive",
  "coyote-error",
@@ -883,7 +896,9 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "paste",
+ "pnet",
  "regex",
+ "reqwest 0.13.1",
  "rmp-serde",
  "rmpv",
  "schemars 1.2.0",
@@ -2284,6 +2299,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "iri-string"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,9 +2638,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minijinja"
-version = "2.14.0"
+version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ea9ac0a51fb5112607099560fdf0f90366ab088a2a9e6e8ae176794e9806aa"
+checksum = "b479616bb6f0779fb0f3964246beda02d4b01144e1b0d5519616e012ccc2a245"
 dependencies = [
  "memo-map",
  "self_cell",
@@ -2683,6 +2707,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nom"
@@ -3128,6 +3158,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "pnet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
+dependencies = [
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
+name = "pnet_base"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
+dependencies = [
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,6 +3653,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "hickory-resolver",
  "http",
  "http-body",
@@ -3553,12 +3675,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -5031,6 +5155,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ axum-extra.workspace = true
 base64.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
+clap.workspace = true
 config.workspace = true
 coyote-derive.workspace = true
 coyote-error.workspace = true
@@ -51,7 +52,9 @@ opentelemetry-otlp.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
 paste.workspace = true
+pnet.workspace = true
 regex.workspace = true
+reqwest.workspace = true
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
@@ -105,7 +108,7 @@ aide = { version = "=0.16.0-alpha.2", features = ["axum", "axum-json", "axum-que
 anyerror = { version = "0.1.13", features = ["anyhow"] }
 anyhow = "1.0.56"
 assert_matches = "1.5.0"
-axum = "0.8.8"
+axum = { version = "0.8.8", features = ["macros"] }
 axum-extra = { version = "0.12.5", features = ["typed-header"] }
 base64 = "0.22"
 byteorder = "1.5.0"
@@ -156,11 +159,12 @@ opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["metrics", "rt-tokio", "rt-tokio-current-thread", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }
 paste = "1.0.15"
 percent-encoding = "2.3.2"
+pnet = "0.35"
 proc-macro2 = "1.0.78"
 quote = "1.0.15"
 rand = "0.9.2"
 regex = "1.5.5"
-reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "hickory-dns"] }
+reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "hickory-dns", "stream"] }
 rmp-serde = "1.3.1"
 rmpv = "1.3.1"
 rustls = "0.23.31"

--- a/config.default.toml
+++ b/config.default.toml
@@ -36,3 +36,16 @@ persistent_db_path = "./db"
 
 # Directory where ephemeral database is stored.
 ephemeral_db_path = "./db"
+
+# Directory where management data is stored
+management_db_path = "./db"
+
+[cluster]
+# The address to listen on for replication traffic
+listen_address = "0.0.0.0:18050"
+# The path in which binlogs are stored
+log_path = "./logs"
+# The path in which cluster snapshots are stored
+snapshot_path = "./snapshots"
+# The name of this cluster
+name = "coyote"

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -51,44 +51,11 @@ pub enum OperationBehavior {
     Update,
 }
 
-impl Default for KvStore {
-    fn default() -> Self {
-        Self::new("default", EvictionPolicy::NoEviction)
-    }
-}
-
 const EXPIRATION_BATCH_SIZE: usize = 100; // FIXME(@svix-lucho): make this configurable?
 
 impl KvStore {
-    // FIXME(@svix-lucho): receive the db from the caller
-    pub fn new(namespace: &str, policy: EvictionPolicy) -> Self {
-        let db = Database::builder(format!("db/kv/{namespace}"))
-            .open()
-            .unwrap();
-
+    pub fn new(namespace: &str, db: Database, policy: EvictionPolicy) -> Self {
         let kv_keyspace = format!("_coyote_kv_{namespace}");
-
-        let tables = {
-            let opts = KeyspaceCreateOptions::default();
-            db.keyspace(&kv_keyspace, || opts).unwrap()
-        };
-
-        Self {
-            db,
-            tables,
-            policy,
-            lru: LinkedHashMap::new(),
-        }
-    }
-
-    // FIXME(@svix-lucho): remove when we receive db from the caller
-    pub fn new_temporary(namespace: &str, policy: EvictionPolicy) -> Self {
-        let db = Database::builder(format!("db/kv/{namespace}"))
-            .temporary(true)
-            .open()
-            .unwrap();
-
-        let kv_keyspace = format!("_coyote_kv_temporary_{namespace}");
 
         let tables = {
             let opts = KeyspaceCreateOptions::default();
@@ -119,6 +86,7 @@ impl KvStore {
         self.fetch_non_expired(key)
     }
 
+    // FIXME(@svix-lucho): needs to be passed now() from the caller!
     fn fetch_non_expired(&mut self, key: &str) -> Result<Option<KvModel>> {
         let Some(data) = KvPairRow::fetch(&self.tables, &key.to_string())? else {
             return Ok(None);
@@ -211,6 +179,7 @@ impl KvStore {
         KvPairRow::iter(&self.tables)
     }
 
+    // FIXME(@svix-lucho): needs to be passed now() from the caller!
     pub fn evict_lru(&mut self, count: usize) -> Result<()> {
         let mut evicted = 0;
 
@@ -288,10 +257,34 @@ mod tests {
     use super::*;
     use jiff::ToSpan;
 
+    struct SetupFixture {
+        _workdir: tempfile::TempDir,
+        store: KvStore,
+    }
+
+    impl SetupFixture {
+        fn new() -> Self {
+            Self::new_with_policy(EvictionPolicy::NoEviction)
+        }
+
+        fn new_with_policy(policy: EvictionPolicy) -> Self {
+            let workdir = tempfile::tempdir().unwrap();
+            let db = Database::builder(workdir.as_ref())
+                .temporary(true)
+                .open()
+                .unwrap();
+            let store = KvStore::new("test", db, policy);
+            Self {
+                _workdir: workdir,
+                store,
+            }
+        }
+    }
+
     #[test]
     fn test_insert_and_get() {
-        let mut store =
-            KvStore::new_temporary(".test_kv_insert_and_get", EvictionPolicy::NoEviction);
+        let setup = SetupFixture::new();
+        let mut store = setup.store;
 
         let key = "test:key1";
         let model = KvModel {
@@ -313,8 +306,8 @@ mod tests {
 
     #[test]
     fn test_insert_behaviors() {
-        let mut store =
-            KvStore::new_temporary(".test_kv_insert_behaviors", EvictionPolicy::NoEviction);
+        let setup = SetupFixture::new();
+        let mut store = setup.store;
 
         let res = store.set(
             "key1",
@@ -372,7 +365,8 @@ mod tests {
 
     #[test]
     fn test_overwrite() {
-        let mut store = KvStore::new_temporary(".test_kv_overwrite", EvictionPolicy::NoEviction);
+        let setup = SetupFixture::new();
+        let mut store = setup.store;
 
         let key = "overwrite:key";
         let model1 = KvModel {
@@ -394,8 +388,8 @@ mod tests {
 
     #[test]
     fn test_clear_expired_removes_expired_entries() {
-        let mut store =
-            KvStore::new_temporary(".test_kv_clear_expired", EvictionPolicy::NoEviction);
+        let setup = SetupFixture::new();
+        let mut store = setup.store;
 
         let expired_model = KvModel {
             expires_at: Some(Timestamp::now().checked_sub(1.hour()).unwrap()),
@@ -490,7 +484,8 @@ mod tests {
 
     #[test]
     fn test_lru_eviction() {
-        let mut kv = KvStore::new_temporary("test_lru", EvictionPolicy::LeastRecentlyUsed);
+        let setup = SetupFixture::new_with_policy(EvictionPolicy::LeastRecentlyUsed);
+        let mut kv = setup.store;
 
         for i in 0..3 {
             insert_key(&mut kv, format!("k{i}").as_str(), None);
@@ -510,10 +505,8 @@ mod tests {
 
     #[test]
     fn test_lru_eviction_with_expiration() {
-        let mut kv = KvStore::new_temporary(
-            ".test_lru_with_expiration",
-            EvictionPolicy::LeastRecentlyUsed,
-        );
+        let setup = SetupFixture::new_with_policy(EvictionPolicy::LeastRecentlyUsed);
+        let mut kv = setup.store;
 
         insert_key(
             &mut kv,
@@ -554,10 +547,8 @@ mod tests {
 
     #[test]
     fn test_lru_eviction_already_expired() {
-        let mut kv = KvStore::new_temporary(
-            ".test_lru_already_expired",
-            EvictionPolicy::LeastRecentlyUsed,
-        );
+        let setup = SetupFixture::new_with_policy(EvictionPolicy::LeastRecentlyUsed);
+        let mut kv = setup.store;
 
         insert_key(
             &mut kv,

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -4,6 +4,7 @@ pub mod tables;
 use std::time::Duration;
 
 use coyote_error::Result;
+use fjall::Database;
 use fjall::KeyspaceCreateOptions;
 use fjall_utils::TableRow;
 use jiff::Timestamp;
@@ -27,14 +28,7 @@ pub enum RateLimitResult {
 }
 
 impl RateLimiter {
-    // FIXME(@svix-lucho): get the db from the app state (caller)
-    pub fn new() -> Self {
-        Self::with_path(".data/rate_limiter_default")
-    }
-
-    pub fn with_path(path: &str) -> Self {
-        let db = fjall::Database::builder(path).open().unwrap();
-
+    pub fn new(path: &str, db: Database) -> Self {
         let rate_limiter_keyspace = format!("_coyote_rate_limiter_{path}");
 
         let tables = {
@@ -192,7 +186,8 @@ mod tests {
 
     fn create_test_limiter() -> (RateLimiter, tempfile::TempDir) {
         let dir = tempdir().unwrap();
-        let limiter = RateLimiter::with_path(dir.path().to_str().unwrap());
+        let db = Database::builder(&dir).temporary(true).open().unwrap();
+        let limiter = RateLimiter::new("rate-limiter", db);
         (limiter, dir)
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -12,6 +12,9 @@ use tracing_subscriber::util::SubscriberInitExt;
 #[derive(Parser)]
 #[clap(author, version, about = env!("CARGO_PKG_DESCRIPTION"), long_about = None)]
 struct Args {
+    #[clap(long)]
+    config_path: Option<String>,
+
     #[clap(subcommand)]
     command: Option<Commands>,
 }
@@ -25,6 +28,8 @@ enum Commands {
         /// The server URL, for example http://localhost:8050
         server_url: String,
     },
+    /// Run the server (this is also the default if no subcommand is passed)
+    Server,
 }
 
 #[tokio::main(flavor = "local")]
@@ -51,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    let cfg = cfg::load()?;
+    let cfg = cfg::load(args.config_path.as_deref())?;
 
     let (tracing_subscriber, otel_tracer_provider) =
         setup_tracing(&cfg, /* for_test = */ false);
@@ -61,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Healthcheck { .. }) => {
             unreachable!("Healthcheck command should be handled before config loading")
         }
-        None => {
+        Some(Commands::Server) | None => {
             run(cfg).await;
         }
     };

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,13 +1,22 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::{fmt, marker::PhantomData, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    fmt,
+    marker::PhantomData,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use crate::error::Result;
 use anyhow::Context;
+use config::ConfigBuilder;
 use fjall::Database;
 use serde::Deserialize;
 use serde_with::with_prefix;
+use tap::Pipe;
 use tracing::Level;
 
 use crate::core::security::JwtSigningConfig;
@@ -36,7 +45,7 @@ impl StorageType for Management {}
 
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct DatabaseConfig<S: StorageType> {
-    pub path: String,
+    pub path: PathBuf,
     #[serde(default)]
     pub filename: Option<String>,
     #[serde(skip_serializing, default)]
@@ -44,7 +53,7 @@ pub struct DatabaseConfig<S: StorageType> {
 }
 
 impl<S: StorageType> DatabaseConfig<S> {
-    fn database(dir: &str, file: &str) -> Result<Database> {
+    fn database(dir: &Path, file: &str) -> Result<Database> {
         let mut path = PathBuf::from(dir);
         path.push(file);
         fjall::Database::builder(path).open().map_err(|e| e.into())
@@ -79,12 +88,51 @@ impl DatabaseConfig<Management> {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+pub struct ClusterConfiguration {
+    /// The address to listen on for replication
+    pub listen_address: SocketAddr,
+
+    pub name: String,
+
+    pub snapshot_path: PathBuf,
+
+    pub log_path: PathBuf,
+
+    #[serde(default = "ClusterConfiguration::default_connection_timeout")]
+    pub connection_timeout: Duration,
+
+    #[serde(default = "ClusterConfiguration::default_heartbeat_interval_ms")]
+    pub heartbeat_interval_ms: u64,
+
+    #[serde(default = "ClusterConfiguration::default_election_timeout_min_ms")]
+    pub election_timeout_min_ms: u64,
+
+    #[serde(default = "ClusterConfiguration::default_election_timeout_max_ms")]
+    pub election_timeout_max_ms: u64,
+}
+
+impl ClusterConfiguration {
+    const fn default_connection_timeout() -> Duration {
+        Duration::from_secs(7)
+    }
+
+    const fn default_heartbeat_interval_ms() -> u64 {
+        500
+    }
+
+    const fn default_election_timeout_min_ms() -> u64 {
+        1500
+    }
+
+    const fn default_election_timeout_max_ms() -> u64 {
+        3000
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub struct ConfigurationInner {
     /// The address to listen on
     pub listen_address: SocketAddr,
-
-    /// The address to listen on for replication/etc
-    pub interserver_listen_address: SocketAddr,
 
     #[serde(flatten, with = "management_db")]
     pub management_db_config: Arc<DatabaseConfig<Management>>,
@@ -121,6 +169,8 @@ pub struct ConfigurationInner {
     pub opentelemetry_service_name: String,
     /// The environment (dev, staging, or prod) that the server is running in.
     pub environment: Environment,
+
+    pub cluster: ClusterConfiguration,
 
     #[serde(flatten)]
     pub internal: InternalConfig,
@@ -181,10 +231,16 @@ impl fmt::Display for LogLevel {
     }
 }
 
-pub fn load() -> anyhow::Result<Arc<ConfigurationInner>> {
+pub fn load(config_path: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner>> {
     let config = config::Config::builder()
         .add_source(config::File::from_str(DEFAULTS, config::FileFormat::Toml))
-        .add_source(config::File::with_name("config.toml"))
+        .pipe(|config: ConfigBuilder<_>| {
+            if let Some(path) = config_path {
+                config.add_source(config::File::with_name(path))
+            } else {
+                config
+            }
+        })
         .add_source(config::Environment::with_prefix("COYOTE"))
         .build()?;
 

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -1,0 +1,162 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use axum::{
+    self, Json,
+    extract::State,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use http::{StatusCode, Uri};
+use openraft::raft::{AppendEntriesRequest, InstallSnapshotRequest, VoteRequest};
+use serde::{Deserialize, Serialize};
+use tap::Pipe;
+
+use super::Node;
+use super::NodeId;
+use super::network::detect_address;
+use super::raft::TypeConfig;
+use crate::{AppState, v1::utils::proto::MsgPack};
+
+pub fn router() -> axum::Router<AppState> {
+    // TODO: implement snapshot methods
+    axum::Router::new()
+        .route("/repl/raft/append_entries", post(append_entries))
+        .route("/repl/raft/vote", post(vote))
+        .route("/repl/raft/stream-snapshot", post(stream_snapshot))
+        .route("/repl/raft/admin/metrics", get(metrics))
+        .route("/repl/raft/admin/add-learner", post(add_learner))
+        .route(
+            "/repl/raft/admin/change-membership",
+            post(change_membership),
+        )
+        .route("/repl/raft/admin/initialize", post(initialize))
+        .route("/repl/health", get(health))
+}
+
+// Helpers
+
+fn internal_error(s: impl ToString) -> Response {
+    (StatusCode::INTERNAL_SERVER_ERROR, s.to_string()).into_response()
+}
+
+fn rpc_response<Ok, Err>(result: Result<Ok, Err>) -> Response
+where
+    Ok: Serialize,
+    Err: Serialize,
+{
+    match result {
+        Ok(ok) => (StatusCode::OK, MsgPack(ok)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, MsgPack(e)).into_response(),
+    }
+}
+
+fn admin_response<Ok, Err>(result: Result<Ok, Err>) -> Response
+where
+    Ok: Serialize,
+    Err: Serialize,
+{
+    match result {
+        Ok(ok) => (StatusCode::OK, Json(ok)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(e)).into_response(),
+    }
+}
+
+// Standard functions
+
+#[tracing::instrument(skip_all)]
+async fn append_entries(
+    State(state): State<AppState>,
+    MsgPack(body): MsgPack<AppendEntriesRequest<TypeConfig>>,
+) -> impl IntoResponse {
+    tracing::debug!(
+        num_entries=body.entries.len(),
+        leader_commit=?body.leader_commit,
+        "appending some entries to the log");
+    state.raft.append_entries(body).await.pipe(rpc_response)
+}
+
+#[tracing::instrument(skip_all)]
+async fn vote(
+    State(state): State<AppState>,
+    MsgPack(body): MsgPack<VoteRequest<NodeId>>,
+) -> impl IntoResponse {
+    tracing::debug!(
+        vote=?body.vote,
+        "recording a vote",
+    );
+    state.raft.vote(body).await.pipe(rpc_response)
+}
+
+#[tracing::instrument(skip_all)]
+async fn stream_snapshot(
+    State(state): State<AppState>,
+    MsgPack(req): MsgPack<InstallSnapshotRequest<TypeConfig>>,
+) -> impl IntoResponse {
+    let _num_bytes = req.data.len();
+    tracing::debug!(
+        num_bytes = req.data.len(),
+        vote = ?req.vote,
+        done = req.done,
+        "streaming part of a snapshot"
+    );
+    state.raft.install_snapshot(req).await.pipe(rpc_response)
+}
+
+// Administrative functions
+
+async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
+    let metrics = state.raft.metrics().borrow().clone();
+
+    Json(metrics)
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AddLearnerRequest {
+    node_id: NodeId,
+    address: String,
+}
+
+async fn add_learner(
+    State(state): State<AppState>,
+    request: Json<AddLearnerRequest>,
+) -> impl IntoResponse {
+    let url = format!("http://{}/repl/raft/vote", request.address);
+    let Ok(Some(addr)) = Uri::try_from(url).map(|v| v.authority().map(|a| a.to_string())) else {
+        return internal_error("invalid address");
+    };
+    let node = Node { addr };
+    admin_response(state.raft.add_learner(request.node_id, node, true).await)
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ChangeMembershipRequest {
+    desired_node_ids: BTreeSet<NodeId>,
+}
+
+async fn change_membership(
+    State(state): State<AppState>,
+    request: Json<ChangeMembershipRequest>,
+) -> impl IntoResponse {
+    state
+        .raft
+        .change_membership(request.desired_node_ids.clone(), false)
+        .await
+        .pipe(admin_response)
+}
+
+async fn initialize(State(state): State<AppState>) -> impl IntoResponse {
+    let addr = match detect_address(&state.cfg) {
+        Ok(a) => a,
+        Err(_e) => return internal_error("could not find any valid addresses"),
+    }
+    .to_string();
+    let my_node = Node { addr };
+    let nodes = [(state.node_id, my_node)]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    state.raft.initialize(nodes).await.pipe(admin_response)
+}
+
+async fn health() -> impl IntoResponse {
+    StatusCode::OK
+}

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use byteorder::{BigEndian, ByteOrder};
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable, Slice, UserKey};
 use openraft::storage::{LogFlushed, RaftLogStorage};
@@ -7,13 +8,12 @@ use openraft::{
 use std::fmt::Debug;
 use std::ops::{Bound, RangeBounds};
 use std::path::Path;
-use tap::{Tap, TapFallible};
+use tap::{Pipe, Tap, TapFallible};
 use tracing::{Instrument as _, Span};
 
+use super::NodeId;
 use super::errors::*;
 use super::raft::TypeConfig;
-
-type NodeId = <TypeConfig as RaftTypeConfig>::NodeId;
 
 // This is an implementation of an openraft Logs store backed by fjall
 
@@ -182,6 +182,32 @@ impl CoyoteLogs {
             log_keyspace,
             meta_keyspace,
         })
+    }
+
+    /// Get the NodeId (or, if we don't have one, make a new one)
+    pub async fn get_node_id(&mut self) -> anyhow::Result<NodeId> {
+        let meta_keyspace = self.meta_keyspace.clone();
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Some(raw_node_id) = meta_keyspace
+                .get("node_id")
+                .context("fetching node ID from logs database")?
+            {
+                let node_id = rmp_serde::from_slice(&raw_node_id)?;
+                tracing::debug!(?node_id, "starting up with existing node ID");
+                node_id
+            } else {
+                let node_id = NodeId::generate();
+                tracing::info!(?node_id, "generated a new node ID");
+                meta_keyspace
+                    .insert("node_id", rmp_serde::to_vec(&node_id)?)
+                    .context("saving node ID to logs database")?;
+                db.persist(PersistMode::SyncAll)?;
+                node_id
+            }
+            .pipe(Ok)
+        })
+        .await?
     }
 
     async fn append_entries_(

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -1,8 +1,17 @@
+mod app;
 mod errors;
 mod logs;
+mod network;
 mod raft;
 mod serialized_state_machine;
 mod state_machine;
 
+pub use app::router;
 pub use logs::CoyoteLogs;
+pub use raft::{Raft, TypeConfig, initialize_raft};
 pub use state_machine::Store;
+
+use openraft::RaftTypeConfig;
+
+pub type NodeId = <raft::TypeConfig as RaftTypeConfig>::NodeId;
+type Node = <raft::TypeConfig as RaftTypeConfig>::Node;

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -1,0 +1,171 @@
+use std::net::SocketAddr;
+use std::time::Instant;
+
+use crate::cfg::Configuration;
+
+use super::raft::TypeConfig;
+use super::{Node, NodeId};
+use http::header;
+use openraft::error::{NetworkError, RPCError, Unreachable};
+use openraft::network::RPCOption;
+use openraft::{RaftNetwork, RaftNetworkFactory, RaftTypeConfig};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+pub(super) struct NetworkFactory {
+    client: reqwest::Client,
+}
+
+impl NetworkFactory {
+    pub(super) fn new(cfg: &Configuration) -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .connect_timeout(cfg.cluster.connection_timeout)
+                .build()
+                .expect("failed to build Raft network"),
+        }
+    }
+}
+
+pub(super) struct NetworkClient {
+    target: NodeId,
+    node: Node,
+    client: reqwest::Client,
+}
+
+impl NetworkClient {
+    async fn send_request<Req, Resp, Err>(
+        &self,
+        path: &str,
+        req: Req,
+    ) -> Result<Resp, openraft::error::RPCError<NodeId, Node, Err>>
+    where
+        Req: Serialize,
+        Err: std::error::Error + DeserializeOwned,
+        Resp: DeserializeOwned,
+    {
+        let start = Instant::now();
+        let addr = self.node.addr.as_str();
+        let url = format!("http://{addr}/{path}");
+        tracing::trace!(url, target=?self.target, "sending internal RPC");
+
+        // TODO: construct this as a stream instead
+        let body = rmp_serde::to_vec(&req).map_err(|err| {
+            tracing::warn!(
+                ?err,
+                "serialization error on RPC! this should be impossible!"
+            );
+            RPCError::Network(NetworkError::new(&err))
+        })?;
+
+        let response = self
+            .client
+            .post(url)
+            .header(header::CONTENT_TYPE, "application/msgpack")
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| {
+                tracing::warn!(err=?e, "error sending message to peer");
+                if e.is_connect() {
+                    RPCError::Unreachable(Unreachable::new(&e))
+                } else {
+                    RPCError::Network(NetworkError::new(&e))
+                }
+            })?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::warn!(status = ?e.status(), "error from responding server");
+                RPCError::Network(NetworkError::new(&e))
+            })?;
+
+        tracing::trace!(
+            status = ?response.status(),
+            duration = ?start.elapsed(),
+            "response from peer server");
+
+        let res_bytes = response
+            .bytes()
+            .await
+            .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+
+        let data: Resp = rmp_serde::from_slice(&res_bytes).map_err(|err| {
+            tracing::warn!(
+                ?err,
+                "deserialization error on RPC! this should be impossible!"
+            );
+            RPCError::Network(NetworkError::new(&err))
+        })?;
+        Ok(data)
+    }
+}
+
+impl RaftNetwork<TypeConfig> for NetworkClient {
+    async fn append_entries(
+        &mut self,
+        rpc: openraft::raft::AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<
+        openraft::raft::AppendEntriesResponse<NodeId>,
+        RPCError<NodeId, Node, openraft::error::RaftError<NodeId>>,
+    > {
+        self.send_request("/repl/raft/append_entries", rpc).await
+    }
+
+    async fn vote(
+        &mut self,
+        rpc: openraft::raft::VoteRequest<<TypeConfig as RaftTypeConfig>::NodeId>,
+        _option: RPCOption,
+    ) -> Result<
+        openraft::raft::VoteResponse<NodeId>,
+        RPCError<NodeId, Node, openraft::error::RaftError<NodeId>>,
+    > {
+        self.send_request("/repl/raft/vote", rpc).await
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        rpc: openraft::raft::InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<
+        openraft::raft::InstallSnapshotResponse<NodeId>,
+        RPCError<
+            NodeId,
+            Node,
+            openraft::error::RaftError<NodeId, openraft::error::InstallSnapshotError>,
+        >,
+    > {
+        self.send_request("/repl/raft/stream-snapshot", rpc).await
+    }
+}
+
+impl RaftNetworkFactory<TypeConfig> for NetworkFactory {
+    type Network = NetworkClient;
+
+    async fn new_client(
+        &mut self,
+        target: <TypeConfig as RaftTypeConfig>::NodeId,
+        node: &<TypeConfig as RaftTypeConfig>::Node,
+    ) -> Self::Network {
+        NetworkClient {
+            target,
+            node: node.clone(),
+            client: self.client.clone(),
+        }
+    }
+}
+
+pub(super) fn detect_address(cfg: &Configuration) -> anyhow::Result<SocketAddr> {
+    // TODO: this should handle the address changing, which it currently can't
+    // TODO: this should handle dual-homed (ipv4 + ipv6) systems
+    let port = cfg.cluster.listen_address.port();
+    for interface in pnet::datalink::interfaces() {
+        if !interface.is_up() || interface.is_loopback() || interface.ips.is_empty() {
+            continue;
+        }
+        if let Some(ip) = interface.ips.iter().find(|i| i.is_ipv4()) {
+            return Ok(SocketAddr::new(ip.ip(), port));
+        }
+    }
+    anyhow::bail!("unable to find any valid interfaces");
+}

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -1,7 +1,12 @@
+use std::sync::Arc;
+
+use fjall::Database;
 use openraft::BasicNode;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use super::state_machine::StoredSnapshot;
+use crate::cfg::Configuration;
 
 // TODO: this should actually be our Operation trait
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -24,26 +29,75 @@ impl Response {
 // TODO: is BasicNode enough for us?
 pub(super) type Node = BasicNode;
 
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct NodeId {
+    inner: Uuid,
+}
+
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl NodeId {
+    pub(super) fn generate() -> Self {
+        Self {
+            inner: Uuid::new_v4(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl From<u64> for NodeId {
+    fn from(value: u64) -> Self {
+        let inner = Uuid::from_u64_pair(value, value);
+        Self { inner }
+    }
+}
+
 openraft::declare_raft_types!(
     pub TypeConfig:
         D = Request,
         R = Response,
         Node = Node,
+        NodeId = NodeId,
         SnapshotData = StoredSnapshot
 );
+
+pub type Raft = openraft::Raft<TypeConfig>;
+
+pub async fn initialize_raft(cfg: &Configuration, db: Database) -> anyhow::Result<(Raft, NodeId)> {
+    let mut logs = super::CoyoteLogs::new(&cfg.cluster.log_path).await?;
+    let id = logs.get_node_id().await?;
+    let config = openraft::Config {
+        heartbeat_interval: cfg.cluster.heartbeat_interval_ms,
+        election_timeout_min: cfg.cluster.election_timeout_min_ms,
+        election_timeout_max: cfg.cluster.election_timeout_max_ms,
+        cluster_name: cfg.cluster.name.clone(),
+        ..Default::default()
+    };
+    let config = Arc::new(config.validate()?);
+    let network = super::network::NetworkFactory::new(cfg);
+    let state_machine =
+        super::state_machine::Store::new(db, cfg.cluster.snapshot_path.clone()).await?;
+    let raft = Raft::new(id, config, network, logs, state_machine).await?;
+    Ok((raft, id))
+}
 
 #[cfg(test)]
 mod tests {
     use fjall::Database;
+    use openraft::StorageIOError;
     use openraft::testing::StoreBuilder;
-    use openraft::{RaftTypeConfig, StorageIOError};
     use tempfile::TempDir;
 
     use super::super::logs::CoyoteLogs;
     use super::super::state_machine::Store;
-    use super::TypeConfig;
-
-    type NodeId = <TypeConfig as RaftTypeConfig>::NodeId;
+    use super::{NodeId, TypeConfig};
 
     struct CoyoteStoreBuilder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ async fn graceful_shutdown_handler() {
 
 pub async fn run(cfg: Configuration) {
     setup_metrics(&cfg);
-    run_with_prefix(cfg, None).await
+    run_with_prefix(cfg, None, None).await
 }
 
 #[derive(Clone)]
@@ -98,12 +98,47 @@ pub struct AppState {
     idempotency_store: crate::v1::modules::idempotency::IdempotencyStore,
     queue_store: crate::v1::modules::queue::QueueStore,
 
+    raft: core::cluster::Raft,
+    node_id: core::cluster::NodeId,
+
     stream_state: stream::State,
+}
+
+async fn run_interserver(cfg: Configuration, state: AppState, listener: Option<TcpListener>) {
+    let listen_address = cfg.cluster.listen_address;
+    let listener = match listener {
+        Some(l) => l,
+        None => TcpListener::bind(listen_address)
+            .await
+            .expect("Error binding to listen_address"),
+    };
+    tracing::debug!(
+        "Inter-Server: Listening on {}",
+        listener.local_addr().unwrap()
+    );
+
+    let app = core::cluster::router().with_state(state.clone());
+    let svc = tower::make::Shared::new(
+        // It is important that this service wraps the router instead of being
+        // applied via `Router::layer`, as it would run after routing then.
+        NormalizePath::trim_trailing_slash(app),
+    );
+
+    axum::serve(listener, svc)
+        .with_graceful_shutdown(graceful_shutdown_handler())
+        .await
+        .unwrap();
+
+    state.raft.shutdown().await.unwrap();
 }
 
 // Made public for the purpose of E2E testing in which a queue prefix is necessary to avoid tests
 // consuming from each others' queues
-pub async fn run_with_prefix(cfg: Configuration, listener: Option<TcpListener>) {
+pub async fn run_with_prefix(
+    cfg: Configuration,
+    listener: Option<TcpListener>,
+    interserver_listener: Option<TcpListener>,
+) {
     // OpenAPI/aide must be initialized before any routers are constructed
     // because its initialization sets generation-global settings which are
     // needed at router-construction time.
@@ -121,23 +156,45 @@ pub async fn run_with_prefix(cfg: Configuration, listener: Option<TcpListener>) 
     let stream_state =
         stream::State::init(persistent_db.clone()).expect("initializing stream state");
 
-    let kv_store = crate::v1::modules::kv::KvStore::new("kv_store", EvictionPolicy::NoEviction);
+    let kv_store = crate::v1::modules::kv::KvStore::new(
+        "kv_store",
+        persistent_db.clone(),
+        EvictionPolicy::NoEviction,
+    );
 
-    let cache_kv_store =
-        crate::v1::modules::kv::KvStore::new("cache_store", EvictionPolicy::LeastRecentlyUsed);
+    let cache_kv_store = crate::v1::modules::kv::KvStore::new(
+        "cache_store",
+        persistent_db.clone(),
+        EvictionPolicy::LeastRecentlyUsed,
+    );
     let cache_store = crate::v1::modules::cache::CacheStore::new(cache_kv_store);
+
+    let (raft, node_id) = core::cluster::initialize_raft(&cfg, persistent_db.clone())
+        .await
+        .expect("failed to initialize cluster");
 
     // build our application with a route
     let app_state = AppState {
         cfg: cfg.clone(),
         kv_store,
         cache_store,
-        rate_limiter: crate::v1::modules::rate_limiter::RateLimiter::new(),
+        rate_limiter: crate::v1::modules::rate_limiter::RateLimiter::new(
+            "rate_limiter_default",
+            persistent_db.clone(),
+        ),
         idempotency_store: crate::v1::modules::idempotency::IdempotencyStore::new(),
         queue_store: crate::v1::modules::queue::QueueStore::new(),
         stream_state,
+        raft,
+        node_id,
     };
     let v1_router = v1::router().with_state::<()>(app_state.clone());
+
+    let interserver = tokio::spawn(run_interserver(
+        cfg.clone(),
+        app_state.clone(),
+        interserver_listener,
+    ));
 
     // Initialize all routes which need to be part of OpenAPI first.
     let app = ApiRouter::new()
@@ -184,6 +241,7 @@ pub async fn run_with_prefix(cfg: Configuration, listener: Option<TcpListener>) 
 
     // Wait for workers to finish cleanup
     let _ = workers.await;
+    let _ = interserver.await;
 }
 
 pub fn setup_tracing(

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,11 +1,11 @@
 mod stream;
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use coyote::{
     cfg::{
-        ConfigurationInner, DatabaseConfig, Environment, Ephemeral, InternalConfig, LogFormat,
-        LogLevel, Management, Persistent,
+        ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, Ephemeral,
+        InternalConfig, LogFormat, LogLevel, Management, Persistent,
     },
     core::security::JwtSigningConfig,
     run_with_prefix,
@@ -19,7 +19,7 @@ use tokio::{net::TcpListener, task::JoinHandle};
 ///
 /// Once it's DROPed, the server and it's resources are cleaned up automatically (or at least, that's the intent.)
 pub struct IsolatedServerHandle {
-    _db_dir: TempDir,
+    _dir: TempDir,
     server_handle: JoinHandle<()>,
 }
 
@@ -39,21 +39,23 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
     let jwt_key = HS256Key::generate();
     let token = "Stubbed token. Should probably be legit when we add auth.";
 
-    let db_dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+    let db_dir = workdir.path().join("db");
+    let log_path = workdir.path().join("logs");
+    let snapshot_path = workdir.path().join("snapshots");
 
     let cfg = Arc::new(ConfigurationInner {
         listen_address: addr,
-        interserver_listen_address: repl_addr,
         management_db_config: Arc::new(DatabaseConfig::<Management> {
-            path: db_dir.path().to_string_lossy().to_string(),
+            path: db_dir.clone(),
             ..Default::default()
         }),
         ephemeral_db_config: Arc::new(DatabaseConfig::<Ephemeral> {
-            path: db_dir.path().to_string_lossy().to_string(),
+            path: db_dir.clone(),
             ..Default::default()
         }),
         persistent_db_config: Arc::new(DatabaseConfig::<Persistent> {
-            path: db_dir.path().to_string_lossy().to_string(),
+            path: db_dir,
             ..Default::default()
         }),
         jwt_signing_config: Arc::new(JwtSigningConfig::HS256(jwt_key)),
@@ -66,16 +68,26 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
         opentelemetry_service_name: "coyote-test".to_string(),
         environment: Environment::Dev,
         internal: InternalConfig {},
+        cluster: ClusterConfiguration {
+            listen_address: repl_addr,
+            name: "coyote-test".to_string(),
+            snapshot_path,
+            log_path,
+            connection_timeout: Duration::from_millis(50),
+            heartbeat_interval_ms: 100,
+            election_timeout_min_ms: 200,
+            election_timeout_max_ms: 300,
+        },
     });
 
     let base_uri = format!("http://{addr}/api/v1");
 
     let server_handle = tokio::spawn(async move {
-        run_with_prefix(cfg, Some(listener)).await;
+        run_with_prefix(cfg, Some(listener), Some(repl_listener)).await;
     });
 
     let handle = IsolatedServerHandle {
-        _db_dir: db_dir,
+        _dir: workdir,
         server_handle,
     };
 


### PR DESCRIPTION
This implements a basic network driver for the server. It still doesn't actually use the raft database as backing for any of the data stores.

To be able to test this, I had to fix the places where KV/Cache/Rate-Limiter were hardcoding paths. And also fix a bunch of other stuff.