### PR TITLE
Implement stream.fetch-locking and stream.ack

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -13,3 +13,6 @@
     * Avoid superfluous, trivial comments. Only add comments to explain *why*s that are non-obvious, or particularly complex and non-trivial logic.
     * The exception is rustdoc comments. rustdoc comments should be concise, clear, and comprehensive.
     * If you update the logic of a function/variable, check the rustdoc comments and update them appropriately.
+* Code guidelines
+  * Keep mutation or state manipulation as isolated as possible
+  * Keep functions short and simple. If a function is too long, split it into shorter, self documenting functions.

--- a/crates/stream/src/entities.rs
+++ b/crates/stream/src/entities.rs
@@ -6,4 +6,5 @@ use uuid::Uuid;
 // We absolutely can (and should) use more robust types.
 pub type StreamId = Uuid;
 pub type MsgId = u64;
+pub type ConsumerGroup = String;
 pub type MsgHeaders = HashMap<String, String>;

--- a/crates/stream/src/entities.rs
+++ b/crates/stream/src/entities.rs
@@ -1,6 +1,9 @@
+use jiff::Timestamp;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
 use uuid::Uuid;
+use validator::Validate;
 
 // FIXME(@svix-gabriel) - I opted for type aliases here just for expediency.
 // We absolutely can (and should) use more robust types.
