### PR TITLE
use a nextest profile to ignore the openraft test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.default]
+default-filter = 'not test(~openraft_slow)'
+
+[profile.ci]
+fail-fast = false
+default-filter = 'all()'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
-      - run: just test --run-ignored all
+      - run: just test --profile ci
   check-codegen:
     name: Check openapi.json and SDKs
     runs-on: ubuntu-24.04

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -130,8 +130,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Test has a long runtime. We still run this in CI using `--run-ignored all`"]
-    fn test_storage() -> anyhow::Result<()> {
+    fn test_storage_openraft_slow() -> anyhow::Result<()> {
         openraft::testing::Suite::test_all(CoyoteStoreBuilder)?;
         Ok(())
     }


### PR DESCRIPTION
I find this to be slightly more discoverable than `#[ignore]` on the test.