### PR TITLE
Switch rate-limiter impl from chrono to jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,6 @@ dependencies = [
  "base64",
  "byteorder",
  "bytes",
- "chrono",
  "config",
  "coyote-derive",
  "coyote-error",
@@ -1013,7 +1012,6 @@ dependencies = [
 name = "coyote-rate-limiter"
 version = "1.76.1"
 dependencies = [
- "chrono",
  "coyote-error",
  "fjall",
  "fjall-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ axum-extra.workspace = true
 base64.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
-chrono.workspace = true
 config.workspace = true
 coyote-derive.workspace = true
 coyote-error.workspace = true
@@ -111,7 +110,6 @@ axum-extra = { version = "0.12.5", features = ["typed-header"] }
 base64 = "0.22"
 byteorder = "1.5.0"
 bytes = "1.1.0"
-chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.1.8", features = ["derive"] }
 clap_complete = "4.5.38"
 colored_json = "5.0.0"

--- a/crates/rate-limiter/Cargo.toml
+++ b/crates/rate-limiter/Cargo.toml
@@ -6,7 +6,6 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-chrono = { workspace = true, features = ["serde"] }
 coyote-error.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true

--- a/crates/rate-limiter/src/algorithms.rs
+++ b/crates/rate-limiter/src/algorithms.rs
@@ -1,4 +1,6 @@
-use chrono::{DateTime, Duration, Utc};
+use std::time::Duration;
+
+use jiff::Timestamp;
 
 pub struct FixedWindow {
     /// Window size
@@ -8,11 +10,11 @@ pub struct FixedWindow {
 }
 
 impl FixedWindow {
-    pub(crate) fn get_window_start(&self, now: DateTime<Utc>) -> DateTime<Utc> {
-        let size_ms = self.size.num_milliseconds();
-        let now_ms = now.timestamp_millis();
+    pub(crate) fn get_window_start(&self, now: Timestamp) -> Timestamp {
+        let size_ms = self.size.as_millis() as i64;
+        let now_ms = now.as_millisecond();
         let window_start_ms = now_ms - (now_ms % size_ms);
-        DateTime::from_timestamp_millis(window_start_ms).unwrap()
+        Timestamp::from_millisecond(window_start_ms).unwrap()
     }
 }
 
@@ -29,14 +31,19 @@ impl TokenBucket {
     pub(crate) fn get_new_capacity(
         &self,
         current: u64,
-        now: DateTime<Utc>,
-        last_refill: DateTime<Utc>,
+        now: Timestamp,
+        last_refill: Timestamp,
     ) -> u64 {
         let mut capacity = current;
         if last_refill < now {
-            let elapsed = now - last_refill;
-            let periods = elapsed.num_milliseconds() / self.refill_interval.num_milliseconds();
-            capacity += periods as u64 * self.refill_rate;
+            let elapsed_millis: u64 = now
+                .duration_since(last_refill)
+                .as_millis()
+                .try_into()
+                .unwrap();
+            let refill_interval_millis: u64 = self.refill_interval.as_millis().try_into().unwrap();
+
+            capacity += (elapsed_millis / refill_interval_millis) * self.refill_rate;
         }
         capacity.min(self.bucket_size)
     }

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod algorithms;
 pub mod tables;
 
-use chrono::{DateTime, Duration, Utc};
+use std::time::Duration;
+
 use coyote_error::Result;
 use fjall::KeyspaceCreateOptions;
 use fjall_utils::TableRow;
+use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -46,7 +48,7 @@ impl RateLimiter {
     // Using the same identifier but changing the algorithm is considered a different resource.
     pub fn limit(
         &self,
-        now: DateTime<Utc>,
+        now: Timestamp,
         identifier: &str,
         delta: u64,
         algorithm: RateLimitConfig,
@@ -56,7 +58,7 @@ impl RateLimiter {
 
     fn limit_inner(
         &self,
-        now: DateTime<Utc>,
+        now: Timestamp,
         identifier: &str,
         delta: u64,
         algorithm: RateLimitConfig,
@@ -85,7 +87,7 @@ impl RateLimiter {
                 let (remaining, result, retry_after) = if state.count + delta > max_tokens {
                     state.count = max_tokens;
                     let window_end = window_start + fw_config.size;
-                    let time_until_reset = window_end - now;
+                    let time_until_reset = window_end.duration_since(now).try_into().unwrap();
                     (0, RateLimitResult::BLOCK, Some(time_until_reset))
                 } else {
                     state.count += delta;
@@ -113,13 +115,13 @@ impl RateLimiter {
 
                 if capacity < delta {
                     let filled_per_millis =
-                        tb_config.refill_rate * tb_config.refill_interval.num_milliseconds() as u64;
-                    let retry_after = (filled_per_millis - capacity).div_ceil(delta) as i64;
+                        tb_config.refill_rate * tb_config.refill_interval.as_millis() as u64;
+                    let retry_after = (filled_per_millis - capacity).div_ceil(delta);
 
                     return Ok((
                         RateLimitResult::BLOCK,
                         capacity,
-                        Some(Duration::milliseconds(retry_after)),
+                        Some(Duration::from_millis(retry_after)),
                     ));
                 }
 
@@ -137,7 +139,7 @@ impl RateLimiter {
 
     pub fn get_remaining(
         &self,
-        now: DateTime<Utc>,
+        now: Timestamp,
         identifier: &str,
         algorithm: RateLimitConfig,
     ) -> Result<(u64, Option<Duration>)> {
@@ -199,7 +201,7 @@ mod tests {
 
         fn config() -> RateLimitConfig {
             RateLimitConfig::FixedWindow(FixedWindow {
-                size: Duration::seconds(1),
+                size: Duration::from_secs(1),
                 tokens: 5,
             })
         }
@@ -209,37 +211,37 @@ mod tests {
             let (limiter, _dir) = create_test_limiter();
             let id = "user1";
 
-            let mut clock = DateTime::from_timestamp_millis(0).unwrap();
+            let mut clock = Timestamp::UNIX_EPOCH;
             let (result, remaining, retry_after) = limiter.limit(clock, id, 3, config()).unwrap();
             assert!(matches!(result, RateLimitResult::OK));
             assert_eq!(remaining, 2);
             assert_eq!(retry_after, None);
 
-            clock += Duration::milliseconds(500);
+            clock += Duration::from_millis(500);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 2, config()).unwrap();
             assert!(matches!(result, RateLimitResult::OK));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, None);
 
-            clock += Duration::milliseconds(400);
+            clock += Duration::from_millis(400);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
             assert!(matches!(result, RateLimitResult::BLOCK));
             assert_eq!(remaining, 0);
-            assert_eq!(retry_after, Some(Duration::milliseconds(100)));
+            assert_eq!(retry_after, Some(Duration::from_millis(100)));
 
             let (remaining_2, retry_after_2) = limiter.get_remaining(clock, id, config()).unwrap();
             assert_eq!(remaining_2, remaining);
             assert_eq!(retry_after_2, retry_after);
 
             // Resets at t=1000ms
-            clock += Duration::milliseconds(100);
+            clock += Duration::from_millis(100);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
             assert!(matches!(result, RateLimitResult::OK));
             assert_eq!(remaining, 4);
             assert_eq!(retry_after, None);
 
             // Doesn't accumulate
-            clock += Duration::milliseconds(100000);
+            clock += Duration::from_millis(100000);
             let (remaining, retry_after) = limiter.get_remaining(clock, id, config()).unwrap();
             assert_eq!(remaining, 5);
             assert_eq!(retry_after, None);
@@ -252,7 +254,7 @@ mod tests {
         fn config() -> RateLimitConfig {
             RateLimitConfig::TokenBucket(TokenBucket {
                 refill_rate: 1,
-                refill_interval: Duration::milliseconds(100),
+                refill_interval: Duration::from_millis(100),
                 bucket_size: 5,
             })
         }
@@ -260,7 +262,7 @@ mod tests {
         fn config_refill_2() -> RateLimitConfig {
             RateLimitConfig::TokenBucket(TokenBucket {
                 refill_rate: 2,
-                refill_interval: Duration::milliseconds(100),
+                refill_interval: Duration::from_millis(100),
                 bucket_size: 5,
             })
         }
@@ -270,7 +272,7 @@ mod tests {
             let (limiter, _dir) = create_test_limiter();
             let id = "user1";
 
-            let clock = Utc::now();
+            let clock = Timestamp::now();
             let (result, remaining, retry_after) = limiter.limit(clock, id, 3, config()).unwrap();
             assert!(matches!(result, RateLimitResult::OK));
             assert_eq!(remaining, 2);
@@ -284,7 +286,7 @@ mod tests {
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
             assert!(matches!(result, RateLimitResult::BLOCK));
             assert_eq!(remaining, 0);
-            assert_eq!(retry_after, Some(Duration::milliseconds(100)));
+            assert_eq!(retry_after, Some(Duration::from_millis(100)));
         }
 
         #[test]
@@ -292,20 +294,20 @@ mod tests {
             let (limiter, _dir) = create_test_limiter();
             let id = "user1";
 
-            let mut clock = Utc::now();
+            let mut clock = Timestamp::now();
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 5, config_refill_2()).unwrap();
             assert!(matches!(result, RateLimitResult::OK));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, None);
 
-            clock += Duration::milliseconds(100);
+            clock += Duration::from_millis(100);
             let (remaining, retry_after) =
                 limiter.get_remaining(clock, id, config_refill_2()).unwrap();
             assert_eq!(remaining, 2);
             assert_eq!(retry_after, None);
 
-            clock += Duration::milliseconds(200);
+            clock += Duration::from_millis(200);
             let (remaining, retry_after) =
                 limiter.get_remaining(clock, id, config_refill_2()).unwrap();
             assert_eq!(remaining, 5);

--- a/crates/rate-limiter/src/tables.rs
+++ b/crates/rate-limiter/src/tables.rs
@@ -1,5 +1,5 @@
-use chrono::{DateTime, Utc};
 use fjall_utils::TableRow;
+use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 // IMPORTANT. Since these are all shared in the same fjall::Keyspace, the table prefixes must be unique.
@@ -12,7 +12,7 @@ static_assertions::const_assert!(fjall_utils::are_all_unique(&[
 pub struct FixedWindowState {
     pub key: String,
     pub count: u64,
-    pub window_start: DateTime<Utc>,
+    pub window_start: Timestamp,
 }
 
 impl TableRow for FixedWindowState {
@@ -28,7 +28,7 @@ impl TableRow for FixedWindowState {
 pub struct TokenBucketState {
     pub key: String,
     pub tokens: u64,
-    pub last_refill: DateTime<Utc>,
+    pub last_refill: Timestamp,
 }
 
 impl TableRow for TokenBucketState {

--- a/src/v1/endpoints/rate_limiter.rs
+++ b/src/v1/endpoints/rate_limiter.rs
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+use std::time::Duration;
+
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Json, extract::State};
-use chrono::{Duration, Utc};
 use coyote_derive::aide_annotate;
+use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -91,7 +93,7 @@ async fn rate_limiter_limit(
     State(AppState { rate_limiter, .. }): State<AppState>,
     ValidatedJson(data): ValidatedJson<RateLimiterCheckIn>,
 ) -> Result<Json<RateLimiterCheckOut>> {
-    let now = Utc::now(); // FIXME(@svix-lucho): should come from consensus?
+    let now = Timestamp::now(); // FIXME(@svix-lucho): should come from consensus?
     let (result, remaining, retry_after) = rate_limiter.limit(
         now,
         &data.key,
@@ -99,14 +101,14 @@ async fn rate_limiter_limit(
         RateLimitConfig::TokenBucket(TokenBucket {
             bucket_size: data.config.capacity,
             refill_rate: data.config.refill_amount,
-            refill_interval: Duration::seconds(data.config.refill_interval_seconds as i64),
+            refill_interval: Duration::from_secs(data.config.refill_interval_seconds),
         }),
     )?;
 
     Ok(Json(RateLimiterCheckOut {
         result,
         remaining,
-        retry_after: retry_after.map(|t| t.num_milliseconds() as u64),
+        retry_after: retry_after.map(|t| t.as_millis() as u64),
     }))
 }
 
@@ -117,20 +119,20 @@ async fn rate_limiter_get_remaining(
     State(AppState { rate_limiter, .. }): State<AppState>,
     ValidatedJson(data): ValidatedJson<RateLimiterGetRemainingIn>,
 ) -> Result<Json<RateLimiterGetRemainingOut>> {
-    let now = Utc::now(); // FIXME(@svix-lucho): should come from consensus?
+    let now = Timestamp::now(); // FIXME(@svix-lucho): should come from consensus?
     let (remaining, retry_after) = rate_limiter.get_remaining(
         now,
         &data.key,
         RateLimitConfig::TokenBucket(TokenBucket {
             bucket_size: data.config.capacity,
             refill_rate: data.config.refill_amount,
-            refill_interval: Duration::seconds(data.config.refill_interval_seconds as i64),
+            refill_interval: Duration::from_secs(data.config.refill_interval_seconds),
         }),
     )?;
 
     Ok(Json(RateLimiterGetRemainingOut {
         remaining,
-        retry_after: retry_after.map(|t| t.num_milliseconds() as u64),
+        retry_after: retry_after.map(|t| t.as_millis() as u64),
     }))
 }
 


### PR DESCRIPTION
I'm not very happy about these `.unwrap()`s, but still better than plain `as` casts that would return bogus results on over- / underflow.

Probably for @svix-lucho to review.