### PR TITLE
KV: some API improvements and more tests

### DIFF
--- a/clients/rust/src/models/kv_get_out.rs
+++ b/clients/rust/src/models/kv_get_out.rs
@@ -10,11 +10,11 @@ pub struct KvGetOut {
 
     pub key: String,
 
-    pub value: String,
+    pub value: Vec<u8>,
 }
 
 impl KvGetOut {
-    pub fn new(key: String, value: String) -> Self {
+    pub fn new(key: String, value: Vec<u8>) -> Self {
         Self {
             expires_at: None,
             key,

--- a/clients/rust/src/models/kv_set_in.rs
+++ b/clients/rust/src/models/kv_set_in.rs
@@ -10,18 +10,19 @@ pub struct KvSetIn {
     pub behavior: Option<OperationBehavior>,
 
     /// Time to live in milliseconds
-    pub expire_in: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expire_in: Option<u64>,
 
     pub key: String,
 
-    pub value: String,
+    pub value: Vec<u8>,
 }
 
 impl KvSetIn {
-    pub fn new(expire_in: u64, key: String, value: String) -> Self {
+    pub fn new(key: String, value: Vec<u8>) -> Self {
         Self {
             behavior: None,
-            expire_in,
+            expire_in: None,
             key,
             value,
         }

--- a/openapi.json
+++ b/openapi.json
@@ -1241,7 +1241,13 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$"
           },
           "value": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0
+            }
           }
         },
         "required": [
@@ -1260,7 +1266,8 @@
             "description": "Time to live in milliseconds",
             "type": "integer",
             "format": "uint64",
-            "minimum": 0
+            "minimum": 1,
+            "nullable": true
           },
           "key": {
             "type": "string",
@@ -1269,12 +1276,17 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$"
           },
           "value": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0
+            }
           }
         },
         "required": [
           "key",
-          "expire_in",
           "value"
         ]
       },

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -29,19 +29,15 @@ pub use crate::v1::modules::kv::worker;
 pub struct KvSetIn {
     #[validate(nested)]
     pub key: Arc<EntityKey>,
-    // FIXME: validate all fields
-    /// Time to live in milliseconds
-    pub expire_in: u64,
 
-    // FIXME: do we want it here? I think we probably want separate commands for insert, upsert,
-    // and update? Or does it get weird?
+    /// Time to live in milliseconds
+    #[validate(range(min = 1))]
+    pub expire_in: Option<u64>,
+
     #[serde(default)]
     pub behavior: OperationBehavior,
 
-    // FIXME: what to do with TTL? Does it get updated on a set, not?
-
-    // FIXME: change to Bytes
-    pub value: String,
+    pub value: Vec<u8>,
 }
 
 impl KvSetIn {
@@ -53,16 +49,10 @@ impl KvSetIn {
             behavior: _,
         } = self;
 
-        let expires_at = if expire_in > 0 {
-            Some(Timestamp::now() + Duration::from_millis(expire_in))
-        } else {
-            None
-        };
+        let expires_at =
+            expire_in.map(|expire_in| Timestamp::now() + Duration::from_millis(expire_in));
 
-        KvModel {
-            expires_at,
-            value: value.into_bytes(),
-        }
+        KvModel { expires_at, value }
     }
 }
 
