### PR TITLE
Fix .gitignore, make `Table` trait slightly more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 .claude
 .vscode
+.TODO.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .claude
 .vscode
 .TODO.md
+logs
+.data/

--- a/Claude.md
+++ b/Claude.md
@@ -1,6 +1,14 @@
 # Rules
 
 * When adding dependencies, add them in alphabetical order.
+* Before making any Rust code changes, disable the rust-analyzer extension to prevent server crashes:
+  ```bash
+  code --disable-extension rust-lang.rust-analyzer
+  ```
+  After completing all Rust code changes, re-enable the extension:
+  ```bash
+  code --enable-extension rust-lang.rust-analyzer
+  ```
 * Comments
     * Avoid superfluous, trivial comments. Only add comments to explain *why*s that are non-obvious, or particularly complex and non-trivial logic.
     * The exception is rustdoc comments. rustdoc comments should be concise, clear, and comprehensive.

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::borrow::Cow;
 
 use coyote_error::{Error, Result};
 use serde::{Serialize, de::DeserializeOwned};
@@ -9,18 +9,22 @@ use serde::{Serialize, de::DeserializeOwned};
 pub trait TableRow: Sized + Serialize + DeserializeOwned {
     const TABLE_PREFIX: &'static str;
 
-    type Key: Display;
+    type Key: AsRef<[u8]> + Clone;
 
     /// Return the field used for indexing into the table.
-    fn get_key(&self) -> &Self::Key;
+    fn get_key(&self) -> Cow<'_, Self::Key>;
 
     fn make_fjall_key(key: &Self::Key) -> fjall::UserKey {
-        let prefix = Self::TABLE_PREFIX;
-        format!("{prefix}{key}").into()
+        let mut key_bytes =
+            Vec::<u8>::with_capacity(Self::TABLE_PREFIX.len() + b"\0".len() + key.as_ref().len());
+        key_bytes.extend_from_slice(Self::TABLE_PREFIX.as_bytes());
+        key_bytes.extend_from_slice(b"\0");
+        key_bytes.extend_from_slice(key.as_ref());
+        key_bytes.into()
     }
 
     fn to_fjall_entry(&self) -> Result<(fjall::UserKey, fjall::UserValue)> {
-        let key = Self::make_fjall_key(self.get_key());
+        let key = Self::make_fjall_key(self.get_key().as_ref());
         // FIXME(@svix-gabriel) - it's not clear if we're committed to using msgpack
         // for internal serialization. Using messagepack for now, but this
         // should be easy to change later.

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -159,7 +159,7 @@ impl KvStore {
             // Delete from the expiration keyspace
             if let Some(expires_at) = data.expires_at {
                 let r = ExpirationRow::new(expires_at, key.to_string());
-                batch.remove_row::<ExpirationRow>(&self.tables, r.get_key())?;
+                batch.remove_row::<ExpirationRow>(&self.tables, r.get_key().as_ref())?;
             }
             batch.remove_row::<KvPairRow>(&self.tables, &key.to_string())?;
         }

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::borrow::Cow;
 
 use fjall_utils::TableRow;
 use jiff::Timestamp;
@@ -21,8 +21,8 @@ impl TableRow for KvPairRow {
     const TABLE_PREFIX: &'static str = "_KV_PAIR_";
     type Key = String;
 
-    fn get_key(&self) -> &Self::Key {
-        &self.key
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Borrowed(&self.key)
     }
 }
 
@@ -45,7 +45,7 @@ impl ExpirationRow {
     }
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub struct ExpirationKey(String);
 
 impl ExpirationKey {
@@ -59,9 +59,9 @@ impl ExpirationKey {
     }
 }
 
-impl Display for ExpirationKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+impl AsRef<[u8]> for ExpirationKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
     }
 }
 
@@ -70,7 +70,7 @@ impl TableRow for ExpirationRow {
 
     type Key = ExpirationKey;
 
-    fn get_key(&self) -> &Self::Key {
-        &self.computed_key
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Borrowed(&self.computed_key)
     }
 }

--- a/crates/rate-limiter/src/tables.rs
+++ b/crates/rate-limiter/src/tables.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use fjall_utils::TableRow;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -19,8 +21,8 @@ impl TableRow for FixedWindowState {
     const TABLE_PREFIX: &'static str = "_FIXED_WINDOW_";
     type Key = String;
 
-    fn get_key(&self) -> &Self::Key {
-        &self.key
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Borrowed(&self.key)
     }
 }
 
@@ -35,7 +37,7 @@ impl TableRow for TokenBucketState {
     const TABLE_PREFIX: &'static str = "_TOKEN_BUCKET_";
     type Key = String;
 
-    fn get_key(&self) -> &Self::Key {
-        &self.key
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Borrowed(&self.key)
     }
 }

--- a/crates/stream/src/tables.rs
+++ b/crates/stream/src/tables.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU64, ops::RangeInclusive};
+use std::{borrow::Cow, num::NonZeroU64, ops::RangeInclusive};
 
 use crate::{
     State,
@@ -26,8 +26,8 @@ impl TableRow for NameToStreamRow {
     const TABLE_PREFIX: &'static str = "_CID2NAME_";
     type Key = String;
 
-    fn get_key(&self) -> &Self::Key {
-        &self.name
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Borrowed(&self.name)
     }
 }
 
@@ -48,8 +48,8 @@ impl TableRow for StreamRow {
 
     type Key = StreamId;
 
-    fn get_key(&self) -> &Self::Key {
-        &self.id
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Borrowed(&self.id)
     }
 }
 


### PR DESCRIPTION
This is a few small changes split off from a larger PR.

The biggest change here is changing `Table::Key` to have different trait bounds to be more flexible, as well as have the return type from `get_key()` be a `Cow<'_, ...>`, which allows rows to return Key types that aren't necessarily referencing the struct.

The other changes are pretty trivial, and explained by individual commits.