### PR TITLE
Refactor idempotency module to use fjall-backed kv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub async fn run_with_prefix(
     let mut openapi = openapi::initialize_openapi();
 
     let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
-    let _ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
+    let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
     let _management_db = DatabaseConfig::management(&cfg.management_db).expect("management db");
 
     let stream_state =
@@ -159,10 +159,18 @@ pub async fn run_with_prefix(
 
     let cache_kv_store = crate::v1::modules::kv::KvStore::new(
         "cache_store",
-        persistent_db.clone(),
+        ephemeral_db.clone(),
         EvictionPolicy::LeastRecentlyUsed,
     );
     let cache_store = crate::v1::modules::cache::CacheStore::new(cache_kv_store);
+
+    let idempotency_kv_store = crate::v1::modules::kv::KvStore::new(
+        "idempotency_store",
+        persistent_db.clone(),
+        EvictionPolicy::NoEviction,
+    );
+    let idempotency_store =
+        crate::v1::modules::idempotency::IdempotencyStore::new(idempotency_kv_store);
 
     let (raft, node_id) = core::cluster::initialize_raft(&cfg, persistent_db.clone())
         .await
@@ -177,7 +185,7 @@ pub async fn run_with_prefix(
             "rate_limiter_default",
             persistent_db.clone(),
         ),
-        idempotency_store: crate::v1::modules::idempotency::IdempotencyStore::new(),
+        idempotency_store,
         queue_store: crate::v1::modules::queue::QueueStore::new(),
         stream_state,
         raft,
@@ -223,7 +231,6 @@ pub async fn run_with_prefix(
         // FIXME: gotta do actual error handling...
         let _ = tokio::join!(
             tokio::spawn(v1::modules::kv::worker(app_state.clone())),
-            tokio::spawn(v1::modules::idempotency::worker(app_state.clone())),
             tokio::spawn(v1::modules::rate_limiter::worker(app_state.clone())),
             tokio::spawn(v1::modules::queue::worker(app_state.clone())),
         );

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -17,7 +17,6 @@ use crate::{
 
 // Re-export types that are used in AppState
 pub use crate::v1::modules::idempotency::IdempotencyStore;
-pub use crate::v1::modules::idempotency::worker;
 
 // ============================================================================
 // API Types
@@ -48,6 +47,7 @@ pub struct IdempotencyCompleteIn {
     pub key: EntityKey,
 
     /// The response to cache
+    /// FIXME(@svix-lucho): change to Bytes
     pub response: String,
 
     /// TTL in seconds for the cached response
@@ -75,7 +75,8 @@ pub struct IdempotencyAbandonOut {}
 #[aide_annotate(op_id = "v1.idempotency.start")]
 async fn idempotency_start(
     State(AppState {
-        idempotency_store, ..
+        mut idempotency_store,
+        ..
     }): State<AppState>,
     ValidatedJson(data): ValidatedJson<IdempotencyStartIn>,
 ) -> Result<Json<IdempotencyStartOut>> {
@@ -83,7 +84,13 @@ async fn idempotency_start(
 
     match idempotency_store.try_start(&key_str, data.ttl_seconds)? {
         None => Ok(Json(IdempotencyStartOut::Locked)),
-        Some(response) => Ok(Json(IdempotencyStartOut::Completed { response })),
+        Some(response) => {
+            let response_str = String::from_utf8(response)
+                .map_err(|_| crate::error::HttpError::internal_server_error(None, None))?;
+            Ok(Json(IdempotencyStartOut::Completed {
+                response: response_str,
+            }))
+        }
     }
 }
 
@@ -91,13 +98,14 @@ async fn idempotency_start(
 #[aide_annotate(op_id = "v1.idempotency.complete")]
 async fn idempotency_complete(
     State(AppState {
-        idempotency_store, ..
+        mut idempotency_store,
+        ..
     }): State<AppState>,
     ValidatedJson(data): ValidatedJson<IdempotencyCompleteIn>,
 ) -> Result<Json<IdempotencyCompleteOut>> {
     let key_str = data.key.to_string();
 
-    idempotency_store.complete(&key_str, data.response, data.ttl_seconds)?;
+    idempotency_store.complete(&key_str, data.response.into_bytes(), data.ttl_seconds)?;
 
     Ok(Json(IdempotencyCompleteOut {}))
 }
@@ -106,7 +114,8 @@ async fn idempotency_complete(
 #[aide_annotate(op_id = "v1.idempotency.abandon")]
 async fn idempotency_abandon(
     State(AppState {
-        idempotency_store, ..
+        mut idempotency_store,
+        ..
     }): State<AppState>,
     ValidatedJson(data): ValidatedJson<IdempotencyAbandonIn>,
 ) -> Result<Json<IdempotencyAbandonOut>> {

--- a/src/v1/modules/idempotency.rs
+++ b/src/v1/modules/idempotency.rs
@@ -7,116 +7,79 @@
 //! services.
 //!
 //! ## TODO FIXME
-//! - Actually need to implement it. I guess it can use KV as its backend.
 //! - The API probably needs changing.
 
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
 
-use crate::{
-    AppState,
-    error::{Error, HttpError, Result},
-};
+use crate::error::{Error, HttpError, Result};
+use coyote_kv::{KvModel, KvStore, OperationBehavior};
 
-/// Get current time in milliseconds since Unix epoch
-fn now_millis() -> u64 {
-    Timestamp::now().as_millisecond() as u64
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum IdempotencyState {
+    /// Request is in progress (locked)
+    InProgress,
+    /// Request completed successfully with a response
+    Completed { response: Vec<u8> },
 }
 
-// ============================================================================
-// Idempotency Store
-// ============================================================================
+impl From<IdempotencyState> for Vec<u8> {
+    fn from(state: IdempotencyState) -> Self {
+        rmp_serde::to_vec(&state).expect("Failed to serialize IdempotencyState")
+    }
+}
+
+impl From<Vec<u8>> for IdempotencyState {
+    fn from(value: Vec<u8>) -> Self {
+        rmp_serde::from_slice(&value).expect("Failed to deserialize IdempotencyState")
+    }
+}
 
 #[derive(Clone)]
 pub struct IdempotencyStore {
-    store: Arc<RwLock<HashMap<String, IdempotencyState>>>,
-}
-
-#[derive(Clone, Debug)]
-enum IdempotencyState {
-    /// Request is in progress (locked)
-    InProgress { expires_at_millis: u64 },
-    /// Request completed successfully with a response
-    Completed {
-        expires_at_millis: u64,
-        // FIXME: Should be at least bytes. Though maybe we need to make it more generic like store
-        // bytes or something?
-        response: String,
-    },
-}
-
-impl Default for IdempotencyStore {
-    fn default() -> Self {
-        Self::new()
-    }
+    pub(crate) kv: KvStore,
 }
 
 impl IdempotencyStore {
-    pub fn new() -> Self {
-        Self {
-            store: Arc::new(RwLock::new(HashMap::new())),
-        }
+    pub fn new(kv: KvStore) -> Self {
+        Self { kv }
     }
 
-    /// Atomically try to acquire the lock for a request.
+    /// Try to acquire the lock for a request.
     /// Returns:
     /// - Ok(None) if lock was acquired (request should proceed)
     /// - Ok(Some(response)) if request was already completed (return cached response)
     /// - Err if request is already in progress (conflict)
-    pub fn try_start(&self, key: &str, ttl_seconds: u64) -> Result<Option<String>> {
-        let now = now_millis();
-        let expires_at_millis = now + (ttl_seconds * 1000);
+    pub fn try_start(&mut self, key: &str, ttl_seconds: u64) -> Result<Option<Vec<u8>>> {
+        let now = Timestamp::now();
+        let expires_at = now + Duration::from_secs(ttl_seconds);
 
-        let mut store = self.store.write().unwrap();
-
-        match store.get(key) {
+        match self.kv.get(key)? {
             None => {
                 // No existing entry - acquire lock
-                store.insert(
-                    key.to_string(),
-                    IdempotencyState::InProgress { expires_at_millis },
-                );
+                let kv_model = KvModel {
+                    value: IdempotencyState::InProgress.into(),
+                    expires_at: Some(expires_at),
+                };
+                self.kv.set(key, &kv_model, OperationBehavior::Insert)?;
                 Ok(None)
             }
-            Some(state) => {
+            Some(kv_model) => {
+                let state: IdempotencyState = kv_model.value.into();
                 match state {
-                    IdempotencyState::InProgress {
-                        expires_at_millis: exp,
-                    } => {
-                        // Check if expired
-                        if now >= *exp {
-                            // Lock expired, replace with new lock
-                            store.insert(
-                                key.to_string(),
-                                IdempotencyState::InProgress { expires_at_millis },
-                            );
-                            Ok(None)
-                        } else {
-                            // Still in progress by another request
-                            Err(Error::http(HttpError::conflict(
-                                Some("Request is already in progress".into()),
-                                None,
-                            )))
-                        }
+                    IdempotencyState::InProgress => {
+                        // Still in progress by another request
+                        Err(Error::http(HttpError::conflict(
+                            Some("Request is already in progress".into()),
+                            None,
+                        )))
                     }
-                    IdempotencyState::Completed {
-                        expires_at_millis: exp,
-                        response,
-                    } => {
-                        // Check if expired
-                        if now >= *exp {
-                            // Response expired, acquire new lock
-                            store.insert(
-                                key.to_string(),
-                                IdempotencyState::InProgress { expires_at_millis },
-                            );
-                            Ok(None)
-                        } else {
-                            // Return cached response
-                            Ok(Some(response.clone()))
-                        }
+                    IdempotencyState::Completed { response } => {
+                        // Return cached response
+                        Ok(Some(response))
                     }
                 }
             }
@@ -124,35 +87,124 @@ impl IdempotencyStore {
     }
 
     /// Complete a request with a successful response
-    pub fn complete(&self, key: &str, response: String, ttl_seconds: u64) -> Result<()> {
-        let now = now_millis();
-        let expires_at_millis = now + (ttl_seconds * 1000);
+    pub fn complete(&mut self, key: &str, response: Vec<u8>, ttl_seconds: u64) -> Result<()> {
+        let now = Timestamp::now();
+        let expires_at = now + Duration::from_secs(ttl_seconds);
 
-        self.store.write().unwrap().insert(
-            key.to_string(),
-            IdempotencyState::Completed {
-                expires_at_millis,
-                response,
-            },
-        );
+        let kv_model = KvModel {
+            value: IdempotencyState::Completed { response }.into(),
+            expires_at: Some(expires_at),
+        };
+        self.kv.set(key, &kv_model, OperationBehavior::Upsert)?;
 
         Ok(())
     }
 
     /// Abandon a request (remove the lock without saving response)
-    pub fn abandon(&self, key: &str) -> Result<()> {
-        self.store.write().unwrap().remove(key);
-        Ok(())
+    pub fn abandon(&mut self, key: &str) -> Result<()> {
+        self.kv.delete(key)
     }
 }
 
-/// This is the worker function for this module, it does background cleanup and accounting.
-pub async fn worker(_state: AppState) -> Result<()> {
-    loop {
-        if crate::is_shutting_down() {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+#[cfg(test)]
+mod tests {
+    use fjall::Database;
+    use test_utils::TestResult;
+
+    use super::*;
+
+    struct SetupFixture {
+        store: IdempotencyStore,
     }
-    Ok(())
+
+    impl SetupFixture {
+        fn new() -> TestResult<Self> {
+            let workdir = tempfile::tempdir()?;
+            let db = Database::builder(workdir.as_ref()).temporary(true).open()?;
+            let kv = KvStore::new("test", db, coyote_kv::EvictionPolicy::NoEviction);
+            let store = IdempotencyStore::new(kv);
+            Ok(Self { store })
+        }
+    }
+
+    #[test]
+    fn test_idempotency_state_serialization() {
+        let state = IdempotencyState::InProgress;
+        let serialized: Vec<u8> = state.clone().into();
+        let deserialized: IdempotencyState = serialized.into();
+        assert_eq!(state, deserialized);
+    }
+
+    #[test]
+    fn test_idempotency_state_serialization_completed() {
+        let state = IdempotencyState::Completed {
+            response: vec![1, 2, 3],
+        };
+        let serialized: Vec<u8> = state.clone().into();
+        let deserialized: IdempotencyState = serialized.into();
+        assert_eq!(state, deserialized);
+    }
+
+    #[test]
+    fn test_idempotency_try_start() -> TestResult {
+        let mut store = SetupFixture::new()?.store;
+        let value = vec![1, 2, 3];
+        let result = store.try_start("test", 10)?;
+        assert_eq!(result, None);
+
+        let result = store.try_start("test", 10);
+        assert!(result.is_err());
+
+        store.abandon("test")?;
+
+        let result = store.try_start("test", 10)?;
+        assert_eq!(result, None);
+
+        store.complete("test", value.clone(), 10)?;
+
+        let result = store.try_start("test", 10)?;
+        assert_eq!(result, Some(value));
+        Ok(())
+    }
+
+    #[test]
+    fn test_idempotency_missing() -> TestResult {
+        let mut store = SetupFixture::new()?.store;
+        let value = vec![1, 2, 3];
+
+        // Can complete a request without starting it first
+        store.complete("test", value.clone(), 10)?;
+
+        let result = store.try_start("test", 10)?;
+        assert_eq!(result, Some(value));
+
+        // Can abandon a request without starting it first
+        store.abandon("test2")?;
+        let result2 = store.try_start("test2", 10)?;
+        assert_eq!(result2, None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_idempotency_ttl() -> TestResult {
+        let mut store = SetupFixture::new()?.store;
+        let value = vec![1, 2, 3];
+
+        store.try_start("test", 1)?;
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let result = store.try_start("test", 1)?;
+        assert_eq!(result, None);
+
+        store.complete("test", value, 1)?;
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let result = store.try_start("test", 1)?;
+        assert_eq!(result, None);
+
+        Ok(())
+    }
 }

--- a/src/v1/modules/kv.rs
+++ b/src/v1/modules/kv.rs
@@ -4,7 +4,11 @@ pub use coyote_kv::{EvictionPolicy, KvModel, KvStore, OperationBehavior};
 
 /// This is the worker function for this module, it does background cleanup and accounting.
 pub async fn worker(mut state: AppState) -> Result<()> {
-    let mut stores = [&mut state.kv_store, &mut state.cache_store.kv];
+    let mut stores = [
+        &mut state.kv_store,
+        &mut state.cache_store.kv,
+        &mut state.idempotency_store.kv,
+    ];
     coyote_kv::worker(&mut stores, crate::is_shutting_down).await;
     Ok(())
 }


### PR DESCRIPTION
`idempotency` was the last module that didn't have a fjall-backed implementation. 

This refactors `idempotency` to use the `kv` as the backend (so it's also backed by fjall). We didn't write an RFC for idempotency yet, so I just kept the existing behavior and API, to serve as a good starting point. 

Like with the other modules, this is written as if everything is single-threaded, there's no consideration for atomicity or concurrency. 

Still TBD: using bytes instead of `string` in the API