### PR TITLE
Config groups, first pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "config",
+ "coyote-configgroup",
  "coyote-derive",
  "coyote-error",
  "coyote-kv",
@@ -959,6 +960,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "coyote-configgroup"
+version = "1.76.1"
+dependencies = [
+ "coyote-error",
+ "fjall",
+ "fjall-utils",
+ "jiff",
+ "schemars 1.2.0",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "coyote-derive"
 version = "1.76.1"
 dependencies = [
@@ -986,6 +1000,7 @@ dependencies = [
 name = "coyote-kv"
 version = "1.76.1"
 dependencies = [
+ "coyote-configgroup",
  "coyote-error",
  "fjall",
  "fjall-utils",
@@ -999,6 +1014,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ axum-extra.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
 config.workspace = true
+coyote-configgroup.workspace = true
 coyote-derive.workspace = true
 coyote-error.workspace = true
 coyote-kv.workspace = true
@@ -111,6 +112,7 @@ concolor-clap = "0.1.0"
 config = { version = "0.15.19", default-features = false, features = ["toml"] }
 coyote.path = "."
 coyote-client.path = "clients/rust"
+coyote-configgroup.path = "crates/coyote-configgroup"
 coyote-derive.path = "crates/coyote-derive"
 coyote-error.path = "crates/coyote-error"
 coyote-kv.path = "crates/kv"

--- a/config.default.toml
+++ b/config.default.toml
@@ -37,9 +37,6 @@ persistent_db.path = "./db"
 # Directory where ephemeral database is stored.
 ephemeral_db.path = "./db"
 
-# Directory where management data is stored
-management_db.path = "./db"
-
 [cluster]
 # The address to listen on for replication traffic
 listen_address = "0.0.0.0:18050"

--- a/crates/coyote-configgroup/Cargo.toml
+++ b/crates/coyote-configgroup/Cargo.toml
@@ -1,28 +1,18 @@
 [package]
-name = "coyote-kv"
+name = "coyote-configgroup"
 edition = "2024"
 license.workspace = true
 version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-coyote-configgroup.workspace = true
 coyote-error.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true
-format-bytes = "0.3.0"
-hashlink.workspace = true
-hex.workspace = true
 jiff.workspace = true
-rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
-static_assertions.workspace = true
-tokio.workspace = true
-tracing.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true
+uuid.workspace = true
 
 [lints]
 workspace = true

--- a/crates/coyote-configgroup/src/entities.rs
+++ b/crates/coyote-configgroup/src/entities.rs
@@ -1,0 +1,128 @@
+use std::fmt::{self, Debug, Display, Formatter};
+use std::num::NonZeroU64;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use uuid::Uuid;
+
+pub type ConfigGroupId = Uuid;
+
+#[derive(Serialize, Deserialize)]
+#[repr(u32)]
+pub enum Module {
+    Cache = 1,
+    Idempotency = 2,
+    KeyValue = 3,
+    RateLimiter = 4,
+    Stream = 5,
+}
+
+// This shouldn't be needed when we're writing keys as bytes
+impl Display for Module {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Module::Cache => 1,
+            Module::Idempotency => 2,
+            Module::KeyValue => 3,
+            Module::RateLimiter => 4,
+            Module::Stream => 5,
+        };
+        write!(f, "{value}")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum StorageType {
+    Persistent = 0,
+    Ephemeral = 1,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+pub enum EvictionPolicy {
+    #[default]
+    NoEviction,
+    LeastRecentlyUsed,
+}
+
+pub trait ModuleConfig:
+    Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + JsonSchema
+{
+    const TABLE_PREFIX: &'static str;
+
+    fn module() -> Module;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct KeyValueConfig {}
+
+impl KeyValueConfig {
+    pub const NAMESPACE: &'static str = "kv_store";
+}
+
+impl KeyValueConfig {
+    pub fn eviction_policy(&self) -> EvictionPolicy {
+        EvictionPolicy::NoEviction
+    }
+}
+
+impl ModuleConfig for KeyValueConfig {
+    const TABLE_PREFIX: &'static str = "_CONFIG_KV_";
+
+    fn module() -> Module {
+        Module::KeyValue
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct CacheConfig {
+    pub eviction_policy: EvictionPolicy,
+}
+
+impl CacheConfig {
+    pub const NAMESPACE: &'static str = "cache_store";
+
+    pub fn eviction_policy(&self) -> EvictionPolicy {
+        self.eviction_policy
+    }
+}
+
+impl ModuleConfig for CacheConfig {
+    const TABLE_PREFIX: &'static str = "_CONFIG_CACHE_";
+
+    fn module() -> Module {
+        Module::Cache
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct StreamConfig {
+    pub retention_period_seconds: Option<NonZeroU64>,
+    pub max_bytes_size: u64,
+    pub storage_type: Option<StorageType>,
+}
+
+impl ModuleConfig for StreamConfig {
+    const TABLE_PREFIX: &'static str = "_CONFIG_STREAM_";
+
+    fn module() -> Module {
+        Module::Stream
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct IdempotencyConfig {}
+
+impl ModuleConfig for IdempotencyConfig {
+    const TABLE_PREFIX: &'static str = "_CONFIG_IDEM_";
+
+    fn module() -> Module {
+        Module::Idempotency
+    }
+}
+
+impl IdempotencyConfig {
+    pub const NAMESPACE: &'static str = "idempotency_store";
+
+    pub fn eviction_policy(&self) -> EvictionPolicy {
+        EvictionPolicy::NoEviction
+    }
+}

--- a/crates/coyote-configgroup/src/lib.rs
+++ b/crates/coyote-configgroup/src/lib.rs
@@ -1,0 +1,89 @@
+use fjall::{Database, Error, KeyspaceCreateOptions};
+
+use crate::entities::{ModuleConfig, StorageType};
+use coyote_error::Result;
+
+pub mod entities;
+pub mod operations;
+mod tables;
+pub use tables::ConfigGroup;
+
+pub fn group_name(key: &str) -> Option<&str> {
+    if !key.contains('/') {
+        return None;
+    }
+    key.split("/").next()
+}
+
+#[derive(Clone)]
+pub struct State {
+    db: fjall::Database,
+    keyspace: fjall::Keyspace,
+    both_dbs: BothDatabases,
+}
+
+// Yeah this is dumb AF. I don't care
+// right now.
+#[derive(Clone)]
+pub struct BothDatabases {
+    pub ephemeral_db: fjall::Database,
+    pub persistent_db: fjall::Database,
+}
+
+impl State {
+    pub fn db(&self) -> &fjall::Database {
+        &self.db
+    }
+
+    pub fn keyspace(&self) -> &fjall::Keyspace {
+        &self.keyspace
+    }
+
+    pub fn init(both_dbs: BothDatabases) -> Result<Self, Error> {
+        const CONFIGGROUP_KEYSPACE: &str = "_coyote_cfggroup";
+
+        let db = both_dbs.persistent_db.clone();
+        let keyspace = {
+            let opts = KeyspaceCreateOptions::default();
+            db.keyspace(CONFIGGROUP_KEYSPACE, || opts)?
+        };
+
+        Ok(Self {
+            db,
+            both_dbs,
+            keyspace,
+        })
+    }
+
+    pub fn fetch_group<C: ModuleConfig>(
+        &self,
+        group_name: String,
+    ) -> Result<Option<ConfigGroup<C>>> {
+        ConfigGroup::fetch(&self.keyspace, &group_name)
+    }
+
+    pub fn fetch_all_groups<C: ModuleConfig>(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<ConfigGroup<C>>>> {
+        ConfigGroup::fetch_all(&self.keyspace)
+    }
+
+    pub fn give_me_the_right_db<C: ModuleConfig>(&self, configgroup: &ConfigGroup<C>) -> Database {
+        match configgroup.storage_type {
+            StorageType::Persistent => self.both_dbs.persistent_db.clone(),
+            StorageType::Ephemeral => self.both_dbs.ephemeral_db.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_group_name() {
+        assert_eq!(group_name("tom/bar"), Some("tom"));
+        assert_eq!(group_name("tom/bar/baz"), Some("tom"));
+        assert_eq!(group_name("bill"), None);
+    }
+}

--- a/crates/coyote-configgroup/src/operations/create_configgroup.rs
+++ b/crates/coyote-configgroup/src/operations/create_configgroup.rs
@@ -1,0 +1,80 @@
+use fjall::Database;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    entities::{ConfigGroupId, ModuleConfig, StorageType},
+    tables::ConfigGroup,
+};
+use coyote_error::Result;
+use fjall_utils::TableRow;
+
+#[derive(Deserialize, Serialize)]
+#[serde(bound = "C: ModuleConfig")]
+pub struct CreateConfigGroup<C: ModuleConfig> {
+    timestamp: Timestamp,
+    name: String,
+    storage_type: Option<StorageType>,
+    config: C,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(bound = "C: ModuleConfig")]
+pub struct CreateConfigGroupOutput<C: ModuleConfig> {
+    pub name: String,
+    pub config: C,
+    pub storage_type: StorageType,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
+}
+
+impl<C: ModuleConfig> CreateConfigGroup<C> {
+    pub fn new(name: String, config: C, storage_type: Option<StorageType>) -> Self {
+        Self {
+            timestamp: Timestamp::now(),
+            name,
+            config,
+            storage_type,
+        }
+    }
+
+    pub fn apply_operation(
+        self,
+        db: &Database,
+        keyspace: &fjall::Keyspace,
+    ) -> Result<CreateConfigGroupOutput<C>> {
+        let configgroup = match ConfigGroup::<C>::fetch(keyspace, &self.name)? {
+            Some(mut configgroup) => {
+                configgroup.storage_type = self.storage_type.unwrap_or(StorageType::Persistent);
+                configgroup.updated_at = self.timestamp;
+                configgroup
+            }
+            None => {
+                let id = ConfigGroupId::new_v4();
+                ConfigGroup {
+                    id,
+                    name: self.name,
+                    storage_type: self.storage_type.unwrap_or(StorageType::Persistent),
+                    created_at: self.timestamp,
+                    updated_at: self.timestamp,
+                    config: self.config,
+                }
+            }
+        };
+
+        {
+            let (k1, v1) = configgroup.to_fjall_entry()?;
+            let mut batch = db.batch();
+            batch.insert(keyspace, k1, v1);
+            batch.commit()?;
+        }
+
+        Ok(CreateConfigGroupOutput {
+            name: configgroup.name,
+            storage_type: configgroup.storage_type,
+            config: configgroup.config,
+            created_at: configgroup.created_at,
+            updated_at: configgroup.updated_at,
+        })
+    }
+}

--- a/crates/coyote-configgroup/src/operations/mod.rs
+++ b/crates/coyote-configgroup/src/operations/mod.rs
@@ -1,0 +1,1 @@
+pub mod create_configgroup;

--- a/crates/coyote-configgroup/src/tables.rs
+++ b/crates/coyote-configgroup/src/tables.rs
@@ -1,0 +1,53 @@
+use std::borrow::Cow;
+
+use fjall::Keyspace;
+use fjall_utils::TableRow;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use coyote_error::Result;
+
+use crate::entities::{ConfigGroupId, ModuleConfig, StorageType};
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "C: ModuleConfig")]
+pub struct ConfigGroup<C: ModuleConfig> {
+    pub id: ConfigGroupId,
+    pub name: String,
+    pub storage_type: StorageType,
+
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
+
+    // Module-specific
+    pub config: C,
+}
+
+impl<C: ModuleConfig> TableRow for ConfigGroup<C> {
+    const TABLE_PREFIX: &'static str = C::TABLE_PREFIX;
+    type Key = String;
+
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Borrowed(&self.name)
+    }
+}
+
+impl<C: ModuleConfig> ConfigGroup<C> {
+    // TODO: Bytes not string
+    pub(crate) fn key(group_name: &str) -> String {
+        format!("{}\0{group_name}", C::module())
+    }
+
+    pub(crate) fn fetch(keyspace: &Keyspace, group_name: &str) -> Result<Option<Self>> {
+        let key = Self::key(group_name);
+        <Self as TableRow>::fetch(keyspace, &key)
+    }
+
+    pub(crate) fn fetch_all(keyspace: &Keyspace) -> Result<impl Iterator<Item = Result<Self>>> {
+        let prefix = format!("{}", C::module());
+        Ok(keyspace.prefix(&prefix).map(|g| {
+            let v = g.value()?;
+            Self::from_fjall_value(v)
+        }))
+    }
+}

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -1,5 +1,9 @@
-use std::time::Duration;
 pub mod tables;
+
+use coyote_configgroup::{
+    ConfigGroup,
+    entities::{CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig},
+};
 use coyote_error::Result;
 use fjall::{Database, KeyspaceCreateOptions};
 
@@ -25,14 +29,6 @@ impl From<KvPairRow> for KvModel {
         }
     }
 }
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub enum EvictionPolicy {
-    #[default]
-    NoEviction,
-    LeastRecentlyUsed,
-}
-
 #[derive(Clone)]
 pub struct KvStore {
     db: fjall::Database,
@@ -227,33 +223,106 @@ const MAX_CAPACITY: u64 = 1024 * 8; // FIXME: make this configurable
 
 /// This is the worker function for this module, it does background cleanup and accounting.
 /// It deletes expired entries from the database and evicts entries if the KvStore is configured to do so.
-pub async fn worker<F>(stores: &mut [&mut KvStore], is_shutting_down: F)
+pub async fn worker<F>(configgroup_state: &coyote_configgroup::State, is_shutting_down: F)
 where
     F: Fn() -> bool,
 {
+    let mut timer = tokio::time::interval(std::time::Duration::from_secs(1));
+
+    let clean_up = |mut store: KvStore| {
+        let now = Timestamp::now();
+        // Expiration cleanup
+        let _ = store.clear_expired(now);
+
+        // Eviction
+        if store.disk_space() > MAX_CAPACITY && store.policy == EvictionPolicy::LeastRecentlyUsed {
+            // FIXME(@svix-lucho): we can add smarter eviction instead of just doing one at a time
+            let _ = store.evict_lru(1);
+        }
+    };
+
     loop {
         if is_shutting_down() {
             break;
         }
-        let now = Timestamp::now();
-        for store in stores.iter_mut() {
-            // Expiration cleanup
-            let _ = store.clear_expired(now);
 
-            // Eviction
-            if store.disk_space() > MAX_CAPACITY
-                && store.policy == EvictionPolicy::LeastRecentlyUsed
-            {
-                // FIXME(@svix-lucho): we can add smarter eviction instead of just doing one at a time
-                let _ = store.evict_lru(1);
+        timer.tick().await;
+
+        let kv_groups = match configgroup_state.fetch_all_groups() {
+            Ok(groups) => groups,
+            Err(e) => {
+                tracing::error!(error = ?e, "Failed to get KV config groups.");
+                continue;
             }
+        };
+
+        for group in kv_groups {
+            let group: ConfigGroup<KeyValueConfig> = match group {
+                Ok(g) => g,
+                Err(e) => {
+                    tracing::error!(error = ?e, "Failed to parse KV config group.");
+                    continue;
+                }
+            };
+            let db = configgroup_state.give_me_the_right_db(&group);
+            let policy = group.config.eviction_policy();
+            let store = KvStore::new(KeyValueConfig::NAMESPACE, db, policy);
+
+            clean_up(store);
         }
-        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let cache_groups = match configgroup_state.fetch_all_groups() {
+            Ok(groups) => groups,
+            Err(e) => {
+                tracing::error!(error = ?e, "Failed to get Cache config groups.");
+                continue;
+            }
+        };
+
+        for group in cache_groups {
+            let group: ConfigGroup<CacheConfig> = match group {
+                Ok(g) => g,
+                Err(e) => {
+                    tracing::error!(error = ?e, "Failed to process Cache config group.");
+                    continue;
+                }
+            };
+            let db = configgroup_state.give_me_the_right_db(&group);
+            let policy = group.config.eviction_policy();
+            let store = KvStore::new(CacheConfig::NAMESPACE, db, policy);
+
+            clean_up(store);
+        }
+
+        let idempotency_groups = match configgroup_state.fetch_all_groups() {
+            Ok(groups) => groups,
+            Err(e) => {
+                tracing::error!(error = ?e, "Failed to get Idempotency config groups.");
+                continue;
+            }
+        };
+
+        for group in idempotency_groups {
+            let group: ConfigGroup<IdempotencyConfig> = match group {
+                Ok(g) => g,
+                Err(e) => {
+                    tracing::error!(error = ?e, "Failed to process Idempotency config group.");
+                    continue;
+                }
+            };
+            let db = configgroup_state.give_me_the_right_db(&group);
+            let policy = group.config.eviction_policy();
+            let store = KvStore::new(CacheConfig::NAMESPACE, db, policy);
+
+            clean_up(store);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use jiff::ToSpan;
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -48,13 +48,6 @@ impl DatabaseConfig {
             db_config.filename.as_deref().unwrap_or("fjall_ephemeral"),
         )
     }
-
-    pub fn management(db_config: &DatabaseConfig) -> Result<Database> {
-        Self::database(
-            &db_config.path,
-            db_config.filename.as_deref().unwrap_or("fjall_management"),
-        )
-    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -104,7 +97,6 @@ pub struct ConfigurationInner {
     /// The address to listen on
     pub listen_address: SocketAddr,
 
-    pub management_db: Arc<DatabaseConfig>,
     pub persistent_db: Arc<DatabaseConfig>,
     pub ephemeral_db: Arc<DatabaseConfig>,
 
@@ -222,7 +214,6 @@ mod tests {
 
     #[derive(Deserialize)]
     struct TestConfig {
-        pub management_db: Arc<DatabaseConfig>,
         pub persistent_db: Arc<DatabaseConfig>,
         pub ephemeral_db: Arc<DatabaseConfig>,
     }
@@ -232,7 +223,6 @@ mod tests {
         let raw_config = r#"
 ephemeral_db = { path = "/1", filename = "test1" }
 persistent_db.path = "/2"
-management_db.path = "/3"
 "#;
 
         let config = config::Config::builder()
@@ -247,8 +237,5 @@ management_db.path = "/3"
 
         assert_eq!(db_config.persistent_db.path, "/2".to_string());
         assert!(db_config.persistent_db.filename.is_none());
-
-        assert_eq!(db_config.management_db.path, "/3".to_string());
-        assert!(db_config.management_db.filename.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,13 @@ use std::{sync::LazyLock, time::Duration};
 
 use aide::axum::ApiRouter;
 use cfg::ConfigurationInner;
-use coyote_kv::EvictionPolicy;
+use coyote_configgroup::{
+    BothDatabases,
+    entities::{CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig},
+    group_name,
+};
+use coyote_error::Result;
+use coyote_kv::KvStore;
 use opentelemetry::{InstrumentationScope, trace::TracerProvider as _};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
@@ -27,7 +33,10 @@ use tower_http::{
 use tracing_subscriber::{Layer as _, layer::SubscriberExt as _};
 use uuid::Uuid;
 
-use crate::cfg::{Configuration, DatabaseConfig};
+use crate::{
+    cfg::{Configuration, DatabaseConfig},
+    v1::modules::{cache::CacheStore, idempotency::IdempotencyStore},
+};
 
 pub mod cfg;
 pub mod core;
@@ -91,17 +100,17 @@ pub async fn run(cfg: Configuration) {
 #[derive(Clone)]
 pub struct AppState {
     cfg: Configuration,
-    // FIXME: is there a way to not have it here. Instead have it fully contained in each module?
-    kv_store: crate::v1::modules::kv::KvStore,
-    cache_store: crate::v1::modules::cache::CacheStore,
     rate_limiter: crate::v1::modules::rate_limiter::RateLimiter,
-    idempotency_store: crate::v1::modules::idempotency::IdempotencyStore,
     queue_store: crate::v1::modules::queue::QueueStore,
 
     raft: core::cluster::Raft,
     node_id: core::cluster::NodeId,
 
     stream_state: stream::State,
+    configgroup_state: coyote_configgroup::State,
+
+    // TODO: Remove this once we have proper default config groups
+    persistent_db: fjall::Database,
 }
 
 async fn run_interserver(cfg: Configuration, state: AppState, listener: Option<TcpListener>) {
@@ -132,6 +141,115 @@ async fn run_interserver(cfg: Configuration, state: AppState, listener: Option<T
     state.raft.shutdown().await.unwrap();
 }
 
+impl AppState {
+    // FIXME: Blocking
+    pub fn kv_store_by_key(&self, key_name: &str) -> Result<KvStore> {
+        let Some(group_name_str) = group_name(key_name) else {
+            // FIXME: This should be a default ConfigGroup struct
+            return Ok(KvStore::new(
+                KeyValueConfig::NAMESPACE,
+                self.persistent_db.clone(),
+                EvictionPolicy::NoEviction,
+            ));
+        };
+
+        let Some(group) = self
+            .configgroup_state
+            .fetch_group::<KeyValueConfig>(group_name_str.to_string())?
+        else {
+            // FIXME: This should be a default ConfigGroup struct
+            return Ok(KvStore::new(
+                KeyValueConfig::NAMESPACE,
+                self.persistent_db.clone(),
+                EvictionPolicy::NoEviction,
+            ));
+        };
+
+        let policy = group.config.eviction_policy();
+        let kv_store = KvStore::new(
+            KeyValueConfig::NAMESPACE,
+            self.configgroup_state.give_me_the_right_db(&group),
+            policy,
+        );
+
+        Ok(kv_store)
+    }
+
+    // FIXME: Blocking
+    pub fn cache_store_by_key(&self, key_name: &str) -> Result<CacheStore> {
+        let Some(group_name_str) = group_name(key_name) else {
+            // FIXME: This should be a default ConfigGroup struct
+            return Ok(CacheStore {
+                kv: KvStore::new(
+                    CacheConfig::NAMESPACE,
+                    self.persistent_db.clone(),
+                    EvictionPolicy::NoEviction,
+                ),
+            });
+        };
+
+        let Some(group) = self
+            .configgroup_state
+            .fetch_group::<CacheConfig>(group_name_str.to_string())?
+        else {
+            // FIXME: This should be a default ConfigGroup struct
+            return Ok(CacheStore {
+                kv: KvStore::new(
+                    CacheConfig::NAMESPACE,
+                    self.persistent_db.clone(),
+                    EvictionPolicy::NoEviction,
+                ),
+            });
+        };
+
+        let policy = group.config.eviction_policy();
+        let kv_store = KvStore::new(
+            CacheConfig::NAMESPACE,
+            self.configgroup_state.give_me_the_right_db(&group),
+            policy,
+        );
+
+        Ok(CacheStore { kv: kv_store })
+    }
+
+    // FIXME: Blocking
+    pub fn idempotency_store_by_key(&self, key_name: &str) -> Result<IdempotencyStore> {
+        let Some(group_name_str) = group_name(key_name) else {
+            // FIXME: This should be a default ConfigGroup struct
+            return Ok(IdempotencyStore {
+                kv: KvStore::new(
+                    IdempotencyConfig::NAMESPACE,
+                    self.persistent_db.clone(),
+                    EvictionPolicy::NoEviction,
+                ),
+            });
+        };
+
+        let Some(group) = self
+            .configgroup_state
+            .fetch_group::<IdempotencyConfig>(group_name_str.to_string())?
+        else {
+            // FIXME: This should be a default ConfigGroup struct
+            return Ok(IdempotencyStore {
+                kv: KvStore::new(
+                    IdempotencyConfig::NAMESPACE,
+                    self.persistent_db.clone(),
+                    EvictionPolicy::NoEviction,
+                ),
+            });
+        };
+
+        let policy = group.config.eviction_policy();
+        let kv_store = KvStore::new(
+            IdempotencyConfig::NAMESPACE,
+            self.configgroup_state.give_me_the_right_db(&group),
+            policy,
+        );
+
+        Ok(IdempotencyStore { kv: kv_store })
+    }
+}
+
 // Made public for the purpose of E2E testing in which a queue prefix is necessary to avoid tests
 // consuming from each others' queues
 pub async fn run_with_prefix(
@@ -146,31 +264,15 @@ pub async fn run_with_prefix(
 
     let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
     let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
-    let _management_db = DatabaseConfig::management(&cfg.management_db).expect("management db");
+
+    let configgroup_state = coyote_configgroup::State::init(BothDatabases {
+        persistent_db: persistent_db.clone(),
+        ephemeral_db: ephemeral_db.clone(),
+    })
+    .expect("initializing configgroup state");
 
     let stream_state =
         stream::State::init(persistent_db.clone()).expect("initializing stream state");
-
-    let kv_store = crate::v1::modules::kv::KvStore::new(
-        "kv_store",
-        persistent_db.clone(),
-        EvictionPolicy::NoEviction,
-    );
-
-    let cache_kv_store = crate::v1::modules::kv::KvStore::new(
-        "cache_store",
-        ephemeral_db.clone(),
-        EvictionPolicy::LeastRecentlyUsed,
-    );
-    let cache_store = crate::v1::modules::cache::CacheStore::new(cache_kv_store);
-
-    let idempotency_kv_store = crate::v1::modules::kv::KvStore::new(
-        "idempotency_store",
-        persistent_db.clone(),
-        EvictionPolicy::NoEviction,
-    );
-    let idempotency_store =
-        crate::v1::modules::idempotency::IdempotencyStore::new(idempotency_kv_store);
 
     let (raft, node_id) = core::cluster::initialize_raft(&cfg, persistent_db.clone())
         .await
@@ -179,17 +281,16 @@ pub async fn run_with_prefix(
     // build our application with a route
     let app_state = AppState {
         cfg: cfg.clone(),
-        kv_store,
-        cache_store,
         rate_limiter: crate::v1::modules::rate_limiter::RateLimiter::new(
             "rate_limiter_default",
             persistent_db.clone(),
         ),
-        idempotency_store,
         queue_store: crate::v1::modules::queue::QueueStore::new(),
         stream_state,
         raft,
         node_id,
+        persistent_db,
+        configgroup_state,
     };
     let v1_router = v1::router().with_state::<()>(app_state.clone());
 

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -92,11 +92,10 @@ pub struct CacheDeleteOut {
 /// Cache Set
 #[aide_annotate(op_id = "v1.cache.set")]
 async fn cache_set(
-    State(AppState {
-        mut cache_store, ..
-    }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<CacheSetIn>,
 ) -> Result<Json<CacheSetOut>> {
+    let mut cache_store = state.cache_store_by_key(&data.key.0)?;
     let key = data.key.clone();
     cache_store.set(key.as_str(), data.into_model())?;
     Ok(Json(CacheSetOut {}))
@@ -105,11 +104,10 @@ async fn cache_set(
 /// Cache Get
 #[aide_annotate(op_id = "v1.cache.get")]
 async fn cache_get(
-    State(AppState {
-        mut cache_store, ..
-    }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<CacheGetIn>,
 ) -> Result<Json<CacheGetOut>> {
+    let mut cache_store = state.cache_store_by_key(&data.key.0)?;
     let model = cache_store
         .get(&data.key)?
         .ok_or_else(|| crate::error::HttpError::not_found(None, None))?;
@@ -119,11 +117,10 @@ async fn cache_get(
 /// Cache Delete
 #[aide_annotate(op_id = "v1.cache.delete")]
 async fn cache_del(
-    State(AppState {
-        mut cache_store, ..
-    }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<CacheDeleteIn>,
 ) -> Result<Json<CacheDeleteOut>> {
+    let mut cache_store = state.cache_store_by_key(&data.key.0)?;
     cache_store.delete(&data.key)?;
     Ok(Json(CacheDeleteOut { deleted: true }))
 }

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -74,14 +74,12 @@ pub struct IdempotencyAbandonOut {}
 /// Start an idempotent request
 #[aide_annotate(op_id = "v1.idempotency.start")]
 async fn idempotency_start(
-    State(AppState {
-        mut idempotency_store,
-        ..
-    }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<IdempotencyStartIn>,
 ) -> Result<Json<IdempotencyStartOut>> {
     let key_str = data.key.to_string();
 
+    let mut idempotency_store = state.idempotency_store_by_key(&key_str)?;
     match idempotency_store.try_start(&key_str, data.ttl_seconds)? {
         None => Ok(Json(IdempotencyStartOut::Locked)),
         Some(response) => {
@@ -97,14 +95,12 @@ async fn idempotency_start(
 /// Complete an idempotent request with a response
 #[aide_annotate(op_id = "v1.idempotency.complete")]
 async fn idempotency_complete(
-    State(AppState {
-        mut idempotency_store,
-        ..
-    }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<IdempotencyCompleteIn>,
 ) -> Result<Json<IdempotencyCompleteOut>> {
     let key_str = data.key.to_string();
 
+    let mut idempotency_store = state.idempotency_store_by_key(&key_str)?;
     idempotency_store.complete(&key_str, data.response.into_bytes(), data.ttl_seconds)?;
 
     Ok(Json(IdempotencyCompleteOut {}))
@@ -113,14 +109,12 @@ async fn idempotency_complete(
 /// Abandon an idempotent request (remove lock without saving response)
 #[aide_annotate(op_id = "v1.idempotency.abandon")]
 async fn idempotency_abandon(
-    State(AppState {
-        mut idempotency_store,
-        ..
-    }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<IdempotencyAbandonIn>,
 ) -> Result<Json<IdempotencyAbandonOut>> {
     let key_str = data.key.to_string();
 
+    let mut idempotency_store = state.idempotency_store_by_key(&key_str)?;
     idempotency_store.abandon(&key_str)?;
 
     Ok(Json(IdempotencyAbandonOut {}))

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -110,9 +110,11 @@ pub struct KvDeleteOut {
 /// KV Set
 #[aide_annotate(op_id = "v1.kv.set")]
 async fn kv_set(
-    State(AppState { mut kv_store, .. }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<KvSetIn>,
 ) -> Result<Json<KvSetOut>> {
+    let mut kv_store = state.kv_store_by_key(&data.key.0)?;
+
     let key = data.key.clone();
     let behavior = data.behavior.clone();
     let model = data.into_model();
@@ -128,9 +130,11 @@ async fn kv_set(
 /// KV Get
 #[aide_annotate(op_id = "v1.kv.get")]
 async fn kv_get(
-    State(AppState { mut kv_store, .. }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<KvGetIn>,
 ) -> Result<Json<KvGetOut>> {
+    let mut kv_store = state.kv_store_by_key(&data.key.0)?;
+
     let model = kv_store
         .get(&data.key.0)
         .map_err(|e| crate::error::Error::generic(e))?;
@@ -148,9 +152,11 @@ async fn kv_get(
 /// KV Delete
 #[aide_annotate(op_id = "v1.kv.delete")]
 async fn kv_del(
-    State(AppState { mut kv_store, .. }): State<AppState>,
+    State(state): State<AppState>,
     ValidatedJson(data): ValidatedJson<KvDeleteIn>,
 ) -> Result<Json<KvDeleteOut>> {
+    let mut kv_store = state.kv_store_by_key(&data.key.0)?;
+
     let deleted = kv_store
         .delete(&data.key.0)
         .map_err(|e| crate::error::Error::generic(e))

--- a/src/v1/modules/cache.rs
+++ b/src/v1/modules/cache.rs
@@ -28,7 +28,6 @@ impl CacheStore {
         self.kv.delete(key)
     }
 }
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct CacheModel {
     pub expires_at: Option<Timestamp>,

--- a/src/v1/modules/idempotency.rs
+++ b/src/v1/modules/idempotency.rs
@@ -108,6 +108,7 @@ impl IdempotencyStore {
 
 #[cfg(test)]
 mod tests {
+    use coyote_configgroup::entities::EvictionPolicy;
     use fjall::Database;
     use test_utils::TestResult;
 
@@ -121,7 +122,7 @@ mod tests {
         fn new() -> TestResult<Self> {
             let workdir = tempfile::tempdir()?;
             let db = Database::builder(workdir.as_ref()).temporary(true).open()?;
-            let kv = KvStore::new("test", db, coyote_kv::EvictionPolicy::NoEviction);
+            let kv = KvStore::new("test", db, EvictionPolicy::NoEviction);
             let store = IdempotencyStore::new(kv);
             Ok(Self { store })
         }

--- a/src/v1/modules/kv.rs
+++ b/src/v1/modules/kv.rs
@@ -1,14 +1,9 @@
 use crate::{AppState, error::Result};
 
-pub use coyote_kv::{EvictionPolicy, KvModel, KvStore, OperationBehavior};
+pub use coyote_kv::{KvModel, KvStore, OperationBehavior};
 
 /// This is the worker function for this module, it does background cleanup and accounting.
-pub async fn worker(mut state: AppState) -> Result<()> {
-    let mut stores = [
-        &mut state.kv_store,
-        &mut state.cache_store.kv,
-        &mut state.idempotency_store.kv,
-    ];
-    coyote_kv::worker(&mut stores, crate::is_shutting_down).await;
+pub async fn worker(state: AppState) -> Result<()> {
+    coyote_kv::worker(&state.configgroup_state, crate::is_shutting_down).await;
     Ok(())
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -49,10 +49,6 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
 
     let cfg = Arc::new(ConfigurationInner {
         listen_address: addr,
-        management_db: Arc::new(DatabaseConfig {
-            path: db_dir.clone(),
-            ..Default::default()
-        }),
         ephemeral_db: Arc::new(DatabaseConfig {
             path: db_dir.clone(),
             ..Default::default()


### PR DESCRIPTION
First attempt at using common configuration to get the correct database
and cache/key-value/idempotency configurations, other modules to
follow later. There's not actually an API right now for creating these
configurations, so this is really just scaffolding at this point.

The key thing to note here is that the proper config group for
most of the modules right now (though this may change) comes from
pulling the "group" name out of the first chunk of the `/`-delimited
key that's used. We then find that in the database and, if it doesn't
exist (which is true for everything right now), we return a default
config. Right now this default is hard-coded. Later it will come from
something that's previously been put into the database via a config
file or some bootstrapping process.

Note that I don't love the name "configgroup", "config_group", or
really anything that's been suggested thus far, but this is what's
been mentioned in the RFC, so keeping it for now.

Also, I removed the management DB. All these databases seem like
overkill. I think we can add it back later as needed.

Tests / proper "default" config groups rather than hard-coded defaults
will follow soon after, but I really want to get some of this code
reviewed / merged before I do too much more.
