### PR TITLE
Add some API tests for kv, cache, rate-limiter

### DIFF
--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -1,0 +1,73 @@
+use serde_json::{Value, json};
+use test_utils::{StatusCode, TestClient, TestResult};
+
+async fn cache_set(client: &TestClient, key: &str, expire_in: u64, value: &str) -> TestResult<()> {
+    client
+        .post("cache/set")
+        .json(json!({
+            "key": key,
+            "expire_in": expire_in,
+            "value": value
+        }))
+        .await?
+        .expect(StatusCode::OK);
+    Ok(())
+}
+
+async fn cache_get(client: &TestClient, key: &str) -> TestResult<Value> {
+    let response = client
+        .post("cache/get")
+        .json(json!({
+            "key": key
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    Ok(response)
+}
+
+#[tokio::test]
+async fn test_cache_set_and_get() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    cache_set(&client, "test-key-1", 60000, "test-value-123").await?;
+
+    let response = cache_get(&client, "test-key-1").await?;
+
+    assert_eq!(response["key"], "test-key-1");
+    assert_eq!(response["value"], "test-value-123");
+    assert!(response["expires_at"].is_string());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cache_set_get_and_delete() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    cache_set(&client, "test-key-2", 30000, "another-value").await?;
+
+    let response = cache_get(&client, "test-key-2").await?;
+    assert_eq!(response["value"], "another-value");
+
+    let delete_response = client
+        .post("cache/delete")
+        .json(json!({
+            "key": "test-key-2"
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(delete_response["deleted"], true);
+
+    client
+        .post("cache/get")
+        .json(json!({
+            "key": "test-key-2"
+        }))
+        .await?
+        .expect(StatusCode::NOT_FOUND);
+
+    Ok(())
+}

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -1,0 +1,102 @@
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use test_utils::{StatusCode, TestClient, TestResult};
+
+async fn kv_set(
+    client: &TestClient,
+    key: &str,
+    expire_in: u64,
+    value: &str,
+    behavior: &str,
+) -> TestResult<()> {
+    client
+        .post("kv/set")
+        .json(json!({
+            "key": key,
+            "expire_in": expire_in,
+            "value": value,
+            "behavior": behavior
+        }))
+        .await?
+        .expect(StatusCode::OK);
+    Ok(())
+}
+
+async fn kv_get(client: &TestClient, key: &str) -> TestResult<Value> {
+    let response = client
+        .post("kv/get")
+        .json(json!({
+            "key": key
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    Ok(response)
+}
+
+#[tokio::test]
+async fn test_kv_set_and_get() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    kv_set(&client, "kv-key-1", 50000, "kv-value-456", "upsert").await?;
+
+    let response = kv_get(&client, "kv-key-1").await?;
+
+    assert_eq!(response["key"], "kv-key-1");
+    assert_eq!(response["value"], "kv-value-456");
+    assert!(response["expires_at"].is_string());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kv_set_with_insert_and_delete() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    kv_set(&client, "kv-key-2", 0, "permanent-value", "insert").await?;
+
+    let response = kv_get(&client, "kv-key-2").await?;
+    assert_eq!(response["value"], "permanent-value");
+    assert_eq!(response["expires_at"], json!(null));
+
+    let delete_response = client
+        .post("kv/delete")
+        .json(json!({
+            "key": "kv-key-2"
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(delete_response["deleted"], true);
+
+    client
+        .post("kv/get")
+        .json(json!({
+            "key": "kv-key-2"
+        }))
+        .await?
+        .expect(StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kv_expiration() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    kv_set(&client, "test-key-3", 100, "test-value-345", "upsert").await?;
+
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    client
+        .post("kv/get")
+        .json(json!({
+            "key": "test-key-3"
+        }))
+        .await?
+        .expect(StatusCode::NOT_FOUND);
+
+    Ok(())
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,3 +1,6 @@
+mod cache;
+mod kv;
+mod rate_limiter;
 mod stream;
 
 use std::{net::SocketAddr, sync::Arc, time::Duration};

--- a/tests/it/rate_limiter.rs
+++ b/tests/it/rate_limiter.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use test_utils::{StatusCode, TestClient, TestResult};
+
+async fn call_limit_token_bucket(
+    client: &TestClient,
+    key: &str,
+    units: u64,
+    capacity: u64,
+    refill_amount: u64,
+    refill_interval_seconds: u64,
+) -> TestResult<Value> {
+    let response = client
+        .post("rate-limiter/limit")
+        .json(json!({
+            "key": key,
+            "units": units,
+            "config": {
+                "capacity": capacity,
+                "refill_amount": refill_amount,
+                "refill_interval_seconds": refill_interval_seconds
+            }
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    Ok(response)
+}
+
+#[tokio::test]
+async fn test_rate_limiter_limit_token_bucket() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+    let refill_interval = 1;
+    let refill_amount = 5;
+    let capacity = 5;
+
+    let response = call_limit_token_bucket(
+        &client,
+        "rl-key-1",
+        1,
+        capacity,
+        refill_amount,
+        refill_interval,
+    )
+    .await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 4);
+    assert_eq!(response["retry_after"], json!(null));
+
+    let response = call_limit_token_bucket(
+        &client,
+        "rl-key-1",
+        2,
+        capacity,
+        refill_amount,
+        refill_interval,
+    )
+    .await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 2);
+    assert_eq!(response["retry_after"], json!(null));
+
+    let response = call_limit_token_bucket(
+        &client,
+        "rl-key-1",
+        2,
+        capacity,
+        refill_amount,
+        refill_interval,
+    )
+    .await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 0);
+    assert_eq!(response["retry_after"], json!(null));
+
+    let response = call_limit_token_bucket(
+        &client,
+        "rl-key-1",
+        1,
+        capacity,
+        refill_amount,
+        refill_interval,
+    )
+    .await?;
+    assert_eq!(response["result"], "BLOCK");
+    assert_eq!(response["remaining"], 0);
+    assert!(response["retry_after"].is_number());
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let response = client
+        .post("rate-limiter/get-remaining")
+        .json(json!({
+            "key": "rl-key-1",
+            "config": {
+                "capacity": capacity,
+                "refill_amount": refill_amount,
+                "refill_interval_seconds": refill_interval
+            }
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(response["remaining"], capacity);
+    assert_eq!(response["retry_after"], json!(null));
+
+    Ok(())
+}


### PR DESCRIPTION
Mostly setting things up, I'll write more comprehensive tests later

Maybe we should use the SDK/codegen to call the API instead of building the HTTP reqs? I'll refactor this if the codegen is ready to use and we want to do that instead, it should be easy.  