### PR TITLE
discovery for coyote peers

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,11 @@
 [profile.default]
 default-filter = 'not test(~openraft_slow)'
+slow-timeout = { period = "10s", terminate-after = 4 }
 
 [profile.ci]
 fail-fast = false
 default-filter = 'all()'
+
+[[profile.ci.overrides]]
+filter = 'test(~openraft_slow)'
+slow-timeout = { period = "60s", terminate-after = 1}

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,6 +2,10 @@
 default-filter = 'not test(~openraft_slow)'
 slow-timeout = { period = "10s", terminate-after = 4 }
 
+[profile.debugging]
+fail-fast = true
+slow-timeout = { period = "120s", terminate-after = 4 }
+
 [profile.ci]
 fail-fast = false
 default-filter = 'all()'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-24.04
+    env:
+      RUST_LOG: debug
+      "COYOTE:LOG_LEVEL": debug
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,9 +877,11 @@ dependencies = [
  "coyote-rate-limiter",
  "ctor",
  "fjall",
+ "futures-util",
  "http",
  "idna_adapter",
  "indexmap",
+ "itertools 0.14.0",
  "jiff",
  "jwt-simple",
  "openraft",
@@ -890,6 +892,7 @@ dependencies = [
  "opentelemetry_sdk",
  "paste",
  "pnet",
+ "rand 0.9.2",
  "regex",
  "reqwest 0.13.1",
  "rmp-serde",
@@ -1333,8 +1336,7 @@ dependencies = [
 [[package]]
 name = "dotenvy"
 version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+source = "git+https://github.com/svix-jbrown/dotenvy.git?rev=ffa0aa149e2c6da57113859001257f0d99b43431#ffa0aa149e2c6da57113859001257f0d99b43431"
 
 [[package]]
 name = "dtor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "jiff",
  "schemars 1.2.0",
  "serde",
+ "tracing",
  "uuid",
 ]
 
@@ -1529,6 +1530,7 @@ dependencies = [
  "fjall",
  "rmp-serde",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,11 @@ coyote-kv.workspace = true
 coyote-proto.workspace = true
 coyote-rate-limiter.workspace = true
 fjall.workspace = true
+futures-util.workspace = true
 http.workspace = true
 idna_adapter.workspace = true
 indexmap.workspace = true
+itertools.workspace = true
 jiff.workspace = true
 jwt-simple.workspace = true
 openraft.workspace = true
@@ -47,6 +49,7 @@ opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
 paste.workspace = true
 pnet.workspace = true
+rand.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 rmp-serde.workspace = true
@@ -123,6 +126,7 @@ dirs = "6.0.0"
 dotenvy = "0.15.7"
 fjall = { version = "3.0.1", features = ["lz4", "metrics"] }
 fjall-utils.path = "crates/fjall-utils"
+futures-util = "0.3"
 hashlink = "0.11"
 hex = "0.4.3"
 hickory-resolver = "0.25.2"
@@ -228,3 +232,6 @@ debug = 0
 # nearly as often as workspace crates in local development.
 opt-level = 3
 strip = true
+
+[patch.crates-io]
+dotenvy = { git = "https://github.com/svix-jbrown/dotenvy.git", rev = "ffa0aa149e2c6da57113859001257f0d99b43431" }

--- a/config.default.toml
+++ b/config.default.toml
@@ -46,3 +46,23 @@ log_path = "./logs"
 snapshot_path = "./snapshots"
 # The name of this cluster
 name = "coyote"
+# The addresses to use to bootstrap the cluster, comma-separated
+# note that the addresses must be the canonical addresses intended to be used for replication
+# seed_nodes = "127.0.0.1:18050, 127.0.0.1:18051"
+
+# the maximum time for a single replication request to take
+replication_request_timeout_ms = 30000
+
+# the maximum time for each request in discovery
+discovery_request_timeout_ms = 10000
+# how long should we poll for discovery after booting
+discovery_timeout_ms = 30000
+
+# the time to handshake all cluster connections
+connection_timeout_ms = 3100
+
+heartbeat_interval_ms = 500
+election_timeout_min_ms = 1500
+election_timeout_max_ms = 3000
+
+auto_initialize = true

--- a/config.default.toml
+++ b/config.default.toml
@@ -57,6 +57,8 @@ replication_request_timeout_ms = 30000
 discovery_request_timeout_ms = 10000
 # how long should we poll for discovery after booting
 discovery_timeout_ms = 30000
+# how long to wait before starting discovery to allow the axum app to boot
+startup_discovery_delay_ms = 10
 
 # the time to handshake all cluster connections
 connection_timeout_ms = 3100

--- a/crates/coyote-configgroup/Cargo.toml
+++ b/crates/coyote-configgroup/Cargo.toml
@@ -12,6 +12,7 @@ fjall-utils.workspace = true
 jiff.workspace = true
 schemars.workspace = true
 serde.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [lints]

--- a/crates/coyote-configgroup/src/lib.rs
+++ b/crates/coyote-configgroup/src/lib.rs
@@ -45,6 +45,17 @@ impl State {
         &self.keyspace
     }
 
+    pub fn flush_and_sync(&self) -> Result<(), Error> {
+        self.db.persist(fjall::PersistMode::SyncAll)?;
+        self.both_dbs
+            .persistent_db
+            .persist(fjall::PersistMode::SyncAll)?;
+        self.both_dbs
+            .ephemeral_db
+            .persist(fjall::PersistMode::SyncAll)?;
+        Ok(())
+    }
+
     pub fn init(both_dbs: BothDatabases) -> Result<Self, Error> {
         const CONFIGGROUP_KEYSPACE: &str = "_coyote_cfggroup";
 
@@ -71,6 +82,10 @@ impl State {
         if fetch.is_some() {
             return Ok(fetch);
         }
+        tracing::trace!(
+            group_name,
+            "cannot find group, falling back to default group"
+        );
 
         ConfigGroup::fetch(&self.keyspace, DEFAULT_GROUP_NAME)
     }

--- a/crates/coyote-configgroup/src/operations/create_configgroup.rs
+++ b/crates/coyote-configgroup/src/operations/create_configgroup.rs
@@ -77,7 +77,7 @@ impl<C: ModuleConfig> CreateConfigGroup<C> {
 
         {
             let (k1, v1) = configgroup.to_fjall_entry()?;
-            let mut batch = db.batch();
+            let mut batch = db.batch().durability(Some(fjall::PersistMode::SyncAll));
             batch.insert(keyspace, k1, v1);
             batch.commit()?;
         }

--- a/crates/coyote-configgroup/src/tables.rs
+++ b/crates/coyote-configgroup/src/tables.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::entities::{ConfigGroupId, ModuleConfig, StorageType};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(bound = "C: ModuleConfig")]
 pub struct ConfigGroup<C: ModuleConfig> {
     pub id: ConfigGroupId,

--- a/crates/fjall-utils/Cargo.toml
+++ b/crates/fjall-utils/Cargo.toml
@@ -11,6 +11,7 @@ coyote-error.workspace = true
 fjall.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -45,7 +45,8 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
 
     fn fetch(keyspace: &fjall::Keyspace, key: &Self::Key) -> Result<Option<Self>> {
         let key = Self::make_fjall_key(key);
-        keyspace.get(&key)?.map(Self::from_fjall_value).transpose()
+        let raw_value = keyspace.get(&key);
+        raw_value?.map(Self::from_fjall_value).transpose()
     }
 
     fn insert(keyspace: &fjall::Keyspace, row: &Self) -> Result<()> {

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -45,8 +45,7 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
 
     fn fetch(keyspace: &fjall::Keyspace, key: &Self::Key) -> Result<Option<Self>> {
         let key = Self::make_fjall_key(key);
-        let raw_value = keyspace.get(&key);
-        raw_value?.map(Self::from_fjall_value).transpose()
+        keyspace.get(&key)?.map(Self::from_fjall_value).transpose()
     }
 
     fn insert(keyspace: &fjall::Keyspace, row: &Self) -> Result<()> {

--- a/development.env
+++ b/development.env
@@ -1,3 +1,3 @@
 # Example .env file for development
-COYOTE_JWT_SECRET=x
-COYOTE_LOG_LEVEL=trace
+COYOTE:JWT_SECRET=x
+COYOTE:LOG_LEVEL=trace

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -162,7 +162,12 @@ pub fn run(bootstrap_cfg_path: Option<&str>, app_config: AppConfig) {
     let bootstrap =
         BootstrapConfig::load(bootstrap_cfg_path).expect("Failed to load bootstrap config");
 
-    tracing::debug!("bootstrap: {bootstrap:?}");
+    tracing::debug!(
+        ?bootstrap,
+        persistent_db=?app_config.persistent_db,
+        ephemeral_db=?app_config.ephemeral_db,
+        "starting bootstrap"
+    );
     let persistent_db =
         DatabaseConfig::persistent(&app_config.persistent_db).expect("persistent db");
     let ephemeral_db = DatabaseConfig::ephemeral(&app_config.ephemeral_db).expect("ephemeral db");
@@ -172,41 +177,50 @@ pub fn run(bootstrap_cfg_path: Option<&str>, app_config: AppConfig) {
     })
     .expect("configgroup state");
 
+    let db = state.db();
+    let keyspace = state.keyspace();
+
     if let Some(kv) = bootstrap.kv {
         for (name, cfg) in kv {
+            tracing::debug!(?name, "bootstrapping kv");
             let create_cmd = cfg.create_config_group(name);
             create_cmd
-                .apply_operation(state.db(), state.keyspace())
+                .apply_operation(db, keyspace)
                 .expect("create config");
         }
     }
 
     if let Some(cache) = bootstrap.cache {
         for (name, cfg) in cache {
+            tracing::debug!(?name, "bootstrapping cache");
             let create_cmd = cfg.create_config_group(name);
             create_cmd
-                .apply_operation(state.db(), state.keyspace())
+                .apply_operation(db, keyspace)
                 .expect("create config");
         }
     }
 
     if let Some(idempotency) = bootstrap.idempotency {
         for (name, cfg) in idempotency {
+            tracing::debug!(?name, "bootstrapping idemptency");
             let create_cmd = cfg.create_config_group(name);
             create_cmd
-                .apply_operation(state.db(), state.keyspace())
+                .apply_operation(db, keyspace)
                 .expect("create config");
         }
     }
 
     if let Some(stream) = bootstrap.stream {
         for (name, cfg) in stream {
+            tracing::debug!(?name, "bootstrapping stream");
             let create_cmd = cfg.create_config_group(name);
             create_cmd
-                .apply_operation(state.db(), state.keyspace())
+                .apply_operation(db, keyspace)
                 .expect("create config");
         }
     }
+
+    state.flush_and_sync().expect("failed to persist DBs");
 
     tracing::info!("done bootstrapping databases");
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -162,7 +162,7 @@ pub fn run(bootstrap_cfg_path: Option<&str>, app_config: AppConfig) {
     let bootstrap =
         BootstrapConfig::load(bootstrap_cfg_path).expect("Failed to load bootstrap config");
 
-    println!("bootstrap: {bootstrap:?}");
+    tracing::debug!("bootstrap: {bootstrap:?}");
     let persistent_db =
         DatabaseConfig::persistent(&app_config.persistent_db).expect("persistent db");
     let ephemeral_db = DatabaseConfig::ephemeral(&app_config.ephemeral_db).expect("ephemeral db");
@@ -207,4 +207,6 @@ pub fn run(bootstrap_cfg_path: Option<&str>, app_config: AppConfig) {
                 .expect("create config");
         }
     }
+
+    tracing::info!("done bootstrapping databases");
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -101,6 +101,12 @@ pub struct ClusterConfiguration {
         with = "crate::serde::duration::millis"
     )]
     pub discovery_timeout: Duration,
+
+    #[serde(
+        rename = "startup_discovery_delay_ms",
+        with = "crate::serde::duration::millis"
+    )]
+    pub startup_discovery_delay: Duration,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -61,35 +61,46 @@ pub struct ClusterConfiguration {
 
     pub log_path: PathBuf,
 
-    #[serde(default = "ClusterConfiguration::default_connection_timeout")]
+    #[serde(default)]
+    pub secret: Option<String>,
+
+    #[serde(
+        rename = "replication_request_timeout_ms",
+        with = "crate::serde::duration::millis"
+    )]
+    pub replication_request_timeout: Duration,
+
+    #[serde(
+        rename = "discovery_request_timeout_ms",
+        with = "crate::serde::duration::millis"
+    )]
+    pub discovery_request_timeout: Duration,
+
+    #[serde(
+        rename = "connection_timeout_ms",
+        with = "crate::serde::duration::millis"
+    )]
     pub connection_timeout: Duration,
 
