### PR TITLE
Add default `configgroup`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +816,7 @@ dependencies = [
  "serde_core",
  "toml",
  "winnow",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -1005,7 +1012,7 @@ dependencies = [
  "fjall",
  "fjall-utils",
  "format-bytes",
- "hashlink",
+ "hashlink 0.11.0",
  "hex",
  "jiff",
  "rmp-serde",
@@ -1023,9 +1030,12 @@ version = "1.76.1"
 dependencies = [
  "anyhow",
  "clap",
+ "config",
  "coyote",
  "dotenvy",
  "reqwest 0.13.1",
+ "serde",
+ "tap",
  "tokio",
  "tracing-subscriber",
 ]
@@ -1422,6 +1432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1554,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1834,11 +1859,29 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5522,6 +5565,17 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.10.0",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 clap_complete = "4.5.38"
 colored_json = "5.0.0"
 concolor-clap = "0.1.0"
-config = { version = "0.15.19", default-features = false, features = ["toml"] }
+config = { version = "0.15.19", default-features = false, features = ["toml", "yaml"] }
 coyote.path = "."
 coyote-client.path = "clients/rust"
 coyote-configgroup.path = "crates/coyote-configgroup"

--- a/bootstrap.default.yaml
+++ b/bootstrap.default.yaml
@@ -1,0 +1,9 @@
+kv:
+  default:
+    storage_type: persistent
+cache:
+  default:
+    storage_type: persistent
+stream:
+  default:
+    storage_type: persistent

--- a/crates/coyote-configgroup/src/entities.rs
+++ b/crates/coyote-configgroup/src/entities.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 pub type ConfigGroupId = Uuid;
 
 #[derive(Serialize, Deserialize)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Module {
     Cache = 1,
     Idempotency = 2,
@@ -49,9 +49,11 @@ pub enum EvictionPolicy {
 pub trait ModuleConfig:
     Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + JsonSchema
 {
-    const TABLE_PREFIX: &'static str;
-
     fn module() -> Module;
+
+    fn eviction_policy(&self) -> EvictionPolicy {
+        EvictionPolicy::NoEviction
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
@@ -61,15 +63,7 @@ impl KeyValueConfig {
     pub const NAMESPACE: &'static str = "kv_store";
 }
 
-impl KeyValueConfig {
-    pub fn eviction_policy(&self) -> EvictionPolicy {
-        EvictionPolicy::NoEviction
-    }
-}
-
 impl ModuleConfig for KeyValueConfig {
-    const TABLE_PREFIX: &'static str = "_CONFIG_KV_";
-
     fn module() -> Module {
         Module::KeyValue
     }
@@ -89,8 +83,6 @@ impl CacheConfig {
 }
 
 impl ModuleConfig for CacheConfig {
-    const TABLE_PREFIX: &'static str = "_CONFIG_CACHE_";
-
     fn module() -> Module {
         Module::Cache
     }
@@ -98,13 +90,9 @@ impl ModuleConfig for CacheConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct StreamConfig {
     pub retention_period_seconds: Option<NonZeroU64>,
-    pub max_bytes_size: u64,
-    pub storage_type: Option<StorageType>,
 }
 
 impl ModuleConfig for StreamConfig {
-    const TABLE_PREFIX: &'static str = "_CONFIG_STREAM_";
-
     fn module() -> Module {
         Module::Stream
     }
@@ -114,8 +102,6 @@ impl ModuleConfig for StreamConfig {
 pub struct IdempotencyConfig {}
 
 impl ModuleConfig for IdempotencyConfig {
-    const TABLE_PREFIX: &'static str = "_CONFIG_IDEM_";
-
     fn module() -> Module {
         Module::Idempotency
     }

--- a/crates/coyote-configgroup/src/lib.rs
+++ b/crates/coyote-configgroup/src/lib.rs
@@ -9,11 +9,16 @@ mod tables;
 
 pub use self::tables::ConfigGroup;
 
-pub fn group_name(key: &str) -> Option<&str> {
+pub const DEFAULT_GROUP_NAME: &str = "default";
+
+pub fn group_name(key: &str) -> &str {
     if !key.contains('/') {
-        return None;
+        return DEFAULT_GROUP_NAME;
     }
-    key.split("/").next()
+    match key.split("/").next() {
+        Some(k) => k,
+        None => DEFAULT_GROUP_NAME,
+    }
 }
 
 #[derive(Clone)]
@@ -56,11 +61,18 @@ impl State {
         })
     }
 
+    // Right now, this should always return something, because there should
+    // always be a `default` group.
     pub fn fetch_group<C: ModuleConfig>(
         &self,
         group_name: String,
     ) -> Result<Option<ConfigGroup<C>>> {
-        ConfigGroup::fetch(&self.keyspace, &group_name)
+        let fetch = ConfigGroup::fetch(&self.keyspace, &group_name)?;
+        if fetch.is_some() {
+            return Ok(fetch);
+        }
+
+        ConfigGroup::fetch(&self.keyspace, DEFAULT_GROUP_NAME)
     }
 
     pub fn fetch_all_groups<C: ModuleConfig>(
@@ -83,8 +95,8 @@ mod tests {
 
     #[test]
     fn test_group_name() {
-        assert_eq!(group_name("tom/bar"), Some("tom"));
-        assert_eq!(group_name("tom/bar/baz"), Some("tom"));
-        assert_eq!(group_name("bill"), None);
+        assert_eq!(group_name("tom/bar"), "tom");
+        assert_eq!(group_name("tom/bar/baz"), "tom");
+        assert_eq!(group_name("bill"), DEFAULT_GROUP_NAME);
     }
 }

--- a/crates/coyote-configgroup/src/operations/create_configgroup.rs
+++ b/crates/coyote-configgroup/src/operations/create_configgroup.rs
@@ -1,4 +1,6 @@
 use coyote_error::Result;
+use std::num::NonZeroU64;
+
 use fjall::Database;
 use fjall_utils::TableRow;
 use jiff::Timestamp;
@@ -15,6 +17,8 @@ pub struct CreateConfigGroup<C: ModuleConfig> {
     timestamp: Timestamp,
     name: String,
     storage_type: Option<StorageType>,
+    #[serde(default)]
+    pub max_storage_bytes: Option<NonZeroU64>,
     config: C,
 }
 
@@ -24,17 +28,25 @@ pub struct CreateConfigGroupOutput<C: ModuleConfig> {
     pub name: String,
     pub config: C,
     pub storage_type: StorageType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_storage_bytes: Option<NonZeroU64>,
     pub created_at: Timestamp,
     pub updated_at: Timestamp,
 }
 
 impl<C: ModuleConfig> CreateConfigGroup<C> {
-    pub fn new(name: String, config: C, storage_type: Option<StorageType>) -> Self {
+    pub fn new(
+        name: String,
+        config: C,
+        storage_type: Option<StorageType>,
+        max_storage_bytes: Option<NonZeroU64>,
+    ) -> Self {
         Self {
             timestamp: Timestamp::now(),
             name,
             config,
             storage_type,
+            max_storage_bytes,
         }
     }
 
@@ -47,6 +59,7 @@ impl<C: ModuleConfig> CreateConfigGroup<C> {
             Some(mut configgroup) => {
                 configgroup.storage_type = self.storage_type.unwrap_or(StorageType::Persistent);
                 configgroup.updated_at = self.timestamp;
+                configgroup.max_storage_bytes = self.max_storage_bytes;
                 configgroup
             }
             None => {
@@ -55,6 +68,7 @@ impl<C: ModuleConfig> CreateConfigGroup<C> {
                     id,
                     name: self.name,
                     storage_type: self.storage_type.unwrap_or(StorageType::Persistent),
+                    max_storage_bytes: self.max_storage_bytes,
                     created_at: self.timestamp,
                     updated_at: self.timestamp,
                     config: self.config,
@@ -72,6 +86,7 @@ impl<C: ModuleConfig> CreateConfigGroup<C> {
         Ok(CreateConfigGroupOutput {
             name: configgroup.name,
             storage_type: configgroup.storage_type,
+            max_storage_bytes: configgroup.max_storage_bytes,
             config: configgroup.config,
             created_at: configgroup.created_at,
             updated_at: configgroup.updated_at,

--- a/crates/coyote-configgroup/src/operations/create_configgroup.rs
+++ b/crates/coyote-configgroup/src/operations/create_configgroup.rs
@@ -17,8 +17,7 @@ pub struct CreateConfigGroup<C: ModuleConfig> {
     timestamp: Timestamp,
     name: String,
     storage_type: Option<StorageType>,
-    #[serde(default)]
-    pub max_storage_bytes: Option<NonZeroU64>,
+    max_storage_bytes: Option<NonZeroU64>,
     config: C,
 }
 

--- a/crates/coyote-configgroup/src/tables.rs
+++ b/crates/coyote-configgroup/src/tables.rs
@@ -25,18 +25,23 @@ pub struct ConfigGroup<C: ModuleConfig> {
 }
 
 impl<C: ModuleConfig> TableRow for ConfigGroup<C> {
-    const TABLE_PREFIX: &'static str = C::TABLE_PREFIX;
-    type Key = String;
+    const TABLE_PREFIX: &'static str = "";
+    type Key = Vec<u8>;
 
     fn get_key(&self) -> Cow<'_, Self::Key> {
-        Cow::Borrowed(&self.name)
+        Cow::Owned(Self::key(&self.name))
     }
 }
 
 impl<C: ModuleConfig> ConfigGroup<C> {
-    // TODO: Bytes not string
-    pub(crate) fn key(group_name: &str) -> String {
-        format!("{}\0{group_name}", C::module())
+    pub(crate) fn key(group_name: &str) -> Vec<u8> {
+        let module = (C::module() as u8).to_be_bytes();
+
+        let mut key = Vec::with_capacity(module.len() + b"\0".len() + group_name.len());
+        key.extend_from_slice(&module);
+        key.extend_from_slice(b"\0");
+        key.extend_from_slice(group_name.as_bytes());
+        key
     }
 
     pub(crate) fn fetch(keyspace: &Keyspace, group_name: &str) -> Result<Option<Self>> {

--- a/crates/coyote-configgroup/src/tables.rs
+++ b/crates/coyote-configgroup/src/tables.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, num::NonZeroU64};
 
 use coyote_error::Result;
 use fjall::Keyspace;
@@ -14,6 +14,8 @@ pub struct ConfigGroup<C: ModuleConfig> {
     pub id: ConfigGroupId,
     pub name: String,
     pub storage_type: StorageType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_storage_bytes: Option<NonZeroU64>,
 
     pub created_at: Timestamp,
     pub updated_at: Timestamp,

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -15,10 +15,16 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
     fn get_key(&self) -> Cow<'_, Self::Key>;
 
     fn make_fjall_key(key: &Self::Key) -> fjall::UserKey {
-        let mut key_bytes =
-            Vec::<u8>::with_capacity(Self::TABLE_PREFIX.len() + b"\0".len() + key.as_ref().len());
-        key_bytes.extend_from_slice(Self::TABLE_PREFIX.as_bytes());
-        key_bytes.extend_from_slice(b"\0");
+        let mut key_bytes = if Self::TABLE_PREFIX.is_empty() {
+            Vec::<u8>::with_capacity(key.as_ref().len())
+        } else {
+            let mut key_bytes = Vec::<u8>::with_capacity(
+                Self::TABLE_PREFIX.len() + b"\0".len() + key.as_ref().len(),
+            );
+            key_bytes.extend_from_slice(Self::TABLE_PREFIX.as_bytes());
+            key_bytes.extend_from_slice(b"\0");
+            key_bytes
+        };
         key_bytes.extend_from_slice(key.as_ref());
         key_bytes.into()
     }
@@ -28,7 +34,7 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
         // FIXME(@svix-gabriel) - it's not clear if we're committed to using msgpack
         // for internal serialization. Using messagepack for now, but this
         // should be easy to change later.
-        let value = rmp_serde::to_vec(&self).map_err(Error::generic)?;
+        let value = rmp_serde::to_vec_named(&self).map_err(Error::generic)?;
 
         Ok((key, value.into()))
     }

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod tables;
 
+use std::num::NonZeroU64;
+
 use coyote_configgroup::{
     ConfigGroup,
     entities::{CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig},
@@ -34,6 +36,7 @@ pub struct KvStore {
     tables: fjall::Keyspace,
     policy: EvictionPolicy,
     lru: LinkedHashMap<String, Option<Timestamp>>,
+    max_storage_bytes: Option<NonZeroU64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -49,7 +52,12 @@ pub enum OperationBehavior {
 const EXPIRATION_BATCH_SIZE: usize = 100; // FIXME(@svix-lucho): make this configurable?
 
 impl KvStore {
-    pub fn new(namespace: &str, db: Database, policy: EvictionPolicy) -> Self {
+    pub fn new(
+        namespace: &str,
+        db: Database,
+        policy: EvictionPolicy,
+        max_storage_bytes: Option<NonZeroU64>,
+    ) -> Self {
         let kv_keyspace = format!("_coyote_kv_{namespace}");
 
         let tables = {
@@ -62,6 +70,7 @@ impl KvStore {
             tables,
             policy,
             lru: LinkedHashMap::new(),
+            max_storage_bytes,
         }
     }
 
@@ -166,8 +175,8 @@ impl KvStore {
         Ok(())
     }
 
-    pub fn disk_space(&self) -> u64 {
-        self.tables.disk_space()
+    pub fn disk_space_exceeds_capacity(&self) -> bool {
+        self.tables.disk_space() > self.max_storage_bytes.unwrap_or(NonZeroU64::MAX).get()
     }
 
     pub fn iter(&self) -> Result<impl Iterator<Item = KvPairRow>> {
@@ -218,8 +227,6 @@ impl KvStore {
     }
 }
 
-const MAX_CAPACITY: u64 = 1024 * 8; // FIXME: make this configurable
-
 /// This is the worker function for this module, it does background cleanup and accounting.
 /// It deletes expired entries from the database and evicts entries if the KvStore is configured to do so.
 pub async fn worker<F>(configgroup_state: &coyote_configgroup::State, is_shutting_down: F)
@@ -234,7 +241,8 @@ where
         let _ = store.clear_expired(now);
 
         // Eviction
-        if store.disk_space() > MAX_CAPACITY && store.policy == EvictionPolicy::LeastRecentlyUsed {
+        if store.disk_space_exceeds_capacity() && store.policy == EvictionPolicy::LeastRecentlyUsed
+        {
             // FIXME(@svix-lucho): we can add smarter eviction instead of just doing one at a time
             let _ = store.evict_lru(1);
         }
@@ -265,7 +273,12 @@ where
             };
             let db = configgroup_state.give_me_the_right_db(&group);
             let policy = group.config.eviction_policy();
-            let store = KvStore::new(KeyValueConfig::NAMESPACE, db, policy);
+            let store = KvStore::new(
+                KeyValueConfig::NAMESPACE,
+                db,
+                policy,
+                group.max_storage_bytes,
+            );
 
             clean_up(store);
         }
@@ -288,7 +301,7 @@ where
             };
             let db = configgroup_state.give_me_the_right_db(&group);
             let policy = group.config.eviction_policy();
-            let store = KvStore::new(CacheConfig::NAMESPACE, db, policy);
+            let store = KvStore::new(CacheConfig::NAMESPACE, db, policy, group.max_storage_bytes);
 
             clean_up(store);
         }
@@ -311,7 +324,7 @@ where
             };
             let db = configgroup_state.give_me_the_right_db(&group);
             let policy = group.config.eviction_policy();
-            let store = KvStore::new(CacheConfig::NAMESPACE, db, policy);
+            let store = KvStore::new(CacheConfig::NAMESPACE, db, policy, group.max_storage_bytes);
 
             clean_up(store);
         }
@@ -342,7 +355,7 @@ mod tests {
                 .temporary(true)
                 .open()
                 .unwrap();
-            let store = KvStore::new("test", db, policy);
+            let store = KvStore::new("test", db, policy, None);
             Self {
                 _workdir: workdir,
                 store,

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU64;
 
 use coyote_configgroup::{
     ConfigGroup,
-    entities::{CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig},
+    entities::{CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig, ModuleConfig},
 };
 use coyote_error::Result;
 use fjall::{Database, KeyspaceCreateOptions};

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -12,9 +12,12 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+config.workspace = true
 coyote.workspace = true
 dotenvy.workspace = true
 reqwest.workspace = true
+serde.workspace = true
+tap.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -5,7 +5,7 @@
 #![forbid(unsafe_code)]
 
 use clap::{Parser, Subcommand};
-use coyote::{cfg, run, setup_tracing};
+use coyote::{bootstrap, cfg, run, setup_tracing};
 use dotenvy::dotenv;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -21,6 +21,8 @@ struct Args {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Bootstrap command
+    Bootstrap { path: Option<String> },
     /// Health check command
     Healthcheck {
         // FIXME: we should make it optional and default to localhost with the settings (when ran
@@ -63,6 +65,9 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber.init();
 
     match args.command {
+        Some(Commands::Bootstrap { path }) => {
+            bootstrap::run(path.as_deref(), cfg);
+        }
         Some(Commands::Healthcheck { .. }) => {
             unreachable!("Healthcheck command should be handled before config loading")
         }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,0 +1,188 @@
+use std::{collections::HashMap, num::NonZeroU64};
+
+use crate::cfg::{Configuration as AppConfig, DatabaseConfig};
+use anyhow::Context;
+use config::ConfigBuilder;
+use coyote_configgroup::{
+    BothDatabases,
+    entities::{
+        CacheConfig, EvictionPolicy, KeyValueConfig, ModuleConfig, StorageType, StreamConfig,
+    },
+    operations::create_configgroup::CreateConfigGroup,
+};
+use serde::Deserialize;
+use tap::Pipe;
+
+const DEFAULTS: &str = include_str!("../bootstrap.default.yaml");
+
+trait IntoModuleConfig {
+    type Output: ModuleConfig;
+
+    fn into_module_config(self) -> Self::Output;
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StorageTypeIn {
+    #[default]
+    Persistent,
+    Ephemeral,
+}
+
+impl From<StorageTypeIn> for StorageType {
+    fn from(value: StorageTypeIn) -> Self {
+        match value {
+            StorageTypeIn::Persistent => StorageType::Persistent,
+            StorageTypeIn::Ephemeral => StorageType::Ephemeral,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvictionPolicyIn {
+    #[default]
+    NoEviction,
+    LeastRecentlyUsed,
+}
+
+impl From<EvictionPolicyIn> for EvictionPolicy {
+    fn from(value: EvictionPolicyIn) -> Self {
+        match value {
+            EvictionPolicyIn::NoEviction => EvictionPolicy::NoEviction,
+            EvictionPolicyIn::LeastRecentlyUsed => EvictionPolicy::LeastRecentlyUsed,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ConfigGroupIn<C> {
+    pub storage_type: Option<StorageTypeIn>,
+    pub max_storage_bytes: Option<NonZeroU64>,
+
+    #[serde(flatten)]
+    pub config: C,
+}
+
+impl<C: IntoModuleConfig> ConfigGroupIn<C> {
+    fn create_config_group(self, name: String) -> CreateConfigGroup<C::Output> {
+        CreateConfigGroup::new(
+            name,
+            self.config.into_module_config(),
+            self.storage_type.map(|x| x.into()),
+            self.max_storage_bytes,
+        )
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct KeyValueConfigIn {}
+
+impl IntoModuleConfig for KeyValueConfigIn {
+    type Output = KeyValueConfig;
+
+    fn into_module_config(self) -> Self::Output {
+        KeyValueConfig {}
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CacheConfigIn {
+    pub eviction_policy: Option<EvictionPolicyIn>,
+}
+
+impl IntoModuleConfig for CacheConfigIn {
+    type Output = CacheConfig;
+
+    fn into_module_config(self) -> Self::Output {
+        CacheConfig {
+            eviction_policy: self.eviction_policy.unwrap_or_default().into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamConfigIn {
+    pub retention_period_seconds: Option<NonZeroU64>,
+}
+
+impl IntoModuleConfig for StreamConfigIn {
+    type Output = StreamConfig;
+
+    fn into_module_config(self) -> Self::Output {
+        StreamConfig {
+            retention_period_seconds: self.retention_period_seconds,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BootstrapConfig {
+    cache: Option<HashMap<String, ConfigGroupIn<CacheConfigIn>>>,
+    kv: Option<HashMap<String, ConfigGroupIn<KeyValueConfigIn>>>,
+    stream: Option<HashMap<String, ConfigGroupIn<StreamConfigIn>>>,
+}
+
+impl BootstrapConfig {
+    fn load(config_path: Option<&str>) -> anyhow::Result<BootstrapConfig> {
+        let config = config::Config::builder()
+            .add_source(config::File::from_str(DEFAULTS, config::FileFormat::Yaml))
+            .pipe(|config: ConfigBuilder<_>| {
+                if let Some(path) = config_path {
+                    config.add_source(config::File::with_name(path))
+                } else {
+                    config
+                }
+            })
+            .add_source(config::Environment::with_prefix("COYOTE"))
+            .build()?;
+
+        let config: BootstrapConfig = config
+            .try_deserialize::<BootstrapConfig>()
+            .context("failed to load bootstrap configuration")?;
+
+        Ok(config)
+    }
+}
+
+pub fn run(bootstrap_cfg_path: Option<&str>, app_config: AppConfig) {
+    let bootstrap =
+        BootstrapConfig::load(bootstrap_cfg_path).expect("Failed to load bootstrap config");
+
+    println!("bootstrap: {bootstrap:?}");
+    let persistent_db =
+        DatabaseConfig::persistent(&app_config.persistent_db).expect("persistent db");
+    let ephemeral_db = DatabaseConfig::ephemeral(&app_config.ephemeral_db).expect("ephemeral db");
+    let state = coyote_configgroup::State::init(BothDatabases {
+        persistent_db,
+        ephemeral_db,
+    })
+    .expect("configgroup state");
+
+    if let Some(kv) = bootstrap.kv {
+        for (name, cfg) in kv {
+            let create_cmd = cfg.create_config_group(name);
+            create_cmd
+                .apply_operation(state.db(), state.keyspace())
+                .expect("create config");
+        }
+    }
+
+    if let Some(cache) = bootstrap.cache {
+        for (name, cfg) in cache {
+            let create_cmd = cfg.create_config_group(name);
+            create_cmd
+                .apply_operation(state.db(), state.keyspace())
+                .expect("create config");
+        }
+    }
+
+    if let Some(stream) = bootstrap.stream {
+        for (name, cfg) in stream {
+            let create_cmd = cfg.create_config_group(name);
+            create_cmd
+                .apply_operation(state.db(), state.keyspace())
+                .expect("create config");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@ use axum::middleware;
 use cfg::ConfigurationInner;
 use coyote_configgroup::{
     BothDatabases,
-    entities::{CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig},
+    entities::{CacheConfig, IdempotencyConfig, KeyValueConfig, ModuleConfig},
     group_name,
 };
-use coyote_error::Result;
+use coyote_error::{Error, Result};
 use coyote_kv::KvStore;
 use opentelemetry::{InstrumentationScope, trace::TracerProvider as _};
 use opentelemetry_otlp::WithExportConfig;
@@ -40,6 +40,7 @@ use crate::{
     v1::modules::{cache::CacheStore, idempotency::IdempotencyStore},
 };
 
+pub mod bootstrap;
 pub mod cfg;
 pub mod core;
 pub use coyote_error as error;
@@ -109,9 +110,6 @@ pub struct AppState {
 
     stream_state: stream::State,
     configgroup_state: coyote_configgroup::State,
-
-    // TODO: Remove this once we have proper default config groups
-    persistent_db: fjall::Database,
 }
 
 async fn run_interserver(cfg: Configuration, state: AppState, listener: Option<TcpListener>) {
@@ -143,30 +141,13 @@ async fn run_interserver(cfg: Configuration, state: AppState, listener: Option<T
 }
 
 impl AppState {
-    // FIXME: Blocking
-    pub fn kv_store_by_key(&self, key_name: &str) -> Result<KvStore> {
-        let Some(group_name_str) = group_name(key_name) else {
-            // FIXME: This should be a default ConfigGroup struct
-            return Ok(KvStore::new(
-                KeyValueConfig::NAMESPACE,
-                self.persistent_db.clone(),
-                EvictionPolicy::NoEviction,
-                None,
-            ));
-        };
+    fn get_store_by_key<C: ModuleConfig>(&self, key_name: &str) -> Result<KvStore> {
+        let group_name = group_name(key_name);
 
-        let Some(group) = self
+        let group = self
             .configgroup_state
-            .fetch_group::<KeyValueConfig>(group_name_str.to_string())?
-        else {
-            // FIXME: This should be a default ConfigGroup struct
-            return Ok(KvStore::new(
-                KeyValueConfig::NAMESPACE,
-                self.persistent_db.clone(),
-                EvictionPolicy::NoEviction,
-                None,
-            ));
-        };
+            .fetch_group::<C>(group_name.to_string())?
+            .ok_or_else(|| Error::generic(format!("group {group_name} not found")))?;
 
         let policy = group.config.eviction_policy();
         let kv_store = KvStore::new(
@@ -179,83 +160,17 @@ impl AppState {
         Ok(kv_store)
     }
 
-    // FIXME: Blocking
-    pub fn cache_store_by_key(&self, key_name: &str) -> Result<CacheStore> {
-        let Some(group_name_str) = group_name(key_name) else {
-            // FIXME: This should be a default ConfigGroup struct
-            return Ok(CacheStore {
-                kv: KvStore::new(
-                    CacheConfig::NAMESPACE,
-                    self.persistent_db.clone(),
-                    EvictionPolicy::NoEviction,
-                    None,
-                ),
-            });
-        };
+    pub fn get_kv_store_by_key(&self, key_name: &str) -> Result<KvStore> {
+        self.get_store_by_key::<KeyValueConfig>(key_name)
+    }
 
-        let Some(group) = self
-            .configgroup_state
-            .fetch_group::<CacheConfig>(group_name_str.to_string())?
-        else {
-            // FIXME: This should be a default ConfigGroup struct
-            return Ok(CacheStore {
-                kv: KvStore::new(
-                    CacheConfig::NAMESPACE,
-                    self.persistent_db.clone(),
-                    EvictionPolicy::NoEviction,
-                    None,
-                ),
-            });
-        };
-
-        let policy = group.config.eviction_policy();
-        let kv_store = KvStore::new(
-            CacheConfig::NAMESPACE,
-            self.configgroup_state.give_me_the_right_db(&group),
-            policy,
-            None,
-        );
-
+    pub fn get_cache_store_by_key(&self, key_name: &str) -> Result<CacheStore> {
+        let kv_store = self.get_store_by_key::<CacheConfig>(key_name)?;
         Ok(CacheStore { kv: kv_store })
     }
 
-    // FIXME: Blocking
-    pub fn idempotency_store_by_key(&self, key_name: &str) -> Result<IdempotencyStore> {
-        let Some(group_name_str) = group_name(key_name) else {
-            // FIXME: This should be a default ConfigGroup struct
-            return Ok(IdempotencyStore {
-                kv: KvStore::new(
-                    IdempotencyConfig::NAMESPACE,
-                    self.persistent_db.clone(),
-                    EvictionPolicy::NoEviction,
-                    None,
-                ),
-            });
-        };
-
-        let Some(group) = self
-            .configgroup_state
-            .fetch_group::<IdempotencyConfig>(group_name_str.to_string())?
-        else {
-            // FIXME: This should be a default ConfigGroup struct
-            return Ok(IdempotencyStore {
-                kv: KvStore::new(
-                    IdempotencyConfig::NAMESPACE,
-                    self.persistent_db.clone(),
-                    EvictionPolicy::NoEviction,
-                    None,
-                ),
-            });
-        };
-
-        let policy = group.config.eviction_policy();
-        let kv_store = KvStore::new(
-            IdempotencyConfig::NAMESPACE,
-            self.configgroup_state.give_me_the_right_db(&group),
-            policy,
-            None,
-        );
-
+    pub fn get_idempotency_store_by_key(&self, key_name: &str) -> Result<IdempotencyStore> {
+        let kv_store = self.get_store_by_key::<IdempotencyConfig>(key_name)?;
         Ok(IdempotencyStore { kv: kv_store })
     }
 }
@@ -298,7 +213,6 @@ pub async fn run_with_prefix(
         stream_state,
         raft,
         node_id,
-        persistent_db,
         configgroup_state,
     };
     let v1_router = v1::router().with_state::<()>(app_state.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ impl AppState {
                 KeyValueConfig::NAMESPACE,
                 self.persistent_db.clone(),
                 EvictionPolicy::NoEviction,
+                None,
             ));
         };
 
@@ -163,6 +164,7 @@ impl AppState {
                 KeyValueConfig::NAMESPACE,
                 self.persistent_db.clone(),
                 EvictionPolicy::NoEviction,
+                None,
             ));
         };
 
@@ -171,6 +173,7 @@ impl AppState {
             KeyValueConfig::NAMESPACE,
             self.configgroup_state.give_me_the_right_db(&group),
             policy,
+            None,
         );
 
         Ok(kv_store)
@@ -185,6 +188,7 @@ impl AppState {
                     CacheConfig::NAMESPACE,
                     self.persistent_db.clone(),
                     EvictionPolicy::NoEviction,
+                    None,
                 ),
             });
         };
@@ -199,6 +203,7 @@ impl AppState {
                     CacheConfig::NAMESPACE,
                     self.persistent_db.clone(),
                     EvictionPolicy::NoEviction,
+                    None,
                 ),
             });
         };
@@ -208,6 +213,7 @@ impl AppState {
             CacheConfig::NAMESPACE,
             self.configgroup_state.give_me_the_right_db(&group),
             policy,
+            None,
         );
 
         Ok(CacheStore { kv: kv_store })
@@ -222,6 +228,7 @@ impl AppState {
                     IdempotencyConfig::NAMESPACE,
                     self.persistent_db.clone(),
                     EvictionPolicy::NoEviction,
+                    None,
                 ),
             });
         };
@@ -236,6 +243,7 @@ impl AppState {
                     IdempotencyConfig::NAMESPACE,
                     self.persistent_db.clone(),
                     EvictionPolicy::NoEviction,
+                    None,
                 ),
             });
         };
@@ -245,6 +253,7 @@ impl AppState {
             IdempotencyConfig::NAMESPACE,
             self.configgroup_state.give_me_the_right_db(&group),
             policy,
+            None,
         );
 
         Ok(IdempotencyStore { kv: kv_store })

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -93,7 +93,7 @@ async fn cache_set(
     State(state): State<AppState>,
     MsgPackOrJson(data): MsgPackOrJson<CacheSetIn>,
 ) -> Result<MsgPackOrJson<CacheSetOut>> {
-    let mut cache_store = state.cache_store_by_key(&data.key.0)?;
+    let mut cache_store = state.get_cache_store_by_key(&data.key.0)?;
     let key = data.key.clone();
     cache_store.set(key.as_str(), data.into_model())?;
     Ok(MsgPackOrJson(CacheSetOut {}))
@@ -105,7 +105,7 @@ async fn cache_get(
     State(state): State<AppState>,
     MsgPackOrJson(data): MsgPackOrJson<CacheGetIn>,
 ) -> Result<MsgPackOrJson<CacheGetOut>> {
-    let mut cache_store = state.cache_store_by_key(&data.key.0)?;
+    let mut cache_store = state.get_cache_store_by_key(&data.key.0)?;
     let model = cache_store
         .get(&data.key)?
         .ok_or_else(|| crate::error::HttpError::not_found(None, None))?;
@@ -118,7 +118,7 @@ async fn cache_del(
     State(state): State<AppState>,
     MsgPackOrJson(data): MsgPackOrJson<CacheDeleteIn>,
 ) -> Result<MsgPackOrJson<CacheDeleteOut>> {
-    let mut cache_store = state.cache_store_by_key(&data.key.0)?;
+    let mut cache_store = state.get_cache_store_by_key(&data.key.0)?;
     cache_store.delete(&data.key)?;
     Ok(MsgPackOrJson(CacheDeleteOut { deleted: true }))
 }

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -75,7 +75,7 @@ async fn idempotency_start(
 ) -> Result<MsgPackOrJson<IdempotencyStartOut>> {
     let key_str = data.key.to_string();
 
-    let mut idempotency_store = state.idempotency_store_by_key(&key_str)?;
+    let mut idempotency_store = state.get_idempotency_store_by_key(&key_str)?;
     match idempotency_store.try_start(&key_str, data.ttl_seconds)? {
         None => Ok(MsgPackOrJson(IdempotencyStartOut::Locked)),
         Some(response) => {
@@ -96,7 +96,7 @@ async fn idempotency_complete(
 ) -> Result<MsgPackOrJson<IdempotencyCompleteOut>> {
     let key_str = data.key.to_string();
 
-    let mut idempotency_store = state.idempotency_store_by_key(&key_str)?;
+    let mut idempotency_store = state.get_idempotency_store_by_key(&key_str)?;
     idempotency_store.complete(&key_str, data.response.into_bytes(), data.ttl_seconds)?;
 
     Ok(MsgPackOrJson(IdempotencyCompleteOut {}))
@@ -110,7 +110,7 @@ async fn idempotency_abandon(
 ) -> Result<MsgPackOrJson<IdempotencyAbandonOut>> {
     let key_str = data.key.to_string();
 
-    let mut idempotency_store = state.idempotency_store_by_key(&key_str)?;
+    let mut idempotency_store = state.get_idempotency_store_by_key(&key_str)?;
     idempotency_store.abandon(&key_str)?;
 
     Ok(MsgPackOrJson(IdempotencyAbandonOut {}))

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -114,7 +114,7 @@ async fn kv_set(
     State(state): State<AppState>,
     MsgPackOrJson(data): MsgPackOrJson<KvSetIn>,
 ) -> Result<MsgPackOrJson<KvSetOut>> {
-    let mut kv_store = state.kv_store_by_key(&data.key.0)?;
+    let mut kv_store = state.get_kv_store_by_key(&data.key.0)?;
 
     let key = data.key.clone();
     let behavior = data.behavior.clone();
@@ -134,7 +134,7 @@ async fn kv_get(
     State(state): State<AppState>,
     MsgPackOrJson(data): MsgPackOrJson<KvGetIn>,
 ) -> Result<MsgPackOrJson<KvGetOut>> {
-    let mut kv_store = state.kv_store_by_key(&data.key.0)?;
+    let mut kv_store = state.get_kv_store_by_key(&data.key.0)?;
 
     let model = kv_store
         .get(&data.key.0)
@@ -156,7 +156,7 @@ async fn kv_del(
     State(state): State<AppState>,
     MsgPackOrJson(data): MsgPackOrJson<KvDeleteIn>,
 ) -> Result<MsgPackOrJson<KvDeleteOut>> {
-    let mut kv_store = state.kv_store_by_key(&data.key.0)?;
+    let mut kv_store = state.get_kv_store_by_key(&data.key.0)?;
 
     let deleted = kv_store
         .delete(&data.key.0)

--- a/src/v1/modules/idempotency.rs
+++ b/src/v1/modules/idempotency.rs
@@ -122,7 +122,7 @@ mod tests {
         fn new() -> TestResult<Self> {
             let workdir = tempfile::tempdir()?;
             let db = Database::builder(workdir.as_ref()).temporary(true).open()?;
-            let kv = KvStore::new("test", db, EvictionPolicy::NoEviction);
+            let kv = KvStore::new("test", db, EvictionPolicy::NoEviction, None);
             let store = IdempotencyStore::new(kv);
             Ok(Self { store })
         }

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -1,0 +1,78 @@
+use std::num::NonZeroU64;
+
+use coyote::{bootstrap, cfg::DatabaseConfig};
+use coyote_configgroup::{
+    BothDatabases,
+    entities::{CacheConfig, EvictionPolicy, KeyValueConfig, StreamConfig},
+};
+use test_utils::TestResult;
+
+use crate::TestContext;
+
+#[tokio::test]
+async fn test_bootstrap() -> TestResult {
+    let TestContext {
+        cfg,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    bootstrap::run(Some("./tests/it/static/bootstrap.test.yaml"), cfg.clone());
+
+    let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
+    let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
+
+    let configgroup_state = coyote_configgroup::State::init(BothDatabases {
+        persistent_db: persistent_db.clone(),
+        ephemeral_db: ephemeral_db.clone(),
+    })
+    .expect("initializing configgroup state");
+
+    let default_kv_group =
+        configgroup_state.fetch_group::<KeyValueConfig>("default".to_string())?;
+
+    let default_cache_group =
+        configgroup_state.fetch_group::<CacheConfig>("default".to_string())?;
+
+    let default_stream_group =
+        configgroup_state.fetch_group::<StreamConfig>("default".to_string())?;
+
+    assert!(default_kv_group.is_some());
+    assert!(default_cache_group.is_some());
+    assert!(default_stream_group.is_some());
+
+    let default_kv_group = default_kv_group.unwrap();
+    assert_eq!(
+        default_kv_group.max_storage_bytes,
+        Some(NonZeroU64::new(1000).unwrap())
+    );
+
+    let Some(kv1) = configgroup_state.fetch_group::<KeyValueConfig>("kv1".to_string())? else {
+        panic!("kv1 missing");
+    };
+    assert_eq!(&kv1.name, "kv1");
+    assert_eq!(kv1.max_storage_bytes, Some(NonZeroU64::new(2000).unwrap()));
+
+    let Some(kv2) = configgroup_state.fetch_group::<KeyValueConfig>("kv2".to_string())? else {
+        panic!("kv2 missing");
+    };
+    assert_eq!(&kv2.name, "kv2");
+    assert_eq!(kv2.max_storage_bytes, Some(NonZeroU64::new(3000).unwrap()));
+
+    let default_cache_group = default_cache_group.unwrap();
+    assert_eq!(
+        default_cache_group.config.eviction_policy,
+        EvictionPolicy::NoEviction
+    );
+
+    let Some(cache1) = configgroup_state.fetch_group::<CacheConfig>("cache1".to_string())? else {
+        panic!("cache1 missing");
+    };
+    assert_eq!(&cache1.name, "cache1");
+    assert_eq!(
+        cache1.config.eviction_policy(),
+        EvictionPolicy::LeastRecentlyUsed
+    );
+
+    Ok(())
+}

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -1,6 +1,8 @@
 use serde_json::{Value, json};
 use test_utils::{StatusCode, TestClient, TestResult};
 
+use crate::TestContext;
+
 async fn cache_set(client: &TestClient, key: &str, expire_in: u64, value: &str) -> TestResult<()> {
     client
         .post("cache/set")
@@ -28,7 +30,11 @@ async fn cache_get(client: &TestClient, key: &str) -> TestResult<Value> {
 
 #[tokio::test]
 async fn test_cache_set_and_get() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     cache_set(&client, "test-key-1", 60000, "test-value-123").await?;
 
@@ -43,7 +49,11 @@ async fn test_cache_set_and_get() -> TestResult {
 
 #[tokio::test]
 async fn test_cache_set_get_and_delete() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     cache_set(&client, "test-key-2", 30000, "another-value").await?;
 

--- a/tests/it/configgroup.rs
+++ b/tests/it/configgroup.rs
@@ -1,0 +1,32 @@
+use coyote::cfg::DatabaseConfig;
+use coyote_configgroup::{BothDatabases, entities::StreamConfig};
+use test_utils::TestResult;
+
+use crate::TestContext;
+
+#[tokio::test]
+async fn test_configgroup_fetch() -> TestResult {
+    let TestContext {
+        cfg,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
+    let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
+
+    let configgroup_state = coyote_configgroup::State::init(BothDatabases {
+        persistent_db: persistent_db.clone(),
+        ephemeral_db: ephemeral_db.clone(),
+    })
+    .expect("initializing configgroup state");
+
+    // Random-name group should resolve to "default" group
+    let random_group =
+        configgroup_state.fetch_group::<StreamConfig>("bloopety-blorp".to_string())?;
+    assert!(random_group.is_some());
+    let random_group = random_group.unwrap();
+    assert_eq!(&random_group.name, "default");
+
+    Ok(())
+}

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use test_utils::{StatusCode, TestClient, TestResult};
 
+use crate::TestContext;
+
 async fn kv_set(
     client: &TestClient,
     key: &str,
@@ -37,7 +39,11 @@ async fn kv_get(client: &TestClient, key: &str) -> TestResult<Value> {
 
 #[tokio::test]
 async fn test_kv_set_and_get() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     kv_set(&client, "kv-key-1", 50000, "kv-value-456", "upsert").await?;
 
@@ -52,7 +58,11 @@ async fn test_kv_set_and_get() -> TestResult {
 
 #[tokio::test]
 async fn test_kv_set_with_insert_and_delete() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     kv_set(&client, "kv-key-2", 0, "permanent-value", "insert").await?;
 
@@ -84,7 +94,11 @@ async fn test_kv_set_with_insert_and_delete() -> TestResult {
 
 #[tokio::test]
 async fn test_kv_expiration() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     kv_set(&client, "test-key-3", 100, "test-value-345", "upsert").await?;
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,4 +1,6 @@
+mod bootstrap;
 mod cache;
+mod configgroup;
 mod kv;
 mod msgpack;
 mod rate_limiter;
@@ -33,7 +35,13 @@ impl Drop for IsolatedServerHandle {
     }
 }
 
-async fn start_server() -> (TestClient, IsolatedServerHandle) {
+pub struct TestContext {
+    pub client: TestClient,
+    pub cfg: Arc<ConfigurationInner>,
+    pub handle: IsolatedServerHandle,
+}
+
+async fn start_server() -> TestContext {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr: SocketAddr = listener.local_addr().unwrap();
 
@@ -82,8 +90,11 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
 
     let base_uri = format!("http://{addr}/api/v1");
 
-    let server_handle = tokio::spawn(async move {
-        run_with_prefix(cfg, Some(listener), Some(repl_listener)).await;
+    let server_handle = tokio::spawn({
+        let cfg = cfg.clone();
+        async move {
+            run_with_prefix(cfg, Some(listener), Some(repl_listener)).await;
+        }
     });
 
     let handle = IsolatedServerHandle {
@@ -93,5 +104,11 @@ async fn start_server() -> (TestClient, IsolatedServerHandle) {
 
     let client = TestClient::new(base_uri, token);
 
-    (client, handle)
+    coyote::bootstrap::run(None, cfg.clone());
+
+    TestContext {
+        client,
+        cfg,
+        handle,
+    }
 }

--- a/tests/it/msgpack.rs
+++ b/tests/it/msgpack.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use test_utils::{StatusCode, TestResult};
 
+use crate::TestContext;
+
 #[derive(Serialize)]
 struct CacheSetIn<'a> {
     key: &'a str,
@@ -17,7 +19,11 @@ struct CacheGetIn<'a> {
 
 #[tokio::test]
 async fn test_cache_set_and_get_msgpack_in() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     client
         .post("cache/set")
@@ -55,7 +61,11 @@ struct CacheGetOut {
 
 #[tokio::test]
 async fn test_cache_set_and_get_msgpack_out() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     client
         .post("cache/set")

--- a/tests/it/rate_limiter.rs
+++ b/tests/it/rate_limiter.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use test_utils::{StatusCode, TestClient, TestResult};
 
+use crate::TestContext;
+
 async fn call_limit_token_bucket(
     client: &TestClient,
     key: &str,
@@ -30,7 +32,11 @@ async fn call_limit_token_bucket(
 
 #[tokio::test]
 async fn test_rate_limiter_limit_token_bucket() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
     let refill_interval = 1;
     let refill_amount = 5;
     let capacity = 5;

--- a/tests/it/static/bootstrap.test.yaml
+++ b/tests/it/static/bootstrap.test.yaml
@@ -1,0 +1,17 @@
+kv:
+  default:
+    storage_type: ephemeral
+    max_storage_bytes: 1000
+  kv1:
+    storage_type: ephemeral
+    max_storage_bytes: 2000
+  kv2:
+    storage_type: persistent
+    max_storage_bytes: 3000
+cache:
+  cache1:
+    storage_type: persistent
+    eviction_policy: "least_recently_used"
+stream:
+  stream2:
+    storage_type: persistent

--- a/tests/it/stream.rs
+++ b/tests/it/stream.rs
@@ -3,9 +3,15 @@ use std::time::Duration;
 use serde_json::json;
 use test_utils::{StatusCode, TestResult};
 
+use crate::TestContext;
+
 #[tokio::test]
 async fn create_stream_upserts() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let response = client
         .post("stream/create")
@@ -58,7 +64,11 @@ async fn create_stream_upserts() -> TestResult {
 
 #[tokio::test]
 async fn stream_append_and_locking_consumption() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let _stream = client
         .post("stream/create")
@@ -164,7 +174,11 @@ async fn stream_append_and_locking_consumption() -> TestResult {
 
 #[tokio::test]
 async fn stream_visibility_timeout() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let _stream = client
         .post("stream/create")
@@ -245,7 +259,11 @@ async fn stream_visibility_timeout() -> TestResult {
 
 #[tokio::test]
 async fn queue_fetch_with_queue_semantics() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let _stream = client
         .post("stream/create")
@@ -332,7 +350,11 @@ async fn queue_fetch_with_queue_semantics() -> TestResult {
 
 #[tokio::test]
 async fn queue_fetch_concurrent_consumers() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let _stream = client
         .post("stream/create")
@@ -425,7 +447,11 @@ async fn queue_fetch_concurrent_consumers() -> TestResult {
 
 #[tokio::test]
 async fn queue_fetch_mixed_visibility_timeouts() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let _stream = client
         .post("stream/create")
@@ -555,7 +581,11 @@ async fn queue_fetch_mixed_visibility_timeouts() -> TestResult {
 
 #[tokio::test]
 async fn queue_fetch_partial_ack_across_blocks() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let _stream = client
         .post("stream/create")
@@ -661,7 +691,11 @@ async fn queue_fetch_partial_ack_across_blocks() -> TestResult {
 
 #[tokio::test]
 async fn queue_fetch_single_ack() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let _stream = client
         .post("stream/create")


### PR DESCRIPTION
Add a `bootstrap` command that will put the "default"
configgroups for the relevant modules into the DB.

Note that I've added some config support for stream, though
it's not actually clear to me that stream will use this
configuration approach. We can remove later if needed.
