### PR TITLE
Idempotency: use vec<u8> for response types, and add e2e tests

### DIFF
--- a/bootstrap.default.yaml
+++ b/bootstrap.default.yaml
@@ -4,6 +4,9 @@ kv:
 cache:
   default:
     storage_type: persistent
+idempotency:
+  default:
+    storage_type: persistent
 stream:
   default:
     storage_type: persistent

--- a/openapi.json
+++ b/openapi.json
@@ -1180,8 +1180,14 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$"
           },
           "response": {
-            "description": "The response to cache\nFIXME(@svix-lucho): change to Bytes",
-            "type": "string"
+            "description": "The response to cache",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0
+            }
           },
           "ttl_seconds": {
             "description": "TTL in seconds for the cached response",
@@ -1242,7 +1248,13 @@
             "type": "object",
             "properties": {
               "response": {
-                "type": "string"
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "maximum": 255,
+                  "minimum": 0
+                }
               },
               "status": {
                 "type": "string",

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -6,7 +6,8 @@ use config::ConfigBuilder;
 use coyote_configgroup::{
     BothDatabases,
     entities::{
-        CacheConfig, EvictionPolicy, KeyValueConfig, ModuleConfig, StorageType, StreamConfig,
+        CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig, ModuleConfig, StorageType,
+        StreamConfig,
     },
     operations::create_configgroup::CreateConfigGroup,
 };
@@ -87,6 +88,17 @@ impl IntoModuleConfig for KeyValueConfigIn {
 }
 
 #[derive(Debug, Deserialize)]
+struct IdempotencyConfigIn {}
+
+impl IntoModuleConfig for IdempotencyConfigIn {
+    type Output = IdempotencyConfig;
+
+    fn into_module_config(self) -> Self::Output {
+        IdempotencyConfig {}
+    }
+}
+
+#[derive(Debug, Deserialize)]
 struct CacheConfigIn {
     pub eviction_policy: Option<EvictionPolicyIn>,
 }
@@ -119,6 +131,7 @@ impl IntoModuleConfig for StreamConfigIn {
 #[derive(Debug, Deserialize)]
 struct BootstrapConfig {
     cache: Option<HashMap<String, ConfigGroupIn<CacheConfigIn>>>,
+    idempotency: Option<HashMap<String, ConfigGroupIn<IdempotencyConfigIn>>>,
     kv: Option<HashMap<String, ConfigGroupIn<KeyValueConfigIn>>>,
     stream: Option<HashMap<String, ConfigGroupIn<StreamConfigIn>>>,
 }
@@ -170,6 +183,15 @@ pub fn run(bootstrap_cfg_path: Option<&str>, app_config: AppConfig) {
 
     if let Some(cache) = bootstrap.cache {
         for (name, cfg) in cache {
+            let create_cmd = cfg.create_config_group(name);
+            create_cmd
+                .apply_operation(state.db(), state.keyspace())
+                .expect("create config");
+        }
+    }
+
+    if let Some(idempotency) = bootstrap.idempotency {
+        for (name, cfg) in idempotency {
             let create_cmd = cfg.create_config_group(name);
             create_cmd
                 .apply_operation(state.db(), state.keyspace())

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -34,7 +34,7 @@ pub enum IdempotencyStartOut {
     /// Lock acquired, request should proceed
     Locked,
     /// Request was already completed, cached response returned
-    Completed { response: String },
+    Completed { response: Vec<u8> },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -43,8 +43,7 @@ pub struct IdempotencyCompleteIn {
     pub key: EntityKey,
 
     /// The response to cache
-    /// FIXME(@svix-lucho): change to Bytes
-    pub response: String,
+    pub response: Vec<u8>,
 
     /// TTL in seconds for the cached response
     #[validate(range(min = 1))]
@@ -78,13 +77,7 @@ async fn idempotency_start(
     let mut idempotency_store = state.get_idempotency_store_by_key(&key_str)?;
     match idempotency_store.try_start(&key_str, data.ttl_seconds)? {
         None => Ok(MsgPackOrJson(IdempotencyStartOut::Locked)),
-        Some(response) => {
-            let response_str = String::from_utf8(response)
-                .map_err(|_| crate::error::HttpError::internal_server_error(None, None))?;
-            Ok(MsgPackOrJson(IdempotencyStartOut::Completed {
-                response: response_str,
-            }))
-        }
+        Some(response) => Ok(MsgPackOrJson(IdempotencyStartOut::Completed { response })),
     }
 }
 
@@ -97,7 +90,7 @@ async fn idempotency_complete(
     let key_str = data.key.to_string();
 
     let mut idempotency_store = state.get_idempotency_store_by_key(&key_str)?;
-    idempotency_store.complete(&key_str, data.response.into_bytes(), data.ttl_seconds)?;
+    idempotency_store.complete(&key_str, data.response, data.ttl_seconds)?;
 
     Ok(MsgPackOrJson(IdempotencyCompleteOut {}))
 }

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -23,8 +23,8 @@ async fn test_bootstrap() -> TestResult {
     let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
 
     let configgroup_state = coyote_configgroup::State::init(BothDatabases {
-        persistent_db: persistent_db.clone(),
-        ephemeral_db: ephemeral_db.clone(),
+        persistent_db,
+        ephemeral_db,
     })
     .expect("initializing configgroup state");
 

--- a/tests/it/configgroup.rs
+++ b/tests/it/configgroup.rs
@@ -16,8 +16,8 @@ async fn test_configgroup_fetch() -> TestResult {
     let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
 
     let configgroup_state = coyote_configgroup::State::init(BothDatabases {
-        persistent_db: persistent_db.clone(),
-        ephemeral_db: ephemeral_db.clone(),
+        persistent_db,
+        ephemeral_db,
     })
     .expect("initializing configgroup state");
 

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -1,0 +1,209 @@
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use test_utils::{StatusCode, TestClient, TestResult};
+
+use crate::TestContext;
+
+async fn start(client: &TestClient, key: &str, ttl_seconds: u64) -> TestResult<Value> {
+    let response = client
+        .post("idempotency/start")
+        .json(json!({
+            "key": key,
+            "ttl_seconds": ttl_seconds
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    Ok(response)
+}
+
+async fn complete(
+    client: &TestClient,
+    key: &str,
+    response: &str,
+    ttl_seconds: u64,
+) -> TestResult<()> {
+    client
+        .post("idempotency/complete")
+        .json(json!({
+            "key": key,
+            "response": response.as_bytes(),
+            "ttl_seconds": ttl_seconds
+        }))
+        .await?
+        .expect(StatusCode::OK);
+    Ok(())
+}
+
+async fn abandon(client: &TestClient, key: &str) -> TestResult<()> {
+    client
+        .post("idempotency/abandon")
+        .json(json!({
+            "key": key
+        }))
+        .await?
+        .expect(StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_idempotency_start_and_complete() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    let response = start(&client, "k1", 60).await?;
+    assert_eq!(response["status"], "locked");
+
+    start(&client, "k2", 60).await?;
+
+    // start again should conflict
+    client
+        .post("idempotency/start")
+        .json(json!({
+            "key": "k2",
+            "ttl_seconds": 60
+        }))
+        .await?
+        .expect(StatusCode::CONFLICT);
+
+    start(&client, "k3", 60).await?;
+    complete(&client, "k3", "v1", 60).await?;
+    complete(&client, "k3", "v2", 60).await?; // can complete same key again
+
+    let response = start(&client, "k3", 60).await?;
+    assert_eq!(response["status"], "completed");
+    assert_eq!(response["response"], json!("v2".as_bytes()));
+
+    start(&client, "k4", 60).await?;
+    abandon(&client, "k4").await?;
+    let response = start(&client, "k4", 60).await?;
+    assert_eq!(response["status"], "locked");
+
+    start(&client, "k5", 60).await?;
+    complete(&client, "k5", "v2", 60).await?;
+    let response = start(&client, "k5", 60).await?;
+    assert_eq!(response["response"], json!("v2".as_bytes()));
+
+    complete(&client, "k5", "v3", 60).await?;
+    let response = start(&client, "k5", 60).await?;
+    assert_eq!(response["status"], "completed");
+    assert_eq!(response["response"], json!("v3".as_bytes()));
+
+    start(&client, "k6", 60).await?;
+    complete(&client, "k6", "v4", 60).await?;
+
+    let response = start(&client, "k6", 60).await?;
+    assert_eq!(response["response"], json!("v4".as_bytes()));
+
+    abandon(&client, "k6").await?;
+
+    let response = start(&client, "k6", 60).await?;
+    assert_eq!(response["status"], "locked");
+
+    start(&client, "k7", 60).await?;
+    complete(&client, "k7", "v1", 60).await?;
+    // can abandon after completing
+    abandon(&client, "k7").await?;
+    let response = start(&client, "k7", 60).await?;
+    assert_eq!(response["status"], "locked");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_idempotency_abandon() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    start(&client, "k1", 1).await?;
+    complete(&client, "k1", "v1", 1).await?;
+    // can abandon after completing
+    abandon(&client, "k1").await?;
+    let response = start(&client, "k1", 1).await?;
+    assert_eq!(response["status"], "locked");
+
+    // can abandon before starting
+    abandon(&client, "k2").await?;
+
+    start(&client, "k3", 1).await?;
+    // can abandon before completing
+    abandon(&client, "k3").await?;
+    let response = start(&client, "k3", 1).await?;
+    assert_eq!(response["status"], "locked");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_idempotency_expiration() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    // start again after expired
+    start(&client, "k1", 1).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let response = start(&client, "k1", 1).await?;
+    assert_eq!(response["status"], "locked");
+
+    // start again after expired (completed)
+    complete(&client, "k2", "v1", 1).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let response = start(&client, "k2", 1).await?;
+    assert_eq!(response["status"], "locked");
+
+    // complete TTL shorter than start
+    start(&client, "k4", 60).await?;
+    complete(&client, "k4", "v1", 1).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let response = start(&client, "k4", 60).await?;
+    assert_eq!(response["status"], "locked");
+
+    // complete TTL longer than start
+    start(&client, "k5", 1).await?;
+    complete(&client, "k5", "v1", 60).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let response = start(&client, "k5", 1).await?;
+    assert_eq!(response["status"], "completed");
+    assert_eq!(response["response"], json!("v1".as_bytes()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_idempotency_validation() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
+
+    client
+        .post("idempotency/start")
+        .json(json!({
+            "key": "k",
+            "ttl_seconds": 0
+        }))
+        .await?
+        .expect(StatusCode::UNPROCESSABLE_ENTITY);
+
+    client
+        .post("idempotency/start")
+        .json(json!({
+            "key": "k"
+            // TTL missing
+        }))
+        .await?
+        .expect(StatusCode::UNPROCESSABLE_ENTITY);
+
+    Ok(())
+}

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -145,7 +145,11 @@ async fn test_kv_expiration() -> TestResult {
 
 #[tokio::test]
 async fn test_kv_update_expiration() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     // Test updating expiration time
     kv_set(&client, "kv4", Some(500), "v4", "upsert").await?;
@@ -185,7 +189,11 @@ async fn test_kv_update_expiration() -> TestResult {
 
 #[tokio::test]
 async fn test_kv_binary_data() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let binary_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     client
@@ -220,7 +228,11 @@ async fn test_kv_binary_data() -> TestResult {
 
 #[tokio::test]
 async fn test_kv_validation() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     let invalid_keys = ["", "key with spaces", "key@special", &"a".repeat(257)];
 
@@ -263,7 +275,11 @@ async fn test_kv_validation() -> TestResult {
 
 #[tokio::test]
 async fn test_kv_delete() -> TestResult {
-    let (client, _server_handle) = super::start_server().await;
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = super::start_server().await;
 
     // let response = client
     //     .post("kv/delete")

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,6 +1,7 @@
 mod bootstrap;
 mod cache;
 mod configgroup;
+mod idempotency;
 mod kv;
 mod msgpack;
 mod rate_limiter;


### PR DESCRIPTION
Also adds idempotency to the groups bootstrap process