### PR TITLE
generate a cluster ID on initialize and use it for discovery

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -27,7 +27,7 @@ pub fn setup_server_simple() -> BenchmarkContext {
         (TestServerBuilder::new().build().await, workdir)
     });
 
-    let server_url = Some(format!("http://{}", server.addr.to_string()));
+    let server_url = Some(format!("http://{}", server.addr));
 
     let client = coyote_client::CoyoteClient::new(
         server.token.clone(),

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -175,6 +175,8 @@ async fn wait_for_initialized(repl_addr: SocketAddr, max_wait: Duration) -> anyh
     let url = format!("http://{repl_addr}/repl/health");
     let deadline = Instant::now() + max_wait;
     let client = reqwest::Client::new();
+    let mut backoff_ms = 10;
+    let max_backoff_time = Duration::from_millis(500);
     loop {
         match tokio::time::timeout_at(deadline, check_initialized(&client, &url)).await {
             Ok(Ok(true)) => {
@@ -189,7 +191,8 @@ async fn wait_for_initialized(repl_addr: SocketAddr, max_wait: Duration) -> anyh
             }
             Err(_) => anyhow::bail!("timed out waiting for server to boot"),
         }
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        tokio::time::sleep(Duration::from_millis(backoff_ms).min(max_backoff_time)).await;
+        backoff_ms *= 2;
     }
 }
 
@@ -236,9 +239,9 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
             snapshot_path,
             log_path,
             connection_timeout: Duration::from_millis(50),
