### PR TITLE
Simplify DB config code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2477554ebf38aea815a9c4729100cfc32f766876c45b9c9c38ef221b9d1a703"
 dependencies = [
  "cfg-if",
- "indexmap 2.13.0",
+ "indexmap",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -110,7 +110,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "http",
- "indexmap 2.13.0",
+ "indexmap",
  "schemars 1.2.0",
  "serde",
  "serde_json",
@@ -127,7 +127,7 @@ version = "0.16.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a02baae51c9c0637df98b62762a431aff6d13d34f05cfc9a30f059dbb8dff72f"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -621,7 +621,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -884,7 +883,7 @@ dependencies = [
  "http",
  "hyper",
  "idna_adapter",
- "indexmap 2.13.0",
+ "indexmap",
  "itertools 0.14.0",
  "jiff",
  "jwt-simple",
@@ -905,7 +904,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "serde_with",
  "stream",
  "tap",
  "tempfile",
@@ -1213,18 +1211,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1242,37 +1230,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.114",
 ]
@@ -1321,7 +1284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -1851,7 +1813,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2228,17 +2190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11c13906586a4b339310541a274dd927aff6fcbb5b8e3af90634c4b31681c792"
 dependencies = [
  "unicode-joining-type",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2827,7 +2778,7 @@ dependencies = [
  "clap",
  "fs-err",
  "heck",
- "indexmap 2.13.0",
+ "indexmap",
  "itertools 0.14.0",
  "minijinja",
  "ron",
@@ -3955,20 +3906,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "indexmap 2.13.0",
+ "indexmap",
  "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
  "serde",
  "serde_json",
 ]
@@ -3980,7 +3919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
  "dyn-clone",
- "indexmap 2.13.0",
+ "indexmap",
  "jiff",
  "ref-cast",
  "schemars_derive 1.2.0",
@@ -4184,37 +4123,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.13.0",
- "schemars 0.9.0",
- "schemars 1.2.0",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
-dependencies = [
- "darling 0.21.3",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -4671,7 +4579,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -4731,7 +4639,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5014,7 +4922,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "once_cell",
  "proc-macro-error2",
  "proc-macro2",
@@ -5684,7 +5592,7 @@ dependencies = [
  "generic-array",
  "getrandom 0.3.4",
  "hmac",
- "indexmap 2.13.0",
+ "indexmap",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error.workspace = true
-serde_with.workspace = true
 stream.workspace = true
 tap.workspace = true
 tokio.workspace = true
@@ -172,7 +171,6 @@ schemars = { version = "1.2.0", features = ["jiff02", "uuid1"] }
 serde = { version = "1.0.184", features = ["derive", "rc"] }
 serde_json = { version = "1.0.74", features = ["arbitrary_precision", "raw_value"] }
 serde_path_to_error = "0.1.7"
-serde_with = "3.16.1"
 static_assertions = "1.1"
 stream.path = "crates/stream"
 syn = "2.0.48"

--- a/config.default.toml
+++ b/config.default.toml
@@ -32,13 +32,13 @@ opentelemetry_service_name = "coyote"
 environment = "dev"
 
 # Directory where persistent database is stored.
-persistent_db_path = "./db"
+persistent_db.path = "./db"
 
 # Directory where ephemeral database is stored.
-ephemeral_db_path = "./db"
+ephemeral_db.path = "./db"
 
 # Directory where management data is stored
-management_db_path = "./db"
+management_db.path = "./db"
 
 [cluster]
 # The address to listen on for replication traffic

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -3,83 +3,53 @@
 
 use std::{
     fmt,
-    marker::PhantomData,
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
 };
 
-use crate::error::Result;
 use anyhow::Context;
 use config::ConfigBuilder;
 use fjall::Database;
 use serde::Deserialize;
-use serde_with::with_prefix;
 use tap::Pipe;
 use tracing::Level;
 
-use crate::core::security::JwtSigningConfig;
+use crate::{core::security::JwtSigningConfig, error::Result};
 
 const DEFAULTS: &str = include_str!("../config.default.toml");
 
 pub type Configuration = Arc<ConfigurationInner>;
 
-with_prefix!(ephemeral_db "ephemeral_db_");
-with_prefix!(persistent_db "persistent_db_");
-with_prefix!(management_db "management_db_");
-
-pub trait StorageType {}
-
-#[derive(Debug, Default)]
-pub struct Ephemeral {}
-impl StorageType for Ephemeral {}
-
-#[derive(Debug, Default)]
-pub struct Persistent {}
-impl StorageType for Persistent {}
-
-#[derive(Debug, Default)]
-pub struct Management {}
-impl StorageType for Management {}
-
 #[derive(Clone, Debug, Default, Deserialize)]
-pub struct DatabaseConfig<S: StorageType> {
+pub struct DatabaseConfig {
     pub path: PathBuf,
-    #[serde(default)]
     pub filename: Option<String>,
-    #[serde(skip)]
-    pub _phantom: PhantomData<S>,
 }
 
-impl<S: StorageType> DatabaseConfig<S> {
+impl DatabaseConfig {
     fn database(dir: &Path, file: &str) -> Result<Database> {
         let mut path = PathBuf::from(dir);
         path.push(file);
         fjall::Database::builder(path).open().map_err(|e| e.into())
     }
-}
 
-impl DatabaseConfig<Persistent> {
-    pub fn persistent(db_config: Arc<DatabaseConfig<Persistent>>) -> Result<Database> {
+    pub fn persistent(db_config: &DatabaseConfig) -> Result<Database> {
         Self::database(
             &db_config.path,
             db_config.filename.as_deref().unwrap_or("fjall_persistent"),
         )
     }
-}
 
-impl DatabaseConfig<Ephemeral> {
-    pub fn ephemeral(db_config: Arc<DatabaseConfig<Ephemeral>>) -> Result<Database> {
+    pub fn ephemeral(db_config: &DatabaseConfig) -> Result<Database> {
         Self::database(
             &db_config.path,
             db_config.filename.as_deref().unwrap_or("fjall_ephemeral"),
         )
     }
-}
 
-impl DatabaseConfig<Management> {
-    pub fn management(db_config: Arc<DatabaseConfig<Management>>) -> Result<Database> {
+    pub fn management(db_config: &DatabaseConfig) -> Result<Database> {
         Self::database(
             &db_config.path,
             db_config.filename.as_deref().unwrap_or("fjall_management"),
@@ -134,14 +104,9 @@ pub struct ConfigurationInner {
     /// The address to listen on
     pub listen_address: SocketAddr,
 
-    #[serde(flatten, with = "management_db")]
-    pub management_db_config: Arc<DatabaseConfig<Management>>,
-
-    #[serde(flatten, with = "persistent_db")]
-    pub persistent_db_config: Arc<DatabaseConfig<Persistent>>,
-
-    #[serde(flatten, with = "ephemeral_db")]
-    pub ephemeral_db_config: Arc<DatabaseConfig<Ephemeral>>,
+    pub management_db: Arc<DatabaseConfig>,
+    pub persistent_db: Arc<DatabaseConfig>,
+    pub ephemeral_db: Arc<DatabaseConfig>,
 
     /// Contains the secret and algorithm for signing JWTs
     #[serde(flatten)]
@@ -257,23 +222,17 @@ mod tests {
 
     #[derive(Deserialize)]
     struct TestConfig {
-        #[serde(flatten, with = "persistent_db")]
-        pub persistent_db_config: Arc<DatabaseConfig<Persistent>>,
-
-        #[serde(flatten, with = "ephemeral_db")]
-        pub ephemeral_db_config: Arc<DatabaseConfig<Ephemeral>>,
-
-        #[serde(flatten, with = "management_db")]
-        pub management_db_config: Arc<DatabaseConfig<Management>>,
+        pub management_db: Arc<DatabaseConfig>,
+        pub persistent_db: Arc<DatabaseConfig>,
+        pub ephemeral_db: Arc<DatabaseConfig>,
     }
 
     #[test]
     fn test_db() {
         let raw_config = r#"
-ephemeral_db_path="/1"
-ephemeral_db_filename="test1"
-persistent_db_path="/2"
-management_db_path="/3"
+ephemeral_db = { path = "/1", filename = "test1" }
+persistent_db.path = "/2"
+management_db.path = "/3"
 "#;
 
         let config = config::Config::builder()
@@ -283,16 +242,13 @@ management_db_path="/3"
 
         let db_config = config.try_deserialize::<TestConfig>().unwrap();
 
-        assert_eq!(db_config.ephemeral_db_config.path, "/1".to_string());
-        assert_eq!(
-            db_config.ephemeral_db_config.filename,
-            Some("test1".to_string())
-        );
+        assert_eq!(db_config.ephemeral_db.path, "/1".to_string());
+        assert_eq!(db_config.ephemeral_db.filename, Some("test1".to_string()));
 
-        assert_eq!(db_config.persistent_db_config.path, "/2".to_string());
-        assert!(db_config.persistent_db_config.filename.is_none());
+        assert_eq!(db_config.persistent_db.path, "/2".to_string());
+        assert!(db_config.persistent_db.filename.is_none());
 
-        assert_eq!(db_config.management_db_config.path, "/3".to_string());
-        assert!(db_config.management_db_config.filename.is_none());
+        assert_eq!(db_config.management_db.path, "/3".to_string());
+        assert!(db_config.management_db.filename.is_none());
     }
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -48,7 +48,7 @@ pub struct DatabaseConfig<S: StorageType> {
     pub path: PathBuf,
     #[serde(default)]
     pub filename: Option<String>,
-    #[serde(skip_serializing, default)]
+    #[serde(skip)]
     pub _phantom: PhantomData<S>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,14 +144,9 @@ pub async fn run_with_prefix(
     // needed at router-construction time.
     let mut openapi = openapi::initialize_openapi();
 
-    let persistent_db =
-        DatabaseConfig::persistent(cfg.persistent_db_config.clone()).expect("persistent db");
-
-    let _ephemeral_db =
-        DatabaseConfig::ephemeral(cfg.ephemeral_db_config.clone()).expect("ephemeral db");
-
-    let _management_db =
-        DatabaseConfig::management(cfg.management_db_config.clone()).expect("management db");
+    let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
+    let _ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
+    let _management_db = DatabaseConfig::management(&cfg.management_db).expect("management db");
 
     let stream_state =
         stream::State::init(persistent_db.clone()).expect("initializing stream state");

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -4,8 +4,8 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use coyote::{
     cfg::{
-        ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, Ephemeral,
-        InternalConfig, LogFormat, LogLevel, Management, Persistent,
+        ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, InternalConfig,
+        LogFormat, LogLevel,
     },
     core::security::JwtSigningConfig,
     run_with_prefix,
@@ -46,15 +46,15 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
 
     let cfg = Arc::new(ConfigurationInner {
         listen_address: addr,
-        management_db_config: Arc::new(DatabaseConfig::<Management> {
+        management_db: Arc::new(DatabaseConfig {
             path: db_dir.clone(),
             ..Default::default()
         }),
-        ephemeral_db_config: Arc::new(DatabaseConfig::<Ephemeral> {
+        ephemeral_db: Arc::new(DatabaseConfig {
             path: db_dir.clone(),
             ..Default::default()
         }),
-        persistent_db_config: Arc::new(DatabaseConfig::<Persistent> {
+        persistent_db: Arc::new(DatabaseConfig {
             path: db_dir,
             ..Default::default()
         }),


### PR DESCRIPTION
I was going to reimplement the parts of `serde_with` used there, but it's actually a lot of stupid boilerplate and.. I don't think we really need those marker types anyways?

This changes how this is configured in TOML, for the better IMO.

Actually I'm now seeing that I could have kept the marker types. Let me know if you feel strongly about keeping them.