@@ -83,8 +73,7 @@ pub struct KvGetOut {
     /// Time of expiry
     pub expires_at: Option<Timestamp>,
 
-    // FIXME: change to Bytes
-    pub value: String,
+    pub value: Vec<u8>,
 }
 
 impl KvGetOut {
@@ -92,7 +81,7 @@ impl KvGetOut {
         Self {
             key,
             expires_at: model.expires_at,
-            value: String::from_utf8(model.value).unwrap_or_else(|_| String::new()),
+            value: model.value,
         }
     }
 }

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
+use jiff::Timestamp;
 use serde_json::{Value, json};
 use test_utils::{StatusCode, TestClient, TestResult};
 
 async fn kv_set(
     client: &TestClient,
     key: &str,
-    expire_in: u64,
+    expire_in: Option<u64>,
     value: &str,
     behavior: &str,
 ) -> TestResult<()> {
@@ -15,7 +16,7 @@ async fn kv_set(
         .json(json!({
             "key": key,
             "expire_in": expire_in,
-            "value": value,
+            "value": value.as_bytes(),
             "behavior": behavior
         }))
         .await?
@@ -35,17 +36,50 @@ async fn kv_get(client: &TestClient, key: &str) -> TestResult<Value> {
     Ok(response)
 }
 
+async fn kv_not_found(client: &TestClient, key: &str) -> TestResult<()> {
+    let _ = client
+        .post("kv/get")
+        .json(json!({
+            "key": key
+        }))
+        .await?
+        .expect(StatusCode::NOT_FOUND)
+        .json();
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_kv_set_and_get() -> TestResult {
     let (client, _server_handle) = super::start_server().await;
 
-    kv_set(&client, "kv-key-1", 50000, "kv-value-456", "upsert").await?;
+    kv_set(&client, "kv-key-1", None, "kv-value-456", "upsert").await?;
 
     let response = kv_get(&client, "kv-key-1").await?;
 
     assert_eq!(response["key"], "kv-key-1");
-    assert_eq!(response["value"], "kv-value-456");
-    assert!(response["expires_at"].is_string());
+    assert_eq!(response["value"], json!("kv-value-456".as_bytes()));
+    assert!(response["expires_at"].is_null());
+
+    let expires_in = 1000;
+    let now = Timestamp::now();
+    kv_set(
+        &client,
+        "kv-key-1",
+        Some(expires_in),
+        "kv-value-456",
+        "upsert",
+    )
+    .await?;
+    let response = kv_get(&client, "kv-key-1").await?;
+
+    let expires_at: Timestamp = serde_json::from_value(response["expires_at"].clone()).unwrap();
+    let expected = now + Duration::from_millis(expires_in);
+    assert!(
+        expires_at
+            .as_millisecond()
+            .abs_diff(expected.as_millisecond())
+            < 5 // tolerance
+    );
 
     Ok(())
 }
@@ -54,10 +88,16 @@ async fn test_kv_set_and_get() -> TestResult {
 async fn test_kv_set_with_insert_and_delete() -> TestResult {
     let (client, _server_handle) = super::start_server().await;
 
-    kv_set(&client, "kv-key-2", 0, "permanent-value", "insert").await?;
+    kv_set(&client, "kv-key-2", None, "value-ignored", "update").await?;
+    kv_not_found(&client, "kv-key-2").await?;
+
+    kv_set(&client, "kv-key-2", None, "permanent-value", "insert").await?;
+
+    // This insert gets ignored
+    kv_set(&client, "kv-key-2", None, "value-ignored-2", "insert").await?;
 
     let response = kv_get(&client, "kv-key-2").await?;
-    assert_eq!(response["value"], "permanent-value");
+    assert_eq!(response["value"], json!("permanent-value".as_bytes()));
     assert_eq!(response["expires_at"], json!(null));
 
     let delete_response = client
@@ -71,13 +111,7 @@ async fn test_kv_set_with_insert_and_delete() -> TestResult {
 
     assert_eq!(delete_response["deleted"], true);
 
-    client
-        .post("kv/get")
-        .json(json!({
-            "key": "kv-key-2"
-        }))
-        .await?
-        .expect(StatusCode::NOT_FOUND);
+    kv_not_found(&client, "kv-key-2").await?;
 
     Ok(())
 }
@@ -86,17 +120,162 @@ async fn test_kv_set_with_insert_and_delete() -> TestResult {
 async fn test_kv_expiration() -> TestResult {
     let (client, _server_handle) = super::start_server().await;
 
-    kv_set(&client, "test-key-3", 100, "test-value-345", "upsert").await?;
+    kv_set(&client, "test-key-3", Some(100), "test-value-345", "upsert").await?;
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
+    kv_not_found(&client, "test-key-3").await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kv_update_expiration() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    // Test updating expiration time
+    kv_set(&client, "kv4", Some(500), "v4", "upsert").await?;
+    kv_set(&client, "kv4", Some(2000), "v4", "upsert").await?;
+
+    let response = kv_get(&client, "kv4").await?;
+    let expires_at = response["expires_at"].as_str().unwrap();
+
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let response = kv_get(&client, "kv4").await?;
+    assert_eq!(response["value"], json!("v4".as_bytes()));
+    assert_eq!(response["expires_at"], expires_at);
+
+    kv_set(&client, "kv5", Some(3000), "v5", "upsert").await?;
+    kv_set(&client, "kv5", Some(500), "v5", "upsert").await?;
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    kv_not_found(&client, "test-key-3").await?;
+
+    // Test updating expired key
+    kv_set(&client, "kv6", Some(500), "v6", "upsert").await?;
+    kv_set(&client, "kv6", Some(100), "v6", "insert").await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let response = kv_get(&client, "kv6").await?;
+    assert_eq!(response["value"], json!("v6".as_bytes()));
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    kv_set(&client, "kv6", Some(500), "v6", "update").await?;
+    kv_not_found(&client, "kv6").await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kv_binary_data() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    let binary_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     client
-        .post("kv/get")
+        .post("kv/set")
         .json(json!({
-            "key": "test-key-3"
+            "key": "kv-key-4",
+            "value": binary_data,
+            "behavior": "upsert"
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .expect(StatusCode::OK);
+
+    let response = kv_get(&client, "kv-key-4").await?;
+    assert_eq!(response["value"], json!(binary_data));
+
+    let empty_vec: Vec<u8> = vec![];
+    client
+        .post("kv/set")
+        .json(json!({
+            "key": "kv-key-4",
+            "value": empty_vec,
+            "behavior": "upsert"
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = kv_get(&client, "kv-key-4").await?;
+    assert_eq!(response["value"], json!([]));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kv_validation() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    let invalid_keys = ["", "key with spaces", "key@special", &"a".repeat(257)];
+
+    for key in invalid_keys {
+        client
+            .post("kv/set")
+            .json(json!({
+                "key": key,
+                "value": "test".as_bytes(),
+                "behavior": "upsert"
+            }))
+            .await?
+            .expect(StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    client
+        .post("kv/set")
+        .json(json!({
+            "key": "kv-key-3",
+            "value": "test".as_bytes(),
+            "expire_in": 0,
+            "behavior": "upsert"
+        }))
+        .await?
+        .expect(StatusCode::UNPROCESSABLE_ENTITY);
+
+    client
+        .post("kv/set")
+        .json(json!({
+            "key": "kv-key-3",
+            "value": "test".as_bytes(),
+            "expire_in": -1,
+            "behavior": "upsert"
+        }))
+        .await?
+        .expect(StatusCode::UNPROCESSABLE_ENTITY);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kv_delete() -> TestResult {
+    let (client, _server_handle) = super::start_server().await;
+
+    // let response = client
+    //     .post("kv/delete")
+    //     .json(json!({
+    //         "key": "kv-key-5"
+    //     }))
+    //     .await?
+    //     .expect(StatusCode::OK)
+    //     .json();
+
+    // FIXME(@svix-lucho): Behavior not implemented yet
+    // assert_eq!(response["deleted"], false);
+
+    kv_set(&client, "kv-key-5", None, "value-5", "upsert").await?;
+
+    let response = client
+        .post("kv/delete")
+        .json(json!({
+            "key": "kv-key-5"
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(response["deleted"], true);
+
+    kv_not_found(&client, "kv-key-5").await?;
 
     Ok(())
 }


### PR DESCRIPTION
- Use `Vec<u8>` instead of `String` for values
- Make `expire_in` an `Option` instead of using `0` as the value when there's no expiration. 
- Add a bunch of e2e tests