### PR TITLE
Add DLQ functionality to Stream

### DIFF
--- a/clients/cli/src/cmds/api/stream.rs
+++ b/clients/cli/src/cmds/api/stream.rs
@@ -80,6 +80,32 @@ impl From<StreamAckOptions> for coyote_client::api::StreamAckOptions {
     }
 }
 
+#[derive(Args, Clone)]
+pub struct StreamDlqOptions {
+    #[arg(long)]
+    pub idempotency_key: Option<String>,
+}
+
+impl From<StreamDlqOptions> for coyote_client::api::StreamDlqOptions {
+    fn from(value: StreamDlqOptions) -> Self {
+        let StreamDlqOptions { idempotency_key } = value;
+        Self { idempotency_key }
+    }
+}
+
+#[derive(Args, Clone)]
+pub struct StreamRedriveOptions {
+    #[arg(long)]
+    pub idempotency_key: Option<String>,
+}
+
+impl From<StreamRedriveOptions> for coyote_client::api::StreamRedriveOptions {
+    fn from(value: StreamRedriveOptions) -> Self {
+        let StreamRedriveOptions { idempotency_key } = value;
+        Self { idempotency_key }
+    }
+}
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct StreamArgs {
@@ -131,6 +157,18 @@ pub enum StreamCommands {
         ack: crate::json::JsonOf<coyote_client::models::Ack>,
         #[clap(flatten)]
         options: StreamAckOptions,
+    },
+    /// Moves a message to the dead letter queue.
+    Dlq {
+        dlq_in: crate::json::JsonOf<coyote_client::models::DlqIn>,
+        #[clap(flatten)]
+        options: StreamDlqOptions,
+    },
+    /// Redrives messages from the dead letter queue back to the stream.
+    Redrive {
+        redrive_in: crate::json::JsonOf<coyote_client::models::RedriveIn>,
+        #[clap(flatten)]
+        options: StreamRedriveOptions,
     },
 }
 
@@ -195,6 +233,23 @@ impl StreamCommands {
                 let resp = client
                     .stream()
                     .ack(ack.into_inner(), Some(options.into()))
+                    .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Dlq { dlq_in, options } => {
+                let resp = client
+                    .stream()
+                    .dlq(dlq_in.into_inner(), Some(options.into()))
+                    .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Redrive {
+                redrive_in,
+                options,
+            } => {
+                let resp = client
+                    .stream()
+                    .redrive(redrive_in.into_inner(), Some(options.into()))
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }

--- a/clients/rust/src/api/mod.rs
+++ b/clients/rust/src/api/mod.rs
@@ -12,7 +12,7 @@ pub use self::{
     rate_limiter::{RateLimiter, RateLimiterGetRemainingOptions, RateLimiterLimitOptions},
     stream::{
         Stream, StreamAckOptions, StreamAckRangeOptions, StreamAppendOptions, StreamCreateOptions,
-        StreamFetchLockingOptions, StreamFetchOptions,
+        StreamDlqOptions, StreamFetchLockingOptions, StreamFetchOptions, StreamRedriveOptions,
     },
 };
 

--- a/clients/rust/src/api/stream.rs
+++ b/clients/rust/src/api/stream.rs
@@ -31,6 +31,16 @@ pub struct StreamAckOptions {
     pub idempotency_key: Option<String>,
 }
 
+#[derive(Default)]
+pub struct StreamDlqOptions {
+    pub idempotency_key: Option<String>,
+}
+
+#[derive(Default)]
+pub struct StreamRedriveOptions {
+    pub idempotency_key: Option<String>,
+}
+
 pub struct Stream<'a> {
     cfg: &'a Configuration,
 }
@@ -129,6 +139,32 @@ impl<'a> Stream<'a> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/ack")
             .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(ack)
+            .execute(self.cfg)
+            .await
+    }
+
+    /// Moves a message to the dead letter queue.
+    pub async fn dlq(&self, dlq_in: DlqIn, options: Option<StreamDlqOptions>) -> Result<DlqOut> {
+        let StreamDlqOptions { idempotency_key } = options.unwrap_or_default();
+
+        crate::request::Request::new(http::Method::POST, "/api/v1/stream/dlq")
+            .with_optional_header_param("idempotency-key", idempotency_key)
+            .with_body_param(dlq_in)
+            .execute(self.cfg)
+            .await
+    }
+
+    /// Redrives messages from the dead letter queue back to the stream.
+    pub async fn redrive(
+        &self,
+        redrive_in: RedriveIn,
+        options: Option<StreamRedriveOptions>,
+    ) -> Result<RedriveOut> {
+        let StreamRedriveOptions { idempotency_key } = options.unwrap_or_default();
+
+        crate::request::Request::new(http::Method::POST, "/api/v1/stream/redrive-dlq")
+            .with_optional_header_param("idempotency-key", idempotency_key)
+            .with_body_param(redrive_in)
             .execute(self.cfg)
             .await
     }

--- a/clients/rust/src/models/dlq_in.rs
+++ b/clients/rust/src/models/dlq_in.rs
@@ -1,0 +1,24 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DlqIn {
+    #[serde(rename = "consumerGroup")]
+    pub consumer_group: String,
+
+    #[serde(rename = "msgId")]
+    pub msg_id: u64,
+
+    pub name: String,
+}
+
+impl DlqIn {
+    pub fn new(consumer_group: String, msg_id: u64, name: String) -> Self {
+        Self {
+            consumer_group,
+            msg_id,
+            name,
+        }
+    }
+}