-    #[serde(default = "ClusterConfiguration::default_heartbeat_interval_ms")]
     pub heartbeat_interval_ms: u64,
 
-    #[serde(default = "ClusterConfiguration::default_election_timeout_min_ms")]
     pub election_timeout_min_ms: u64,
 
-    #[serde(default = "ClusterConfiguration::default_election_timeout_max_ms")]
     pub election_timeout_max_ms: u64,
-}
 
-impl ClusterConfiguration {
-    const fn default_connection_timeout() -> Duration {
-        Duration::from_secs(7)
-    }
+    #[serde(default)]
+    pub seed_nodes: Vec<SocketAddr>,
 
-    const fn default_heartbeat_interval_ms() -> u64 {
-        500
-    }
+    /// Automatically initialize the cluster on bootup if we can't discover any
+    /// peers and we don't have any existing state. If you initialize all peers
+    /// at exactly the same time, this can potentially cause errors.
+    pub auto_initialize: bool,
 
-    const fn default_election_timeout_min_ms() -> u64 {
-        1500
-    }
-
-    const fn default_election_timeout_max_ms() -> u64 {
-        3000
-    }
+    #[serde(
+        rename = "discovery_timeout_ms",
+        with = "crate::serde::duration::millis"
+    )]
+    pub discovery_timeout: Duration,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -198,7 +209,13 @@ pub fn load(config_path: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner>
                 config
             }
         })