@@ -8,3 +11,17 @@ pub type StreamId = Uuid;
 pub type MsgId = u64;
 pub type ConsumerGroup = String;
 pub type MsgHeaders = HashMap<String, String>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+pub struct MsgIn {
+    pub payload: Vec<u8>,
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+pub struct MsgOut {
+    pub id: MsgId,
+    pub payload: Vec<u8>,
+    pub headers: HashMap<String, String>,
+    pub timestamp: Timestamp,
+}

--- a/crates/stream/src/operations/ack.rs
+++ b/crates/stream/src/operations/ack.rs
@@ -1,0 +1,70 @@
+use crate::{
+    State,
+    entities::{ConsumerGroup, MsgId, StreamId},
+    tables::{LeaseDiff, LeaseRow},
+};
+use coyote_error::{HttpError, Result};
+use jiff::Timestamp;
+
+pub struct Ack {
+    lease_diff: LeaseDiff,
+}
+
+pub struct AckOutput {}
+
+impl Ack {
+    pub fn new(
+        state: &State,
+        stream_id: StreamId,
+        cg: ConsumerGroup,
+        min_msg_id: MsgId,
+        max_msg_id: MsgId,
+    ) -> Result<Self> {
+        let now = Timestamp::now();
+        let leases = LeaseRow::fetch_all(state, stream_id, &cg)?;
+        validate_ack_bounds(&leases, max_msg_id)?;
+
+        let mut lease_diff = LeaseRow::cull_and_compact(leases, now);
+        // This new lease is potentially redundant with an extant lease.
+        // However, any redundancy will be removed by future calls to `cull_and_compact`.
+        lease_diff.to_insert.push(LeaseRow {
+            stream_id,
+            cg,
+            block_start: min_msg_id,
+            block_end: max_msg_id,
+            leased_at: now,
+            expires_at: Timestamp::MAX,
+            acked_at: Some(now),
+        });
+
+        Ok(Self { lease_diff })
+    }
+
+    pub fn apply_operation(self, state: &State) -> Result<AckOutput> {
+        let mut batch = state.db.batch();
+        self.lease_diff.apply_diff(state, &mut batch)?;
+        batch.commit()?;
+        Ok(AckOutput {})
+    }
+}
+
+fn validate_ack_bounds(leases: &[LeaseRow], max_msg_id: MsgId) -> Result<()> {
+    let highest_bound = leases.iter().map(|l| l.block_end).max().ok_or_else(|| {
+        HttpError::bad_request(
+            Some("invalid_ack".to_owned()),
+            Some("No leases exist for this consumer group".to_owned()),
+        )
+    })?;
+
+    if max_msg_id > highest_bound {
+        return Err(HttpError::bad_request(
+            Some("invalid_ack".to_owned()),
+            Some(format!(
+                "Ack range exceeds highest lease bound. max_msg_id={max_msg_id}, highest_bound={highest_bound}"
+            )),
+        )
+        .into());
+    }
+
+    Ok(())
+}

--- a/crates/stream/src/operations/append_to_stream.rs
+++ b/crates/stream/src/operations/append_to_stream.rs
@@ -1,20 +1,10 @@
 use crate::{
     State,
-    entities::{MsgId, StreamId},
+    entities::{MsgId, MsgIn, StreamId},
     tables::{MsgRow, msg_row_key},
 };
 use coyote_error::Result;
 use jiff::Timestamp;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use validator::Validate;
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
-pub struct MsgIn {
-    pub payload: Vec<u8>,
-    pub headers: HashMap<String, String>,
-}
 
 pub struct AppendToStream {
     stream_id: StreamId,

--- a/crates/stream/src/operations/fetch_locking.rs
+++ b/crates/stream/src/operations/fetch_locking.rs
@@ -1,0 +1,87 @@
+use std::num::NonZeroU16;
+
+use crate::{
+    State,
+    entities::{ConsumerGroup, MsgId, MsgOut, StreamId},
+    tables::{LeaseDiff, LeaseRow, MsgRow},
+};
+use coyote_error::{HttpError, Result};
+use jiff::Timestamp;
+
+pub struct FetchLocking {
+    lease_diff: LeaseDiff,
+    msgs: Vec<(MsgId, MsgRow)>,
+}
+
+pub struct FetchLockingOutput {
+    pub msgs: Vec<MsgOut>,
+}
+
+impl FetchLocking {
+    pub fn new(
+        state: &State,
+        stream_id: StreamId,
+        cg: ConsumerGroup,
+        batch_size: NonZeroU16,
+        visibility_timeout: std::time::Duration,
+    ) -> Result<Self> {
+        let now = Timestamp::now();
+        let leases = LeaseRow::fetch_all(state, stream_id, &cg)?;
+
+        let has_active_lease = leases.iter().any(|lease| lease.is_active(now));
+
+        if has_active_lease {
+            return Err(HttpError::bad_request(
+                Some("consumer_group_locked".to_owned()),
+                Some("Concurrent reads from the same consumer group".to_string()),
+            )
+            .into());
+        }
+
+        let acked_leases = leases.iter().filter(|lease| lease.acked_at.is_some());
+        let msgs = MsgRow::fetch_available(state, stream_id, acked_leases, batch_size.into())?;
+
+        if msgs.is_empty() {
+            // FIXME(@svix-gabriel) this isn't really an error, but we need to go back
+            // and change any HttpErrors anyway, so this is simpler for now.
+            return Err(HttpError::bad_request(
+                Some("empty_stream".to_owned()),
+                Some("no messages available".to_string()),
+            )
+            .into());
+        }
+
+        let mut lease_diff = LeaseRow::cull_and_compact(leases, now);
+
+        lease_diff.to_insert.push(LeaseRow {
+            stream_id,
+            cg,
+            block_start: msgs.first().unwrap().0,
+            block_end: msgs.last().unwrap().0,
+            leased_at: now,
+            expires_at: now + visibility_timeout,
+            acked_at: None,
+        });
+
+        Ok(Self { lease_diff, msgs })
+    }
+
+    pub fn apply_operation(self, state: &State) -> Result<FetchLockingOutput> {
+        let mut batch = state.db.batch();
+        self.lease_diff.apply_diff(state, &mut batch)?;
+        batch.commit()?;
+
+        let msgs = self
+            .msgs
+            .into_iter()
+            .map(|(id, msg)| MsgOut {
+                id,
+                payload: msg.payload,
+                headers: msg.headers,
+                timestamp: msg.created_at,
+            })
+            .collect();
+
+        Ok(FetchLockingOutput { msgs })
+    }
+}

--- a/crates/stream/src/operations/mod.rs
+++ b/crates/stream/src/operations/mod.rs
@@ -1,5 +1,9 @@
-pub mod append_to_stream;
-pub mod create_stream;
+mod ack;
+mod append_to_stream;
+mod create_stream;
+mod fetch_locking;
 
+pub use ack::*;
 pub use append_to_stream::*;
 pub use create_stream::*;
+pub use fetch_locking::*;

--- a/crates/stream/src/tables.rs
+++ b/crates/stream/src/tables.rs
@@ -61,7 +61,7 @@ impl TableRow for StreamRow {
 
 /// A lease represents a consumer group's "hold" on a block of messages. This is used to prevent multiple consumers in the same consumer group
 /// from touching the same messages.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct LeaseRow {
     pub stream_id: StreamId,
     pub cg: ConsumerGroup,
@@ -72,12 +72,12 @@ pub(crate) struct LeaseRow {
     pub leased_at: Timestamp,
     /// LeaseRows expire based on the visibility timeout.
     pub expires_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// When the block of messages was acknowledged / processed by a consumer in the group.
     pub acked_at: Option<Timestamp>,
 }
 
-/// For the key, we use a composit of (stream_id, consumer_group, block_end).
+/// For the key, we use a composite of (stream_id, consumer_group, block_end).
 /// This ensures we can easily fetch all of the leases for a (stream_id, consumer_group).
 #[derive(Clone)]
 pub(crate) struct LeaseKey(Vec<u8>);
@@ -128,7 +128,7 @@ pub(crate) struct LeaseDiff {
 impl LeaseDiff {
     pub(crate) fn apply_diff(self, state: &State, batch: &mut OwnedWriteBatch) -> Result<()> {
         for lease in self.to_delete {
-            let key = lease.get_key().into_owned().0;
+            let key = LeaseRow::make_fjall_key(lease.get_key().as_ref());
             batch.remove(&state.metadata_tables, key);
         }
 
@@ -162,7 +162,7 @@ impl LeaseRow {
     /// Any Lease that has expired (it's expiration time is past `now`), can be trivially
     /// deleted.
     ///
-    /// Any leases that where 1) `acked_at.is_some()`, and 2) the message ranges are overlapping,
+    /// Any leases where 1) `acked_at.is_some()`, and 2) the message ranges are overlapping,
     /// can be compacted. This involves deleting the old leases, and replacing them with merged lease.
     pub(crate) fn cull_and_compact(leases: Vec<Self>, now: Timestamp) -> LeaseDiff {
         let mut to_delete = Vec::new();
@@ -241,6 +241,10 @@ impl LeaseRow {
             to_delete,
             to_insert,
         }
+    }
+
+    pub(crate) fn is_active(&self, now: Timestamp) -> bool {
+        self.acked_at.is_none() && self.expires_at > now
     }
 }
 
@@ -370,13 +374,13 @@ impl MsgRow {
 
     /// Fetch up to `batch_size` available messages, in order, from the stream.
     /// Messages captured by the leases are excluded.
-    pub(crate) fn fetch_available(
+    pub(crate) fn fetch_available<'a>(
         state: &State,
         stream_id: StreamId,
-        leases: &[LeaseRow],
+        leases: impl IntoIterator<Item = &'a LeaseRow>,
         batch_size: NonZeroUsize,
     ) -> Result<Vec<(MsgId, MsgRow)>> {
-        let blocked_ranges = merge_lease_ranges(leases);
+        let blocked_ranges = merge_lease_ranges(leases.into_iter());
         let mut msgs_left = batch_size.into();
         let mut results = Vec::with_capacity(msgs_left);
 
@@ -394,7 +398,7 @@ impl MsgRow {
             let n = MsgRow::fetch_in_range(state, range, &mut results, msgs_left)?;
             msgs_left -= n;
 
-            if msgs_left <= 0 {
+            if msgs_left == 0 {
                 return Ok(results);
             }
         }
@@ -416,9 +420,8 @@ struct BlockedRange {
 }
 
 /// Merge and sort lease ranges for the given stream into non-overlapping blocked ranges.
-fn merge_lease_ranges(leases: &[LeaseRow]) -> Vec<BlockedRange> {
+fn merge_lease_ranges<'a>(leases: impl Iterator<Item = &'a LeaseRow>) -> Vec<BlockedRange> {
     let mut ranges: Vec<BlockedRange> = leases
-        .iter()
         .map(|l| BlockedRange {
             start: l.block_start,
             end: l.block_end,
@@ -933,7 +936,7 @@ mod tests {
             let state = test_state("fetch_available_empty_stream");
             let stream_id = StreamId::new_v4();
 
-            let result = MsgRow::fetch_available(&state, stream_id, &[], batch(10)).unwrap();
+            let result = MsgRow::fetch_available(&state, stream_id, [], batch(10)).unwrap();
 
             assert!(result.is_empty());
         }
@@ -944,7 +947,7 @@ mod tests {
             let stream_id = StreamId::new_v4();
             insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
 
-            let result = MsgRow::fetch_available(&state, stream_id, &[], batch(10)).unwrap();
+            let result = MsgRow::fetch_available(&state, stream_id, [], batch(10)).unwrap();
 
             assert_eq!(result.len(), 5);
             assert_eq!(result[0].0, 1);
@@ -960,7 +963,7 @@ mod tests {
             let stream_id = StreamId::new_v4();
             insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-            let result = MsgRow::fetch_available(&state, stream_id, &[], batch(3)).unwrap();
+            let result = MsgRow::fetch_available(&state, stream_id, [], batch(3)).unwrap();
 
             assert_eq!(result.len(), 3);
             assert_eq!(result[0].0, 1);
@@ -1142,7 +1145,7 @@ mod tests {
             let stream_id = StreamId::new_v4();
             insert_msgs(&state, stream_id, &[1, 2, 3]);
 
-            let result = MsgRow::fetch_available(&state, stream_id, &[], batch(10)).unwrap();
+            let result = MsgRow::fetch_available(&state, stream_id, [], batch(10)).unwrap();
 
             assert_eq!(result.len(), 3);
             assert_eq!(result[0].1.payload, b"msg-1");

--- a/crates/stream/src/tables.rs
+++ b/crates/stream/src/tables.rs
@@ -1,11 +1,16 @@
-use std::{borrow::Cow, num::NonZeroU64, ops::RangeInclusive};
+use std::{
+    borrow::Cow,
+    num::{NonZeroU64, NonZeroUsize},
+    ops::RangeInclusive,
+};
 
 use crate::{
     State,
-    entities::{MsgHeaders, MsgId, StreamId},
+    entities::{ConsumerGroup, MsgHeaders, MsgId, StreamId},
 };
 
 use coyote_error::{Error, Result};
+use fjall::OwnedWriteBatch;
 use fjall_utils::TableRow;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -14,6 +19,7 @@ use serde::{Deserialize, Serialize};
 static_assertions::const_assert!(fjall_utils::are_all_unique(&[
     NameToStreamRow::TABLE_PREFIX,
     StreamRow::TABLE_PREFIX,
+    LeaseRow::TABLE_PREFIX,
 ]));
 
 #[derive(Serialize, Deserialize)]
@@ -49,7 +55,209 @@ impl TableRow for StreamRow {
     type Key = StreamId;
 
     fn get_key(&self) -> Cow<'_, Self::Key> {
-        Cow::Borrowed(&self.id)
+        Cow::Owned(self.id)
+    }
+}
+
+/// A lease represents a consumer group's "hold" on a block of messages. This is used to prevent multiple consumers in the same consumer group
+/// from touching the same messages.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct LeaseRow {
+    pub stream_id: StreamId,
+    pub cg: ConsumerGroup,
+    /// The first id of the message in the block held by the LeaseRow.
+    pub block_start: MsgId,
+    /// The last id of the message in the block held by the LeaseRow.
+    pub block_end: MsgId,
+    pub leased_at: Timestamp,
+    /// LeaseRows expire based on the visibility timeout.
+    pub expires_at: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// When the block of messages was acknowledged / processed by a consumer in the group.
+    pub acked_at: Option<Timestamp>,
+}
+
+/// For the key, we use a composit of (stream_id, consumer_group, block_end).
+/// This ensures we can easily fetch all of the leases for a (stream_id, consumer_group).
+#[derive(Clone)]
+pub(crate) struct LeaseKey(Vec<u8>);
+
+impl LeaseKey {
+    pub(crate) fn new(id: StreamId, cg: &ConsumerGroup, block_end: MsgId) -> Self {
+        let msg_id = block_end.to_be_bytes();
+        let id = id.as_bytes();
+
+        let mut key = Vec::with_capacity(id.len() + cg.len() + msg_id.len() + b"\0\0".len());
+        key.extend_from_slice(id);
+        key.extend_from_slice(b"\0");
+        key.extend_from_slice(cg.as_bytes());
+        key.extend_from_slice(b"\0");
+        key.extend_from_slice(&msg_id);
+
+        Self(key)
+    }
+
+    fn prefix(id: StreamId, cg: &ConsumerGroup) -> Vec<u8> {
+        let id_bytes = id.as_bytes();
+        let cg_bytes = cg.as_bytes();
+
+        let mut prefix = Vec::with_capacity(
+            LeaseRow::TABLE_PREFIX.len()
+                + b"\0".len()
+                + id_bytes.len()
+                + b"\0".len()
+                + cg_bytes.len()
+                + b"\0".len(),
+        );
+        prefix.extend_from_slice(LeaseRow::TABLE_PREFIX.as_bytes());
+        prefix.extend_from_slice(b"\0");
+        prefix.extend_from_slice(id_bytes);
+        prefix.extend_from_slice(b"\0");
+        prefix.extend_from_slice(cg_bytes);
+        prefix.extend_from_slice(b"\0");
+
+        prefix
+    }
+}
+
+pub(crate) struct LeaseDiff {
+    pub to_delete: Vec<LeaseRow>,
+    pub to_insert: Vec<LeaseRow>,
+}
+
+impl LeaseDiff {
+    pub(crate) fn apply_diff(self, state: &State, batch: &mut OwnedWriteBatch) -> Result<()> {
+        for lease in self.to_delete {
+            let key = lease.get_key().into_owned().0;
+            batch.remove(&state.metadata_tables, key);
+        }
+
+        for lease in self.to_insert {
+            let (key, val) = lease.to_fjall_entry()?;
+            batch.insert(&state.metadata_tables, key, val);
+        }
+
+        Ok(())
+    }
+}
+
+impl LeaseRow {
+    pub(crate) fn fetch_all(state: &State, id: StreamId, cg: &ConsumerGroup) -> Result<Vec<Self>> {
+        let prefix = LeaseKey::prefix(id, cg);
+
+        state
+            .metadata_tables
+            .prefix(prefix)
+            .map(|entry| {
+                let value = entry.value()?;
+                Self::from_fjall_value(value)
+            })
+            .collect()
+    }
+
+    /// Given a set of Leases, returns a diff describing
+    ///     1. Leases to delete from the database.
+    ///     2. Leases to insert.
+    ///
+    /// Any Lease that has expired (it's expiration time is past `now`), can be trivially
+    /// deleted.
+    ///
+    /// Any leases that where 1) `acked_at.is_some()`, and 2) the message ranges are overlapping,
+    /// can be compacted. This involves deleting the old leases, and replacing them with merged lease.
+    pub(crate) fn cull_and_compact(leases: Vec<Self>, now: Timestamp) -> LeaseDiff {
+        let mut to_delete = Vec::new();
+        let mut to_insert = Vec::new();
+
+        let mut acked_leases: Vec<Self> = Vec::new();
+
+        for lease in leases {
+            if lease.expires_at < now {
+                to_delete.push(lease);
+            } else if lease.acked_at.is_some() {
+                acked_leases.push(lease);
+            }
+        }
+
+        if acked_leases.is_empty() {
+            return LeaseDiff {
+                to_delete,
+                to_insert,
+            };
+        }
+
+        acked_leases.sort_by_key(|l| l.block_start);
+
+        let mut groups: Vec<Vec<Self>> = Vec::new();
+        let mut current_group = vec![acked_leases.remove(0)];
+
+        for lease in acked_leases {
+            let last = current_group.last().unwrap();
+            if last.block_end + 1 >= lease.block_start {
+                current_group.push(lease);
+            } else {
+                groups.push(std::mem::take(&mut current_group));
+                current_group.push(lease);
+            }
+        }
+        groups.push(current_group);
+
+        for group in groups {
+            if group.len() == 1 {
+                continue;
+            }
+
+            let stream_id = group[0].stream_id;
+            let cg = group[0].cg.clone();
+
+            let mut block_start = MsgId::MAX;
+            let mut block_end = MsgId::MIN;
+            let mut leased_at = Timestamp::MAX;
+            let mut expires_at = Timestamp::MIN;
+            let mut acked_at = Timestamp::MIN;
+
+            for lease in group {
+                block_start = block_start.min(lease.block_start);
+                block_end = block_end.max(lease.block_end);
+                leased_at = leased_at.min(lease.leased_at);
+                expires_at = expires_at.max(lease.expires_at);
+                if let Some(ack) = lease.acked_at {
+                    acked_at = acked_at.max(ack);
+                }
+                to_delete.push(lease);
+            }
+
+            to_insert.push(Self {
+                stream_id,
+                cg,
+                block_start,
+                block_end,
+                leased_at,
+                expires_at,
+                acked_at: Some(acked_at),
+            });
+        }
+
+        LeaseDiff {
+            to_delete,
+            to_insert,
+        }
+    }
+}
+
+impl AsRef<[u8]> for LeaseKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl TableRow for LeaseRow {
+    const TABLE_PREFIX: &'static str = "_CSLEASE_";
+
+    type Key = LeaseKey;
+
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        let key = LeaseKey::new(self.stream_id, &self.cg, self.block_end);
+        Cow::Owned(key)
     }
 }
 
@@ -63,7 +271,6 @@ impl TableRow for StreamRow {
 #[derive(Serialize, Deserialize)]
 pub(crate) struct MsgRow {
     pub payload: Vec<u8>,
-    #[serde(skip_serializing_if = "MsgHeaders::is_empty")]
     pub headers: MsgHeaders,
     pub created_at: Timestamp,
 }
@@ -100,12 +307,11 @@ fn msg_row_key_range(s_id: StreamId, range: RangeInclusive<MsgId>) -> RangeInclu
 }
 
 impl MsgRow {
-    /// Returns the *next* id for a msg in the stream.
-    pub(crate) fn get_next_msg_id_in_stream(state: &State, stream_id: StreamId) -> Result<MsgId> {
+    pub(crate) fn max_id_in_stream(state: &State, stream_id: StreamId) -> Result<Option<MsgId>> {
         let range = msg_row_key_range(stream_id, MsgId::MIN..=MsgId::MAX);
 
         let Some(max_entry) = state.msg_table.range(range).next_back() else {
-            return Ok(MsgId::MIN);
+            return Ok(None);
         };
 
         let key: MsgRowKey = max_entry
@@ -116,7 +322,15 @@ impl MsgRow {
 
         let msg_id = parse_msg_id(key)?;
 
-        Ok(msg_id + 1)
+        Ok(Some(msg_id))
+    }
+
+    /// Returns the *next* id for a msg in the stream.
+    pub(crate) fn get_next_msg_id_in_stream(state: &State, stream_id: StreamId) -> Result<MsgId> {
+        match Self::max_id_in_stream(state, stream_id)? {
+            None => Ok(MsgId::MIN),
+            Some(id) => Ok(id + 1),
+        }
     }
 
     pub(crate) fn to_fjall_value(&self) -> Result<fjall::UserValue> {
@@ -124,11 +338,501 @@ impl MsgRow {
             .map(fjall::UserValue::from)
             .map_err(Error::generic)
     }
+
+    /// Fetches messages in the specified range, filling up the buffer with at most batch_size msgs.
+    ///
+    /// Returns the number msgs fetched successfully.
+    fn fetch_in_range(
+        state: &State,
+        range: RangeInclusive<MsgRowKey>,
+        buf: &mut Vec<(MsgId, MsgRow)>,
+        batch_size: usize,
+    ) -> Result<usize> {
+        let mut n = 0;
+
+        let msgs = state.msg_table.range(range).take(batch_size);
+
+        for entry in msgs {
+            let (key_slice, val_slice) = entry.into_inner()?;
+
+            let key: MsgRowKey = key_slice.as_ref().try_into().map_err(Error::generic)?;
+
+            let msg_id = parse_msg_id(key)?;
+
+            let msg_row: MsgRow = rmp_serde::from_slice(&val_slice).map_err(Error::generic)?;
+
+            buf.push((msg_id, msg_row));
+            n += 1;
+        }
+
+        Ok(n)
+    }
+
+    /// Fetch up to `batch_size` available messages, in order, from the stream.
+    /// Messages captured by the leases are excluded.
+    pub(crate) fn fetch_available(
+        state: &State,
+        stream_id: StreamId,
+        leases: &[LeaseRow],
+        batch_size: NonZeroUsize,
+    ) -> Result<Vec<(MsgId, MsgRow)>> {
+        let blocked_ranges = merge_lease_ranges(leases);
+        let mut msgs_left = batch_size.into();
+        let mut results = Vec::with_capacity(msgs_left);
+
+        let mut min = MsgId::MIN;
+        for block in blocked_ranges {
+            let max = block.start.saturating_sub(1);
+            if max == MsgId::MIN {
+                min = block.end + 1;
+                continue;
+            }
+
+            let range = msg_row_key_range(stream_id, min..=max);
+            min = block.end + 1;
+
+            let n = MsgRow::fetch_in_range(state, range, &mut results, msgs_left)?;
+            msgs_left -= n;
+
+            if msgs_left <= 0 {
+                return Ok(results);
+            }
+        }
+
+        if msgs_left > 0 {
+            let range = msg_row_key_range(stream_id, min..=MsgId::MAX);
+            MsgRow::fetch_in_range(state, range, &mut results, msgs_left)?;
+        }
+
+        Ok(results)
+    }
+}
+
+#[derive(Debug)]
+/// A range of message IDs that are blocked by leases.
+struct BlockedRange {
+    start: MsgId,
+    end: MsgId,
+}
+
+/// Merge and sort lease ranges for the given stream into non-overlapping blocked ranges.
+fn merge_lease_ranges(leases: &[LeaseRow]) -> Vec<BlockedRange> {
+    let mut ranges: Vec<BlockedRange> = leases
+        .iter()
+        .map(|l| BlockedRange {
+            start: l.block_start,
+            end: l.block_end,
+        })
+        .collect();
+
+    if ranges.len() <= 1 {
+        return ranges;
+    }
+
+    ranges.sort_by_key(|r| r.start);
+
+    let mut merged = Vec::with_capacity(ranges.len());
+    let mut current = ranges.remove(0);
+
+    for range in ranges {
+        // Check for overlap or adjacency.
+        if range.start <= current.end.saturating_add(1) {
+            current.end = current.end.max(range.end);
+        } else {
+            merged.push(current);
+            current = range;
+        }
+    }
+    merged.push(current);
+
+    merged
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ts(secs: i64) -> Timestamp {
+        Timestamp::from_second(secs).unwrap()
+    }
+
+    #[test]
+    fn cull_and_compact_expired_lease_is_deleted() {
+        let stream_id = StreamId::new_v4();
+        let lease = LeaseRow {
+            stream_id,
+            cg: "cg1".to_string(),
+            block_start: 1,
+            block_end: 5,
+            leased_at: ts(0),
+            expires_at: ts(50),
+            acked_at: None,
+        };
+
+        let diff = LeaseRow::cull_and_compact(vec![lease.clone()], ts(100));
+
+        assert_eq!(diff.to_delete.len(), 1);
+        assert_eq!(diff.to_delete[0], lease);
+        assert!(diff.to_insert.is_empty());
+    }
+
+    #[test]
+    fn cull_and_compact_active_lease_unchanged() {
+        let stream_id = StreamId::new_v4();
+        let lease = LeaseRow {
+            stream_id,
+            cg: "cg1".to_string(),
+            block_start: 1,
+            block_end: 5,
+            leased_at: ts(0),
+            expires_at: ts(200),
+            acked_at: None,
+        };
+
+        let diff = LeaseRow::cull_and_compact(vec![lease], ts(100));
+
+        assert!(diff.to_delete.is_empty());
+        assert!(diff.to_insert.is_empty());
+    }
+
+    #[test]
+    fn cull_and_compact_single_acked_lease_unchanged() {
+        let stream_id = StreamId::new_v4();
+        let lease = LeaseRow {
+            stream_id,
+            cg: "cg1".to_string(),
+            block_start: 1,
+            block_end: 5,
+            leased_at: ts(0),
+            expires_at: ts(200),
+            acked_at: Some(ts(50)),
+        };
+
+        let diff = LeaseRow::cull_and_compact(vec![lease], ts(100));
+
+        assert!(diff.to_delete.is_empty());
+        assert!(diff.to_insert.is_empty());
+    }
+
+    #[test]
+    fn cull_and_compact_multiple_expired_leases_all_deleted() {
+        let stream_id = StreamId::new_v4();
+        let leases = vec![
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 1,
+                block_end: 5,
+                leased_at: ts(0),
+                expires_at: ts(50),
+                acked_at: None,
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 6,
+                block_end: 10,
+                leased_at: ts(0),
+                expires_at: ts(60),
+                acked_at: None,
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 20,
+                block_end: 25,
+                leased_at: ts(0),
+                expires_at: ts(70),
+                acked_at: None,
+            },
+        ];
+
+        let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+        assert_eq!(diff.to_delete.len(), 3);
+        assert!(diff.to_insert.is_empty());
+    }
+
+    #[test]
+    fn cull_and_compact_multiple_active_leases_unchanged() {
+        let stream_id = StreamId::new_v4();
+        let leases = vec![
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 1,
+                block_end: 5,
+                leased_at: ts(0),
+                expires_at: ts(200),
+                acked_at: None,
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 6,
+                block_end: 10,
+                leased_at: ts(0),
+                expires_at: ts(200),
+                acked_at: None,
+            },
+        ];
+
+        let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+        assert!(diff.to_delete.is_empty());
+        assert!(diff.to_insert.is_empty());
+    }
+
+    #[test]
+    fn cull_and_compact_two_adjacent_acked_leases_are_compacted() {
+        let stream_id = StreamId::new_v4();
+        let leases = vec![
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 1,
+                block_end: 5,
+                leased_at: ts(10),
+                expires_at: ts(200),
+                acked_at: Some(ts(20)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 6,
+                block_end: 10,
+                leased_at: ts(15),
+                expires_at: ts(200),
+                acked_at: Some(ts(25)),
+            },
+        ];
+
+        let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+        assert_eq!(diff.to_delete.len(), 2);
+        assert_eq!(diff.to_insert.len(), 1);
+
+        let merged = &diff.to_insert[0];
+        assert_eq!(merged.block_start, 1);
+        assert_eq!(merged.block_end, 10);
+        assert_eq!(merged.acked_at, Some(ts(25)));
+    }
+
+    #[test]
+    fn cull_and_compact_two_overlapping_acked_leases_are_compacted() {
+        let stream_id = StreamId::new_v4();
+        let leases = vec![
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 1,
+                block_end: 7,
+                leased_at: ts(10),
+                expires_at: ts(200),
+                acked_at: Some(ts(20)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 5,
+                block_end: 12,
+                leased_at: ts(15),
+                expires_at: ts(200),
+                acked_at: Some(ts(25)),
+            },
+        ];
+
+        let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+        assert_eq!(diff.to_delete.len(), 2);
+        assert_eq!(diff.to_insert.len(), 1);
+
+        let merged = &diff.to_insert[0];
+        assert_eq!(merged.block_start, 1);
+        assert_eq!(merged.block_end, 12);
+    }
+
+    #[test]
+    fn cull_and_compact_two_non_adjacent_acked_leases_not_compacted() {
+        let stream_id = StreamId::new_v4();
+        let leases = vec![
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 1,
+                block_end: 5,
+                leased_at: ts(10),
+                expires_at: ts(200),
+                acked_at: Some(ts(20)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 10,
+                block_end: 15,
+                leased_at: ts(15),
+                expires_at: ts(200),
+                acked_at: Some(ts(25)),
+            },
+        ];
+
+        let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+        assert!(diff.to_delete.is_empty());
+        assert!(diff.to_insert.is_empty());
+    }
+
+    #[test]
+    fn cull_and_compact_chain_of_adjacent_acked_leases_all_compacted() {
+        let stream_id = StreamId::new_v4();
+        let leases = vec![
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 1,
+                block_end: 5,
+                leased_at: ts(10),
+                expires_at: ts(200),
+                acked_at: Some(ts(20)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 6,
+                block_end: 10,
+                leased_at: ts(15),
+                expires_at: ts(200),
+                acked_at: Some(ts(25)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 11,
+                block_end: 15,
+                leased_at: ts(18),
+                expires_at: ts(200),
+                acked_at: Some(ts(30)),
+            },
+        ];
+
+        let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+        assert_eq!(diff.to_delete.len(), 3);
+        assert_eq!(diff.to_insert.len(), 1);
+
+        let merged = &diff.to_insert[0];
+        assert_eq!(merged.block_start, 1);
+        assert_eq!(merged.block_end, 15);
+        assert_eq!(merged.acked_at, Some(ts(30)));
+    }
+
+    #[test]
+    fn cull_and_compact_mixed_expired_active_and_acked() {
+        let stream_id = StreamId::new_v4();
+        let leases = vec![
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 1,
+                block_end: 5,
+                leased_at: ts(0),
+                expires_at: ts(50),
+                acked_at: None,
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 6,
+                block_end: 10,
+                leased_at: ts(0),
+                expires_at: ts(200),
+                acked_at: None,
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 20,
+                block_end: 25,
+                leased_at: ts(0),
+                expires_at: ts(200),
+                acked_at: Some(ts(50)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 26,
+                block_end: 30,
+                leased_at: ts(0),
+                expires_at: ts(200),
+                acked_at: Some(ts(55)),
+            },
+        ];
+
+        let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+        assert_eq!(diff.to_delete.len(), 3);
+        assert_eq!(diff.to_insert.len(), 1);
+
+        let merged = &diff.to_insert[0];
+        assert_eq!(merged.block_start, 20);
+        assert_eq!(merged.block_end, 30);
+    }
+
+    #[test]
+    fn cull_and_compact_multiple_separate_groups_of_acked_leases() {
+        let stream_id = StreamId::new_v4();
+        let leases = vec![
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 1,
+                block_end: 5,
+                leased_at: ts(10),
+                expires_at: ts(200),
+                acked_at: Some(ts(20)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 6,
+                block_end: 10,
+                leased_at: ts(15),
+                expires_at: ts(200),
+                acked_at: Some(ts(25)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 50,
+                block_end: 55,
+                leased_at: ts(10),
+                expires_at: ts(200),
+                acked_at: Some(ts(20)),
+            },
+            LeaseRow {
+                stream_id,
+                cg: ConsumerGroup::from("cg1".to_string()),
+                block_start: 56,
+                block_end: 60,
+                leased_at: ts(15),
+                expires_at: ts(200),
+                acked_at: Some(ts(25)),
+            },
+        ];
+
+        let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+        assert_eq!(diff.to_delete.len(), 4);
+        assert_eq!(diff.to_insert.len(), 2);
+
+        let mut merged: Vec<_> = diff.to_insert.iter().collect();
+        merged.sort_by_key(|l| l.block_start);
+
+        assert_eq!(merged[0].block_start, 1);
+        assert_eq!(merged[0].block_end, 10);
+        assert_eq!(merged[1].block_start, 50);
+        assert_eq!(merged[1].block_end, 60);
+    }
 
     #[test]
     fn msg_row_keys_are_sorted_correctly() {
@@ -178,5 +882,311 @@ mod tests {
         assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, MsgId::MAX - 1));
         assert_eq!(s2_msgs.next().unwrap(), msg_row_key(s2, MsgId::MAX));
         assert_eq!(s2_msgs.next(), None);
+    }
+
+    mod fetch_available_tests {
+        use super::*;
+
+        fn test_state(name: &str) -> State {
+            let db = fjall::Database::builder(name)
+                .temporary(true)
+                .open()
+                .unwrap();
+            State::init(db).unwrap()
+        }
+
+        fn insert_msg(state: &State, stream_id: StreamId, msg_id: MsgId) {
+            let row = MsgRow {
+                payload: format!("msg-{msg_id}").into_bytes(),
+                headers: MsgHeaders::new(),
+                created_at: ts(msg_id as i64),
+            };
+            let key = msg_row_key(stream_id, msg_id);
+            let val = row.to_fjall_value().unwrap();
+            state.msg_table.insert(key, val).unwrap();
+        }
+
+        fn insert_msgs(state: &State, stream_id: StreamId, ids: &[MsgId]) {
+            for &id in ids {
+                insert_msg(state, stream_id, id);
+            }
+        }
+
+        fn lease(stream_id: StreamId, block_start: MsgId, block_end: MsgId) -> LeaseRow {
+            LeaseRow {
+                stream_id,
+                cg: "test-cg".to_string(),
+                block_start,
+                block_end,
+                leased_at: ts(0),
+                expires_at: ts(1000),
+                acked_at: None,
+            }
+        }
+
+        fn batch(n: usize) -> NonZeroUsize {
+            NonZeroUsize::new(n).unwrap()
+        }
+
+        #[test]
+        fn empty_stream_returns_empty() {
+            let state = test_state("fetch_available_empty_stream");
+            let stream_id = StreamId::new_v4();
+
+            let result = MsgRow::fetch_available(&state, stream_id, &[], batch(10)).unwrap();
+
+            assert!(result.is_empty());
+        }
+
+        #[test]
+        fn no_leases_returns_messages_in_order() {
+            let state = test_state("fetch_available_no_leases");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
+
+            let result = MsgRow::fetch_available(&state, stream_id, &[], batch(10)).unwrap();
+
+            assert_eq!(result.len(), 5);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 2);
+            assert_eq!(result[2].0, 3);
+            assert_eq!(result[3].0, 4);
+            assert_eq!(result[4].0, 5);
+        }
+
+        #[test]
+        fn batch_size_limits_results() {
+            let state = test_state("fetch_available_batch_size_limits");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let result = MsgRow::fetch_available(&state, stream_id, &[], batch(3)).unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 2);
+            assert_eq!(result[2].0, 3);
+        }
+
+        #[test]
+        fn all_messages_leased_returns_empty() {
+            let state = test_state("fetch_available_all_leased");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
+
+            let leases = vec![lease(stream_id, 1, 5)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert!(result.is_empty());
+        }
+
+        #[test]
+        fn lease_at_start_skips_leased_messages() {
+            let state = test_state("fetch_available_lease_at_start");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
+
+            let leases = vec![lease(stream_id, 1, 2)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0].0, 3);
+            assert_eq!(result[1].0, 4);
+            assert_eq!(result[2].0, 5);
+        }
+
+        #[test]
+        fn lease_at_end_returns_messages_before_lease() {
+            let state = test_state("fetch_available_lease_at_end");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
+
+            let leases = vec![lease(stream_id, 4, 5)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 2);
+            assert_eq!(result[2].0, 3);
+        }
+
+        #[test]
+        fn lease_in_middle_returns_messages_on_both_sides() {
+            let state = test_state("fetch_available_lease_in_middle");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
+
+            let leases = vec![lease(stream_id, 2, 4)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 5);
+        }
+
+        #[test]
+        fn multiple_leases_with_gap_returns_gap_messages() {
+            let state = test_state("fetch_available_multiple_leases_gap");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            let leases = vec![lease(stream_id, 1, 3), lease(stream_id, 7, 10)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0].0, 4);
+            assert_eq!(result[1].0, 5);
+            assert_eq!(result[2].0, 6);
+        }
+
+        #[test]
+        fn overlapping_leases_are_handled() {
+            let state = test_state("fetch_available_overlapping_leases");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            // Overlapping leases: 1-5 and 3-7
+            let leases = vec![lease(stream_id, 1, 5), lease(stream_id, 3, 7)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0].0, 8);
+            assert_eq!(result[1].0, 9);
+            assert_eq!(result[2].0, 10);
+        }
+
+        #[test]
+        fn adjacent_leases_block_full_range() {
+            let state = test_state("fetch_available_adjacent_leases");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            // Adjacent leases: 1-5 and 6-10
+            let leases = vec![lease(stream_id, 1, 5), lease(stream_id, 6, 10)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert!(result.is_empty());
+        }
+
+        #[test]
+        fn batch_size_respects_limit_with_leases() {
+            let state = test_state("fetch_available_batch_with_leases");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            // Lease at start
+            let leases = vec![lease(stream_id, 1, 3)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(2)).unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0].0, 4);
+            assert_eq!(result[1].0, 5);
+        }
+
+        #[test]
+        fn sparse_messages_with_leases() {
+            let state = test_state("fetch_available_sparse_messages");
+            let stream_id = StreamId::new_v4();
+            // Sparse message IDs
+            insert_msgs(&state, stream_id, &[10, 20, 30, 40, 50]);
+
+            // Lease covers 15-35, blocking messages 20 and 30
+            let leases = vec![lease(stream_id, 15, 35)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0].0, 10);
+            assert_eq!(result[1].0, 40);
+            assert_eq!(result[2].0, 50);
+        }
+
+        #[test]
+        fn single_message_leased() {
+            let state = test_state("fetch_available_single_msg_leased");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
+
+            // Lease covers only message 3
+            let leases = vec![lease(stream_id, 3, 3)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 4);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 2);
+            assert_eq!(result[2].0, 4);
+            assert_eq!(result[3].0, 5);
+        }
+
+        #[test]
+        fn unsorted_leases_handled_correctly() {
+            let state = test_state("fetch_available_unsorted_leases");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            // Leases provided out of order
+            let leases = vec![lease(stream_id, 7, 8), lease(stream_id, 2, 3)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 6);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 4);
+            assert_eq!(result[2].0, 5);
+            assert_eq!(result[3].0, 6);
+            assert_eq!(result[4].0, 9);
+            assert_eq!(result[5].0, 10);
+        }
+
+        #[test]
+        fn returned_msg_payload_is_correct() {
+            let state = test_state("fetch_available_payload_correct");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3]);
+
+            let result = MsgRow::fetch_available(&state, stream_id, &[], batch(10)).unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0].1.payload, b"msg-1");
+            assert_eq!(result[1].1.payload, b"msg-2");
+            assert_eq!(result[2].1.payload, b"msg-3");
+        }
+
+        #[test]
+        fn lease_boundary_exactly_at_message() {
+            let state = test_state("fetch_available_boundary_exact");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
+
+            // Lease starts exactly at msg 2 and ends exactly at msg 4
+            let leases = vec![lease(stream_id, 2, 4)];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 5);
+        }
+
+        #[test]
+        fn many_small_leases() {
+            let state = test_state("fetch_available_many_small_leases");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            // Many single-message leases blocking even numbers
+            let leases = vec![
+                lease(stream_id, 2, 2),
+                lease(stream_id, 4, 4),
+                lease(stream_id, 6, 6),
+                lease(stream_id, 8, 8),
+                lease(stream_id, 10, 10),
+            ];
+            let result = MsgRow::fetch_available(&state, stream_id, &leases, batch(10)).unwrap();
+
+            assert_eq!(result.len(), 5);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 3);
+            assert_eq!(result[2].0, 5);
+            assert_eq!(result[3].0, 7);
+            assert_eq!(result[4].0, 9);
+        }
     }
 }

