### PR TITLE
raft: wire up kv::set to go through consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ version = "1.76.1"
 dependencies = [
  "coyote-configgroup",
  "coyote-error",
+ "coyote-operations",
  "fjall",
  "fjall-utils",
  "format-bytes",
@@ -1042,6 +1043,20 @@ dependencies = [
  "tap",
  "tokio",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "coyote-operations"
+version = "1.76.1"
+dependencies = [
+ "axum",
+ "bytes",
+ "coyote-error",
+ "http",
+ "http-serde",
+ "rmp-serde",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -2058,6 +2073,16 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "coyote-derive",
  "coyote-error",
  "coyote-kv",
+ "coyote-operations",
  "coyote-proto",
  "coyote-rate-limiter",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ zip.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 ctor.workspace = true
+rand.workspace = true
 rmp-serde.workspace = true
 rmpv.workspace = true
 tempfile.workspace = true
@@ -121,6 +122,7 @@ coyote-configgroup.path = "crates/coyote-configgroup"
 coyote-derive.path = "crates/coyote-derive"
 coyote-error.path = "crates/coyote-error"
 coyote-kv.path = "crates/kv"
+coyote-operations.path = "crates/coyote-operations"
 coyote-proto.path = "crates/coyote-proto"
 coyote-rate-limiter.path = "crates/rate-limiter"
 ctor = "0.6.3"
@@ -134,6 +136,7 @@ hex = "0.4.3"
 hickory-resolver = "0.25.2"
 http = "1.1.0"
 http-body-util = "0.1.2"
+http-serde = "2"
 hyper = { version = "1.8.1", features = ["full"] }
 hyper-rustls = "0.27.7"
 hyper-tls = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ coyote-configgroup.workspace = true
 coyote-derive.workspace = true
 coyote-error.workspace = true
 coyote-kv.workspace = true
+coyote-operations.workspace = true
 coyote-proto.workspace = true
 coyote-rate-limiter.workspace = true
 fjall.workspace = true

--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -67,6 +67,11 @@ impl Error {
     }
 
     #[track_caller]
+    pub fn operation(code: StatusCode, detail: Option<String>) -> Self {
+        Self::new(ErrorType::Operation { code, detail })
+    }
+
+    #[track_caller]
     pub fn trace(mut self) -> Self {
         self.trace.push(Location::caller());
         self
@@ -93,6 +98,11 @@ impl IntoResponse for Error {
                 tracing::debug!("{:?}, location: {:?}", &s, stringified);
                 s.into_response()
             }
+            ErrorType::Operation {
+                code,
+                detail: Some(detail),
+            } => (code, detail).into_response(),
+            ErrorType::Operation { code, detail: _ } => code.into_response(),
             s => {
                 tracing::error!("type: {:?}, location: {:?}", s, stringified);
                 (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({}))).into_response()
@@ -145,6 +155,11 @@ pub enum ErrorType {
     Http(HttpError),
     /// Timeout error
     Timeout(String),
+    /// An error from an Operation application
+    Operation {
+        code: StatusCode,
+        detail: Option<String>,
+    },
 }
 
 impl fmt::Display for ErrorType {
@@ -152,6 +167,13 @@ impl fmt::Display for ErrorType {
         match self {
             Self::Generic(s) | Self::Validation(s) | Self::Timeout(s) => s.fmt(f),
             Self::Http(s) => s.fmt(f),
+            Self::Operation { detail, code } => {
+                if let Some(detail) = detail {
+                    detail.fmt(f)
+                } else {
+                    write!(f, "code {code}")
+                }
+            }
         }
     }
 }

--- a/crates/coyote-operations/Cargo.toml
+++ b/crates/coyote-operations/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "coyote-operations"
+edition = "2024"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+axum.workspace = true
+bytes.workspace = true
+coyote-error.workspace = true
+http.workspace = true
+http-serde.workspace = true
+rmp-serde.workspace = true
+serde.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -1,0 +1,37 @@
+use axum::response::IntoResponse;
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+pub trait OperationResponse {}
+
+impl<T: Serialize + DeserializeOwned + Clone> OperationResponse for T {}
+
+pub trait OperationRequest {}
+
+impl<T: Serialize + DeserializeOwned + Clone> OperationRequest for T {}
+
+/// coyote_error::Error isn't Serialize or Deserialize, and can contain arbitrary
+/// inner error types, which makes it very hard to make serialize or deserialize.
+/// This is a nerfed error type that can be sent across the raft boundary.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OperationError {
+    #[serde(with = "http_serde::status_code")]
+    status: http::StatusCode,
+}
+
+impl From<coyote_error::Error> for OperationError {
+    fn from(value: coyote_error::Error) -> Self {
+        Self {
+            status: value.into_response().status(),
+        }
+    }
+}
+
+impl From<OperationError> for coyote_error::Error {
+    fn from(value: OperationError) -> Self {
+        Self::operation(value.status, None)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, OperationError>;

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -5,12 +5,19 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 pub trait OperationResponse: Serialize + DeserializeOwned + Clone + Debug {
     /// The module-level `Response` enum
-    type ResponseParent: TryInto<Self>;
+    type ResponseParent: ModuleResponse + TryInto<Self>;
 }
 
 pub trait OperationRequest: Serialize + DeserializeOwned + Clone + Debug {
     /// The specific Response structure for this request
     type Response: OperationResponse;
+    type RequestParent: ModuleRequest;
+}
+
+pub trait ModuleResponse: Serialize + DeserializeOwned + Clone + Debug {}
+
+pub trait ModuleRequest: Serialize + DeserializeOwned + Clone + Debug {
+    type Response: ModuleResponse;
 }
 
 /// coyote_error::Error isn't Serialize or Deserialize, and can contain arbitrary

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -3,13 +3,15 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-pub trait OperationResponse {}
+pub trait OperationResponse: Serialize + DeserializeOwned + Clone + Debug {
+    /// The module-level `Response` enum
+    type ResponseParent: TryInto<Self>;
+}
 
-impl<T: Serialize + DeserializeOwned + Clone> OperationResponse for T {}
-
-pub trait OperationRequest {}
-
-impl<T: Serialize + DeserializeOwned + Clone> OperationRequest for T {}
+pub trait OperationRequest: Serialize + DeserializeOwned + Clone + Debug {
+    /// The specific Response structure for this request
+    type Response: OperationResponse;
+}
 
 /// coyote_error::Error isn't Serialize or Deserialize, and can contain arbitrary
 /// inner error types, which makes it very hard to make serialize or deserialize.

--- a/crates/kv/Cargo.toml
+++ b/crates/kv/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [dependencies]
 coyote-configgroup.workspace = true
 coyote-error.workspace = true
+coyote-operations.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true
 format-bytes = "0.3.0"

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -134,12 +134,7 @@ impl KvStore {
         Ok(())
     }
 
-    pub fn set_operation(
-        &self,
-        key: String,
-        model: KvModel,
-        behavior: OperationBehavior,
-    ) -> SetOperation {
+    pub fn set_operation(key: String, model: KvModel, behavior: OperationBehavior) -> SetOperation {
         SetOperation::new(key, model, behavior)
     }
 

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -14,9 +14,14 @@ use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::tables::{ExpirationRow, KvPairRow};
+pub mod operations;
 
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+use crate::{
+    operations::SetOperation,
+    tables::{ExpirationRow, KvPairRow},
+};
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct KvModel {
     pub expires_at: Option<Timestamp>,
     pub value: Vec<u8>,
@@ -129,7 +134,22 @@ impl KvStore {
         Ok(())
     }
 
+    pub fn set_operation(
+        &self,
+        key: String,
+        model: KvModel,
+        behavior: OperationBehavior,
+    ) -> SetOperation {
+        SetOperation::new(key, model, behavior)
+    }
+
     pub fn set(&mut self, key: &str, model: &KvModel, behavior: OperationBehavior) -> Result<()> {
+        // TODO: remove this method
+        tracing::error!("unsafe method KvStore::set called!");
+        self.set_(key, model, behavior)
+    }
+
+    fn set_(&mut self, key: &str, model: &KvModel, behavior: OperationBehavior) -> Result<()> {
         match behavior {
             OperationBehavior::Upsert => {
                 self.insert_with_expiration(key, model)?;

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -1,4 +1,4 @@
-use super::{KvRequest, KvResponse, Response};
+use super::{KvRequest, Operation, Response};
 use coyote_operations::{OperationRequest, OperationResponse, Result};
 use serde::{Deserialize, Serialize};
 
@@ -15,8 +15,6 @@ impl DeleteOperation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteResponse(pub Result<()>);
-
-impl KvResponse for DeleteResponse {}
 
 impl DeleteOperation {
     fn apply_real(self, state: &mut crate::KvStore) -> Result<()> {
@@ -37,4 +35,5 @@ impl OperationResponse for DeleteResponse {
 
 impl OperationRequest for DeleteOperation {
     type Response = DeleteResponse;
+    type RequestParent = Operation;
 }

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -1,0 +1,36 @@
+use super::{KvRequest, KvResponse};
+use coyote_operations::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteOperation {
+    pub(crate) key: String,
+}
+
+impl DeleteOperation {
+    pub fn new(key: String) -> Self {
+        Self { key }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteResponse(pub Result<()>);
+
+impl KvResponse for DeleteResponse {
+    type Request = DeleteOperation;
+}
+
+impl DeleteOperation {
+    fn apply_real(self, state: &mut crate::KvStore) -> Result<()> {
+        state.delete(&self.key)?;
+        Ok(())
+    }
+}
+
+impl KvRequest for DeleteOperation {
+    type Response = DeleteResponse;
+
+    fn apply(self, state: &mut crate::KvStore) -> Self::Response {
+        DeleteResponse(self.apply_real(state))
+    }
+}

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -1,5 +1,5 @@
-use super::{KvRequest, KvResponse};
-use coyote_operations::Result;
+use super::{KvRequest, KvResponse, Response};
+use coyote_operations::{OperationRequest, OperationResponse, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,9 +16,7 @@ impl DeleteOperation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteResponse(pub Result<()>);
 
-impl KvResponse for DeleteResponse {
-    type Request = DeleteOperation;
-}
+impl KvResponse for DeleteResponse {}
 
 impl DeleteOperation {
     fn apply_real(self, state: &mut crate::KvStore) -> Result<()> {
@@ -28,9 +26,15 @@ impl DeleteOperation {
 }
 
 impl KvRequest for DeleteOperation {
-    type Response = DeleteResponse;
-
-    fn apply(self, state: &mut crate::KvStore) -> Self::Response {
+    fn apply(self, state: &mut crate::KvStore) -> DeleteResponse {
         DeleteResponse(self.apply_real(state))
     }
+}
+
+impl OperationResponse for DeleteResponse {
+    type ResponseParent = Response;
+}
+
+impl OperationRequest for DeleteOperation {
+    type Response = DeleteResponse;
 }

--- a/crates/kv/src/operations/mod.rs
+++ b/crates/kv/src/operations/mod.rs
@@ -11,15 +11,12 @@ pub trait KvResponse: TryFrom<Response> + coyote_operations::OperationResponse
 where
     Self: 'static,
 {
-    type Request: KvRequest + 'static;
 }
 
 pub trait KvRequest: Into<Operation> + coyote_operations::OperationRequest
 where
     Self: 'static,
 {
-    type Response: KvResponse + 'static;
-
     fn apply(self, state: &mut KvStore) -> Self::Response;
 }
 

--- a/crates/kv/src/operations/mod.rs
+++ b/crates/kv/src/operations/mod.rs
@@ -1,0 +1,88 @@
+use super::KvStore;
+use serde::{Deserialize, Serialize};
+
+mod delete;
+mod set;
+
+pub use delete::DeleteOperation;
+pub use set::SetOperation;
+
+pub trait KvResponse: TryFrom<Response> + coyote_operations::OperationResponse
+where
+    Self: 'static,
+{
+    type Request: KvRequest + 'static;
+}
+
+pub trait KvRequest: Into<Operation> + coyote_operations::OperationRequest
+where
+    Self: 'static,
+{
+    type Response: KvResponse + 'static;
+
+    fn apply(self, state: &mut KvStore) -> Self::Response;
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Operation {
+    Set(set::SetOperation),
+    Delete(delete::DeleteOperation),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum Response {
+    Set(set::SetResponse),
+    Delete(delete::DeleteResponse),
+}
+
+impl Operation {
+    pub fn apply(self, state: &mut KvStore) -> Response {
+        match self {
+            Self::Set(req) => Response::Set(req.apply(state)),
+            Self::Delete(req) => Response::Delete(req.apply(state)),
+        }
+    }
+
+    pub fn key_name(&self) -> &str {
+        match self {
+            Self::Set(req) => req.key.as_ref(),
+            Self::Delete(req) => req.key.as_ref(),
+        }
+    }
+}
+
+impl From<set::SetOperation> for Operation {
+    fn from(value: set::SetOperation) -> Self {
+        Self::Set(value)
+    }
+}
+
+impl From<delete::DeleteOperation> for Operation {
+    fn from(value: delete::DeleteOperation) -> Self {
+        Self::Delete(value)
+    }
+}
+
+impl TryFrom<Response> for set::SetResponse {
+    type Error = ();
+
+    fn try_from(value: Response) -> Result<Self, Self::Error> {
+        if let Response::Set(value) = value {
+            Ok(value)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<Response> for delete::DeleteResponse {
+    type Error = ();
+
+    fn try_from(value: Response) -> Result<Self, Self::Error> {
+        if let Response::Delete(value) = value {
+            Ok(value)
+        } else {
+            Err(())
+        }
+    }
+}

--- a/crates/kv/src/operations/mod.rs
+++ b/crates/kv/src/operations/mod.rs
@@ -7,13 +7,7 @@ mod set;
 pub use delete::DeleteOperation;
 pub use set::SetOperation;
 
-pub trait KvResponse: TryFrom<Response> + coyote_operations::OperationResponse
-where
-    Self: 'static,
-{
-}
-
-pub trait KvRequest: Into<Operation> + coyote_operations::OperationRequest
+trait KvRequest: Into<Operation> + coyote_operations::OperationRequest
 where
     Self: 'static,
 {
@@ -26,11 +20,17 @@ pub enum Operation {
     Delete(delete::DeleteOperation),
 }
 
+impl coyote_operations::ModuleRequest for Operation {
+    type Response = Response;
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Response {
     Set(set::SetResponse),
     Delete(delete::DeleteResponse),
 }
+
+impl coyote_operations::ModuleResponse for Response {}
 
 impl Operation {
     pub fn apply(self, state: &mut KvStore) -> Response {

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -1,0 +1,44 @@
+use crate::{KvModel, OperationBehavior};
+
+use super::{KvRequest, KvResponse};
+use coyote_operations::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetOperation {
+    pub(crate) key: String,
+    pub(crate) model: KvModel,
+    pub(crate) behavior: OperationBehavior,
+}
+
+impl SetOperation {
+    pub fn new(key: String, model: KvModel, behavior: OperationBehavior) -> Self {
+        Self {
+            key,
+            model,
+            behavior,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetResponse(pub Result<()>);
+
+impl KvResponse for SetResponse {
+    type Request = SetOperation;
+}
+
+impl SetOperation {
+    fn apply_real(self, state: &mut crate::KvStore) -> Result<()> {
+        state.set_(&self.key, &self.model, self.behavior)?;
+        Ok(())
+    }
+}
+
+impl KvRequest for SetOperation {
+    type Response = SetResponse;
+
+    fn apply(self, state: &mut crate::KvStore) -> Self::Response {
+        SetResponse(self.apply_real(state))
+    }
+}

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -1,6 +1,6 @@
 use crate::{KvModel, OperationBehavior};
 
-use super::{KvRequest, KvResponse, Response};
+use super::{KvRequest, Operation, Response};
 use coyote_operations::{OperationRequest, OperationResponse, Result};
 use serde::{Deserialize, Serialize};
 
@@ -24,14 +24,13 @@ impl SetOperation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetResponse(pub Result<()>);
 
-impl KvResponse for SetResponse {}
-
 impl OperationResponse for SetResponse {
     type ResponseParent = Response;
 }
 
 impl OperationRequest for SetOperation {
     type Response = SetResponse;
+    type RequestParent = Operation;
 }
 
 impl SetOperation {

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -1,7 +1,7 @@
 use crate::{KvModel, OperationBehavior};
 
-use super::{KvRequest, KvResponse};
-use coyote_operations::Result;
+use super::{KvRequest, KvResponse, Response};
+use coyote_operations::{OperationRequest, OperationResponse, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -24,8 +24,14 @@ impl SetOperation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetResponse(pub Result<()>);
 
-impl KvResponse for SetResponse {
-    type Request = SetOperation;
+impl KvResponse for SetResponse {}
+
+impl OperationResponse for SetResponse {
+    type ResponseParent = Response;
+}
+
+impl OperationRequest for SetOperation {
+    type Response = SetResponse;
 }
 
 impl SetOperation {
@@ -36,9 +42,7 @@ impl SetOperation {
 }
 
 impl KvRequest for SetOperation {
-    type Response = SetResponse;
-
-    fn apply(self, state: &mut crate::KvStore) -> Self::Response {
+    fn apply(self, state: &mut crate::KvStore) -> SetResponse {
         SetResponse(self.apply_real(state))
     }
 }

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 lint:
+    cargo +nightly clippy --workspace --fix --allow-dirty --all-features --all-targets
     cargo +nightly fmt
     cargo sort --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
-    cargo +nightly clippy --workspace --fix --allow-dirty --all-features --all-targets
 
 # Test the backend
 test *args='':

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 lint:
-    cargo +nightly clippy --workspace --fix --allow-dirty --all-features --all-targets
     cargo +nightly fmt
     cargo sort --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
+    cargo +nightly clippy --workspace --fix --allow-dirty --all-features --all-targets
 
 # Test the backend
 test *args='':

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -114,8 +114,8 @@ pub struct ConfigurationInner {
     /// The address to listen on
     pub listen_address: SocketAddr,
 
-    pub persistent_db: Arc<DatabaseConfig>,
-    pub ephemeral_db: Arc<DatabaseConfig>,
+    pub persistent_db: DatabaseConfig,
+    pub ephemeral_db: DatabaseConfig,
 
     /// Contains the secret and algorithm for signing JWTs
     #[serde(flatten)]
@@ -148,6 +148,27 @@ pub struct ConfigurationInner {
 
     #[serde(flatten)]
     pub internal: InternalConfig,
+}
+
+#[cfg(test)]
+/// make a ConfigurationInner for testing use
+impl Default for ConfigurationInner {
+    fn default() -> Self {
+        use rand::distr::{Alphanumeric, SampleString};
+
+        let jwt_key = Alphanumeric.sample_string(&mut rand::rng(), 32);
+
+        let config = config::Config::builder()
+            .add_source(config::File::from_str(DEFAULTS, config::FileFormat::Toml))
+            .set_default("jwt_algorithm", "HS256")
+            .unwrap()
+            .set_default("jwt_secret", jwt_key)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        config.try_deserialize::<ConfigurationInner>().unwrap()
+    }
 }
 
 const fn default_opentelemetry_metrics_period() -> u64 {
@@ -237,8 +258,8 @@ mod tests {
 
     #[derive(Deserialize)]
     struct TestConfig {
-        pub persistent_db: Arc<DatabaseConfig>,
-        pub ephemeral_db: Arc<DatabaseConfig>,
+        pub persistent_db: DatabaseConfig,
+        pub ephemeral_db: DatabaseConfig,
     }
 
     #[test]

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use axum::{
-    Json,
+    Extension, Json,
     extract::State,
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -17,7 +17,7 @@ use openraft::{
 use serde::Serialize;
 use tap::{Pipe, TapFallible};
 
-use super::{Node, NodeId, network::detect_address, proto::*, raft::TypeConfig};
+use super::{Node, NodeId, handle::RaftState, network::detect_address, proto::*, raft::TypeConfig};
 use crate::AppState;
 
 pub fn router() -> axum::Router<AppState> {
@@ -70,7 +70,7 @@ where
 
 #[tracing::instrument(skip_all)]
 async fn append_entries(
-    State(state): State<AppState>,
+    Extension(state): Extension<RaftState>,
     MsgPack(body): MsgPack<AppendEntriesRequest<TypeConfig>>,
 ) -> impl IntoResponse {
     tracing::debug!(
@@ -82,7 +82,7 @@ async fn append_entries(
 
 #[tracing::instrument(skip_all)]
 async fn vote(
-    State(state): State<AppState>,
+    Extension(state): Extension<RaftState>,
     MsgPack(body): MsgPack<VoteRequest<NodeId>>,
 ) -> impl IntoResponse {
     tracing::debug!(
@@ -94,7 +94,7 @@ async fn vote(
 
 #[tracing::instrument(skip_all)]
 async fn stream_snapshot(
-    State(state): State<AppState>,
+    Extension(state): Extension<RaftState>,
     MsgPack(req): MsgPack<InstallSnapshotRequest<TypeConfig>>,
 ) -> impl IntoResponse {
     let _num_bytes = req.data.len();
@@ -109,9 +109,12 @@ async fn stream_snapshot(
 
 // Administrative functions
 
-async fn discover(State(app_state): State<AppState>) -> Json<DiscoverResponse> {
+async fn discover(
+    State(app_state): State<AppState>,
+    Extension(raft_state): Extension<RaftState>,
+) -> Json<DiscoverResponse> {
     let cluster_name = app_state.cfg.cluster.name.clone();
-    let cluster = app_state
+    let cluster = raft_state
         .raft
         .with_raft_state(move |state| DiscoverClusterResponse {
             last_committed_log_id: state.committed,
@@ -128,20 +131,20 @@ async fn discover(State(app_state): State<AppState>) -> Json<DiscoverResponse> {
         .tap_err(|err| tracing::warn!(?err, "failed to find local cluster state"))
         .ok();
     let response = DiscoverResponse {
-        node_id: app_state.node_id,
+        node_id: raft_state.node_id,
         cluster,
     };
     Json(response)
 }
 
-async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
+async fn metrics(Extension(state): Extension<RaftState>) -> impl IntoResponse {
     let metrics = state.raft.metrics().borrow().clone();
 
     Json(metrics)
 }
 
 async fn add_learner(
-    State(state): State<AppState>,
+    Extension(state): Extension<RaftState>,
     Json(request): Json<AddLearnerRequest>,
 ) -> impl IntoResponse {
     let url = format!("http://{}/repl/raft/vote", request.address);
@@ -153,15 +156,15 @@ async fn add_learner(
 }
 
 async fn upgrade_learner(
-    State(state): State<AppState>,
+    Extension(raft_state): Extension<RaftState>,
     Json(request): Json<UpgradeLearnerRequest>,
 ) -> impl IntoResponse {
     let request = ChangeMembers::AddVoterIds([request.node_id].into_iter().collect());
-    admin_response(state.raft.change_membership(request, true).await)
+    admin_response(raft_state.raft.change_membership(request, true).await)
 }
 
 async fn change_membership(
-    State(state): State<AppState>,
+    Extension(state): Extension<RaftState>,
     Json(request): Json<ChangeMembershipRequest>,
 ) -> impl IntoResponse {
     state
@@ -171,8 +174,11 @@ async fn change_membership(
         .pipe(admin_response)
 }
 
-async fn initialize(State(state): State<AppState>) -> impl IntoResponse {
-    let addr = match detect_address(&state.cfg) {
+async fn initialize(
+    State(app_state): State<AppState>,
+    Extension(state): Extension<RaftState>,
+) -> impl IntoResponse {
+    let addr = match detect_address(&app_state.cfg) {
         Ok(a) => a,
         Err(_e) => return internal_error("could not find any valid addresses"),
     }
@@ -184,7 +190,7 @@ async fn initialize(State(state): State<AppState>) -> impl IntoResponse {
     state.raft.initialize(nodes).await.pipe(admin_response)
 }
 
-async fn health(State(state): State<AppState>) -> impl IntoResponse {
+async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {
     let leader = state.raft.current_leader().await;
     let me = state.node_id;
     state

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -1,0 +1,13 @@
+use crate::AppState;
+
+use super::handle::{Request, Response};
+
+pub(super) fn apply_request(request: Request, state: &AppState) -> anyhow::Result<Response> {
+    Ok(match request {
+        Request::Kv(req) => {
+            // TODO: this shouldn't be mut but KvStore currently requires it
+            let mut store = state.get_kv_store_by_key(req.key_name())?;
+            Response::Kv(req.apply(&mut store))
+        }
+    })
+}

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -148,6 +148,7 @@ impl Discovery {
 
     pub(super) async fn discover_cluster(mut self) -> anyhow::Result<()> {
         if self.cfg.cluster.seed_nodes.is_empty() {
+            tracing::debug!("no seed nodes provided, initializing a one-node cluster");
             self.initialize_cluster(BTreeMap::new()).await?;
             return Ok(());
         }

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -1,0 +1,35 @@
+use super::raft::{NodeId, Raft};
+use coyote_kv::operations::KvRequest;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum Request {
+    Kv(coyote_kv::operations::Operation),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum Response {
+    Blank,
+    Kv(coyote_kv::operations::Response),
+}
+
+#[derive(Clone)]
+pub struct RaftState {
+    pub raft: Raft,
+    pub node_id: NodeId,
+}
+
+impl RaftState {
+    pub async fn client_write_kv<O: KvRequest>(&self, op: O) -> O::Response {
+        let request = Request::Kv(op.into());
+        // TODO: don't unwrap here!
+        let response = self.raft.client_write(request).await.unwrap();
+        let Response::Kv(response) = response.data else {
+            panic!("got back incorrect response");
+        };
+        let Ok(resp) = O::Response::try_from(response) else {
+            panic!("got back incorrect response");
+        };
+        resp
+    }
+}

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -1,16 +1,59 @@
-use super::raft::{NodeId, Raft};
+use super::raft::{Node, NodeId, Raft};
 use coyote_kv::operations::KvRequest;
+use coyote_operations::{OperationRequest, OperationResponse};
+use openraft::error::{ClientWriteError, RaftError};
 use serde::{Deserialize, Serialize};
+
+type WriteResult<T> = Result<T, RaftError<NodeId, ClientWriteError<NodeId, Node>>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseParseError {
+    InvalidVariant,
+}
+
+impl std::fmt::Display for ResponseParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for ResponseParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        "Invalid response from consensus system"
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Request {
     Kv(coyote_kv::operations::Operation),
 }
 
+impl<T: KvRequest> From<T> for Request {
+    fn from(value: T) -> Self {
+        let op: coyote_kv::operations::Operation = value.into();
+        Request::Kv(op)
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Response {
     Blank,
     Kv(coyote_kv::operations::Response),
+}
+
+impl TryFrom<Response> for coyote_kv::operations::Response {
+    type Error = ResponseParseError;
+
+    fn try_from(value: Response) -> Result<Self, Self::Error> {
+        match value {
+            Response::Kv(v) => Ok(v),
+            _ => Err(ResponseParseError::InvalidVariant),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -20,16 +63,24 @@ pub struct RaftState {
 }
 
 impl RaftState {
-    pub async fn client_write_kv<O: KvRequest>(&self, op: O) -> O::Response {
-        let request = Request::Kv(op.into());
-        // TODO: don't unwrap here!
-        let response = self.raft.client_write(request).await.unwrap();
-        let Response::Kv(response) = response.data else {
-            panic!("got back incorrect response");
+    /// Write a single operation into the Raft log and return its response.
+    pub async fn client_write<O>(&self, op: O) -> WriteResult<O::Response>
+    where
+        O: Into<Request> + OperationRequest,
+        <<O as OperationRequest>::Response as OperationResponse>::ResponseParent: TryFrom<Response>,
+    {
+        let request = op.into();
+        let response = self.raft.client_write(request).await?;
+        let Ok(module_response) =
+            <<O as OperationRequest>::Response as OperationResponse>::ResponseParent::try_from(
+                response.data,
+            )
+        else {
+            panic!("failed to deserialize module response");
         };
-        let Ok(resp) = O::Response::try_from(response) else {
-            panic!("got back incorrect response");
+        let Ok(resp) = module_response.try_into() else {
+            panic!("failed to deserialize module response");
         };
-        resp
+        Ok(resp)
     }
 }

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -1,5 +1,4 @@
 use super::raft::{Node, NodeId, Raft};
-use coyote_kv::operations::KvRequest;
 use coyote_operations::{OperationRequest, OperationResponse};
 use openraft::error::{ClientWriteError, RaftError};
 use serde::{Deserialize, Serialize};
@@ -32,10 +31,9 @@ pub enum Request {
     Kv(coyote_kv::operations::Operation),
 }
 
-impl<T: KvRequest> From<T> for Request {
+impl<T: Into<coyote_kv::operations::Operation>> From<T> for Request {
     fn from(value: T) -> Self {
-        let op: coyote_kv::operations::Operation = value.into();
-        Request::Kv(op)
+        Request::Kv(value.into())
     }
 }
 
@@ -68,19 +66,23 @@ impl RaftState {
     where
         O: Into<Request> + OperationRequest,
         <<O as OperationRequest>::Response as OperationResponse>::ResponseParent: TryFrom<Response>,
+        <<<O as OperationRequest>::Response as OperationResponse>::ResponseParent as TryFrom<
+            Response,
+        >>::Error: std::fmt::Debug,
+        <<<O as OperationRequest>::Response as OperationResponse>::ResponseParent as TryInto<
+            <O as OperationRequest>::Response,
+        >>::Error: std::fmt::Debug,
     {
         let request = op.into();
         let response = self.raft.client_write(request).await?;
-        let Ok(module_response) =
+        let module_response =
             <<O as OperationRequest>::Response as OperationResponse>::ResponseParent::try_from(
                 response.data,
             )
-        else {
-            panic!("failed to deserialize module response");
-        };
-        let Ok(resp) = module_response.try_into() else {
-            panic!("failed to deserialize module response");
-        };
+            .expect("raft response should be convertible into module response type");
+        let resp = module_response
+            .try_into()
+            .expect("module response should be convertible into target type");
         Ok(resp)
     }
 }

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -1,8 +1,10 @@
 use openraft::RaftTypeConfig;
 
 mod app;
+mod applier;
 mod discovery;
 mod errors;
+mod handle;
 mod logs;
 mod network;
 pub mod proto;
@@ -12,6 +14,7 @@ mod state_machine;
 
 pub use self::{
     app::router,
+    handle::RaftState,
     logs::CoyoteLogs,
     raft::{Raft, TypeConfig, initialize_raft},
     state_machine::Store,

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -83,7 +83,10 @@ pub async fn initialize_raft(
             s.committed.is_some() || s.membership_state.effective().nodes().count() > 0
         })
         .await?;
-    if !has_cluster {
+    if has_cluster {
+        tracing::debug!("node already has cluster information; skipping discovery");
+    } else {
+        tracing::debug!("node has no cluster information; kicking off discovery");
         let disco = Discovery::new(cfg.clone(), raft.clone(), id)?;
         tokio::spawn(async move {
             if let Err(err) = disco.discover_cluster().await {
@@ -92,6 +95,7 @@ pub async fn initialize_raft(
                     "discovery failed; this node must be manually initialized"
                 );
             }
+            tracing::info!("discovery succeeded");
         });
     }
     Ok(RaftState { raft, node_id: id })

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -1,30 +1,15 @@
 use std::sync::Arc;
 
-use fjall::Database;
 use openraft::BasicNode;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::{discovery::Discovery, state_machine::StoredSnapshot};
-use crate::cfg::Configuration;
-
-// TODO: this should actually be our Operation trait
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct Request {
-    key: String,
-}
-
-// TODO: the value here needs to actually be the response from Operation
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct Response {
-    value: Option<String>,
-}
-
-impl Response {
-    pub(crate) fn blank() -> Self {
-        Self { value: None }
-    }
-}
+use super::{
+    discovery::Discovery,
+    handle::{RaftState, Request, Response},
+    state_machine::StoredSnapshot,
+};
+use crate::{AppState, cfg::Configuration};
 
 // TODO: is BasicNode enough for us?
 pub(super) type Node = BasicNode;
@@ -71,7 +56,10 @@ openraft::declare_raft_types!(
 
 pub type Raft = openraft::Raft<TypeConfig>;
 
-pub async fn initialize_raft(cfg: &Configuration, db: Database) -> anyhow::Result<(Raft, NodeId)> {
+pub async fn initialize_raft(
+    cfg: &Configuration,
+    app_state: AppState,
+) -> anyhow::Result<RaftState> {
     let mut logs = super::CoyoteLogs::new(&cfg.cluster.log_path).await?;
     let id = logs.get_node_id().await?;
     let config = openraft::Config {
@@ -83,8 +71,12 @@ pub async fn initialize_raft(cfg: &Configuration, db: Database) -> anyhow::Resul
     };
     let config = Arc::new(config.validate()?);
     let network = super::network::NetworkFactory::new(cfg);
+
+    // TODO: handle ephemeral DB
+    let db = app_state.configgroup_state.db().clone();
+
     let state_machine =
-        super::state_machine::Store::new(db, cfg.cluster.snapshot_path.clone()).await?;
+        super::state_machine::Store::new(db, cfg.cluster.snapshot_path.clone(), app_state).await?;
     let raft = Raft::new(id, config, network, logs, state_machine).await?;
     let has_cluster = raft
         .with_raft_state(|s| {
@@ -102,7 +94,7 @@ pub async fn initialize_raft(cfg: &Configuration, db: Database) -> anyhow::Resul
             }
         });
     }
-    Ok((raft, id))
+    Ok(RaftState { raft, node_id: id })
 }
 
 #[cfg(test)]
@@ -111,8 +103,12 @@ mod tests {
     use openraft::{StorageIOError, testing::StoreBuilder};
     use tempfile::TempDir;
 
-    use super::{NodeId, TypeConfig};
-    use crate::core::cluster::{logs::CoyoteLogs, state_machine::Store};
+    use crate::{AppState, cfg::ConfigurationInner};
+
+    use super::{
+        super::{logs::CoyoteLogs, state_machine::Store},
+        NodeId, TypeConfig,
+    };
 
     struct CoyoteStoreBuilder;
 
@@ -125,10 +121,22 @@ mod tests {
 
             let mut data_path = workdir.path().to_path_buf();
             data_path.push("data");
+            let mut e_data_path = workdir.path().to_path_buf();
+            e_data_path.push("edata");
+
             let mut snapshot_path = workdir.path().to_path_buf();
             snapshot_path.push("snapshots");
+
+            let mut cfg = ConfigurationInner::default();
+            cfg.ephemeral_db.path = e_data_path.clone();
+            cfg.persistent_db.path = data_path.clone();
+            let cfg = cfg.into();
+
             let db = Database::builder(data_path).open()?;
-            let store = Store::new(db, snapshot_path).await?;
+
+            let app_state: AppState = AppState::new(cfg);
+
+            let store = Store::new(db, snapshot_path, app_state).await?;
 
             Ok((workdir, logs, store))
         }

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -8,16 +8,17 @@ use std::{
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
 use openraft::{
     EntryPayload, LogId, RaftSnapshotBuilder, RaftTypeConfig, Snapshot, SnapshotMeta,
-    StoredMembership, storage::RaftStateMachine,
+    StorageIOError, StoredMembership, storage::RaftStateMachine,
 };
 use serde::{Deserialize, Serialize};
 
 use super::{
     errors::*,
+    handle::Response,
     raft::{Node, TypeConfig},
     serialized_state_machine,
 };
-use crate::core::cluster::raft;
+use crate::AppState;
 
 type NodeId = <TypeConfig as RaftTypeConfig>::NodeId;
 type StorageError = openraft::StorageError<NodeId>;
@@ -31,6 +32,7 @@ struct LastSnapshot {
 
 #[derive(Clone)]
 pub struct Store {
+    state: AppState,
     db: Database,
     snapshot_directory: PathBuf,
     meta_keyspace: Keyspace,
@@ -59,7 +61,11 @@ impl SnapshotIdx for SnapshotMeta<NodeId, Node> {
 const METADATA_KEYSPACE: &str = "_raft_metadata";
 
 impl Store {
-    pub async fn new(db: Database, snapshot_directory: PathBuf) -> anyhow::Result<Self> {
+    pub async fn new(
+        db: Database,
+        snapshot_directory: PathBuf,
+        app_state: AppState,
+    ) -> anyhow::Result<Self> {
         if let Err(e) = tokio::fs::create_dir_all(&snapshot_directory).await
             && e.kind() != ErrorKind::AlreadyExists
         {
@@ -68,6 +74,7 @@ impl Store {
         let meta_keyspace = db.keyspace(METADATA_KEYSPACE, KeyspaceCreateOptions::default)?;
         let mut this = Self {
             db,
+            state: app_state,
             snapshot_directory,
             meta_keyspace,
             last_snapshot: Arc::new(RwLock::new(None)),
@@ -350,7 +357,7 @@ impl RaftStateMachine<TypeConfig> for Store {
         Ok((self.last_applied_log_id, self.last_membership.clone()))
     }
 
-    async fn apply<I>(&mut self, entries: I) -> StorageResult<Vec<raft::Response>>
+    async fn apply<I>(&mut self, entries: I) -> StorageResult<Vec<Response>>
     where
         I: IntoIterator<Item = <TypeConfig as RaftTypeConfig>::Entry> + openraft::OptionalSend,
         I::IntoIter: openraft::OptionalSend,
@@ -365,18 +372,27 @@ impl RaftStateMachine<TypeConfig> for Store {
             match item.payload {
                 EntryPayload::Blank => {
                     tracing::trace!("heartbeat");
-                    replies.push(raft::Response::blank())
+                    replies.push(Response::Blank)
                 }
                 EntryPayload::Normal(req) => {
-                    // TODO actually apply something
                     tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
+                    let reply = match super::applier::apply_request(req, &self.state) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            tracing::error!("failed to apply raft log");
+                            return Err(StorageError::IO {
+                                source: StorageIOError::apply(item.log_id, e),
+                            });
+                        }
+                    };
+                    replies.push(reply);
                 }
                 EntryPayload::Membership(last_membership) => {
                     tracing::trace!("changing cluster membership");
                     self.last_membership =
                         StoredMembership::new(Some(item.log_id), last_membership);
                     changed_membership = true;
-                    replies.push(raft::Response::blank())
+                    replies.push(Response::Blank)
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ pub fn setup_tracing_for_tests() {
                 // Output is only printed for failing tests, but still we shouldn't overload
                 // the output with unnecessary info. When debugging a specific test, it's easy
                 // to override this default by setting the `RUST_LOG` environment variable.
-                "coyote=debug".into()
+                "coyote=debug,it=debug".into()
             }),
         )
         .with(tracing_subscriber::fmt::layer().with_test_writer())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{sync::LazyLock, time::Duration};
 
 use aide::axum::ApiRouter;
-use axum::middleware;
+use axum::{Extension, middleware};
 use cfg::ConfigurationInner;
 use coyote_configgroup::{
     BothDatabases,
@@ -39,6 +39,7 @@ use uuid::Uuid;
 
 use crate::{
     cfg::{Configuration, DatabaseConfig},
+    core::cluster::RaftState,
     v1::modules::{cache::CacheStore, idempotency::IdempotencyStore},
 };
 
@@ -108,14 +109,16 @@ pub struct AppState {
     cfg: Configuration,
     rate_limiter: crate::v1::modules::rate_limiter::RateLimiter,
 
-    raft: core::cluster::Raft,
-    node_id: core::cluster::NodeId,
-
     stream_state: stream::State,
     configgroup_state: coyote_configgroup::State,
 }
 
-async fn run_interserver(cfg: Configuration, state: AppState, listener: Option<TcpListener>) {
+async fn run_interserver(
+    cfg: Configuration,
+    state: AppState,
+    raft: RaftState,
+    listener: Option<TcpListener>,
+) {
     let listen_address = cfg.cluster.listen_address;
     let listener = match listener {
         Some(l) => l,
@@ -130,6 +133,7 @@ async fn run_interserver(cfg: Configuration, state: AppState, listener: Option<T
 
     let app = core::cluster::router()
         .with_state(state.clone())
+        .layer(Extension(raft.clone()))
         .layer(middleware::from_fn(coyote_proto::capture_accept_hdr));
     let svc = tower::make::Shared::new(
         // It is important that this service wraps the router instead of being
@@ -142,10 +146,33 @@ async fn run_interserver(cfg: Configuration, state: AppState, listener: Option<T
         .await
         .unwrap();
 
-    state.raft.shutdown().await.unwrap();
+    raft.raft.shutdown().await.unwrap();
 }
 
 impl AppState {
+    fn new(cfg: Configuration) -> Self {
+        let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
+        let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
+
+        let configgroup_state = coyote_configgroup::State::init(BothDatabases {
+            persistent_db: persistent_db.clone(),
+            ephemeral_db,
+        })
+        .expect("initializing configgroup state");
+
+        let stream_state =
+            stream::State::init(persistent_db.clone()).expect("initializing stream state");
+        AppState {
+            cfg,
+            rate_limiter: crate::v1::modules::rate_limiter::RateLimiter::new(
+                "rate_limiter_default",
+                persistent_db,
+            ),
+            stream_state,
+            configgroup_state,
+        }
+    }
+
     fn get_store_by_key<C: ModuleConfig>(&self, key_name: &str) -> Result<KvStore> {
         let group_name = group_name(key_name);
 
@@ -192,39 +219,21 @@ pub async fn run_with_prefix(
     // needed at router-construction time.
     let mut openapi = openapi::initialize_openapi();
 
-    let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
-    let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
+    // build our application with a route
+    let app_state = AppState::new(cfg.clone());
 
-    let configgroup_state = coyote_configgroup::State::init(BothDatabases {
-        persistent_db: persistent_db.clone(),
-        ephemeral_db: ephemeral_db.clone(),
-    })
-    .expect("initializing configgroup state");
-
-    let stream_state =
-        stream::State::init(persistent_db.clone()).expect("initializing stream state");
-
-    let (raft, node_id) = core::cluster::initialize_raft(&cfg, persistent_db.clone())
+    let raft_state = core::cluster::initialize_raft(&cfg, app_state.clone())
         .await
         .expect("failed to initialize cluster");
 
-    // build our application with a route
-    let app_state = AppState {
-        cfg: cfg.clone(),
-        rate_limiter: crate::v1::modules::rate_limiter::RateLimiter::new(
-            "rate_limiter_default",
-            persistent_db.clone(),
-        ),
-        stream_state,
-        raft,
-        node_id,
-        configgroup_state,
-    };
-    let v1_router = v1::router().with_state::<()>(app_state.clone());
+    let v1_router = v1::router()
+        .with_state::<()>(app_state.clone())
+        .layer(Extension(raft_state.clone()));
 
     let interserver = tokio::spawn(run_interserver(
         cfg.clone(),
         app_state.clone(),
+        raft_state.clone(),
         interserver_listener,
     ));
 

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -6,6 +6,8 @@ use std::{sync::Arc, time::Duration};
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_derive::aide_annotate;
+use coyote_error::ResultExt;
+use coyote_kv::KvStore;
 use coyote_proto::MsgPackOrJson;
 use jiff::Timestamp;
 use schemars::JsonSchema;
@@ -100,18 +102,15 @@ pub struct KvDeleteOut {
 /// KV Set
 #[aide_annotate(op_id = "v1.kv.set")]
 async fn kv_set(
-    State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<KvSetIn>,
 ) -> Result<MsgPackOrJson<KvSetOut>> {
-    let kv_store = state.get_kv_store_by_key(&data.key.0)?;
-
     let key = data.key.0.clone();
     let behavior = data.behavior.clone();
     let model = data.into_model();
 
-    let operation = kv_store.set_operation(key, model, behavior);
-    repl.client_write_kv(operation).await.0?;
+    let operation = KvStore::set_operation(key, model, behavior);
+    repl.client_write(operation).await.map_err_generic()?.0?;
 
     let ret = KvSetOut {};
     Ok(MsgPackOrJson(ret))

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -4,7 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use aide::axum::{ApiRouter, routing::post_with};
-use axum::extract::State;
+use axum::{Extension, extract::State};
 use coyote_derive::aide_annotate;
 use coyote_proto::MsgPackOrJson;
 use jiff::Timestamp;
@@ -14,7 +14,7 @@ use validator::Validate;
 
 use crate::{
     AppState,
-    core::types::EntityKey,
+    core::{cluster::RaftState, types::EntityKey},
     error::Result,
     v1::{
         modules::kv::{KvModel, OperationBehavior},
@@ -101,17 +101,17 @@ pub struct KvDeleteOut {
 #[aide_annotate(op_id = "v1.kv.set")]
 async fn kv_set(
     State(state): State<AppState>,
+    Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<KvSetIn>,
 ) -> Result<MsgPackOrJson<KvSetOut>> {
-    let mut kv_store = state.get_kv_store_by_key(&data.key.0)?;
+    let kv_store = state.get_kv_store_by_key(&data.key.0)?;
 
-    let key = data.key.clone();
+    let key = data.key.0.clone();
     let behavior = data.behavior.clone();
     let model = data.into_model();
 
-    kv_store
-        .set(&key.0, &model, behavior)
-        .map_err(|e| crate::error::Error::generic(e))?;
+    let operation = kv_store.set_operation(key, model, behavior);
+    repl.client_write_kv(operation).await.0?;
 
     let ret = KvSetOut {};
     Ok(MsgPackOrJson(ret))

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -22,7 +22,7 @@ async fn kv_set(
             "behavior": behavior
         }))
         .await?
-        .expect(StatusCode::OK);
+        .ensure(StatusCode::OK)?;
     Ok(())
 }
 
@@ -33,7 +33,7 @@ async fn kv_get(client: &TestClient, key: &str) -> TestResult<Value> {
             "key": key
         }))
         .await?
-        .expect(StatusCode::OK)
+        .ensure(StatusCode::OK)?
         .json();
     Ok(response)
 }
@@ -45,7 +45,7 @@ async fn kv_not_found(client: &TestClient, key: &str) -> TestResult<()> {
             "key": key
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND)
+        .ensure(StatusCode::NOT_FOUND)?
         .json();
     Ok(())
 }

--- a/tests/it/server/mod.rs
+++ b/tests/it/server/mod.rs
@@ -119,7 +119,7 @@ impl TestServerBuilder {
 
         let client = TestClient::new(base_uri, &token);
 
-        wait_for_initialized(repl_addr, Duration::from_secs(2))
+        wait_for_initialized(repl_addr, Duration::from_secs(8))
             .await
             .expect("failed to initialize server");
 
@@ -140,12 +140,14 @@ pub struct TestContext {
 }
 
 async fn check_initialized(client: &reqwest::Client, url: &str) -> anyhow::Result<bool> {
+    tracing::debug!("checking if server is initialized yet...");
     let response = client
         .get(url)
         .timeout(Duration::from_millis(10))
         .send()
         .await?;
     if response.status() != 200 {
+        tracing::debug!(status=%response.status(), "server returned an error");
         return Ok(false);
     }
     let body: HealthResponse = response.json().await?;
@@ -175,6 +177,7 @@ async fn wait_for_initialized(repl_addr: SocketAddr, max_wait: Duration) -> anyh
             }
             Err(_) => anyhow::bail!("timed out waiting for server to boot"),
         }
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }
 
@@ -201,15 +204,15 @@ pub(crate) fn build_config_without_server(
     let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
 
     let cfg = cfg.unwrap_or_else(|| ConfigurationInner {
-        listen_address: addr.clone(),
-        ephemeral_db: Arc::new(DatabaseConfig {
+        listen_address: addr,
+        ephemeral_db: DatabaseConfig {
             path: db_dir.clone(),
             ..Default::default()
-        }),
-        persistent_db: Arc::new(DatabaseConfig {
+        },
+        persistent_db: DatabaseConfig {
             path: db_dir,
             ..Default::default()
-        }),
+        },
         jwt_signing_config: Arc::new(JwtSigningConfig::HS256(jwt_key)),
         log_level: LogLevel::Debug,
         log_format: LogFormat::Default,
@@ -221,14 +224,14 @@ pub(crate) fn build_config_without_server(
         environment: Environment::Dev,
         internal: InternalConfig {},
         cluster: ClusterConfiguration {
-            listen_address: addr.clone(),
+            listen_address: addr,
             name: "coyote-test".to_string(),
             snapshot_path,
             log_path,
             connection_timeout: Duration::from_millis(50),
-            heartbeat_interval_ms: 100,
-            election_timeout_min_ms: 200,
-            election_timeout_max_ms: 300,
+            heartbeat_interval_ms: 5,
+            election_timeout_min_ms: 10,
+            election_timeout_max_ms: 30,
             auto_initialize: true,
             discovery_request_timeout: Duration::from_millis(10),
             discovery_timeout: Duration::from_secs(1),


### PR DESCRIPTION
This is a sketch of what it would look like to map high-level operations into the consensus layer.

Obviously it's extremely verbose; I think it would be quite reasonable to write a macro to generate all of the code in `crates/kv/src/operations/mod.rs` and much of the code in `crates/kv/src/operations/set.rs` and `crates/kv/src/operations/delete.rs`. I'm envisioning something like

```rust
// complete contents of mod.rs

mod set;
mod delete;

impl_module_operations!(
  Set => set::SetOperation + set::SetResponse,
  Delete => delete::DeleteOperation + delete::DeleteResponse
)
```

I have that part mostly built and would plan to put it in the `coyote-operations` trait so we can reuse it across all modules.

I also think we can make a macro for the stuff in `handle.rs`. I had initially hoped to use `enum_dispatch` for it, but it doesn't support associated types. I still think we can have something like

```rust
impl_handles!(
  Kv => coyote_kv::operations::KvRequest + coyote_kv::Operations::KvResponse
)
```

and have that generate  the Request type, the Response type, and the various convenience methods on the handle object.

This is not landable as-is for several reasons, including that it breaks rate-limiting and cache (which... internally do cross-module writes, which will be annoying to implement).

Like I said, mostly just a sketch. This does actually work, though.