### PR TITLE
Fix bug in rate limiter and add more tests

### DIFF
--- a/crates/rate-limiter/src/algorithms.rs
+++ b/crates/rate-limiter/src/algorithms.rs
@@ -33,8 +33,10 @@ impl TokenBucket {
         current: u64,
         now: Timestamp,
         last_refill: Timestamp,
-    ) -> u64 {
+    ) -> (u64, Timestamp) {
         let mut capacity = current;
+        let mut new_last_refill = last_refill;
+
         if last_refill < now {
             let elapsed_millis: u64 = now
                 .duration_since(last_refill)
@@ -42,10 +44,15 @@ impl TokenBucket {
                 .try_into()
                 .unwrap();
             let refill_interval_millis: u64 = self.refill_interval.as_millis().try_into().unwrap();
+            let intervals = elapsed_millis / refill_interval_millis;
 
-            capacity += (elapsed_millis / refill_interval_millis) * self.refill_rate;
+            capacity += intervals * self.refill_rate;
+            capacity = capacity.min(self.bucket_size);
+
+            new_last_refill += self.refill_interval.saturating_mul(intervals as u32);
         }
-        capacity.min(self.bucket_size)
+
+        (capacity, new_last_refill)
     }
 }
 

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -104,7 +104,8 @@ impl RateLimiter {
                     },
                 );
 
-                let capacity = tb_config.get_new_capacity(bucket.tokens, now, bucket.last_refill);
+                let (capacity, new_last_refill) =
+                    tb_config.get_new_capacity(bucket.tokens, now, bucket.last_refill);
 
                 if capacity < delta {
                     let filled_per_millis =
@@ -118,7 +119,7 @@ impl RateLimiter {
                     ));
                 }
 
-                bucket.last_refill = now;
+                bucket.last_refill = new_last_refill;
                 bucket.tokens = capacity - delta;
 
                 if update {
@@ -312,6 +313,42 @@ mod tests {
                 limiter.limit(clock, id, 2, config_refill_2()).unwrap();
             assert!(matches!(result, RateLimitResult::OK));
             assert_eq!(remaining, 3);
+            assert_eq!(retry_after, None);
+        }
+
+        #[test]
+        fn refill_interval_tracking() {
+            let (limiter, _dir) = create_test_limiter();
+            let id = "user1";
+
+            fn make_config() -> RateLimitConfig {
+                RateLimitConfig::TokenBucket(TokenBucket {
+                    refill_rate: 2,
+                    refill_interval: Duration::from_secs(5),
+                    bucket_size: 6,
+                })
+            }
+
+            let mut clock = Timestamp::now();
+
+            let (result, remaining, retry_after) =
+                limiter.limit(clock, id, 2, make_config()).unwrap();
+            assert!(matches!(result, RateLimitResult::OK));
+            assert_eq!(remaining, 4);
+            assert_eq!(retry_after, None);
+
+            clock += Duration::from_secs(2);
+            let (result, remaining, retry_after) =
+                limiter.limit(clock, id, 1, make_config()).unwrap();
+            assert!(matches!(result, RateLimitResult::OK));
+            assert_eq!(remaining, 3);
+            assert_eq!(retry_after, None);
+
+            clock += Duration::from_secs(3);
+            let (result, remaining, retry_after) =
+                limiter.limit(clock, id, 1, make_config()).unwrap();
+            assert!(matches!(result, RateLimitResult::OK));
+            assert_eq!(remaining, 4); // 4 (previous) + 2 (refill) - 1 (consumed)
             assert_eq!(retry_after, None);
         }
     }

--- a/tests/it/rate_limiter.rs
+++ b/tests/it/rate_limiter.rs
@@ -32,6 +32,30 @@ async fn call_limit_token_bucket(
     Ok(response)
 }
 
