### PR TITLE
Implement queue semantics with Stream

### DIFF
--- a/clients/cli/src/cmds/api/stream.rs
+++ b/clients/cli/src/cmds/api/stream.rs
@@ -29,6 +29,19 @@ impl From<StreamAppendOptions> for coyote_client::api::StreamAppendOptions {
 }
 
 #[derive(Args, Clone)]
+pub struct StreamFetchOptions {
+    #[arg(long)]
+    pub idempotency_key: Option<String>,
+}
+
+impl From<StreamFetchOptions> for coyote_client::api::StreamFetchOptions {
+    fn from(value: StreamFetchOptions) -> Self {
+        let StreamFetchOptions { idempotency_key } = value;
+        Self { idempotency_key }
+    }
+}
+
+#[derive(Args, Clone)]
 pub struct StreamFetchLockingOptions {
     #[arg(long)]
     pub idempotency_key: Option<String>,
@@ -75,6 +88,16 @@ pub enum StreamCommands {
         #[clap(flatten)]
         options: StreamAppendOptions,
     },
+    /// Fetches messages from the stream, while allowing concurrent access from other consumers in the same group.
+    ///
+    /// Unlike `stream.fetch-locking`, this does not block other consumers within the same consumer group from reading
+    /// messages from the Stream. The consumer will still take an exclusive lock on the messages fetched, and that lock is held
+    /// until the visibility timeout expires, or the messages are acked.
+    Fetch {
+        fetch_from_stream_in: crate::json::JsonOf<coyote_client::models::FetchFromStreamIn>,
+        #[clap(flatten)]
+        options: StreamFetchOptions,
+    },
     /// Fetches messages from the stream, locking over the consumer group.
     ///
     /// This call prevents other consumers within the same consumer group from reading from the stream
@@ -116,6 +139,16 @@ impl StreamCommands {
                 let resp = client
                     .stream()
                     .append(append_to_stream_in.into_inner(), Some(options.into()))
+                    .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Fetch {
+                fetch_from_stream_in,
+                options,
+            } => {
+                let resp = client
+                    .stream()
+                    .fetch(fetch_from_stream_in.into_inner(), Some(options.into()))
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }

--- a/clients/rust/src/api/mod.rs
+++ b/clients/rust/src/api/mod.rs
@@ -12,7 +12,7 @@ pub use self::{
     rate_limiter::{RateLimiter, RateLimiterGetRemainingOptions, RateLimiterLimitOptions},
     stream::{
         Stream, StreamAckOptions, StreamAppendOptions, StreamCreateOptions,
-        StreamFetchLockingOptions,
+        StreamFetchLockingOptions, StreamFetchOptions,
     },
 };
 

--- a/clients/rust/src/api/stream.rs
+++ b/clients/rust/src/api/stream.rs
@@ -12,6 +12,11 @@ pub struct StreamAppendOptions {
 }
 
 #[derive(Default)]
+pub struct StreamFetchOptions {
+    pub idempotency_key: Option<String>,
+}
+
+#[derive(Default)]
 pub struct StreamFetchLockingOptions {
     pub idempotency_key: Option<String>,
 }
@@ -56,6 +61,25 @@ impl<'a> Stream<'a> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/append")
             .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(append_to_stream_in)
+            .execute(self.cfg)
+            .await
+    }
+
+    /// Fetches messages from the stream, while allowing concurrent access from other consumers in the same group.
+    ///
+    /// Unlike `stream.fetch-locking`, this does not block other consumers within the same consumer group from reading
+    /// messages from the Stream. The consumer will still take an exclusive lock on the messages fetched, and that lock is held
+    /// until the visibility timeout expires, or the messages are acked.
+    pub async fn fetch(
+        &self,
+        fetch_from_stream_in: FetchFromStreamIn,
+        options: Option<StreamFetchOptions>,
+    ) -> Result<FetchFromStreamOut> {
+        let StreamFetchOptions { idempotency_key } = options.unwrap_or_default();
+
+        crate::request::Request::new(http::Method::POST, "/api/v1/stream/fetch")
+            .with_optional_header_param("idempotency-key", idempotency_key)
+            .with_body_param(fetch_from_stream_in)
             .execute(self.cfg)
             .await
     }

--- a/crates/stream/src/operations/fetch.rs
+++ b/crates/stream/src/operations/fetch.rs
@@ -1,0 +1,75 @@
+use std::num::NonZeroU16;
+
+use crate::{
+    State,
+    entities::{ConsumerGroup, MsgId, MsgOut, StreamName},
+    tables::{LeaseDiff, LeaseRow, MsgRow, NameToStreamRow},
+};
+use coyote_error::Result;
+use jiff::Timestamp;
+
+pub struct Fetch {
+    lease_diff: LeaseDiff,
+    msgs: Vec<(MsgId, MsgRow)>,
+}
+
+pub struct FetchOutput {
+    pub msgs: Vec<MsgOut>,
+}
+
+impl Fetch {
+    pub fn new(
+        state: &State,
+        name: StreamName,
+        cg: ConsumerGroup,
+        batch_size: NonZeroU16,
+        visibility_timeout: std::time::Duration,
+    ) -> Result<Self> {
+        let stream_id = NameToStreamRow::get_stream_id(state, &name)?;
+        let now = Timestamp::now();
+        let leases = LeaseRow::fetch_all(state, stream_id, &cg)?;
+
+        // Unlike FetchLocking, we don't block on active leases.
+        // Instead, we exclude both acked and active leases from the fetch.
+        let blocked_leases = leases
+            .iter()
+            .filter(|lease| lease.acked_at.is_some() || lease.is_active(now));
+
+        let msgs = MsgRow::fetch_available(state, stream_id, blocked_leases, batch_size.into())?;
+
+        let mut lease_diff = LeaseRow::cull_and_compact(leases, now);
+
+        if !msgs.is_empty() {
+            lease_diff.to_insert.push(LeaseRow {
+                stream_id,
+                cg,
+                block_start: msgs.first().unwrap().0,
+                block_end: msgs.last().unwrap().0,
+                leased_at: now,
+                expires_at: now + visibility_timeout,
+                acked_at: None,
+            });
+        }
+
+        Ok(Self { lease_diff, msgs })
+    }
+
+    pub fn apply_operation(self, state: &State) -> Result<FetchOutput> {
+        let mut batch = state.db.batch();
+        self.lease_diff.apply_diff(state, &mut batch)?;
+        batch.commit()?;
+
+        let msgs = self
+            .msgs
+            .into_iter()
+            .map(|(id, msg)| MsgOut {
+                id,
+                payload: msg.payload,
+                headers: msg.headers,
+                timestamp: msg.created_at,
+            })
+            .collect();
+
+        Ok(FetchOutput { msgs })
+    }
+}

--- a/crates/stream/src/operations/mod.rs
+++ b/crates/stream/src/operations/mod.rs
@@ -1,9 +1,11 @@
 mod ack;
 mod append_to_stream;
 mod create_stream;
+mod fetch;
 mod fetch_locking;
 
 pub use ack::*;
 pub use append_to_stream::*;
 pub use create_stream::*;
+pub use fetch::*;
 pub use fetch_locking::*;

--- a/crates/stream/src/tables.rs
+++ b/crates/stream/src/tables.rs
@@ -403,21 +403,18 @@ impl MsgRow {
 
         let mut min = MsgId::MIN;
         for block in blocked_ranges {
-            let max = block.start.saturating_sub(1);
-            if max == MsgId::MIN {
-                min = block.end + 1;
-                continue;
-            }
+            if block.start > min {
+                let max = block.start - 1;
+                let range = msg_row_key_range(stream_id, min..=max);
 
-            let range = msg_row_key_range(stream_id, min..=max);
+                let n = MsgRow::fetch_in_range(state, range, &mut results, msgs_left)?;
+                msgs_left -= n;
+
+                if msgs_left == 0 {
+                    return Ok(results);
+                }
+            }
             min = block.end + 1;
-
-            let n = MsgRow::fetch_in_range(state, range, &mut results, msgs_left)?;
-            msgs_left -= n;
-
-            if msgs_left == 0 {
-                return Ok(results);
-            }
         }
 
         if msgs_left > 0 {

--- a/openapi.json
+++ b/openapi.json
@@ -670,6 +670,54 @@
         ]
       }
     },
