### PR TITLE
Use just test in CI, skip expensive raft test outside of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-nextest
+      - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - run: just test --run-ignored all

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -130,6 +130,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "Test has a long runtime. We still run this in CI using `--run-ignored all`"]
     fn test_storage() -> anyhow::Result<()> {
         openraft::testing::Suite::test_all(CoyoteStoreBuilder)?;
         Ok(())


### PR DESCRIPTION
This does 2 things

- Change CI to use `just test` instead of `cargo test`.  This indirectly uses cargo nextest, which should be faster.
- `ignore` a really long, expensive test by default. The test takes 30+ seconds to run locally, and it seems like this is hard to change. Instead, we'll only run it by default in CI.