### PR TITLE
Fix lint errors w/SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
           # cf https://github.com/Swatinem/rust-cache/issues/95
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt -- --check
-      # TODO: re-enable when stuff passes cargo-clippy
-      # - run: cargo clippy -- --workspace -all-features --all-targets
+      - run: cargo clippy --workspace --all-features --all-targets
       - run: cargo sort --check --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
   # TODO: re-enable cargo-machete when we're further along in dev
   # check-unused-deps:

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -6,7 +6,7 @@ use concolor_clap::{Color, ColorChoice};
 use coyote_client::{CoyoteClient, CoyoteOptions};
 
 use self::{
-    cmds::api::{CacheArgs, KvArgs, QueueArgs, RateLimiterArgs, StreamArgs},
+    cmds::api::{CacheArgs, KvArgs, RateLimiterArgs, StreamArgs},
     config::Config,
 };
 
@@ -62,7 +62,6 @@ impl Cli {
 enum RootCommands {
     Cache(CacheArgs),
     Kv(KvArgs),
-    Queue(QueueArgs),
     RateLimit(RateLimiterArgs),
     Stream(StreamArgs),
     /// Get the version of the Svix CLI
@@ -106,10 +105,6 @@ async fn main() -> Result<()> {
         RootCommands::Kv(args) => {
             let cfg = cfg?;
             let client = get_client(&cfg)?;
-            args.command.exec(&client, color_mode).await?;
-        }
-        RootCommands::Queue(args) => {
-            let client = get_client(&cfg?)?;
             args.command.exec(&client, color_mode).await?;
         }
         RootCommands::RateLimit(args) => {


### PR DESCRIPTION
When I nuked the modules and SDK, it caused compile errors because I didn't notice we needed to remove the `QueueArgs` (which now don't exist) in the client code.