-        .add_source(config::Environment::with_prefix("COYOTE"))
+        .add_source(
+            config::Environment::with_prefix("COYOTE")
+                .list_separator(",")
+                .separator(":")
+                .try_parsing(true)
+                .with_list_parse_key("cluster.seed_nodes"),
+        )
         .build()?;
 
     let config = config

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -184,6 +184,28 @@ async fn initialize(State(state): State<AppState>) -> impl IntoResponse {
     state.raft.initialize(nodes).await.pipe(admin_response)
 }
 
-async fn health() -> impl IntoResponse {
-    StatusCode::OK
+async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    let leader = state.raft.current_leader().await;
+    let me = state.node_id;
+    state
+        .raft
+        .with_raft_state(move |s| {
+            let response = HealthResponse {
+                node_id: me,
+                last_committed_log_index: s.committed.map(|l| l.index),
+                server_state: s.server_state,
+                leader,
+            };
+            let status = if s.server_state.is_leader()
+                || s.server_state.is_follower()
+                || s.server_state.is_candidate()
+            {
+                StatusCode::OK
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, Json(response)).into_response()
+        })
+        .await
+        .map_err(|e| internal_error(e).into_response())
 }

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use axum::{
     Json,
@@ -8,24 +8,30 @@ use axum::{
 };
 use coyote_proto::MsgPack;
 use http::{StatusCode, Uri};
-use openraft::raft::{AppendEntriesRequest, InstallSnapshotRequest, VoteRequest};
-use serde::{Deserialize, Serialize};
-use tap::Pipe;
+use openraft::{
+    ChangeMembers,
+    raft::{AppendEntriesRequest, InstallSnapshotRequest, VoteRequest},
+};
+use serde::Serialize;
+use tap::{Pipe, TapFallible};
 
 use super::Node;
 use super::NodeId;
 use super::network::detect_address;
+use super::proto::*;
 use super::raft::TypeConfig;
 use crate::AppState;
 
 pub fn router() -> axum::Router<AppState> {
     // TODO: implement snapshot methods
     axum::Router::new()
+        .route("/repl/discover", get(discover))
         .route("/repl/raft/append_entries", post(append_entries))
         .route("/repl/raft/vote", post(vote))
         .route("/repl/raft/stream-snapshot", post(stream_snapshot))
         .route("/repl/raft/admin/metrics", get(metrics))
         .route("/repl/raft/admin/add-learner", post(add_learner))
+        .route("/repl/raft/admin/upgrade-learner", post(upgrade_learner))
         .route(
             "/repl/raft/admin/change-membership",
             post(change_membership),
@@ -105,16 +111,35 @@ async fn stream_snapshot(
 
 // Administrative functions
 
+async fn discover(State(app_state): State<AppState>) -> Json<DiscoverResponse> {
+    let cluster_name = app_state.cfg.cluster.name.clone();
+    let cluster = app_state
+        .raft
+        .with_raft_state(move |state| DiscoverClusterResponse {
+            last_committed_log_id: state.committed,
+            cluster_name,
+            state: state.server_state,
+            known_peers: state
+                .membership_state
+                .committed()
+                .nodes()
+                .map(|(nid, n)| (*nid, n.addr.parse().unwrap()))
+                .collect(),
+        })
+        .await
+        .tap_err(|err| tracing::warn!(?err, "failed to find local cluster state"))
+        .ok();
+    let response = DiscoverResponse {
+        node_id: app_state.node_id,
+        cluster,
+    };
+    Json(response)
+}
+
 async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
     let metrics = state.raft.metrics().borrow().clone();
 
     Json(metrics)
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct AddLearnerRequest {
-    node_id: NodeId,
-    address: String,
 }
 
 async fn add_learner(
@@ -129,9 +154,12 @@ async fn add_learner(
     admin_response(state.raft.add_learner(request.node_id, node, true).await)
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-struct ChangeMembershipRequest {
-    desired_node_ids: BTreeSet<NodeId>,
+async fn upgrade_learner(
+    State(state): State<AppState>,
+    request: Json<UpgradeLearnerRequest>,
+) -> impl IntoResponse {
+    let request = ChangeMembers::AddVoterIds([request.node_id].into_iter().collect());
+    admin_response(state.raft.change_membership(request, true).await)
 }
 
 async fn change_membership(

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)] // we can't use MsgPackOrJson because these endpoints are not OpenAPI-based
+
 use std::collections::BTreeMap;
 
 use axum::{
@@ -67,7 +69,6 @@ where
 // Standard functions
 
 #[tracing::instrument(skip_all)]
-#[axum::debug_handler]
 async fn append_entries(
     State(state): State<AppState>,
     MsgPack(body): MsgPack<AppendEntriesRequest<TypeConfig>>,

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -15,11 +15,7 @@ use openraft::{
 use serde::Serialize;
 use tap::{Pipe, TapFallible};
 
-use super::Node;
-use super::NodeId;
-use super::network::detect_address;
-use super::proto::*;
-use super::raft::TypeConfig;
+use super::{Node, NodeId, network::detect_address, proto::*, raft::TypeConfig};
 use crate::AppState;
 
 pub fn router() -> axum::Router<AppState> {

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -140,6 +140,7 @@ impl Discovery {
     pub(super) async fn discover_cluster(mut self) -> anyhow::Result<()> {
         if self.cfg.cluster.seed_nodes.is_empty() {
             self.initialize_cluster(BTreeMap::new()).await?;
+            return Ok(());
         }
 
         tracing::debug!("starting new cluster discovery");

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -1,0 +1,226 @@
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use futures_util::{StreamExt, stream};
+use itertools::Itertools;
+use openraft::ServerState;
+use tap::Pipe;
+use url::Url;
+
+use super::network::build_client;
+use super::raft::{Node, NodeId, Raft};
+use crate::core::cluster::network::detect_address;
+use crate::core::cluster::proto::{
+    AddLearnerRequest, DiscoverClusterResponse, DiscoverResponse, UpgradeLearnerRequest,
+};
+use crate::{Configuration, shutting_down_token};
+
+const CONCURRENT_FETCHES: usize = 8;
+
+pub(super) struct Discovery {
+    client: reqwest::Client,
+    my_node_id: NodeId,
+    raft: Raft,
+    cfg: Configuration,
+    my_addr: SocketAddr,
+}
+
+impl Discovery {
+    pub(super) fn new(cfg: Configuration, raft: Raft, my_node_id: NodeId) -> anyhow::Result<Self> {
+        let client = build_client(&cfg, cfg.cluster.discovery_request_timeout)?;
+        Ok(Self {
+            my_addr: detect_address(&cfg)?,
+            client,
+            cfg,
+            raft,
+            my_node_id,
+        })
+    }
+
+    async fn poll_seeds(&self) -> (Option<SocketAddr>, BTreeMap<SocketAddr, DiscoverResponse>) {
+        let mut responses = self.cfg.cluster.seed_nodes.iter().copied().map(|s| async move {
+                    let url_string = format!("http://{s}/repl/discover");
+                    let url = match Url::parse(&url_string) {
+                        Ok(url) => url,
+                        Err(err) => {
+                            tracing::warn!(peer=?s, ?err, "invalid seed node");
+                            return None;
+                        }
+                    };
+                    let response = match self.client.get(url).send().await {
+                        Ok(resp) => resp,
+                        Err(err) => {
+                            tracing::warn!(peer=?s, ?err, "unable to poll seed node");
+                            return None;
+                        }
+                    };
+                    let response: DiscoverResponse = match response.json().await {
+                        Ok(resp) => resp,
+                        Err(err) => {
+                            tracing::warn!(peer=?s, ?err, "unable to read response body from seed node");
+                            return None
+                        }
+                    };
+                    Some((s, response))
+                }).pipe(stream::iter)
+                .buffer_unordered(CONCURRENT_FETCHES)
+                .filter_map(futures_util::future::ready)
+                .collect::<BTreeMap<_, _>>()
+                .await;
+        let my_addr = responses
+            .iter()
+            .find(|(_k, v)| v.node_id == self.my_node_id)
+            .map(|(k, _)| k.to_owned());
+        if let Some(addr) = &my_addr {
+            responses.remove(addr);
+        }
+        (my_addr, responses)
+    }
+
+    async fn join_cluster(
+        &self,
+        cluster_name: String,
+        peers: Vec<(SocketAddr, NodeId, DiscoverClusterResponse)>,
+    ) -> anyhow::Result<()> {
+        tracing::info!(?cluster_name, "joining running cluster");
+        let Some((leader_addr, _leader_node_id, leader_cluster)) = peers
+            .iter()
+            .find_or_first(|p| p.2.state == ServerState::Leader)
+        else {
+            anyhow::bail!("failed to find any peers to join!");
+        };
+        let Some(log_id) = leader_cluster.last_committed_log_id else {
+            anyhow::bail!("existing cluster has no logs");
+        };
+        // TODO: if any of these steps fail, how do we recover?
+        let url = format!("http://{leader_addr}/repl/raft/admin/add-learner");
+        let request = AddLearnerRequest {
+            node_id: self.my_node_id,
+            address: self.my_addr.to_string(),
+        };
+        self.client.post(url).json(&request).send().await?;
+        tracing::debug!("waiting to catch up in replication");
+        self.raft
+            .wait(None)
+            .log_index_at_least(Some(log_id.index), "waiting to catch up to leader")
+            .await?;
+        tracing::debug!("adding self as a full member");
+        let url = format!("http://{leader_addr}/repl/raft/admin/upgrade-learner");
+        let request = UpgradeLearnerRequest {
+            node_id: self.my_node_id,
+        };
+        self.client.post(url).json(&request).send().await?;
+        Ok(())
+    }
+
+    async fn initialize_cluster(
+        &self,
+        discovered_seeds: BTreeMap<SocketAddr, DiscoverResponse>,
+    ) -> anyhow::Result<()> {
+        if !self.cfg.cluster.auto_initialize {
+            tracing::warn!(
+                "auto-initialization disabled, but we found no peers. You must manually initialize!"
+            );
+            return Ok(());
+        }
+        let my_node = Node::new(self.my_addr);
+        let mut nodes = [(self.my_node_id, my_node)]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>();
+        for (peer_address, response) in discovered_seeds {
+            tracing::trace!(?peer_address, ?response, "adding node to new cluster");
+            nodes.insert(response.node_id, Node::new(peer_address));
+        }
+        self.raft.initialize(nodes).await?;
+        tracing::info!("initialized new cluster");
+        Ok(())
+    }
+
+    pub(super) async fn discover_cluster(mut self) -> anyhow::Result<()> {
+        if self.cfg.cluster.seed_nodes.is_empty() {
+            self.initialize_cluster(BTreeMap::new()).await?;
+        }
+
+        tracing::debug!("starting new cluster discovery");
+
+        let deadline = Instant::now() + self.cfg.cluster.discovery_timeout;
+        // delay a little bit to allow simultaneous startups to finish
+        let token = shutting_down_token();
+        if token
+            .run_until_cancelled(tokio::time::sleep(self.cfg.cluster.startup_discovery_delay))
+            .await
+            .is_none()
+        {
+            return Ok(());
+        }
+        let mut rounds_with_no_peers = 0;
+        while Instant::now() < deadline {
+            let (my_addr, discovered_seeds) = self.poll_seeds().await;
+            if let Some(addr) = my_addr {
+                self.my_addr = addr;
+            }
+            tracing::debug!(?discovered_seeds, "discovered peers");
+            if let Some(addr) = my_addr {
+                tracing::debug!(?addr, "discovered my seed address")
+            };
+
+            let num_nodes_in_live_clusters = discovered_seeds
+                .values()
+                .filter(|v| {
+                    v.cluster
+                        .as_ref()
+                        .map(|c| c.last_committed_log_id.is_some())
+                        .unwrap_or(false)
+                })
+                .count();
+
+            if num_nodes_in_live_clusters == 0 {
+                rounds_with_no_peers += 1;
+                // TODO: magic number
+                if rounds_with_no_peers > 3 {
+                    if let Err(err) = self.initialize_cluster(discovered_seeds).await {
+                        tracing::error!(?err, "failed to initialize cluster");
+                    }
+                    return Ok(());
+                }
+            } else {
+                let clusters_to_peers = discovered_seeds
+                    .into_iter()
+                    .filter_map(|(k, v)| {
+                        if let Some(cluster) = v.cluster {
+                            if cluster.last_committed_log_id.is_none() {
+                                None
+                            } else {
+                                Some((cluster.cluster_name.clone(), (k, v.node_id, cluster)))
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                    .into_group_map();
+
+                if clusters_to_peers.len() == 1 {
+                    let (cluster_name, config) = clusters_to_peers.into_iter().next().unwrap();
+                    if let Err(err) = self.join_cluster(cluster_name, config).await {
+                        tracing::error!(?err, "failed to join cluster!");
+                    } else {
+                        tracing::info!("finished joining cluster");
+                        return Ok(());
+                    }
+                } else {
+                    tracing::warn!("found multiple live clusters");
+                }
+            }
+            let sleep_time = Duration::from_millis(rand::random_range(100..=1000));
+            if token
+                .run_until_cancelled(tokio::time::sleep(sleep_time))
+                .await
+                .is_none()
+            {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -1,6 +1,8 @@
-use std::collections::BTreeMap;
-use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeMap,
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
 
 use futures_util::{StreamExt, stream};
 use itertools::Itertools;
@@ -8,13 +10,20 @@ use openraft::ServerState;
 use tap::Pipe;
 use url::Url;
 
-use super::network::build_client;
-use super::raft::{Node, NodeId, Raft};
-use crate::core::cluster::network::detect_address;
-use crate::core::cluster::proto::{
-    AddLearnerRequest, DiscoverClusterResponse, DiscoverResponse, UpgradeLearnerRequest,
+use super::{
+    network::build_client,
+    raft::{Node, NodeId, Raft},
 };
-use crate::{Configuration, shutting_down_token};
+use crate::{
+    Configuration,
+    core::cluster::{
+        network::detect_address,
+        proto::{
+            AddLearnerRequest, DiscoverClusterResponse, DiscoverResponse, UpgradeLearnerRequest,
+        },
+    },
+    shutting_down_token,
+};
 
 const CONCURRENT_FETCHES: usize = 8;
 

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -1,7 +1,9 @@
 mod app;
+mod discovery;
 mod errors;
 mod logs;
 mod network;
+mod proto;
 mod raft;
 mod serialized_state_machine;
 mod state_machine;

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -5,7 +5,7 @@ mod discovery;
 mod errors;
 mod logs;
 mod network;
-mod proto;
+pub mod proto;
 mod raft;
 mod serialized_state_machine;
 mod state_machine;

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -1,17 +1,19 @@
-use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::{
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
 
 use crate::cfg::Configuration;
 
-use super::raft::TypeConfig;
-use super::{Node, NodeId};
+use super::{Node, NodeId, raft::TypeConfig};
 use anyhow::Context;
 use http::{HeaderMap, HeaderValue, header};
-use openraft::error::{NetworkError, RPCError, Unreachable};
-use openraft::network::RPCOption;
-use openraft::{RaftNetwork, RaftNetworkFactory, RaftTypeConfig};
-use serde::Serialize;
-use serde::de::DeserializeOwned;
+use openraft::{
+    RaftNetwork, RaftNetworkFactory, RaftTypeConfig,
+    error::{NetworkError, RPCError, Unreachable},
+    network::RPCOption,
+};
+use serde::{Serialize, de::DeserializeOwned};
 
 pub(super) fn build_client(
     cfg: &Configuration,

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -1,16 +1,36 @@
 use std::net::SocketAddr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::cfg::Configuration;
 
 use super::raft::TypeConfig;
 use super::{Node, NodeId};
-use http::header;
+use anyhow::Context;
+use http::{HeaderMap, HeaderValue, header};
 use openraft::error::{NetworkError, RPCError, Unreachable};
 use openraft::network::RPCOption;
 use openraft::{RaftNetwork, RaftNetworkFactory, RaftTypeConfig};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+
+pub(super) fn build_client(
+    cfg: &Configuration,
+    _request_timeout: Duration,
+) -> anyhow::Result<reqwest::Client> {
+    let mut headers = HeaderMap::new();
+    if let Some(secret) = &cfg.cluster.secret {
+        let header_value = format!("Bearer {secret}");
+        let header_value =
+            HeaderValue::from_str(&header_value).context("invalid interserver secret")?;
+        headers.insert(header::AUTHORIZATION, header_value);
+    }
+    let client = reqwest::Client::builder()
+        .connect_timeout(cfg.cluster.connection_timeout)
+        .default_headers(headers)
+        .build()
+        .context("building raft network client")?;
+    Ok(client)
+}
 
 pub(super) struct NetworkFactory {
     client: reqwest::Client,
@@ -19,9 +39,7 @@ pub(super) struct NetworkFactory {
 impl NetworkFactory {
     pub(super) fn new(cfg: &Configuration) -> Self {
         Self {
-            client: reqwest::Client::builder()
-                .connect_timeout(cfg.cluster.connection_timeout)
-                .build()
+            client: build_client(cfg, cfg.cluster.replication_request_timeout)
                 .expect("failed to build Raft network"),
         }
     }

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -1,0 +1,41 @@
+//! This module contains custom protocol extensions for the interserver protocol
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::SocketAddr,
+};
+
+use openraft::{LogId, ServerState};
+use serde::{Deserialize, Serialize};
+
+use super::raft::NodeId;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(super) struct DiscoverClusterResponse {
+    pub cluster_name: String,
+    pub known_peers: BTreeMap<NodeId, SocketAddr>,
+    pub state: ServerState,
+    pub last_committed_log_id: Option<LogId<NodeId>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(super) struct DiscoverResponse {
+    pub node_id: NodeId,
+    pub cluster: Option<DiscoverClusterResponse>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(super) struct AddLearnerRequest {
+    pub node_id: NodeId,
+    pub address: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(super) struct UpgradeLearnerRequest {
+    pub node_id: NodeId,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(super) struct ChangeMembershipRequest {
+    pub desired_node_ids: BTreeSet<NodeId>,
+}

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -39,3 +39,11 @@ pub(super) struct UpgradeLearnerRequest {
 pub(super) struct ChangeMembershipRequest {
     pub desired_node_ids: BTreeSet<NodeId>,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HealthResponse {
+    pub node_id: NodeId,
+    pub last_committed_log_index: Option<u64>,
+    pub server_state: ServerState,
+    pub leader: Option<NodeId>,
+}

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -5,6 +5,7 @@ use openraft::BasicNode;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::discovery::Discovery;
 use super::state_machine::StoredSnapshot;
 use crate::cfg::Configuration;
 
@@ -34,6 +35,7 @@ pub(super) type Node = BasicNode;
 )]
 #[serde(transparent)]
 pub struct NodeId {
+    #[serde(with = "uuid::serde::simple")]
     inner: Uuid,
 }
 
@@ -85,6 +87,22 @@ pub async fn initialize_raft(cfg: &Configuration, db: Database) -> anyhow::Resul
     let state_machine =
         super::state_machine::Store::new(db, cfg.cluster.snapshot_path.clone()).await?;
     let raft = Raft::new(id, config, network, logs, state_machine).await?;
+    let has_cluster = raft
+        .with_raft_state(|s| {
+            s.committed.is_some() || s.membership_state.effective().nodes().count() > 0
+        })
+        .await?;
+    if !has_cluster {
+        let disco = Discovery::new(cfg.clone(), raft.clone(), id)?;
+        tokio::spawn(async move {
+            if let Err(err) = disco.discover_cluster().await {
+                tracing::error!(
+                    ?err,
+                    "discovery failed; this node must be manually initialized"
+                );
+            }
+        });
+    }
     Ok((raft, id))
 }
 

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -5,8 +5,7 @@ use openraft::BasicNode;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::discovery::Discovery;
-use super::state_machine::StoredSnapshot;
+use super::{discovery::Discovery, state_machine::StoredSnapshot};
 use crate::cfg::Configuration;
 
 // TODO: this should actually be our Operation trait

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -122,6 +122,7 @@ fn deserialize_keyspace<R: Read + Seek>(
     keyspace: &Keyspace,
     chunks: Vec<Chunk>,
 ) -> anyhow::Result<()> {
+    tracing::warn!(name=%keyspace.name(), "clearing keyspace");
     keyspace.clear()?;
     let mut key_buf = vec![];
     let mut value_buf = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod cfg;
 pub mod core;
 pub use coyote_error as error;
 pub mod openapi;
+mod serde;
 pub mod v1;
 
 const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![warn(clippy::all)]
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{sync::LazyLock, time::Duration};
 
 use aide::axum::ApiRouter;
@@ -445,9 +447,15 @@ pub fn setup_tracing_for_tests() {
 }
 
 #[cfg(test)]
+static TEST_TRACING_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(test)]
 #[ctor::ctor]
 fn test_setup() {
-    setup_tracing_for_tests();
+    if !TEST_TRACING_INITIALIZED.load(Ordering::Acquire) {
+        setup_tracing_for_tests();
+        TEST_TRACING_INITIALIZED.store(true, Ordering::Release);
+    }
 }
 
 mod docs {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,25 @@
+#![allow(unused)]
+
+pub(crate) mod duration {
+    /// Deserialize a Duration as a number of milliseconds
+    pub(crate) mod millis {
+        use serde::{Deserialize, Deserializer, Serialize, Serializer};
+        use std::time::Duration;
+
+        pub(crate) fn serialize<S>(x: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let raw = x.as_millis();
+            raw.serialize(serializer)
+        }
+
+        pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let millis: u64 = Deserialize::deserialize(deserializer)?;
+            Ok(Duration::from_millis(millis))
+        }
+    }
+}

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -7,15 +7,10 @@ use coyote_configgroup::{
 };
 use test_utils::TestResult;
 
-use crate::TestContext;
-
 #[tokio::test]
 async fn test_bootstrap() -> TestResult {
-    let TestContext {
-        cfg,
-        handle: _handle,
-        ..
-    } = super::start_server().await;
+    let ctx = super::build_config_without_server();
+    let cfg = ctx.cfg;
 
     bootstrap::run(Some("./tests/it/static/bootstrap.test.yaml"), cfg.clone());
 

--- a/tests/it/configgroup.rs
+++ b/tests/it/configgroup.rs
@@ -2,8 +2,6 @@ use coyote::cfg::DatabaseConfig;
 use coyote_configgroup::{BothDatabases, entities::StreamConfig};
 use test_utils::TestResult;
 
-use crate::ServerlessTestContext;
-
 #[tokio::test]
 async fn test_configgroup_fetch() -> TestResult {
     let ctx = super::build_config_without_server();

--- a/tests/it/configgroup.rs
+++ b/tests/it/configgroup.rs
@@ -2,15 +2,12 @@ use coyote::cfg::DatabaseConfig;
 use coyote_configgroup::{BothDatabases, entities::StreamConfig};
 use test_utils::TestResult;
 
-use crate::TestContext;
+use crate::ServerlessTestContext;
 
 #[tokio::test]
 async fn test_configgroup_fetch() -> TestResult {
-    let TestContext {
-        cfg,
-        handle: _handle,
-        ..
-    } = super::start_server().await;
+    let ctx = super::build_config_without_server();
+    let cfg = ctx.cfg;
 
     let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
     let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -7,20 +7,24 @@ mod msgpack;
 mod rate_limiter;
 mod stream;
 
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc};
 
 use coyote::{
     cfg::{
         ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, InternalConfig,
         LogFormat, LogLevel,
     },
-    core::security::JwtSigningConfig,
+    core::{cluster::proto::HealthResponse, security::JwtSigningConfig},
     run_with_prefix,
 };
 use jwt_simple::prelude::*;
 use tempfile::TempDir;
 use test_utils::TestClient;
-use tokio::{net::TcpListener, task::JoinHandle};
+use tokio::{
+    net::TcpListener,
+    task::JoinHandle,
+    time::{Duration, Instant},
+};
 
 /// Handle to an isolated test server.
 ///
@@ -40,6 +44,45 @@ pub struct TestContext {
     pub client: TestClient,
     pub cfg: Arc<ConfigurationInner>,
     pub handle: IsolatedServerHandle,
+}
+
+async fn check_initialized(client: &reqwest::Client, url: &str) -> anyhow::Result<bool> {
+    let response = client
+        .get(url)
+        .timeout(Duration::from_millis(10))
+        .send()
+        .await?;
+    if response.status() != 200 {
+        return Ok(false);
+    }
+    let body: HealthResponse = response.json().await?;
+    if body.server_state.is_leader() {
+        tracing::warn!(state=?body.server_state, "booted, but not leader");
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+async fn wait_for_initialized(repl_addr: SocketAddr, max_wait: Duration) -> anyhow::Result<()> {
+    tracing::info!("waiting for server to boot up");
+    let url = format!("http://{repl_addr}/repl/health");
+    let deadline = Instant::now() + max_wait;
+    let client = reqwest::Client::new();
+    loop {
+        match tokio::time::timeout_at(deadline, check_initialized(&client, &url)).await {
+            Ok(Ok(true)) => {
+                tracing::info!("server started!");
+                return Ok(());
+            }
+            Ok(Ok(false)) => {
+                tracing::debug!("server not yet up");
+            }
+            Ok(Err(err)) => {
+                tracing::warn!(?err, "error waiting for server to boot");
+            }
+            Err(_) => anyhow::bail!("timed out waiting for server to boot"),
+        }
+    }
 }
 
 async fn start_server() -> TestContext {
@@ -98,6 +141,11 @@ async fn start_server() -> TestContext {
 
     let base_uri = format!("http://{addr}/api/v1");
 
+    // TODO: this directly touches the database, so causes crashes if it runs
+    // concurrently with anything else that reads the databases. Should it go through
+    // the handle in the app somehow instead?
+    coyote::bootstrap::run(None, cfg.clone());
+
     let server_handle = tokio::spawn({
         let cfg = cfg.clone();
         async move {
@@ -112,7 +160,9 @@ async fn start_server() -> TestContext {
 
     let client = TestClient::new(base_uri, token);
 
-    coyote::bootstrap::run(None, cfg.clone());
+    wait_for_initialized(repl_addr, Duration::from_secs(2))
+        .await
+        .expect("failed to initialize server");
 
     TestContext {
         client,

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -11,11 +11,11 @@ use std::{net::SocketAddr, sync::Arc};
 
 use coyote::{
     cfg::{
-        ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, InternalConfig,
-        LogFormat, LogLevel,
+        ClusterConfiguration, Configuration, ConfigurationInner, DatabaseConfig, Environment,
+        InternalConfig, LogFormat, LogLevel,
     },
     core::{cluster::proto::HealthResponse, security::JwtSigningConfig},
-    run_with_prefix,
+    run_with_prefix, setup_tracing_for_tests,
 };
 use jwt_simple::prelude::*;
 use tempfile::TempDir;
@@ -85,23 +85,28 @@ async fn wait_for_initialized(repl_addr: SocketAddr, max_wait: Duration) -> anyh
     }
 }
 
-async fn start_server() -> TestContext {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr: SocketAddr = listener.local_addr().unwrap();
+/// TestContext without a running server. Since there's no background task for a server,
+/// you need to ensure to keep this context object alive for your whole test to prevent
+/// the workdir from being dropped and cleaned up
+struct ServerlessTestContext {
+    pub cfg: Arc<ConfigurationInner>,
+    workdir: TempDir,
+}
 
-    let repl_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let repl_addr: SocketAddr = repl_listener.local_addr().unwrap();
+fn build_config_without_server() -> ServerlessTestContext {
+    setup_tracing_for_tests();
 
     let jwt_key = HS256Key::generate();
-    let token = "Stubbed token. Should probably be legit when we add auth.";
 
     let workdir = tempfile::tempdir().unwrap();
     let db_dir = workdir.path().join("db");
     let log_path = workdir.path().join("logs");
     let snapshot_path = workdir.path().join("snapshots");
 
+    let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+
     let cfg = Arc::new(ConfigurationInner {
-        listen_address: addr,
+        listen_address: addr.clone(),
         ephemeral_db: Arc::new(DatabaseConfig {
             path: db_dir.clone(),
             ..Default::default()
@@ -121,7 +126,7 @@ async fn start_server() -> TestContext {
         environment: Environment::Dev,
         internal: InternalConfig {},
         cluster: ClusterConfiguration {
-            listen_address: repl_addr,
+            listen_address: addr.clone(),
             name: "coyote-test".to_string(),
             snapshot_path,
             log_path,
@@ -139,12 +144,33 @@ async fn start_server() -> TestContext {
         },
     });
 
-    let base_uri = format!("http://{addr}/api/v1");
+    // TODO: do bootstrap through the server APIs instead of just directly
+    // touching the databases? Need to make sure that this never runs
+    // concurrently with the other DB accesses
+    coyote::bootstrap::run(None, Arc::clone(&cfg));
 
-    // TODO: this directly touches the database, so causes crashes if it runs
-    // concurrently with anything else that reads the databases. Should it go through
-    // the handle in the app somehow instead?
-    coyote::bootstrap::run(None, cfg.clone());
+    ServerlessTestContext { cfg, workdir }
+}
+
+async fn start_server() -> TestContext {
+    let token = "Stubbed token. Should probably be legit when we add auth.";
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+
+    let repl_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let repl_addr: SocketAddr = repl_listener.local_addr().unwrap();
+
+    let ServerlessTestContext { cfg, workdir } = build_config_without_server();
+
+    let cfg = {
+        let mut cfg_inner = Arc::unwrap_or_clone(cfg);
+        cfg_inner.listen_address = addr;
+        cfg_inner.cluster.listen_address = repl_addr;
+        Arc::new(cfg_inner)
+    };
+
+    let base_uri = format!("http://{addr}/api/v1");
 
     let server_handle = tokio::spawn({
         let cfg = cfg.clone();

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -56,7 +56,7 @@ async fn check_initialized(client: &reqwest::Client, url: &str) -> anyhow::Resul
         return Ok(false);
     }
     let body: HealthResponse = response.json().await?;
-    if body.server_state.is_leader() {
+    if !body.server_state.is_leader() {
         tracing::warn!(state=?body.server_state, "booted, but not leader");
         return Ok(false);
     }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -76,6 +76,12 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
             heartbeat_interval_ms: 100,
             election_timeout_min_ms: 200,
             election_timeout_max_ms: 300,
+            auto_initialize: true,
+            discovery_request_timeout: Duration::from_millis(10),
+            discovery_timeout: Duration::from_secs(1),
+            secret: None,
+            seed_nodes: vec![],
+            replication_request_timeout: Duration::from_millis(50),
         },
     });
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -11,8 +11,8 @@ use std::{net::SocketAddr, sync::Arc};
 
 use coyote::{
     cfg::{
-        ClusterConfiguration, Configuration, ConfigurationInner, DatabaseConfig, Environment,
-        InternalConfig, LogFormat, LogLevel,
+        ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, InternalConfig,
+        LogFormat, LogLevel,
     },
     core::{cluster::proto::HealthResponse, security::JwtSigningConfig},
     run_with_prefix, setup_tracing_for_tests,

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -82,6 +82,7 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
             secret: None,
             seed_nodes: vec![],
             replication_request_timeout: Duration::from_millis(50),
+            startup_discovery_delay: Duration::from_millis(0),
         },
     });
 


### PR DESCRIPTION
This adds some basic discovery for cluster bootup, based on a configured list of seed nodes.

When a new node comes up, it reaches out to all of the seed nodes. If there is a single cluster containing some subset of them, it attempts to join that cluster. If none of them are in a cluster, it attempts to initialize a new cluster. This is somewhat racy, because if you launch several nodes at the same time they all might try to initialize and you'd end up with 3 one-node clusters; I'll have work on improving that, but I wanted to get //something// out.

This also changes the config system. I like the idea of using a nested config (where cluster config is in its own Table), but this doesn't play super-well with the `config` module. I reconfigured it to support nested config for environment variables (separated by the `:` character), which required fixing up the `dotenvy` crate to also support such keys. The SHA here is https://github.com/allan2/dotenvy/pull/161 rebased on top 0.15.