+    "/api/v1/stream/fetch": {
+      "post": {
+        "tags": [
+          "Stream"
+        ],
+        "summary": "Fetch From Stream",
+        "description": "Fetches messages from the stream, while allowing concurrent access from other consumers in the same group.\n\nUnlike `stream.fetch-locking`, this does not block other consumers within the same consumer group from reading\nmessages from the Stream. The consumer will still take an exclusive lock on the messages fetched, and that lock is held\nuntil the visibility timeout expires, or the messages are acked.",
+        "operationId": "v1.stream.fetch",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "idempotency-key",
+            "description": "The request's idempotency key",
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FetchFromStreamIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FetchFromStreamOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/stream/fetch-locking": {
       "post": {
         "tags": [

--- a/src/v1/endpoints/stream.rs
+++ b/src/v1/endpoints/stream.rs
@@ -185,6 +185,42 @@ async fn locking_fetch_from_stream(
     Ok(Json(FetchFromStreamOut { msgs: out.msgs }))
 }
 
+/// Fetches messages from the stream, while allowing concurrent access from other consumers in the same group.
+///
+/// Unlike `stream.fetch-locking`, this does not block other consumers within the same consumer group from reading
+/// messages from the Stream. The consumer will still take an exclusive lock on the messages fetched, and that lock is held
+/// until the visibility timeout expires, or the messages are acked.
+#[aide_annotate(op_id = "v1.stream.fetch")]
+async fn fetch_from_stream(
+    State(AppState { stream_state, .. }): State<AppState>,
+    ValidatedJson(data): ValidatedJson<FetchFromStreamIn>,
+) -> Result<Json<FetchFromStreamOut>> {
+    /*
+    FIXME(@svix-gabriel)
+
+    This is missing a few important things
+        1. We haven't setup thread-per-core, so this could go to any thread.
+        2. We haven't setup quorum/raft stuff yet, so there's no consensus..
+
+    I didn't want to let either of these things block developing stream,
+    so in practice the structure of this handler will look different once those two pieces are in place.
+    */
+
+    let out = tokio::task::spawn_blocking(move || {
+        let op = stream::operations::Fetch::new(
+            &stream_state,
+            data.name,
+            data.consumer_group,
+            data.batch_size,
+            Duration::from_secs(data.visibility_timeout_seconds),
+        )?;
+        op.apply_operation(&stream_state)
+    })
+    .await??;
+
+    Ok(Json(FetchFromStreamOut { msgs: out.msgs }))
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AckIn {
@@ -242,6 +278,11 @@ pub fn router() -> ApiRouter<AppState> {
         .api_route_with(
             "/stream/append",
             post_with(append_to_stream, append_to_stream_operation),
+            &tag,
+        )
+        .api_route_with(
+            "/stream/fetch",
+            post_with(fetch_from_stream, fetch_from_stream_operation),
             &tag,
         )
         .api_route_with(

--- a/tests/it/stream.rs
+++ b/tests/it/stream.rs
@@ -242,3 +242,419 @@ async fn stream_visibility_timeout() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn queue_fetch_with_queue_semantics() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    let _stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "name": "test-stream",
+            "msgs": [
+                {"payload": [1, 2], "headers": {"msg": "1"}},
+                {"payload": [3, 4], "headers": {"msg": "2"}},
+                {"payload": [5, 6], "headers": {"msg": "3"}},
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch first batch of 2 messages
+    let fetch1 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 2,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 2);
+    assert_eq!(
+        msgs1[0],
+        json!({"id": 0, "payload": [1, 2], "headers": {"msg": "1"}, "timestamp": msgs1[0]["timestamp"]})
+    );
+    assert_eq!(
+        msgs1[1],
+        json!({"id": 1, "payload": [3, 4], "headers": {"msg": "2"}, "timestamp": msgs1[1]["timestamp"]})
+    );
+
+    // Ack the first batch
+    let max_msg_id = &msgs1[1]["id"];
+    client
+        .post("stream/ack")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "maxMsgId": max_msg_id
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch second batch - should get remaining message
+    let fetch2 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 2,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 1);
+    assert_eq!(
+        msgs2[0],
+        json!({"id": 2, "payload": [5, 6], "headers": {"msg": "3"}, "timestamp": msgs2[0]["timestamp"]})
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_fetch_concurrent_consumers() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    let _stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "name": "test-stream",
+            "msgs": [
+                {"payload": [1, 2], "headers": {"msg": "A"}},
+                {"payload": [3, 4], "headers": {"msg": "B"}},
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch message A with a short visibility timeout
+    let fetch1 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 1,
+            "visibilityTimeoutSeconds": 2
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 1);
+    assert_eq!(
+        msgs1[0],
+        json!({"id": 0, "payload": [1, 2], "headers": {"msg": "A"}, "timestamp": msgs1[0]["timestamp"]})
+    );
+
+    // Fetch again - should get message B (not blocked by A's lock)
+    let fetch2 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 1,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 1);
+    assert_eq!(
+        msgs2[0],
+        json!({"id": 1, "payload": [3, 4], "headers": {"msg": "B"}, "timestamp": msgs2[0]["timestamp"]})
+    );
+
+    // Wait for A's visibility timeout to expire
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Fetch again - should get message A back (its lock expired)
+    let fetch3 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 1,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs3 = fetch3["msgs"].as_array().unwrap();
+    assert_eq!(msgs3.len(), 1);
+    assert_eq!(
+        msgs3[0],
+        json!({"id": 0, "payload": [1, 2], "headers": {"msg": "A"}, "timestamp": msgs3[0]["timestamp"]})
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_fetch_mixed_visibility_timeouts() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    let _stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "name": "test-stream",
+            "msgs": [
+                {"payload": [0], "headers": {"msg": "A"}},
+                {"payload": [1], "headers": {"msg": "B"}},
+                {"payload": [2], "headers": {"msg": "C"}},
+                {"payload": [3], "headers": {"msg": "D"}},
+                {"payload": [4], "headers": {"msg": "E"}},
+                {"payload": [5], "headers": {"msg": "F"}},
+                {"payload": [6], "headers": {"msg": "G"}},
+                {"payload": [7], "headers": {"msg": "H"}},
+                {"payload": [8], "headers": {"msg": "I"}},
+                {"payload": [9], "headers": {"msg": "J"}},
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch A + B with short visibility timeout
+    let fetch1 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 2,
+            "visibilityTimeoutSeconds": 2
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 2);
+    assert_eq!(msgs1[0]["headers"]["msg"], "A");
+    assert_eq!(msgs1[1]["headers"]["msg"], "B");
+
+    // Fetch C + D with short visibility timeout
+    let fetch2 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 2,
+            "visibilityTimeoutSeconds": 2
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 2);
+    assert_eq!(msgs2[0]["headers"]["msg"], "C");
+    assert_eq!(msgs2[1]["headers"]["msg"], "D");
+
+    // Fetch E + F with LONG visibility timeout
+    let fetch3 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 2,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs3 = fetch3["msgs"].as_array().unwrap();
+    assert_eq!(msgs3.len(), 2);
+    assert_eq!(msgs3[0]["headers"]["msg"], "E");
+    assert_eq!(msgs3[1]["headers"]["msg"], "F");
+
+    // Ack C + D
+    client
+        .post("stream/ack")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "minMsgId": msgs2[0]["id"],
+            "maxMsgId": msgs2[1]["id"]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Wait for A+B visibility timeout to expire (but not E+F)
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Fetch remaining - should get A, B (expired), G, H, I, J (never fetched)
+    // Should NOT get C, D (acked) or E, F (still locked)
+    let fetch4 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 10,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs4 = fetch4["msgs"].as_array().unwrap();
+    assert_eq!(msgs4.len(), 6);
+    assert_eq!(msgs4[0]["headers"]["msg"], "A");
+    assert_eq!(msgs4[1]["headers"]["msg"], "B");
+    assert_eq!(msgs4[2]["headers"]["msg"], "G");
+    assert_eq!(msgs4[3]["headers"]["msg"], "H");
+    assert_eq!(msgs4[4]["headers"]["msg"], "I");
+    assert_eq!(msgs4[5]["headers"]["msg"], "J");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_fetch_partial_ack_across_blocks() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    let _stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "name": "test-stream",
+            "msgs": [
+                {"payload": [0], "headers": {"msg": "A"}},
+                {"payload": [1], "headers": {"msg": "B"}},
+                {"payload": [2], "headers": {"msg": "C"}},
+                {"payload": [3], "headers": {"msg": "D"}},
+                {"payload": [4], "headers": {"msg": "E"}},
+                {"payload": [5], "headers": {"msg": "F"}},
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch first block: A, B, C (ids 0, 1, 2)
+    let fetch1 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 3,
+            "visibilityTimeoutSeconds": 2
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 3);
+    assert_eq!(msgs1[0]["headers"]["msg"], "A");
+    assert_eq!(msgs1[1]["headers"]["msg"], "B");
+    assert_eq!(msgs1[2]["headers"]["msg"], "C");
+
+    // Fetch second block: D, E, F (ids 3, 4, 5)
+    let fetch2 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 3,
+            "visibilityTimeoutSeconds": 2
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 3);
+    assert_eq!(msgs2[0]["headers"]["msg"], "D");
+    assert_eq!(msgs2[1]["headers"]["msg"], "E");
+    assert_eq!(msgs2[2]["headers"]["msg"], "F");
+
+    // Ack a range that overlaps both blocks but doesn't fully cover either:
+    // minMsgId=1, maxMsgId=4 acks B, C, D, E (but NOT A or F)
+    client
+        .post("stream/ack")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "minMsgId": 1,
+            "maxMsgId": 4
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Wait for visibility timeout to expire
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Fetch again - should get A and F back (the unacked messages)
+    let fetch3 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 10,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs3 = fetch3["msgs"].as_array().unwrap();
+    assert_eq!(msgs3.len(), 2);
+    assert_eq!(msgs3[0]["headers"]["msg"], "A");
+    assert_eq!(msgs3[1]["headers"]["msg"], "F");
+
+    Ok(())
+}


### PR DESCRIPTION
This adds the `stream.fetch` RPC call, which is equivalent to "Queue semantics" for Stream.

When we say "queue semantics", we mean:
- multiple consumers in the same group can make requests concurrently
- Instead of limiting a single consumer, with head of line blocking, each consumer simply grabs messages "in order", and those messages are locked (for the duration of the visibility timeout).

This was pretty easy to do using the Lease helper APIs added in a prior PR.

TODOs

- There's no locking logic in place to actually protect against parallel fetch calls. We were gonna rely on the "shared nothing" architecture, but that's been put on hold until all of the raft/consensus algorithm stuff is sorted out

- no DLQing yet. That's the next PR

- I imagine we'll hash out API details, but the core functionality for supporting queue semantics is all here.