-            heartbeat_interval_ms: 5,
-            election_timeout_min_ms: 10,
-            election_timeout_max_ms: 30,
+            heartbeat_interval_ms: 50,
+            election_timeout_min_ms: 100,
+            election_timeout_max_ms: 300,
             auto_initialize: true,
             discovery_request_timeout: Duration::from_millis(10),
             discovery_timeout: Duration::from_secs(1),

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -40,8 +40,22 @@ pub fn router() -> axum::Router<AppState> {
 
 // Helpers
 
+#[derive(Debug, Serialize)]
+struct BasicError {
+    error_message: String,
+}
+
+impl<T: ToString> From<T> for BasicError {
+    fn from(value: T) -> Self {
+        Self {
+            error_message: value.to_string(),
+        }
+    }
+}
+
 fn internal_error(s: impl ToString) -> Response {
-    (StatusCode::INTERNAL_SERVER_ERROR, s.to_string()).into_response()
+    let body = BasicError::from(s);
+    (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
 }
 
 fn rpc_response<Ok, Err>(result: Result<Ok, Err>) -> Response
@@ -58,11 +72,14 @@ where
 fn admin_response<Ok, Err>(result: Result<Ok, Err>) -> Response
 where
     Ok: Serialize,
-    Err: Serialize,
+    Err: ToString,
 {
     match result {
         Ok(ok) => (StatusCode::OK, Json(ok)).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(e)).into_response(),
+        Err(e) => {
+            let error = BasicError::from(e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+        }
     }
 }
 
@@ -114,12 +131,14 @@ async fn discover(
     Extension(raft_state): Extension<RaftState>,
 ) -> MsgPack<DiscoverResponse> {
     let cluster_name = app_state.cfg.cluster.name.clone();
+    let cluster_id = raft_state.state_machine.cluster_id().await;
     let cluster = raft_state
         .raft
         .with_raft_state(move |state| DiscoverClusterResponse {
             last_committed_log_id: state.committed,
             cluster_name,
             state: state.server_state,
+            cluster_id,
             known_peers: state
                 .membership_state
                 .committed()
@@ -187,12 +206,15 @@ async fn initialize(
     let nodes = [(state.node_id, my_node)]
         .into_iter()
         .collect::<BTreeMap<_, _>>();
-    state.raft.initialize(nodes).await.pipe(admin_response)
+    super::raft::initialize_cluster(&state.raft, nodes)
+        .await
+        .pipe(admin_response)
 }
 
 async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {
     let leader = state.raft.current_leader().await;
     let me = state.node_id;
+    let cluster_id = state.state_machine.cluster_id().await;
     state
         .raft
         .with_raft_state(move |s| {
@@ -200,6 +222,7 @@ async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {
                 node_id: me,
                 last_committed_log_index: s.committed.map(|l| l.index),
                 server_state: s.server_state,
+                cluster_id,
                 leader,
             };
             let status = if s.server_state.is_leader()

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -1,13 +1,18 @@
-use crate::AppState;
+use super::{
+    handle::{Request, Response},
+    state_machine::Store,
+};
 
-use super::handle::{Request, Response};
-
-pub(super) fn apply_request(request: Request, state: &AppState) -> anyhow::Result<Response> {
+pub(super) async fn apply_request(
+    request: Request,
+    state_machine: &mut Store,
+) -> anyhow::Result<Response> {
     Ok(match request {
         Request::Kv(req) => {
             // TODO: this shouldn't be mut but KvStore currently requires it
-            let mut store = state.get_kv_store_by_key(req.key_name())?;
+            let mut store = state_machine.state.get_kv_store_by_key(req.key_name())?;
             Response::Kv(req.apply(&mut store))
         }
+        Request::ClusterInternal(req) => Response::ClusterInternal(req.apply(state_machine).await?),
     })
 }

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -14,6 +14,7 @@ use url::Url;
 use super::{
     network::build_client,
     raft::{Node, NodeId, Raft},
+    state_machine::ClusterId,
 };
 use crate::{
     Configuration,
@@ -90,10 +91,10 @@ impl Discovery {
 
     async fn join_cluster(
         &self,
-        cluster_name: String,
+        cluster_id: ClusterId,
         peers: Vec<(SocketAddr, NodeId, DiscoverClusterResponse)>,
     ) -> anyhow::Result<()> {
-        tracing::info!(?cluster_name, "joining running cluster");
+        tracing::info!(?cluster_id, "joining running cluster");
         let Some((leader_addr, _leader_node_id, leader_cluster)) = peers
             .iter()
             .find_or_first(|p| p.2.state == ServerState::Leader)
@@ -142,7 +143,8 @@ impl Discovery {
             tracing::trace!(?peer_address, ?response, "adding node to new cluster");
             nodes.insert(response.node_id, Node::new(peer_address));
         }
-        self.raft.initialize(nodes).await?;
+        tracing::debug!(?nodes, "initializing cluster with nodes");
+        super::raft::initialize_cluster(&self.raft, nodes).await?;
         tracing::info!("initialized new cluster");
         Ok(())
     }
@@ -203,8 +205,11 @@ impl Discovery {
                         if let Some(cluster) = v.cluster {
                             if cluster.last_committed_log_id.is_none() {
                                 None
+                            } else if let Some(cluster_id) = cluster.cluster_id {
+                                Some((cluster_id, (k, v.node_id, cluster)))
                             } else {
-                                Some((cluster.cluster_name.clone(), (k, v.node_id, cluster)))
+                                tracing::warn!("found a last_committed_log_id, but no cluster_id! refusing to join");
+                                None
                             }
                         } else {
                             None
@@ -213,8 +218,8 @@ impl Discovery {
                     .into_group_map();
 
                 if clusters_to_peers.len() == 1 {
-                    let (cluster_name, config) = clusters_to_peers.into_iter().next().unwrap();
-                    if let Err(err) = self.join_cluster(cluster_name, config).await {
+                    let (cluster_id, config) = clusters_to_peers.into_iter().next().unwrap();
+                    if let Err(err) = self.join_cluster(cluster_id, config).await {
                         tracing::error!(?err, "failed to join cluster!");
                     } else {
                         tracing::info!("finished joining cluster");

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -1,4 +1,10 @@
-use super::raft::{Node, NodeId, Raft};
+use crate::{cfg::Configuration, core::cluster::state_machine::StoreHandle};
+
+use super::{
+    discovery::Discovery,
+    operations::{InternalRequest, InternalResponse},
+    raft::{Node, NodeId, Raft},
+};
 use coyote_operations::{OperationRequest, OperationResponse};
 use openraft::error::{ClientWriteError, RaftError};
 use serde::{Deserialize, Serialize};
@@ -28,6 +34,7 @@ impl std::error::Error for ResponseParseError {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Request {
+    ClusterInternal(InternalRequest),
     Kv(coyote_kv::operations::Operation),
 }
 
@@ -40,6 +47,7 @@ impl<T: Into<coyote_kv::operations::Operation>> From<T> for Request {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Response {
     Blank,
+    ClusterInternal(InternalResponse),
     Kv(coyote_kv::operations::Response),
 }
 
@@ -58,6 +66,7 @@ impl TryFrom<Response> for coyote_kv::operations::Response {
 pub struct RaftState {
     pub raft: Raft,
     pub node_id: NodeId,
+    pub state_machine: StoreHandle,
 }
 
 impl RaftState {
@@ -84,5 +93,28 @@ impl RaftState {
             .try_into()
             .expect("module response should be convertible into target type");
         Ok(resp)
+    }
+
+    pub async fn run_discovery_if_necessary(&self, cfg: Configuration) -> anyhow::Result<()> {
+        let has_cluster = self
+            .raft
+            .with_raft_state(|s| {
+                s.committed.is_some() || s.membership_state.effective().nodes().count() > 0
+            })
+            .await?;
+        if has_cluster {
+            tracing::debug!("node already has cluster information; skipping discovery");
+        } else {
+            tracing::debug!("node has no cluster information; kicking off discovery");
+            let disco = Discovery::new(cfg, self.raft.clone(), self.node_id)?;
+            if let Err(err) = disco.discover_cluster().await {
+                tracing::error!(
+                    ?err,
+                    "discovery failed; this node must be manually initialized"
+                );
+            }
+            tracing::info!("discovery succeeded");
+        }
+        Ok(())
     }
 }

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -7,6 +7,7 @@ mod errors;
 mod handle;
 mod logs;
 mod network;
+mod operations;
 pub mod proto;
 mod raft;
 mod serialized_state_machine;

--- a/src/core/cluster/operations.rs
+++ b/src/core/cluster/operations.rs
@@ -1,0 +1,23 @@
+use crate::core::cluster::state_machine::ClusterId;
+
+use super::state_machine::Store;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum InternalRequest {
+    SetClusterId(ClusterId),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum InternalResponse {
+    Ok,
+}
+
+impl InternalRequest {
+    pub(super) async fn apply(self, state_machine: &mut Store) -> anyhow::Result<InternalResponse> {
+        match self {
+            Self::SetClusterId(uuid) => state_machine.set_cluster_id(uuid).await?,
+        }
+        Ok(InternalResponse::Ok)
+    }
+}

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -8,11 +8,14 @@ use std::{
 use openraft::{LogId, ServerState};
 use serde::{Deserialize, Serialize};
 
+use crate::core::cluster::state_machine::ClusterId;
+
 use super::raft::NodeId;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(super) struct DiscoverClusterResponse {
     pub cluster_name: String,
+    pub cluster_id: Option<ClusterId>,
     pub known_peers: BTreeMap<NodeId, SocketAddr>,
     pub state: ServerState,
     pub last_committed_log_id: Option<LogId<NodeId>>,
@@ -46,4 +49,5 @@ pub struct HealthResponse {
     pub last_committed_log_index: Option<u64>,
     pub server_state: ServerState,
     pub leader: Option<NodeId>,
+    pub cluster_id: Option<ClusterId>,
 }

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -1,15 +1,25 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
 
-use openraft::BasicNode;
+use openraft::{
+    BasicNode,
+    error::{InitializeError, RaftError},
+};
 use serde::{Deserialize, Serialize};
+use tap::TapFallible;
 use uuid::Uuid;
 
 use super::{
-    discovery::Discovery,
     handle::{RaftState, Request, Response},
     state_machine::StoredSnapshot,
 };
-use crate::{AppState, cfg::Configuration};
+use crate::{
+    AppState,
+    cfg::Configuration,
+    core::cluster::{
+        operations::InternalRequest,
+        state_machine::{ClusterId, StoreHandle},
+    },
+};
 
 // TODO: is BasicNode enough for us?
 pub(super) type Node = BasicNode;
@@ -56,6 +66,37 @@ openraft::declare_raft_types!(
 
 pub type Raft = openraft::Raft<TypeConfig>;
 
+pub(super) async fn initialize_cluster(
+    raft: &Raft,
+    cluster: BTreeMap<NodeId, Node>,
+) -> anyhow::Result<()> {
+    let start = Instant::now();
+    let voters = cluster.keys().copied().collect::<Vec<_>>();
+    match raft.initialize(cluster).await {
+        Ok(_) => {}
+        Err(RaftError::APIError(InitializeError::NotAllowed(_))) => {
+            tracing::debug!("cluster already initialized, ignoring");
+            return Ok(());
+        }
+        Err(err) => {
+            tracing::error!(?err, "error initializing cluster");
+            return Err(err.into());
+        }
+    };
+    raft.wait(None)
+        .voter_ids(voters, "waiting for cluster to bootstrap")
+        .await?;
+    let new_id = ClusterId::generate();
+    tracing::debug!(cluster_id=?new_id, "cluster initialized, setting cluster_id");
+    raft.client_write(Request::ClusterInternal(InternalRequest::SetClusterId(
+        new_id,
+    )))
+    .await
+    .tap_err(|err| tracing::error!(?err, "failed to set initial cluster id"))?;
+    tracing::debug!(elapsed=?start.elapsed(), "initialization finished");
+    Ok(())
+}
+
 pub async fn initialize_raft(
     cfg: &Configuration,
     app_state: AppState,
@@ -77,28 +118,13 @@ pub async fn initialize_raft(
 
     let state_machine =
         super::state_machine::Store::new(db, cfg.cluster.snapshot_path.clone(), app_state).await?;
-    let raft = Raft::new(id, config, network, logs, state_machine).await?;
-    let has_cluster = raft
-        .with_raft_state(|s| {
-            s.committed.is_some() || s.membership_state.effective().nodes().count() > 0
-        })
-        .await?;
-    if has_cluster {
-        tracing::debug!("node already has cluster information; skipping discovery");
-    } else {
-        tracing::debug!("node has no cluster information; kicking off discovery");
-        let disco = Discovery::new(cfg.clone(), raft.clone(), id)?;
-        tokio::spawn(async move {
-            if let Err(err) = disco.discover_cluster().await {
-                tracing::error!(
-                    ?err,
-                    "discovery failed; this node must be manually initialized"
-                );
-            }
-            tracing::info!("discovery succeeded");
-        });
-    }
-    Ok(RaftState { raft, node_id: id })
+    let state_machine: StoreHandle = state_machine.into();
+    let raft = Raft::new(id, config, network, logs, state_machine.clone()).await?;
+    Ok(RaftState {
+        raft,
+        node_id: id,
+        state_machine,
+    })
 }
 
 #[cfg(test)]
@@ -110,14 +136,17 @@ mod tests {
     use crate::{AppState, cfg::ConfigurationInner};
 
     use super::{
-        super::{logs::CoyoteLogs, state_machine::Store},
+        super::{
+            logs::CoyoteLogs,
+            state_machine::{Store, StoreHandle},
+        },
         NodeId, TypeConfig,
     };
 
     struct CoyoteStoreBuilder;
 
     impl CoyoteStoreBuilder {
-        async fn setup() -> anyhow::Result<(TempDir, CoyoteLogs, Store)> {
+        async fn setup() -> anyhow::Result<(TempDir, CoyoteLogs, StoreHandle)> {
             let workdir = tempfile::tempdir()?;
             let mut log_path = workdir.path().to_path_buf();
             log_path.push("logs");
@@ -142,14 +171,14 @@ mod tests {
 
             let store = Store::new(db, snapshot_path, app_state).await?;
 
-            Ok((workdir, logs, store))
+            Ok((workdir, logs, store.into()))
         }
     }
 
-    impl StoreBuilder<TypeConfig, CoyoteLogs, Store, TempDir> for CoyoteStoreBuilder {
+    impl StoreBuilder<TypeConfig, CoyoteLogs, StoreHandle, TempDir> for CoyoteStoreBuilder {
         async fn build(
             &self,
-        ) -> Result<(TempDir, CoyoteLogs, Store), openraft::StorageError<NodeId>> {
+        ) -> Result<(TempDir, CoyoteLogs, StoreHandle), openraft::StorageError<NodeId>> {
             Self::setup().await.map_err(|e| openraft::StorageError::IO {
                 source: StorageIOError::write(e),
             })

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -10,7 +10,10 @@ use openraft::{
     EntryPayload, LogId, RaftSnapshotBuilder, RaftTypeConfig, Snapshot, SnapshotMeta,
     StorageIOError, StoredMembership, storage::RaftStateMachine,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tap::TapFallible;
+use tokio::sync::RwLock as TokioRwLock;
+use uuid::Uuid;
 
 use super::{
     errors::*,
@@ -30,9 +33,27 @@ struct LastSnapshot {
     path: PathBuf,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[serde(transparent)]
+pub struct ClusterId(#[serde(with = "uuid::serde::simple")] Uuid);
+
+impl ClusterId {
+    pub(super) fn generate() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
 #[derive(Clone)]
+pub struct StoreHandle(Arc<TokioRwLock<Store>>);
+
+impl From<Store> for StoreHandle {
+    fn from(value: Store) -> Self {
+        Self(Arc::new(TokioRwLock::new(value)))
+    }
+}
+
 pub struct Store {
-    state: AppState,
+    pub(super) state: AppState,
     db: Database,
     snapshot_directory: PathBuf,
     meta_keyspace: Keyspace,
@@ -40,6 +61,7 @@ pub struct Store {
     last_applied_log_id: Option<LogId<NodeId>>,
     last_membership: StoredMembership<NodeId, Node>,
     last_snapshot: Arc<RwLock<Option<LastSnapshot>>>,
+    cluster_id: Option<ClusterId>,
 }
 
 trait SnapshotIdx {
@@ -81,9 +103,41 @@ impl Store {
             snapshot_idx: 0,
             last_applied_log_id: None,
             last_membership: Default::default(),
+            cluster_id: None,
         };
         this.load_information().await?;
         Ok(this)
+    }
+
+    pub fn cluster_id(&self) -> Option<&ClusterId> {
+        self.cluster_id.as_ref()
+    }
+
+    pub(super) async fn set_cluster_id(&mut self, id: ClusterId) -> anyhow::Result<()> {
+        let keyspace = self.meta_keyspace.clone();
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let serialized = rmp_serde::to_vec(&id)?;
+            keyspace.insert("cluster_uuid", serialized)?;
+            Ok(())
+        })
+        .await??;
+        self.cluster_id = Some(id);
+        Ok(())
+    }
+
+    fn try_read_field<T: DeserializeOwned>(
+        snapshot: &fjall::Snapshot,
+        keyspace: &Keyspace,
+        key: &str,
+    ) -> anyhow::Result<T> {
+        if let Some(raw_data) = snapshot.get(keyspace, key)? {
+            rmp_serde::from_slice(&raw_data).map_err(|err| {
+                tracing::warn!(?key, ?err, "error deserializing key from meta keyspace");
+                err.into()
+            })
+        } else {
+            anyhow::bail!("no such key {key:?}");
+        }
     }
 
     #[tracing::instrument(skip(self))]
@@ -91,35 +145,25 @@ impl Store {
         let db = self.db.clone();
         let keyspace = self.meta_keyspace.clone();
 
-        let (last_applied_log_id, last_membership, last_snapshot) =
-            tokio::task::spawn_blocking(move || -> anyhow::Result<(_, _, _)> {
+        let (last_applied_log_id, last_membership, last_snapshot, cluster_id) =
+            tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
                 let snapshot = db.snapshot();
-                let last_applied_log_id = if let Some(raw_last_applied_log_id) =
-                    snapshot.get(&keyspace, "last_applied_log_id")?
-                {
-                    let last_applied_log_id = rmp_serde::from_slice(&raw_last_applied_log_id)?;
-                    Some(last_applied_log_id)
-                } else {
-                    None
-                };
-                let last_membership = if let Some(raw_last_membership) =
-                    snapshot.get(&keyspace, "last_membership")?
-                {
-                    rmp_serde::from_slice(&raw_last_membership)?
-                } else {
-                    tracing::trace!("found no last_membership in database!");
-                    Default::default()
-                };
-
+                let last_applied_log_id =
+                    Self::try_read_field(&snapshot, &keyspace, "last_applied_log_id").ok();
+                let last_membership = Self::try_read_field(&snapshot, &keyspace, "last_membership")
+                    .tap_err(|_| tracing::trace!("found no last membership in the database!"))
+                    .unwrap_or_default();
                 let last_snapshot =
-                    if let Some(raw_snapshot_data) = snapshot.get(&keyspace, "last_snapshot")? {
-                        let s: LastSnapshot = rmp_serde::from_slice(&raw_snapshot_data)?;
-                        Some(s)
-                    } else {
-                        None
-                    };
+                    Self::try_read_field::<LastSnapshot>(&snapshot, &keyspace, "last_snapshot")
+                        .ok();
+                let cluster_id = Self::try_read_field(&snapshot, &keyspace, "cluster_uuid").ok();
 
-                Ok((last_applied_log_id, last_membership, last_snapshot))
+                Ok((
+                    last_applied_log_id,
+                    last_membership,
+                    last_snapshot,
+                    cluster_id,
+                ))
             })
             .await??;
         self.last_applied_log_id = last_applied_log_id;
@@ -128,6 +172,7 @@ impl Store {
             .as_ref()
             .map(|s| s.meta.snapshot_idx())
             .unwrap_or(0);
+        self.cluster_id = cluster_id;
         *self.last_snapshot.write().unwrap() = last_snapshot;
         Ok(())
     }
@@ -145,7 +190,7 @@ impl Store {
             path: snapshot_path,
         };
         tracing::trace!(last_snapshot=?data, "setting last_snapshot");
-        let serialized = rmp_serde::to_vec(&data)?;
+        let serialized = rmp_serde::to_vec_named(&data)?;
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             keyspace.insert("last_snapshot", serialized)?;
             db.persist(fjall::PersistMode::SyncAll)?;
@@ -163,8 +208,8 @@ impl Store {
             "storing id values");
         let mut tx = self.db.batch().durability(Some(PersistMode::Buffer));
         let keyspace = self.meta_keyspace.clone();
-        let last_applied_log_id = rmp_serde::encode::to_vec(&self.last_applied_log_id)?;
-        let last_membership = rmp_serde::encode::to_vec(&self.last_membership)?;
+        let last_applied_log_id = rmp_serde::encode::to_vec_named(&self.last_applied_log_id)?;
+        let last_membership = rmp_serde::encode::to_vec_named(&self.last_membership)?;
         tokio::task::spawn_blocking(move || {
             tx.insert(&keyspace, "last_applied_log_id", last_applied_log_id);
             tx.insert(&keyspace, "last_membership", last_membership);
@@ -209,6 +254,130 @@ impl Store {
             .await?;
         self.set_last_snapshot_(meta.clone(), snapshot.path).await?;
         Ok(())
+    }
+
+    async fn apply_<I>(&mut self, entries: I) -> StorageResult<Vec<Response>>
+    where
+        I: IntoIterator<Item = <TypeConfig as RaftTypeConfig>::Entry> + openraft::OptionalSend,
+        I::IntoIter: openraft::OptionalSend,
+    {
+        let mut replies = vec![];
+        let mut changed_log_id = false;
+        let mut changed_membership = false;
+        for item in entries {
+            self.last_applied_log_id = Some(item.log_id);
+            changed_log_id = true;
+
+            match item.payload {
+                EntryPayload::Blank => {
+                    tracing::trace!("heartbeat");
+                    replies.push(Response::Blank)
+                }
+                EntryPayload::Normal(req) => {
+                    tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
+                    let reply = match super::applier::apply_request(req, self).await {
+                        Ok(o) => o,
+                        Err(e) => {
+                            tracing::error!("failed to apply raft log");
+                            return Err(StorageError::IO {
+                                source: StorageIOError::apply(item.log_id, e),
+                            });
+                        }
+                    };
+                    replies.push(reply);
+                }
+                EntryPayload::Membership(last_membership) => {
+                    tracing::trace!("changing cluster membership");
+                    self.last_membership =
+                        StoredMembership::new(Some(item.log_id), last_membership);
+                    changed_membership = true;
+                    replies.push(Response::Blank)
+                }
+            }
+        }
+        if changed_log_id || changed_membership {
+            self.record_ids_().await.map_err(write_err)?;
+        }
+        Ok(replies)
+    }
+
+    async fn begin_receiving_snapshot_(
+        &mut self,
+    ) -> StorageResult<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>> {
+        let path = self
+            .snapshot_directory
+            .with_file_name(format!("coyote-incoming-snapshot-{}", self.snapshot_idx));
+        self.snapshot_idx += 1;
+        let f = tokio::fs::File::create_new(path.clone())
+            .await
+            .map_err(|e| write_snapshot_err(&e))?;
+        Ok(Box::new(StoredSnapshot { path, file: f }))
+    }
+
+    fn prep_snapshot_builder_(&mut self) {
+        self.snapshot_idx += 1;
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn get_current_snapshot_(
+        &mut self,
+    ) -> StorageResult<Option<openraft::Snapshot<TypeConfig>>> {
+        // clone to avoid holding a lock over an await point
+        let last_snapshot = self.last_snapshot.read().unwrap().clone();
+        if let Some(last_snapshot) = last_snapshot {
+            tracing::trace!(?last_snapshot, "found last_snapshot");
+            let f = tokio::fs::File::open(&last_snapshot.path)
+                .await
+                .map_err(|e| read_snapshot_err(&e))?;
+            Ok(Some(Snapshot {
+                meta: last_snapshot.meta.clone(),
+                snapshot: Box::new(StoredSnapshot {
+                    file: f,
+                    path: last_snapshot.path.clone(),
+                }),
+            }))
+        } else {
+            tracing::trace!("found no last_snapshot");
+            Ok(None)
+        }
+    }
+
+    async fn build_snapshot_(&mut self) -> StorageResult<openraft::Snapshot<TypeConfig>> {
+        let last_log_id = self.last_applied_log_id;
+        let last_membership = self.last_membership.clone();
+
+        let snapshot_id = if let Some(last) = last_log_id {
+            format!("{}-{}-{}", last.leader_id, last.index, self.snapshot_idx)
+        } else {
+            format!("x-x-{}", self.snapshot_idx)
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id,
+            last_membership,
+            snapshot_id,
+        };
+
+        let keyspaces = self
+            .db
+            .list_keyspace_names()
+            .into_iter()
+            .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
+            .map(|s| s.to_string())
+            .collect();
+
+        let snapshot =
+            StoredSnapshot::new(&meta, &self.snapshot_directory, self.db.clone(), keyspaces)
+                .await
+                .map_err(write_snapshot_err)?;
+
+        self.set_last_snapshot_(meta.clone(), snapshot.path.clone())
+            .await
+            .map_err(write_snapshot_err)?;
+
+        let snapshot = Box::new(snapshot);
+
+        Ok(Snapshot { meta, snapshot })
     }
 }
 
@@ -308,53 +477,20 @@ impl StoredSnapshot {
     }
 }
 
-impl RaftSnapshotBuilder<TypeConfig> for Store {
+impl RaftSnapshotBuilder<TypeConfig> for StoreHandle {
     async fn build_snapshot(&mut self) -> StorageResult<openraft::Snapshot<TypeConfig>> {
-        let last_log_id = self.last_applied_log_id;
-        let last_membership = self.last_membership.clone();
-
-        let snapshot_id = if let Some(last) = last_log_id {
-            format!("{}-{}-{}", last.leader_id, last.index, self.snapshot_idx)
-        } else {
-            format!("x-x-{}", self.snapshot_idx)
-        };
-
-        let meta = SnapshotMeta {
-            last_log_id,
-            last_membership,
-            snapshot_id,
-        };
-
-        let keyspaces = self
-            .db
-            .list_keyspace_names()
-            .into_iter()
-            .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
-            .map(|s| s.to_string())
-            .collect();
-
-        let snapshot =
-            StoredSnapshot::new(&meta, &self.snapshot_directory, self.db.clone(), keyspaces)
-                .await
-                .map_err(write_snapshot_err)?;
-
-        self.set_last_snapshot_(meta.clone(), snapshot.path.clone())
-            .await
-            .map_err(write_snapshot_err)?;
-
-        let snapshot = Box::new(snapshot);
-
-        Ok(Snapshot { meta, snapshot })
+        self.0.write().await.build_snapshot_().await
     }
 }
 
-impl RaftStateMachine<TypeConfig> for Store {
+impl RaftStateMachine<TypeConfig> for StoreHandle {
     type SnapshotBuilder = Self;
 
     async fn applied_state(
         &mut self,
     ) -> StorageResult<(Option<LogId<NodeId>>, StoredMembership<NodeId, Node>)> {
-        Ok((self.last_applied_log_id, self.last_membership.clone()))
+        let this = self.0.read().await;
+        Ok((this.last_applied_log_id, this.last_membership.clone()))
     }
 
     async fn apply<I>(&mut self, entries: I) -> StorageResult<Vec<Response>>
@@ -362,61 +498,17 @@ impl RaftStateMachine<TypeConfig> for Store {
         I: IntoIterator<Item = <TypeConfig as RaftTypeConfig>::Entry> + openraft::OptionalSend,
         I::IntoIter: openraft::OptionalSend,
     {
-        let mut replies = vec![];
-        let mut changed_log_id = false;
-        let mut changed_membership = false;
-        for item in entries {
-            self.last_applied_log_id = Some(item.log_id);
-            changed_log_id = true;
-
-            match item.payload {
-                EntryPayload::Blank => {
-                    tracing::trace!("heartbeat");
-                    replies.push(Response::Blank)
-                }
-                EntryPayload::Normal(req) => {
-                    tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
-                    let reply = match super::applier::apply_request(req, &self.state) {
-                        Ok(o) => o,
-                        Err(e) => {
-                            tracing::error!("failed to apply raft log");
-                            return Err(StorageError::IO {
-                                source: StorageIOError::apply(item.log_id, e),
-                            });
-                        }
-                    };
-                    replies.push(reply);
-                }
-                EntryPayload::Membership(last_membership) => {
-                    tracing::trace!("changing cluster membership");
-                    self.last_membership =
-                        StoredMembership::new(Some(item.log_id), last_membership);
-                    changed_membership = true;
-                    replies.push(Response::Blank)
-                }
-            }
-        }
-        if changed_log_id || changed_membership {
-            self.record_ids_().await.map_err(write_err)?;
-        }
-        Ok(replies)
+        self.0.write().await.apply_(entries).await
     }
 
     async fn begin_receiving_snapshot(
         &mut self,
     ) -> StorageResult<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>> {
-        let path = self
-            .snapshot_directory
-            .with_file_name(format!("coyote-incoming-snapshot-{}", self.snapshot_idx));
-        self.snapshot_idx += 1;
-        let f = tokio::fs::File::create_new(path.clone())
-            .await
-            .map_err(|e| write_snapshot_err(&e))?;
-        Ok(Box::new(StoredSnapshot { path, file: f }))
+        self.0.write().await.begin_receiving_snapshot_().await
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
-        self.snapshot_idx += 1;
+        self.0.write().await.prep_snapshot_builder_();
         self.clone()
     }
 
@@ -424,24 +516,7 @@ impl RaftStateMachine<TypeConfig> for Store {
     async fn get_current_snapshot(
         &mut self,
     ) -> StorageResult<Option<openraft::Snapshot<TypeConfig>>> {
-        // clone to avoid holding a lock over an await point
-        let last_snapshot = self.last_snapshot.read().unwrap().clone();
-        if let Some(last_snapshot) = last_snapshot {
-            tracing::trace!(?last_snapshot, "found last_snapshot");
-            let f = tokio::fs::File::open(&last_snapshot.path)
-                .await
-                .map_err(|e| read_snapshot_err(&e))?;
-            Ok(Some(Snapshot {
-                meta: last_snapshot.meta.clone(),
-                snapshot: Box::new(StoredSnapshot {
-                    file: f,
-                    path: last_snapshot.path.clone(),
-                }),
-            }))
-        } else {
-            tracing::trace!("found no last_snapshot");
-            Ok(None)
-        }
+        self.0.write().await.get_current_snapshot_().await
     }
 
     #[tracing::instrument(skip(self, meta))]
@@ -450,8 +525,17 @@ impl RaftStateMachine<TypeConfig> for Store {
         meta: &openraft::SnapshotMeta<NodeId, Node>,
         snapshot: Box<StoredSnapshot>,
     ) -> StorageResult<()> {
-        self.install_snapshot_(meta, snapshot)
+        self.0
+            .write()
+            .await
+            .install_snapshot_(meta, snapshot)
             .await
             .map_err(read_snapshot_err)
+    }
+}
+
+impl StoreHandle {
+    pub async fn cluster_id(&self) -> Option<ClusterId> {
+        self.0.read().await.cluster_id().copied()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@
 
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::{sync::LazyLock, time::Duration};
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use aide::axum::ApiRouter;
 use axum::{Extension, middleware};
@@ -27,7 +30,7 @@ use opentelemetry_sdk::{
         span_processor_with_async_runtime::BatchSpanProcessor,
     },
 };
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, sync::Barrier};
 use tokio_util::sync::CancellationToken;
 use tower_http::{
     ServiceExt,
@@ -119,6 +122,7 @@ async fn run_interserver(
     state: AppState,
     raft: RaftState,
     listener: Option<TcpListener>,
+    bind_barrier: Arc<Barrier>,
 ) {
     let listen_address = cfg.cluster.listen_address;
     let listener = match listener {
@@ -131,6 +135,7 @@ async fn run_interserver(
         "Inter-Server: Listening on {}",
         listener.local_addr().unwrap()
     );
+    bind_barrier.wait().await;
 
     let app = core::cluster::router()
         .with_state(state.clone())
@@ -231,12 +236,27 @@ pub async fn run_with_prefix(
         .with_state::<()>(app_state.clone())
         .layer(Extension(raft_state.clone()));
 
+    let interserver_started_barrier = Arc::new(Barrier::new(2));
+
     let interserver = tokio::spawn(run_interserver(
         cfg.clone(),
         app_state.clone(),
         raft_state.clone(),
         interserver_listener,
+        Arc::clone(&interserver_started_barrier),
     ));
+
+    tokio::spawn({
+        let raft_state = raft_state.clone();
+        let cfg = cfg.clone();
+        async move {
+            interserver_started_barrier.wait().await;
+            raft_state
+                .run_discovery_if_necessary(cfg)
+                .await
+                .expect("should be able to initialize discovery");
+        }
+    });
 
     // Initialize all routes which need to be part of OpenAPI first.
     let api_router = ApiRouter::new()


### PR DESCRIPTION
One of the issues with discovery is that it used the `cluster_name` field, and if you had multiple nodes bootstrapping at the same time into different clusters with the same name, you could get split-brain.

This makes the cluster generate a cluster UUID on initialization and write it through the log. Subsequent discovery calls use the cluster UUID to disambiguate seed peers instead of the cluster name, to prevent weird split-brain. This is also the beginning of framework for writing internal maintenance messages through the log.

To do this, I change the underlying StateMachine (`Store`) to be an `Arc<RwLock<_>>` so that it can be cheaply copied. It should've always worked this way, and I'm pretty sure the old way (with a deep-Clone) would cause duplicate snapshot indices.

Part of #76