--- a/src/v1/endpoints/stream.rs
+++ b/src/v1/endpoints/stream.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::num::NonZeroU64;
+use std::{
+    num::{NonZeroU16, NonZeroU64},
+    time::Duration,
+};
 
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Json, extract::State};
@@ -11,8 +14,8 @@ use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use stream::{
-    entities::{MsgId, StreamId},
-    operations::{CreateStreamOutput, MsgIn},
+    entities::{ConsumerGroup, MsgId, MsgIn, MsgOut, StreamId},
+    operations::CreateStreamOutput,
 };
 use validator::Validate;
 
@@ -131,6 +134,105 @@ async fn append_to_stream(
     }))
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchFromStreamIn {
+    stream_id: StreamId,
+    consumer_group: ConsumerGroup,
+
+    /// How many messages to read from the stream.
+    batch_size: NonZeroU16,
+
+    /// How long messages are locked by the consumer.
+    visibility_timeout_seconds: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchFromStreamOut {
+    msgs: Vec<MsgOut>,
+}
+
+/// Fetches messages from the stream, locking over the consumer group.
+///
+/// This call prevents other consumers within the same consumer group from reading from the stream
+/// until either the visibility timeout expires, or the last message in the batch is acknowledged.
+#[aide_annotate(op_id = "v1.stream.fetch-locking")]
+async fn locking_fetch_from_stream(
+    State(AppState { stream_state, .. }): State<AppState>,
+    ValidatedJson(data): ValidatedJson<FetchFromStreamIn>,
+) -> Result<Json<FetchFromStreamOut>> {
+    /*
+    FIXME(@svix-gabriel)
+
+    This is missing a few important things
+        1. We haven't setup thread-per-core, so this could go to any thread.
+        2. We haven't setup quorum/raft stuff yet, so there's no consensus..
+
+    I didn't want to let either of these things block developing stream,
+    so in practice the structure of this handler will look different once those two pieces are in place.
+    */
+
+    let out = tokio::task::spawn_blocking(move || {
+        let op = stream::operations::FetchLocking::new(
+            &stream_state,
+            data.stream_id,
+            data.consumer_group,
+            data.batch_size,
+            Duration::from_secs(data.visibility_timeout_seconds),
+        )?;
+        op.apply_operation(&stream_state)
+    })
+    .await??;
+
+    Ok(Json(FetchFromStreamOut { msgs: out.msgs }))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AckIn {
+    stream_id: StreamId,
+    consumer_group: ConsumerGroup,
+    min_msg_id: Option<MsgId>,
+    max_msg_id: MsgId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AckOut {}
+
+/// Acks the messages for the consumer group, allowing more messages to be consumed.
+#[aide_annotate(op_id = "v1.stream.ack")]
+async fn ack(
+    State(AppState { stream_state, .. }): State<AppState>,
+    ValidatedJson(data): ValidatedJson<AckIn>,
+) -> Result<Json<AckOut>> {
+    /*
+    FIXME(@svix-gabriel)
+
+    This is missing a few important things
+        1. We haven't setup thread-per-core, so this could go to any thread.
+        2. We haven't setup quorum/raft stuff yet, so there's no consensus..
+
+    I didn't want to let either of these things block developing stream,
+    so in practice the structure of this handler will look different once those two pieces are in place.
+    */
+
+    let _out = tokio::task::spawn_blocking(move || {
+        let op = stream::operations::Ack::new(
+            &stream_state,
+            data.stream_id,
+            data.consumer_group,
+            data.min_msg_id.unwrap_or(MsgId::MIN),
+            data.max_msg_id,
+        )?;
+        op.apply_operation(&stream_state)
+    })
+    .await??;
+
+    Ok(Json(AckOut {}))
+}
+
 pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Stream");
 
@@ -145,4 +247,13 @@ pub fn router() -> ApiRouter<AppState> {
             post_with(append_to_stream, append_to_stream_operation),
             &tag,
         )
+        .api_route_with(
+            "/stream/fetch-locking",
+            post_with(
+                locking_fetch_from_stream,
+                locking_fetch_from_stream_operation,
+            ),
+            &tag,
+        )
+        .api_route_with("/stream/ack", post_with(ack, ack_operation), &tag)
 }

--- a/tests/it/stream.rs
+++ b/tests/it/stream.rs
@@ -1,8 +1,10 @@
+use std::time::Duration;
+
 use serde_json::json;
 use test_utils::{StatusCode, TestResult};
 
 #[tokio::test]
-async fn test_create_stream() -> TestResult {
+async fn create_stream_upserts() -> TestResult {
     let (client, _server_handle) = super::start_server().await;
 
     let response = client
@@ -54,13 +56,33 @@ async fn test_create_stream() -> TestResult {
         })
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn stream_append_and_locking_consumption() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    let stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    let id = &stream["id"];
+
     client
         .post("stream/append")
         .json(json!({
             "streamId": id,
             "msgs": [
-                {"payload": [1, 2, 3], "headers": {}},
-                {"payload": [4, 5, 6], "headers": {"key": "value"}}
+                {"payload": [1, 2], "headers": {"msg": "1"}},
+                {"payload": [3, 4], "headers": {"msg": "2"}},
+                {"payload": [5, 6], "headers": {"msg": "3"}},
             ]
         }))
         .await?
@@ -71,11 +93,158 @@ async fn test_create_stream() -> TestResult {
         .json(json!({
             "streamId": id,
             "msgs": [
-                {"payload": [7, 8, 9], "headers": {}}
+                {"payload": [7, 8], "headers": {"msg": "4"}},
+                {"payload": [9, 10], "headers": {"msg": "5"}},
             ]
         }))
         .await?
         .expect(StatusCode::OK);
+
+    // Fetch first batch of 3 messages
+    let fetch1 = client
+        .post("stream/fetch-locking")
+        .json(json!({
+            "streamId": id,
+            "consumerGroup": "test-group",
+            "batchSize": 3,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 3);
+    assert_eq!(
+        msgs1[0],
+        json!({"id": 0, "payload": [1, 2], "headers": {"msg": "1"}, "timestamp": msgs1[0]["timestamp"]})
+    );
+    assert_eq!(
+        msgs1[1],
+        json!({"id": 1, "payload": [3, 4], "headers": {"msg": "2"}, "timestamp": msgs1[1]["timestamp"]})
+    );
+    assert_eq!(
+        msgs1[2],
+        json!({"id": 2, "payload": [5, 6], "headers": {"msg": "3"}, "timestamp": msgs1[2]["timestamp"]})
+    );
+
+    // Ack the first batch
+    let max_msg_id = &msgs1[2]["id"];
+    client
+        .post("stream/ack")
+        .json(json!({
+            "streamId": id,
+            "consumerGroup": "test-group",
+            "maxMsgId": max_msg_id
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch second batch - should get remaining 2 messages
+    let fetch2 = client
+        .post("stream/fetch-locking")
+        .json(json!({
+            "streamId": id,
+            "consumerGroup": "test-group",
+            "batchSize": 3,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 2);
+    assert_eq!(
+        msgs2[0],
+        json!({"id": 3, "payload": [7, 8], "headers": {"msg": "4"}, "timestamp": msgs2[0]["timestamp"]})
+    );
+    assert_eq!(
+        msgs2[1],
+        json!({"id": 4, "payload": [9, 10], "headers": {"msg": "5"}, "timestamp": msgs2[1]["timestamp"]})
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn stream_visibility_timeout() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    let stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    let id = &stream["id"];
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "streamId": id,
+            "msgs": [
+                {"payload": [1, 2], "headers": {"msg": "1"}},
+                {"payload": [3, 4], "headers": {"msg": "2"}},
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch messages with a short visibility timeout (1 second)
+    let fetch1 = client
+        .post("stream/fetch-locking")
+        .json(json!({
+            "streamId": id,
+            "consumerGroup": "test-group",
+            "batchSize": 3,
+            "visibilityTimeoutSeconds": 1
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 2);
+    assert_eq!(
+        msgs1[0],
+        json!({"id": 0, "payload": [1, 2], "headers": {"msg": "1"}, "timestamp": msgs1[0]["timestamp"]})
+    );
+    assert_eq!(
+        msgs1[1],
+        json!({"id": 1, "payload": [3, 4], "headers": {"msg": "2"}, "timestamp": msgs1[1]["timestamp"]})
+    );
+
+    // Wait for the visibility timeout to expire
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Fetch again - should get the same messages since they weren't acked
+    let fetch2 = client
+        .post("stream/fetch-locking")
+        .json(json!({
+            "streamId": id,
+            "consumerGroup": "test-group",
+            "batchSize": 3,
+            "visibilityTimeoutSeconds": 1
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 2);
+    assert_eq!(
+        msgs2[0],
+        json!({"id": 0, "payload": [1, 2], "headers": {"msg": "1"}, "timestamp": msgs2[0]["timestamp"]})
+    );
+    assert_eq!(
+        msgs2[1],
+        json!({"id": 1, "payload": [3, 4], "headers": {"msg": "2"}, "timestamp": msgs2[1]["timestamp"]})
+    );
 
     Ok(())
 }


### PR DESCRIPTION
(Sorry for the heckin-chonker PR. It's a lot of tests, so the diff isn't as bad as it looks).

This implements `stream.fetch-locking`, which consumes messages from the Stream using "Stream semantics" (head of line blocking, no concurrent consumers form the same consumer group).

This also implements `stream.ack`, which will work for both `stream.fetch-locking`, as well as the "queue" variation for consuming messages.

How I recommend viewing this PR

1. First, I'd look at the new tests for fetch-locking and ack functionality. [here](https://github.com/svix/coyote-private/pull/41/changes#diff-03b82057a4ff27433313ee9e4ade0876d63e1d3a72a46ee1952445c82bf8e435). This should hopefully be semi-convincing that the core feature works, so you can understand the guarantees made by the new RPC calls.
2. Then, I'd look at the first commit in isolation: [Add helper methods for interacting with Leases](https://github.com/svix/coyote-private/pull/41/changes/f70314da2cb84d5c9dac43908260989fdfadd6d6). This adds the Lease table, and a bunch of helper methods for working with Leases. (These are the same Leases described in the original [Stream RFC](https://github.com/svix/rfc/pull/38/changes)). 
3. Finally, the last commit, which implements the operations and RPC calls on top of the helper methods. This commit is much more straightforward than the others.

The Lease logic here is fairly complicated, but I opted to implement it fully in this PR, because it will make the `queue` implementation much more straightforward, since queue semantics will use Leases as well.

# TODOs
- As shown in the demo, this uses `streamIds`. I'll fix this in a later PR so users can just pass in the stream name, and we don't expose the ID at all.