--- a/clients/rust/src/models/dlq_out.rs
+++ b/clients/rust/src/models/dlq_out.rs
@@ -1,0 +1,12 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DlqOut {}
+
+impl DlqOut {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/clients/rust/src/models/mod.rs
+++ b/clients/rust/src/models/mod.rs
@@ -15,6 +15,8 @@ mod cache_set_in;
 mod cache_set_out;
 mod create_stream_in;
 mod create_stream_out;
+mod dlq_in;
+mod dlq_out;
 mod fetch_from_stream_in;
 mod fetch_from_stream_out;
 mod kv_delete_in;
@@ -32,19 +34,22 @@ mod rate_limiter_check_out;
 mod rate_limiter_config;
 mod rate_limiter_get_remaining_in;
 mod rate_limiter_get_remaining_out;
+mod redrive_in;
+mod redrive_out;
 
 pub use self::{
     ack::Ack, ack_msg_range_in::AckMsgRangeIn, ack_msg_range_out::AckMsgRangeOut, ack_out::AckOut,
     append_to_stream_in::AppendToStreamIn, append_to_stream_out::AppendToStreamOut,
     cache_delete_in::CacheDeleteIn, cache_delete_out::CacheDeleteOut, cache_get_in::CacheGetIn,
     cache_get_out::CacheGetOut, cache_set_in::CacheSetIn, cache_set_out::CacheSetOut,
-    create_stream_in::CreateStreamIn, create_stream_out::CreateStreamOut,
-    fetch_from_stream_in::FetchFromStreamIn, fetch_from_stream_out::FetchFromStreamOut,
-    kv_delete_in::KvDeleteIn, kv_delete_out::KvDeleteOut, kv_get_in::KvGetIn, kv_get_out::KvGetOut,
-    kv_set_in::KvSetIn, kv_set_out::KvSetOut, msg_in::MsgIn, msg_out::MsgOut,
-    operation_behavior::OperationBehavior, rate_limit_result::RateLimitResult,
-    rate_limiter_check_in::RateLimiterCheckIn, rate_limiter_check_out::RateLimiterCheckOut,
-    rate_limiter_config::RateLimiterConfig,
+    create_stream_in::CreateStreamIn, create_stream_out::CreateStreamOut, dlq_in::DlqIn,
+    dlq_out::DlqOut, fetch_from_stream_in::FetchFromStreamIn,
+    fetch_from_stream_out::FetchFromStreamOut, kv_delete_in::KvDeleteIn,
+    kv_delete_out::KvDeleteOut, kv_get_in::KvGetIn, kv_get_out::KvGetOut, kv_set_in::KvSetIn,
+    kv_set_out::KvSetOut, msg_in::MsgIn, msg_out::MsgOut, operation_behavior::OperationBehavior,
+    rate_limit_result::RateLimitResult, rate_limiter_check_in::RateLimiterCheckIn,
+    rate_limiter_check_out::RateLimiterCheckOut, rate_limiter_config::RateLimiterConfig,
     rate_limiter_get_remaining_in::RateLimiterGetRemainingIn,
-    rate_limiter_get_remaining_out::RateLimiterGetRemainingOut,
+    rate_limiter_get_remaining_out::RateLimiterGetRemainingOut, redrive_in::RedriveIn,
+    redrive_out::RedriveOut,
 };

--- a/clients/rust/src/models/msg_in.rs
+++ b/clients/rust/src/models/msg_in.rs
@@ -4,13 +4,17 @@ use serde::{Deserialize, Serialize};
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MsgIn {
-    pub headers: std::collections::HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<std::collections::HashMap<String, String>>,
 
     pub payload: Vec<u8>,
 }
 
 impl MsgIn {
-    pub fn new(headers: std::collections::HashMap<String, String>, payload: Vec<u8>) -> Self {
-        Self { headers, payload }
+    pub fn new(payload: Vec<u8>) -> Self {
+        Self {
+            headers: None,
+            payload,
+        }
     }
 }

--- a/clients/rust/src/models/redrive_in.rs
+++ b/clients/rust/src/models/redrive_in.rs
@@ -1,0 +1,20 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RedriveIn {
+    #[serde(rename = "consumerGroup")]
+    pub consumer_group: String,
+
+    pub name: String,
+}
+
+impl RedriveIn {
+    pub fn new(consumer_group: String, name: String) -> Self {
+        Self {
+            consumer_group,
+            name,
+        }
+    }
+}

--- a/clients/rust/src/models/redrive_out.rs
+++ b/clients/rust/src/models/redrive_out.rs
@@ -1,0 +1,12 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RedriveOut {}
+
+impl RedriveOut {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/crates/stream/src/entities.rs
+++ b/crates/stream/src/entities.rs
@@ -17,6 +17,7 @@ pub type MsgHeaders = HashMap<String, String>;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct MsgIn {
     pub payload: Vec<u8>,
+    #[serde(default)]
     pub headers: HashMap<String, String>,
 }
 

--- a/crates/stream/src/operations/ack.rs
+++ b/crates/stream/src/operations/ack.rs
@@ -26,7 +26,17 @@ impl Ack {
         let leases = LeaseRow::fetch_all(state, stream_id, &cg)?;
         validate_ack_bounds(&leases, max_msg_id)?;
 
-        let mut lease_diff = LeaseRow::cull_and_compact(leases, now);
+        let mut lease_diff = LeaseRow::cull_and_compact(leases.clone(), now);
+
+        // Shrink any active leases that overlap with the acked range
+        LeaseRow::shrink_active_leases_for_range(
+            &leases,
+            min_msg_id,
+            max_msg_id,
+            now,
+            &mut lease_diff,
+        );
+
         // This new lease is potentially redundant with an extant lease.
         // However, any redundancy will be removed by future calls to `cull_and_compact`.
         lease_diff.to_insert.push(LeaseRow {
@@ -37,6 +47,7 @@ impl Ack {
             leased_at: now,
             expires_at: Timestamp::MAX,
             acked_at: Some(now),
+            dlq_at: None,
         });
 
         Ok(Self { lease_diff })

--- a/crates/stream/src/operations/dlq.rs
+++ b/crates/stream/src/operations/dlq.rs
@@ -1,0 +1,69 @@
+use crate::{
+    State,
+    entities::{ConsumerGroup, MsgId, StreamName},
+    tables::{LeaseDiff, LeaseRow, NameToStreamRow},
+};
+use coyote_error::{HttpError, Result};
+use jiff::Timestamp;
+
+pub struct Dlq {
+    lease_diff: LeaseDiff,
+}
+
+pub struct DlqOutput {}
+
+impl Dlq {
+    pub fn new(state: &State, name: StreamName, cg: ConsumerGroup, msg_id: MsgId) -> Result<Self> {
+        let stream_id = NameToStreamRow::get_stream_id(state, &name)?;
+        let now = Timestamp::now();
+        let leases = LeaseRow::fetch_all(state, stream_id, &cg)?;
+
+        validate_dlq_bounds(&leases, msg_id)?;
+
+        let mut lease_diff = LeaseRow::cull_and_compact(leases.clone(), now);
+
+        // Shrink any active leases that cover this message
+        LeaseRow::shrink_active_leases_for_range(&leases, msg_id, msg_id, now, &mut lease_diff);
+
+        lease_diff.to_insert.push(LeaseRow {
+            stream_id,
+            cg,
+            block_start: msg_id,
+            block_end: msg_id,
+            leased_at: now,
+            expires_at: Timestamp::MAX,
+            acked_at: None,
+            dlq_at: Some(now),
+        });
+
+        Ok(Self { lease_diff })
+    }
+
+    pub fn apply_operation(self, state: &State) -> Result<DlqOutput> {
+        let mut batch = state.db.batch();
+        self.lease_diff.apply_diff(state, &mut batch)?;
+        batch.commit()?;
+        Ok(DlqOutput {})
+    }
+}
+
+fn validate_dlq_bounds(leases: &[LeaseRow], msg_id: MsgId) -> Result<()> {
+    let highest_bound = leases.iter().map(|l| l.block_end).max().ok_or_else(|| {
+        HttpError::bad_request(
+            Some("invalid_dlq".to_owned()),
+            Some("No leases exist for this consumer group".to_owned()),
+        )
+    })?;
+
+    if msg_id > highest_bound {
+        return Err(HttpError::bad_request(
+            Some("invalid_dlq".to_owned()),
+            Some(format!(
+                "DLQ message id exceeds highest lease bound. msg_id={msg_id}, highest_bound={highest_bound}"
+            )),
+        )
+        .into());
+    }
+
+    Ok(())
+}

--- a/crates/stream/src/operations/fetch.rs
+++ b/crates/stream/src/operations/fetch.rs
@@ -5,7 +5,7 @@ use jiff::Timestamp;
 
 use crate::{
     State,
-    entities::{ConsumerGroup, MsgId, MsgOut, StreamName},
+    entities::{ConsumerGroup, MsgId, MsgOut, StreamId, StreamName},
     tables::{LeaseDiff, LeaseRow, MsgRow, NameToStreamRow},
 };
 
@@ -16,6 +16,58 @@ pub struct Fetch {
 
 pub struct FetchOutput {
     pub msgs: Vec<MsgOut>,
+}
+
+/// Groups message IDs into contiguous ranges.
+/// Returns a vector of (start, end) tuples representing each contiguous block.
+fn group_into_contiguous_ranges(msg_ids: &[MsgId]) -> Vec<(MsgId, MsgId)> {
+    if msg_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ranges = Vec::new();
+    let mut range_start = msg_ids[0];
+    let mut range_end = msg_ids[0];
+
+    for &id in &msg_ids[1..] {
+        if id == range_end + 1 {
+            // Contiguous with current range
+            range_end = id;
+        } else {
+            // Gap found, close current range and start new one
+            ranges.push((range_start, range_end));
+            range_start = id;
+            range_end = id;
+        }
+    }
+    // Don't forget the last range
+    ranges.push((range_start, range_end));
+
+    ranges
+}
+
+/// Creates leases for each contiguous block of messages.
+pub(crate) fn create_leases_for_msgs(
+    msg_ids: &[MsgId],
+    stream_id: StreamId,
+    cg: ConsumerGroup,
+    now: Timestamp,
+    visibility_timeout: std::time::Duration,
+    lease_diff: &mut LeaseDiff,
+) {
+    let ranges = group_into_contiguous_ranges(msg_ids);
+    for (block_start, block_end) in ranges {
+        lease_diff.to_insert.push(LeaseRow {
+            stream_id,
+            cg: cg.clone(),
+            block_start,
+            block_end,
+            leased_at: now,
+            expires_at: now + visibility_timeout,
+            acked_at: None,
+            dlq_at: None,
+        });
+    }
 }
 
 impl Fetch {
@@ -31,26 +83,26 @@ impl Fetch {
         let leases = LeaseRow::fetch_all(state, stream_id, &cg)?;
 
         // Unlike FetchLocking, we don't block on active leases.
-        // Instead, we exclude both acked and active leases from the fetch.
+        // Instead, we exclude acked, DLQ'd, and active leases from the fetch.
         let blocked_leases = leases
             .iter()
-            .filter(|lease| lease.acked_at.is_some() || lease.is_active(now));
+            .filter(|lease| lease.acked_at.is_some() || lease.is_dlq() || lease.is_active(now));
 
         let msgs = MsgRow::fetch_available(state, stream_id, blocked_leases, batch_size.into())?;
 
         let mut lease_diff = LeaseRow::cull_and_compact(leases, now);
 
-        if !msgs.is_empty() {
-            lease_diff.to_insert.push(LeaseRow {
-                stream_id,
-                cg,
-                block_start: msgs.first().unwrap().0,
-                block_end: msgs.last().unwrap().0,
-                leased_at: now,
-                expires_at: now + visibility_timeout,
-                acked_at: None,
-            });
-        }
+        // Create separate leases for each contiguous block of messages.
+        // This prevents covering gaps (e.g., DLQ'd messages) with a single range lease.
+        let msg_ids: Vec<MsgId> = msgs.iter().map(|(id, _)| *id).collect();
+        create_leases_for_msgs(
+            &msg_ids,
+            stream_id,
+            cg,
+            now,
+            visibility_timeout,
+            &mut lease_diff,
+        );
 
         Ok(Self { lease_diff, msgs })
     }

--- a/crates/stream/src/operations/fetch_locking.rs
+++ b/crates/stream/src/operations/fetch_locking.rs
@@ -6,11 +6,13 @@ use jiff::Timestamp;
 use crate::{
     State,
     entities::{ConsumerGroup, MsgId, MsgOut, StreamName},
-    tables::{LeaseDiff, LeaseRow, MsgRow, NameToStreamRow},
+    tables::{LeaseRow, MsgRow, NameToStreamRow},
 };
 
+use super::fetch::create_leases_for_msgs;
+
 pub struct FetchLocking {
-    lease_diff: LeaseDiff,
+    lease_diff: crate::tables::LeaseDiff,
     msgs: Vec<(MsgId, MsgRow)>,
 }
 
@@ -40,8 +42,10 @@ impl FetchLocking {
             .into());
         }
 
-        let acked_leases = leases.iter().filter(|lease| lease.acked_at.is_some());
-        let msgs = MsgRow::fetch_available(state, stream_id, acked_leases, batch_size.into())?;
+        let blocked_leases = leases
+            .iter()
+            .filter(|lease| lease.acked_at.is_some() || lease.is_dlq());
+        let msgs = MsgRow::fetch_available(state, stream_id, blocked_leases, batch_size.into())?;
 
         if msgs.is_empty() {
             // FIXME(@svix-gabriel) this isn't really an error, but we need to go back
@@ -55,15 +59,16 @@ impl FetchLocking {
 
         let mut lease_diff = LeaseRow::cull_and_compact(leases, now);
 
-        lease_diff.to_insert.push(LeaseRow {
+        // Create separate leases for each contiguous block of messages.
+        let msg_ids: Vec<MsgId> = msgs.iter().map(|(id, _)| *id).collect();
+        create_leases_for_msgs(
+            &msg_ids,
             stream_id,
             cg,
-            block_start: msgs.first().unwrap().0,
-            block_end: msgs.last().unwrap().0,
-            leased_at: now,
-            expires_at: now + visibility_timeout,
-            acked_at: None,
-        });
+            now,
+            visibility_timeout,
+            &mut lease_diff,
+        );
 
         Ok(Self { lease_diff, msgs })
     }

--- a/crates/stream/src/operations/mod.rs
+++ b/crates/stream/src/operations/mod.rs
@@ -1,7 +1,11 @@
 mod ack;
 mod append_to_stream;
 mod create_stream;
+mod dlq;
 mod fetch;
 mod fetch_locking;
+mod redrive;
 
 pub use self::{ack::*, append_to_stream::*, create_stream::*, fetch::*, fetch_locking::*};
+pub use dlq::*;
+pub use redrive::*;

--- a/crates/stream/src/operations/redrive.rs
+++ b/crates/stream/src/operations/redrive.rs
@@ -1,0 +1,39 @@
+use crate::{
+    State,
+    entities::{ConsumerGroup, StreamName},
+    tables::{LeaseDiff, LeaseRow, NameToStreamRow},
+};
+use coyote_error::Result;
+use jiff::Timestamp;
+
+pub struct Redrive {
+    lease_diff: LeaseDiff,
+}
+
+pub struct RedriveOutput {}
+
+impl Redrive {
+    pub fn new(state: &State, name: StreamName, cg: ConsumerGroup) -> Result<Self> {
+        let stream_id = NameToStreamRow::get_stream_id(state, &name)?;
+        let now = Timestamp::now();
+        let leases = LeaseRow::fetch_all(state, stream_id, &cg)?;
+
+        let mut lease_diff = LeaseRow::cull_and_compact(leases.clone(), now);
+
+        // Delete all DLQ'd leases - this makes those messages available again
+        for lease in leases {
+            if lease.is_dlq() {
+                lease_diff.to_delete.push(lease);
+            }
+        }
+
+        Ok(Self { lease_diff })
+    }
+
+    pub fn apply_operation(self, state: &State) -> Result<RedriveOutput> {
+        let mut batch = state.db.batch();
+        self.lease_diff.apply_diff(state, &mut batch)?;
+        batch.commit()?;
+        Ok(RedriveOutput {})
+    }
+}

--- a/crates/stream/src/tables.rs
+++ b/crates/stream/src/tables.rs
@@ -89,9 +89,12 @@ pub(crate) struct LeaseRow {
     pub leased_at: Timestamp,
     /// LeaseRows expire based on the visibility timeout.
     pub expires_at: Timestamp,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// When the block of messages was acknowledged / processed by a consumer in the group.
+    #[serde(default)]
     pub acked_at: Option<Timestamp>,
+    /// DLQ'd messages are saved as a lease.
+    #[serde(default)]
+    pub dlq_at: Option<Timestamp>,
 }
 
 /// For the key, we use a composite of (stream_id, consumer_group, block_end).
@@ -177,37 +180,54 @@ impl LeaseRow {
     ///     2. Leases to insert.
     ///
     /// Any Lease that has expired (it's expiration time is past `now`), can be trivially
-    /// deleted.
+    /// deleted. DLQ'd leases are never deleted by expiration.
     ///
-    /// Any leases where 1) `acked_at.is_some()`, and 2) the message ranges are overlapping,
-    /// can be compacted. This involves deleting the old leases, and replacing them with merged lease.
+    /// Any acked or DLQ'd leases where the message ranges are adjacent or overlapping
+    /// can be compacted. This involves deleting the old leases, and replacing them with
+    /// a merged lease.
     pub(crate) fn cull_and_compact(leases: Vec<Self>, now: Timestamp) -> LeaseDiff {
         let mut to_delete = Vec::new();
         let mut to_insert = Vec::new();
 
         let mut acked_leases: Vec<Self> = Vec::new();
+        let mut dlq_leases: Vec<Self> = Vec::new();
 
         for lease in leases {
-            if lease.expires_at < now {
+            if lease.dlq_at.is_some() {
+                dlq_leases.push(lease);
+            } else if lease.expires_at < now {
                 to_delete.push(lease);
             } else if lease.acked_at.is_some() {
                 acked_leases.push(lease);
             }
         }
 
-        if acked_leases.is_empty() {
-            return LeaseDiff {
-                to_delete,
-                to_insert,
-            };
+        Self::compact_adjacent(acked_leases, &mut to_delete, &mut to_insert);
+        Self::compact_adjacent(dlq_leases, &mut to_delete, &mut to_insert);
+
+        LeaseDiff {
+            to_delete,
+            to_insert,
+        }
+    }
+
+    /// Compacts adjacent or overlapping leases by merging them into a single lease.
+    /// Groups of size 1 are left untouched.
+    fn compact_adjacent(
+        mut leases: Vec<Self>,
+        to_delete: &mut Vec<Self>,
+        to_insert: &mut Vec<Self>,
+    ) {
+        if leases.is_empty() {
+            return;
         }
 
-        acked_leases.sort_by_key(|l| l.block_start);
+        leases.sort_by_key(|l| l.block_start);
 
         let mut groups: Vec<Vec<Self>> = Vec::new();
-        let mut current_group = vec![acked_leases.remove(0)];
+        let mut current_group = vec![leases.remove(0)];
 
-        for lease in acked_leases {
+        for lease in leases {
             let last = current_group.last().unwrap();
             if last.block_end + 1 >= lease.block_start {
                 current_group.push(lease);
@@ -226,42 +246,82 @@ impl LeaseRow {
             let stream_id = group[0].stream_id;
             let cg = group[0].cg.clone();
 
-            let mut block_start = MsgId::MAX;
-            let mut block_end = MsgId::MIN;
-            let mut leased_at = Timestamp::MAX;
-            let mut expires_at = Timestamp::MIN;
-            let mut acked_at = Timestamp::MIN;
+            let mut merged = LeaseRow {
+                stream_id,
+                cg,
+                block_start: MsgId::MAX,
+                block_end: MsgId::MIN,
+                leased_at: Timestamp::MAX,
+                expires_at: Timestamp::MIN,
+                acked_at: None,
+                dlq_at: None,
+            };
 
             for lease in group {
-                block_start = block_start.min(lease.block_start);
-                block_end = block_end.max(lease.block_end);
-                leased_at = leased_at.min(lease.leased_at);
-                expires_at = expires_at.max(lease.expires_at);
+                merged.block_start = merged.block_start.min(lease.block_start);
+                merged.block_end = merged.block_end.max(lease.block_end);
+                merged.leased_at = merged.leased_at.min(lease.leased_at);
+                merged.expires_at = merged.expires_at.max(lease.expires_at);
                 if let Some(ack) = lease.acked_at {
-                    acked_at = acked_at.max(ack);
+                    merged.acked_at = Some(merged.acked_at.map_or(ack, |a| a.max(ack)));
+                }
+                if let Some(dlq) = lease.dlq_at {
+                    merged.dlq_at = Some(merged.dlq_at.map_or(dlq, |d| d.max(dlq)));
                 }
                 to_delete.push(lease);
             }
 
-            to_insert.push(Self {
-                stream_id,
-                cg,
-                block_start,
-                block_end,
-                leased_at,
-                expires_at,
-                acked_at: Some(acked_at),
-            });
-        }
-
-        LeaseDiff {
-            to_delete,
-            to_insert,
+            to_insert.push(merged);
         }
     }
 
     pub(crate) fn is_active(&self, now: Timestamp) -> bool {
-        self.acked_at.is_none() && self.expires_at > now
+        self.acked_at.is_none() && self.dlq_at.is_none() && self.expires_at > now
+    }
+
+    pub(crate) fn is_dlq(&self) -> bool {
+        self.dlq_at.is_some()
+    }
+
+    /// Shrinks or splits active leases to exclude a range of message IDs.
+    /// This is called when messages are acked or DLQ'd to ensure the active lease
+    /// no longer blocks those messages.
+    pub(crate) fn shrink_active_leases_for_range(
+        leases: &[Self],
+        min_msg_id: MsgId,
+        max_msg_id: MsgId,
+        now: Timestamp,
+        lease_diff: &mut LeaseDiff,
+    ) {
+        for lease in leases {
+            if !lease.is_active(now) {
+                continue;
+            }
+
+            // It only makes sense to shrink the lease if it overlaps with the msg range.
+            if lease.block_end < min_msg_id || max_msg_id < lease.block_start {
+                continue;
+            }
+
+            lease_diff.to_delete.push(lease.clone());
+
+            // Create replacement lease(s) for any parts that don't overlap with the range
+            // Left remainder: [lease.block_start, min_msg_id - 1] if lease starts before range
+            if lease.block_start < min_msg_id {
+                lease_diff.to_insert.push(Self {
+                    block_end: min_msg_id - 1,
+                    ..lease.clone()
+                });
+            }
+
+            // Right remainder: [max_msg_id + 1, lease.block_end] if lease ends after range
+            if lease.block_end > max_msg_id {
+                lease_diff.to_insert.push(Self {
+                    block_start: max_msg_id + 1,
+                    ..lease.clone()
+                });
+            }
+        }
     }
 }
 
@@ -484,6 +544,7 @@ mod tests {
             leased_at: ts(0),
             expires_at: ts(50),
             acked_at: None,
+            dlq_at: None,
         };
 
         let diff = LeaseRow::cull_and_compact(vec![lease.clone()], ts(100));
@@ -504,6 +565,7 @@ mod tests {
             leased_at: ts(0),
             expires_at: ts(200),
             acked_at: None,
+            dlq_at: None,
         };
 
         let diff = LeaseRow::cull_and_compact(vec![lease], ts(100));
@@ -523,6 +585,7 @@ mod tests {
             leased_at: ts(0),
             expires_at: ts(200),
             acked_at: Some(ts(50)),
+            dlq_at: None,
         };
 
         let diff = LeaseRow::cull_and_compact(vec![lease], ts(100));
@@ -543,6 +606,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(50),
                 acked_at: None,
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -552,6 +616,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(60),
                 acked_at: None,
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -561,6 +626,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(70),
                 acked_at: None,
+                dlq_at: None,
             },
         ];
 
@@ -582,6 +648,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(200),
                 acked_at: None,
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -591,6 +658,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(200),
                 acked_at: None,
+                dlq_at: None,
             },
         ];
 
@@ -612,6 +680,7 @@ mod tests {
                 leased_at: ts(10),
                 expires_at: ts(200),
                 acked_at: Some(ts(20)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -621,6 +690,7 @@ mod tests {
                 leased_at: ts(15),
                 expires_at: ts(200),
                 acked_at: Some(ts(25)),
+                dlq_at: None,
             },
         ];
 
@@ -647,6 +717,7 @@ mod tests {
                 leased_at: ts(10),
                 expires_at: ts(200),
                 acked_at: Some(ts(20)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -656,6 +727,7 @@ mod tests {
                 leased_at: ts(15),
                 expires_at: ts(200),
                 acked_at: Some(ts(25)),
+                dlq_at: None,
             },
         ];
 
@@ -681,6 +753,7 @@ mod tests {
                 leased_at: ts(10),
                 expires_at: ts(200),
                 acked_at: Some(ts(20)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -690,6 +763,7 @@ mod tests {
                 leased_at: ts(15),
                 expires_at: ts(200),
                 acked_at: Some(ts(25)),
+                dlq_at: None,
             },
         ];
 
@@ -711,6 +785,7 @@ mod tests {
                 leased_at: ts(10),
                 expires_at: ts(200),
                 acked_at: Some(ts(20)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -720,6 +795,7 @@ mod tests {
                 leased_at: ts(15),
                 expires_at: ts(200),
                 acked_at: Some(ts(25)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -729,6 +805,7 @@ mod tests {
                 leased_at: ts(18),
                 expires_at: ts(200),
                 acked_at: Some(ts(30)),
+                dlq_at: None,
             },
         ];
 
@@ -755,6 +832,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(50),
                 acked_at: None,
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -764,6 +842,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(200),
                 acked_at: None,
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -773,6 +852,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(200),
                 acked_at: Some(ts(50)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -782,6 +862,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(200),
                 acked_at: Some(ts(55)),
+                dlq_at: None,
             },
         ];
 
@@ -807,6 +888,7 @@ mod tests {
                 leased_at: ts(10),
                 expires_at: ts(200),
                 acked_at: Some(ts(20)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -816,6 +898,7 @@ mod tests {
                 leased_at: ts(15),
                 expires_at: ts(200),
                 acked_at: Some(ts(25)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -825,6 +908,7 @@ mod tests {
                 leased_at: ts(10),
                 expires_at: ts(200),
                 acked_at: Some(ts(20)),
+                dlq_at: None,
             },
             LeaseRow {
                 stream_id,
@@ -834,6 +918,7 @@ mod tests {
                 leased_at: ts(15),
                 expires_at: ts(200),
                 acked_at: Some(ts(25)),
+                dlq_at: None,
             },
         ];
 
@@ -938,6 +1023,7 @@ mod tests {
                 leased_at: ts(0),
                 expires_at: ts(1000),
                 acked_at: None,
+                dlq_at: None,
             }
         }
 
@@ -1204,6 +1290,124 @@ mod tests {
             assert_eq!(result[2].0, 5);
             assert_eq!(result[3].0, 7);
             assert_eq!(result[4].0, 9);
+        }
+
+        #[test]
+        fn dlq_lease_blocks_message() {
+            let state = test_state("fetch_available_dlq_blocks");
+            let stream_id = StreamId::new_v4();
+            insert_msgs(&state, stream_id, &[1, 2, 3, 4, 5]);
+
+            // Create a DLQ lease for message 3
+            let dlq_lease = LeaseRow {
+                stream_id,
+                cg: "test-cg".to_string(),
+                block_start: 3,
+                block_end: 3,
+                leased_at: ts(0),
+                expires_at: Timestamp::MAX,
+                acked_at: None,
+                dlq_at: Some(ts(100)),
+            };
+            let result =
+                MsgRow::fetch_available(&state, stream_id, &[dlq_lease], batch(10)).unwrap();
+
+            assert_eq!(result.len(), 4);
+            assert_eq!(result[0].0, 1);
+            assert_eq!(result[1].0, 2);
+            assert_eq!(result[2].0, 4);
+            assert_eq!(result[3].0, 5);
+        }
+
+        #[test]
+        fn cull_and_compact_preserves_dlq_leases() {
+            let stream_id = StreamId::new_v4();
+            let dlq_lease = LeaseRow {
+                stream_id,
+                cg: "cg1".to_string(),
+                block_start: 3,
+                block_end: 3,
+                leased_at: ts(0),
+                expires_at: ts(50), // Even if expired time-wise, DLQ should be preserved
+                acked_at: None,
+                dlq_at: Some(ts(10)),
+            };
+
+            let diff = LeaseRow::cull_and_compact(vec![dlq_lease], ts(100));
+
+            // DLQ lease should NOT be deleted even though it's "expired"
+            assert!(diff.to_delete.is_empty());
+            assert!(diff.to_insert.is_empty());
+        }
+
+        #[test]
+        fn cull_and_compact_adjacent_dlq_leases_are_compacted() {
+            let stream_id = StreamId::new_v4();
+            let leases = vec![
+                LeaseRow {
+                    stream_id,
+                    cg: "cg1".to_string(),
+                    block_start: 1,
+                    block_end: 3,
+                    leased_at: ts(0),
+                    expires_at: Timestamp::MAX,
+                    acked_at: None,
+                    dlq_at: Some(ts(10)),
+                },
+                LeaseRow {
+                    stream_id,
+                    cg: "cg1".to_string(),
+                    block_start: 4,
+                    block_end: 6,
+                    leased_at: ts(5),
+                    expires_at: Timestamp::MAX,
+                    acked_at: None,
+                    dlq_at: Some(ts(20)),
+                },
+            ];
+
+            let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+            assert_eq!(diff.to_delete.len(), 2);
+            assert_eq!(diff.to_insert.len(), 1);
+
+            let merged = &diff.to_insert[0];
+            assert_eq!(merged.block_start, 1);
+            assert_eq!(merged.block_end, 6);
+            assert_eq!(merged.dlq_at, Some(ts(20)));
+            assert!(merged.acked_at.is_none());
+        }
+
+        #[test]
+        fn cull_and_compact_non_adjacent_dlq_leases_not_compacted() {
+            let stream_id = StreamId::new_v4();
+            let leases = vec![
+                LeaseRow {
+                    stream_id,
+                    cg: "cg1".to_string(),
+                    block_start: 1,
+                    block_end: 3,
+                    leased_at: ts(0),
+                    expires_at: Timestamp::MAX,
+                    acked_at: None,
+                    dlq_at: Some(ts(10)),
+                },
+                LeaseRow {
+                    stream_id,
+                    cg: "cg1".to_string(),
+                    block_start: 10,
+                    block_end: 12,
+                    leased_at: ts(5),
+                    expires_at: Timestamp::MAX,
+                    acked_at: None,
+                    dlq_at: Some(ts(20)),
+                },
+            ];
+
+            let diff = LeaseRow::cull_and_compact(leases, ts(100));
+
+            assert!(diff.to_delete.is_empty());
+            assert!(diff.to_insert.is_empty());
         }
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -861,6 +861,102 @@
           }
         ]
       }
+    },
+    "/api/v1/stream/dlq": {
+      "post": {
+        "tags": [
+          "Stream"
+        ],
+        "summary": "Dlq",
+        "description": "Moves a message to the dead letter queue.",
+        "operationId": "v1.stream.dlq",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "idempotency-key",
+            "description": "The request's idempotency key",
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DlqIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DlqOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stream/redrive-dlq": {
+      "post": {
+        "tags": [
+          "Stream"
+        ],
+        "summary": "Redrive",
+        "description": "Redrives messages from the dead letter queue back to the stream.",
+        "operationId": "v1.stream.redrive",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "idempotency-key",
+            "description": "The request's idempotency key",
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RedriveIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedriveOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -1108,6 +1204,30 @@
           "createdAt",
           "updatedAt"
         ]
+      },
+      "DlqIn": {
+        "type": "object",
+        "properties": {
+          "consumerGroup": {
+            "type": "string"
+          },
+          "msgId": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "consumerGroup",
+          "msgId"
+        ]
+      },
+      "DlqOut": {
+        "type": "object"
       },
       "FetchFromStreamIn": {
         "type": "object",
@@ -1384,7 +1504,8 @@
             "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "default": {}
           },
           "payload": {
             "type": "array",
@@ -1397,8 +1518,7 @@
           }
         },
         "required": [
-          "payload",
-          "headers"
+          "payload"
         ]
       },
       "MsgOut": {
@@ -1581,6 +1701,24 @@
         "required": [
           "remaining"
         ]
+      },
+      "RedriveIn": {
+        "type": "object",
+        "properties": {
+          "consumerGroup": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "consumerGroup"
+        ]
+      },
+      "RedriveOut": {
+        "type": "object"
       }
     }
   },

--- a/src/v1/endpoints/stream.rs
+++ b/src/v1/endpoints/stream.rs
@@ -297,6 +297,64 @@ async fn ack(
 #[serde(rename_all = "camelCase")]
 struct AckOut {}
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct DlqIn {
+    name: StreamName,
+    consumer_group: ConsumerGroup,
+    msg_id: MsgId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct DlqOut {}
+
+/// Moves a message to the dead letter queue.
+#[aide_annotate(op_id = "v1.stream.dlq")]
+async fn dlq(
+    State(AppState { stream_state, .. }): State<AppState>,
+    MsgPackOrJson(data): MsgPackOrJson<DlqIn>,
+) -> Result<MsgPackOrJson<DlqOut>> {
+    let _out = tokio::task::spawn_blocking(move || {
+        let op = stream::operations::Dlq::new(
+            &stream_state,
+            data.name,
+            data.consumer_group,
+            data.msg_id,
+        )?;
+        op.apply_operation(&stream_state)
+    })
+    .await??;
+
+    Ok(MsgPackOrJson(DlqOut {}))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct RedriveIn {
+    name: StreamName,
+    consumer_group: ConsumerGroup,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct RedriveOut {}
+
+/// Redrives messages from the dead letter queue back to the stream.
+#[aide_annotate(op_id = "v1.stream.redrive")]
+async fn redrive(
+    State(AppState { stream_state, .. }): State<AppState>,
+    MsgPackOrJson(data): MsgPackOrJson<RedriveIn>,
+) -> Result<MsgPackOrJson<RedriveOut>> {
+    let _out = tokio::task::spawn_blocking(move || {
+        let op = stream::operations::Redrive::new(&stream_state, data.name, data.consumer_group)?;
+        op.apply_operation(&stream_state)
+    })
+    .await??;
+
+    Ok(MsgPackOrJson(RedriveOut {}))
+}
+
 pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Stream");
 
@@ -330,4 +388,10 @@ pub fn router() -> ApiRouter<AppState> {
             &tag,
         )
         .api_route_with("/stream/ack", post_with(ack, ack_operation), &tag)
+        .api_route_with("/stream/dlq", post_with(dlq, dlq_operation), &tag)
+        .api_route_with(
+            "/stream/redrive-dlq",
+            post_with(redrive, redrive_operation),
+            &tag,
+        )
 }

--- a/tests/it/stream.rs
+++ b/tests/it/stream.rs
@@ -783,3 +783,341 @@ async fn queue_fetch_single_ack() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn queue_dlq_and_redrive() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    let _stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "name": "test-stream",
+            "msgs": [
+                {"payload": [0], "headers": {"msg": "A"}},
+                {"payload": [1], "headers": {"msg": "B"}},
+                {"payload": [2], "headers": {"msg": "C"}},
+                {"payload": [3], "headers": {"msg": "D"}},
+                {"payload": [4], "headers": {"msg": "E"}},
+                {"payload": [5], "headers": {"msg": "F"}},
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch all messages
+    let fetch1 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 6,
+            "visibilityTimeoutSeconds": 2
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 6);
+
+    // DLQ messages B and D (ids 1 and 3)
+    for msg_id in [1, 3] {
+        client
+            .post("stream/dlq")
+            .json(json!({
+                "name": "test-stream",
+                "consumerGroup": "test-group",
+                "msgId": msg_id
+            }))
+            .await?
+            .expect(StatusCode::OK);
+    }
+
+    // Wait for visibility timeout to expire (from fetch1's lease covering 0-5)
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Fetch - should get A, C, E, F (B and D are in DLQ)
+    let fetch2 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 10,
+            "visibilityTimeoutSeconds": 2
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 4);
+    assert_eq!(msgs2[0]["headers"]["msg"], "A");
+    assert_eq!(msgs2[1]["headers"]["msg"], "C");
+    assert_eq!(msgs2[2]["headers"]["msg"], "E");
+    assert_eq!(msgs2[3]["headers"]["msg"], "F");
+
+    // Ack the fetched messages (A, C, E, F) individually so B and D aren't acked
+    for msg_id in [0, 2, 4, 5] {
+        client
+            .post("stream/ack")
+            .json(json!({
+                "name": "test-stream",
+                "consumerGroup": "test-group",
+                "msgId": msg_id
+            }))
+            .await?
+            .expect(StatusCode::OK);
+    }
+
+    // Redrive the DLQ
+    client
+        .post("stream/redrive-dlq")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group"
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Wait for visibility timeout to expire (from fetch2's lease)
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Fetch again - should get B and D (redriven from DLQ, others acked)
+    let fetch3 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 10,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs3 = fetch3["msgs"].as_array().unwrap();
+    assert_eq!(msgs3.len(), 2);
+    assert_eq!(msgs3[0]["headers"]["msg"], "B");
+    assert_eq!(msgs3[1]["headers"]["msg"], "D");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_dlq_with_partial_ack_and_redrive() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    let _stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "name": "test-stream",
+            "msgs": [
+                {"payload": [0], "headers": {"msg": "A"}},
+                {"payload": [1], "headers": {"msg": "B"}},
+                {"payload": [2], "headers": {"msg": "C"}},
+                {"payload": [3], "headers": {"msg": "D"}},
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch first 3 messages
+    let fetch1 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 3,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 3);
+    assert_eq!(msgs1[0]["headers"]["msg"], "A");
+    assert_eq!(msgs1[1]["headers"]["msg"], "B");
+    assert_eq!(msgs1[2]["headers"]["msg"], "C");
+
+    // DLQ message B (id 1)
+    client
+        .post("stream/dlq")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "msgId": 1
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Ack messages A and C (ids 0 and 2)
+    for msg_id in [0, 2] {
+        client
+            .post("stream/ack")
+            .json(json!({
+                "name": "test-stream",
+                "consumerGroup": "test-group",
+                "msgId": msg_id
+            }))
+            .await?
+            .expect(StatusCode::OK);
+    }
+
+    // Redrive the DLQ
+    client
+        .post("stream/redrive-dlq")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group"
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch again - should get B (redriven from DLQ) and D (never fetched)
+    let fetch2 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 3,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 2);
+    assert_eq!(msgs2[0]["headers"]["msg"], "B");
+    assert_eq!(msgs2[1]["headers"]["msg"], "D");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_ack_dlqd_message_prevents_redrive() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    let _stream = client
+        .post("stream/create")
+        .json(json!({
+            "name": "test-stream",
+            "maxByteSize": 1024,
+            "retentionPeriodSeconds": 9999
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    client
+        .post("stream/append")
+        .json(json!({
+            "name": "test-stream",
+            "msgs": [
+                {"payload": [1, 2], "headers": {"msg": "A"}},
+            ]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let fetch1 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 1,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs1 = fetch1["msgs"].as_array().unwrap();
+    assert_eq!(msgs1.len(), 1);
+    assert_eq!(msgs1[0]["headers"]["msg"], "A");
+
+    client
+        .post("stream/dlq")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "msgId": msgs1[0]["id"]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("stream/ack")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "msgId": msgs1[0]["id"]
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("stream/redrive-dlq")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group"
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fetch again, even though the message was DLQd, since the message
+    // was also ACK'd, it shouldn't be redriven.
+    // This is to try to approximate exactly-once semantics as much as is
+    // possible.
+    let fetch2 = client
+        .post("stream/fetch")
+        .json(json!({
+            "name": "test-stream",
+            "consumerGroup": "test-group",
+            "batchSize": 10,
+            "visibilityTimeoutSeconds": 3600
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = fetch2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 0);
+
+    Ok(())
+}


### PR DESCRIPTION
This implements DLQ functionality for Stream. It works with both "stream" and "queue" semantics.

This is
- The ability to DLQ specific messages for a `(stream, consumer_group)`
- The ability to redrive the entire DLQ for a `(stream, consumer_group)` so those messages are visible again.

Rather than using a separate DLQ table like originally planned, it was simpler to just track DLQ'd messages with more Leases. Maybe we'll change this approach in the future 🤷.

I recommend reviewing commit https://github.com/svix/coyote-private/pull/62/changes/b650bf05df27f9c1304e28879fd2437fad38fc98 first, as it's really the bulk of the changes.