+async fn call_limit_fixed_window(
+    client: &TestClient,
+    key: &str,
+    units: u64,
+    max_requests: u64,
+    window_size_seconds: u64,
+) -> TestResult<Value> {
+    let response = client
+        .post("rate-limiter/limit")
+        .json(json!({
+            "key": key,
+            "units": units,
+            "method": "fixed_window",
+            "config": {
+                "max_requests": max_requests,
+                "window_size_seconds": window_size_seconds
+            }
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    Ok(response)
+}
+
 #[tokio::test]
 async fn test_rate_limiter_limit_token_bucket() -> TestResult {
     let TestContext {
@@ -113,6 +137,157 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
         .json();
 
     assert_eq!(response["remaining"], capacity);
+    assert_eq!(response["retry_after"], json!(null));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rate_limiter_limit_fixed_window() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+    let max_requests = 5;
+    let window_size_seconds = 1;
+
+    let response =
+        call_limit_fixed_window(&client, "rl-key-1", 1, max_requests, window_size_seconds).await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 4);
+    assert_eq!(response["retry_after"], json!(null));
+
+    let response =
+        call_limit_fixed_window(&client, "rl-key-1", 2, max_requests, window_size_seconds).await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 2);
+    assert_eq!(response["retry_after"], json!(null));
+
+    let response =
+        call_limit_fixed_window(&client, "rl-key-1", 2, max_requests, window_size_seconds).await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 0);
+    assert_eq!(response["retry_after"], json!(null));
+
+    let response =
+        call_limit_fixed_window(&client, "rl-key-1", 1, max_requests, window_size_seconds).await?;
+    assert_eq!(response["result"], "BLOCK");
+    assert_eq!(response["remaining"], 0);
+    assert!(response["retry_after"].is_number());
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let response = client
+        .post("rate-limiter/get-remaining")
+        .json(json!({
+            "key": "rl-key-1",
+            "method": "fixed_window",
+            "config": {
+                "max_requests": max_requests,
+                "window_size_seconds": window_size_seconds
+            }
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(response["remaining"], max_requests);
+    assert_eq!(response["retry_after"], json!(null));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rate_limiter_change_algorithm() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+    let max_requests = 5;
+    let window_size_seconds = 1;
+
+    let response =
+        call_limit_fixed_window(&client, "rl-key-1", 1, max_requests, window_size_seconds).await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 4);
+    assert_eq!(response["retry_after"], json!(null));
+
+    // Calling limit with the same key but a different algorithm behaves as a different key
+    let response = call_limit_token_bucket(&client, "rl-key-1", 1, 5, 1, 1).await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 4);
+    assert_eq!(response["retry_after"], json!(null));
+
+    // Change algorithm parameters
+    let response = call_limit_token_bucket(&client, "rl-key-1", 1, 10, 4, 2).await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 3);
+    assert_eq!(response["retry_after"], json!(null));
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let response = call_limit_token_bucket(&client, "rl-key-1", 1, 10, 4, 2).await?;
+    assert_eq!(response["result"], "OK");
+    assert_eq!(response["remaining"], 6); // 3 (previous) + 4 (refill) - 1 (consumed)
+    assert_eq!(response["retry_after"], json!(null));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rate_limiter_refill_interval() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+    let refill_interval = 5;
+    let refill_amount = 10;
+
+    let capacity = 6;
+
+    call_limit_token_bucket(
+        &client,
+        "rl-key-1",
+        2,
+        capacity,
+        refill_amount,
+        refill_interval,
+    )
+    .await?;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let response = call_limit_token_bucket(
+        &client,
+        "rl-key-1",
+        1,
+        capacity,
+        refill_amount,
+        refill_interval,
+    )
+    .await?;
+    assert_eq!(response["remaining"], 3); // Does not refill between intervals
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let response = client
+        .post("rate-limiter/get-remaining")
+        .json(json!({
+                "key": "rl-key-1",
+                "method": "token_bucket",
+                "config": {
+                    "capacity": capacity,
+                    "refill_amount": refill_amount,
+                    "refill_interval_seconds": refill_interval
+                }
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(response["remaining"], 6); // fill up to capacity
     assert_eq!(response["retry_after"], json!(null));
 
     Ok(())


### PR DESCRIPTION
The token bucket implementation had a very stupid bug 🤦  because it was updating the `last_refill` time on every `limit` call, so the bucket never got refilled. I didn't catch it in the existing tests because I tested it with `get_remaining`, which didn't repro the bug.

This adds a test for this case, and a few more tests for the module. 