### PR TITLE
raft: port log storage to use TableRow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ dependencies = [
  "coyote-rate-limiter",
  "ctor",
  "fjall",
+ "fjall-utils",
  "futures-util",
  "http",
  "idna_adapter",
@@ -1674,11 +1675,14 @@ dependencies = [
 name = "fjall-utils"
 version = "0.0.1"
 dependencies = [
+ "byteorder",
  "coyote-error",
  "fjall",
  "rmp-serde",
  "serde",
+ "tap",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ coyote-operations.workspace = true
 coyote-proto.workspace = true
 coyote-rate-limiter.workspace = true
 fjall.workspace = true
+fjall-utils.workspace = true
 futures-util.workspace = true
 http.workspace = true
 idna_adapter.workspace = true

--- a/crates/fjall-utils/Cargo.toml
+++ b/crates/fjall-utils/Cargo.toml
@@ -7,11 +7,14 @@ rust-version.workspace = true
 edition = "2024"
 
 [dependencies]
+byteorder.workspace = true
 coyote-error.workspace = true
 fjall.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
+tap.workspace = true
 tracing.workspace = true
+uuid.workspace = true
 
 [lints]
 workspace = true

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -1,6 +1,8 @@
 mod table_row;
 
-pub use self::table_row::{TableRow, WriteBatchExt};
+pub use self::table_row::{
+    KeyspaceExt, MonotonicTableKey, MonotonicTableRowExt, TableKey, TableRow, WriteBatchExt,
+};
 
 /// Useful for verifying all table prefixes for a given keyspace are unique,
 /// at compile time.

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -56,7 +56,7 @@ impl TableKey for u64 {
 
     fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         if bytes.len() != 8 {
-            return Err(Error::generic("invalid byte length in key key"));
+            return Err(Error::generic("invalid byte length in key"));
         }
         Ok(BigEndian::read_u64(bytes))
     }

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -1,7 +1,72 @@
-use std::borrow::Cow;
+use byteorder::{BigEndian, ByteOrder};
+use fjall::{Guard, UserKey};
+use std::{
+    borrow::Cow,
+    ops::{Bound, RangeBounds},
+};
+use uuid::Uuid;
 
-use coyote_error::{Error, Result};
+use coyote_error::{Error, Result, ResultExt};
 use serde::{Serialize, de::DeserializeOwned};
+
+/// A trait for primary keys in fjall.
+pub trait TableKey: Clone {
+    fn as_bytes(&self) -> Cow<'_, [u8]>;
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self>;
+}
+
+impl TableKey for String {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.as_bytes())
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        let owned: Vec<u8> = bytes.to_owned();
+        Self::from_utf8(owned).map_err_generic()
+    }
+}
+
+impl TableKey for Vec<u8> {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self)
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(bytes.to_owned())
+    }
+}
+
+impl TableKey for Uuid {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.as_bytes())
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        Self::from_slice(bytes).map_err_generic()
+    }
+}
+
+impl TableKey for u64 {
+    fn as_bytes(&self) -> std::borrow::Cow<'_, [u8]> {
+        let mut buf = vec![0u8; 8];
+        BigEndian::write_u64(&mut buf, *self);
+        Cow::Owned(buf)
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != 8 {
+            return Err(Error::generic("invalid byte length in key key"));
+        }
+        Ok(BigEndian::read_u64(bytes))
+    }
+}
+
+impl MonotonicTableKey for u64 {}
+
+/// Marker trait indicating that a table key is **monotonic** with its
+/// underlying byte representation; that is to say, if K1 > K2, then byte(K1) > byte(K2)
+pub trait MonotonicTableKey {}
 
 /// A trait for types that can be stored as rows in a fjall keyspace.
 ///
@@ -9,23 +74,24 @@ use serde::{Serialize, de::DeserializeOwned};
 pub trait TableRow: Sized + Serialize + DeserializeOwned {
     const TABLE_PREFIX: &'static str;
 
-    type Key: AsRef<[u8]> + Clone;
+    type Key: TableKey;
 
     /// Return the field used for indexing into the table.
     fn get_key(&self) -> Cow<'_, Self::Key>;
 
     fn make_fjall_key(key: &Self::Key) -> fjall::UserKey {
+        let raw_key_bytes = key.as_bytes();
         let mut key_bytes = if Self::TABLE_PREFIX.is_empty() {
-            Vec::<u8>::with_capacity(key.as_ref().len())
+            Vec::<u8>::with_capacity(raw_key_bytes.len())
         } else {
             let mut key_bytes = Vec::<u8>::with_capacity(
-                Self::TABLE_PREFIX.len() + b"\0".len() + key.as_ref().len(),
+                Self::TABLE_PREFIX.len() + b"\0".len() + raw_key_bytes.len(),
             );
             key_bytes.extend_from_slice(Self::TABLE_PREFIX.as_bytes());
             key_bytes.extend_from_slice(b"\0");
             key_bytes
         };
-        key_bytes.extend_from_slice(key.as_ref());
+        key_bytes.extend_from_slice(&raw_key_bytes);
         key_bytes.into()
     }
 
@@ -60,11 +126,150 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
         Ok(())
     }
 
-    fn iter(keyspace: &fjall::Keyspace) -> Result<impl Iterator<Item = Self>> {
+    fn key_from_key(key: fjall::UserKey) -> Result<Self::Key> {
+        let without_bytes = if Self::TABLE_PREFIX.is_empty() {
+            &key
+        } else {
+            &key[Self::TABLE_PREFIX.len() + 1..]
+        };
+        Self::Key::try_from_bytes(without_bytes)
+    }
+
+    /// Iterate over all of the key/value pairs in this table, in sorted order
+    fn iter(keyspace: &fjall::Keyspace) -> impl Iterator<Item = Result<(Self::Key, Self)>> {
+        let prefix = Self::prefix_with(&[]);
+        keyspace.prefix(prefix).map(|g| {
+            let (k, v) = g.into_inner()?;
+            let value = Self::from_fjall_value(v)?;
+            let key = Self::key_from_key(k)?;
+            Ok((key, value))
+        })
+    }
+
+    fn values(keyspace: &fjall::Keyspace) -> Result<impl Iterator<Item = Self>> {
         Ok(keyspace.prefix(Self::TABLE_PREFIX).map(|g| {
             let v = g.value().expect("iter error?");
             Self::from_fjall_value(v).expect("deserialize error?")
         }))
+    }
+
+    fn prefix_with(bytes: &[u8]) -> Vec<u8> {
+        if Self::TABLE_PREFIX.is_empty() {
+            bytes.to_owned()
+        } else {
+            let mut prefix_bytes = Vec::with_capacity(Self::TABLE_PREFIX.len() + 1 + bytes.len());
+            prefix_bytes.extend(Self::TABLE_PREFIX.as_bytes());
+            prefix_bytes.push(0x00);
+            prefix_bytes.extend(bytes);
+            prefix_bytes
+        }
+    }
+
+    fn end_prefix() -> Option<Vec<u8>> {
+        if Self::TABLE_PREFIX.is_empty() {
+            None
+        } else {
+            let mut prefix_bytes = Vec::with_capacity(Self::TABLE_PREFIX.len() + 1);
+            prefix_bytes.extend(Self::TABLE_PREFIX.as_bytes());
+            prefix_bytes.push(0x01);
+            Some(prefix_bytes)
+        }
+    }
+}
+
+fn increment(v: &mut Vec<u8>) {
+    for byte in v.iter_mut().rev() {
+        if *byte < 0xff {
+            *byte += 1;
+            break;
+        }
+    }
+    v.insert(0, 0x01)
+}
+
+fn range_helper<T, B>(
+    keyspace: &fjall::Keyspace,
+    bounds: B,
+) -> impl DoubleEndedIterator<Item = Guard>
+where
+    T: TableRow,
+    T::Key: MonotonicTableKey,
+    B: RangeBounds<T::Key>,
+{
+    let start = match bounds.start_bound() {
+        Bound::Unbounded => T::prefix_with(&[]),
+        Bound::Included(x) => T::prefix_with(x.as_bytes().as_ref()),
+        Bound::Excluded(x) => {
+            let mut bytes = T::prefix_with(x.as_bytes().as_ref());
+            increment(&mut bytes);
+            bytes
+        }
+    };
+    match bounds.end_bound() {
+        Bound::Unbounded => {
+            if let Some(end) = T::end_prefix() {
+                keyspace.range(start..end)
+            } else {
+                keyspace.range(start..)
+            }
+        }
+        Bound::Included(x) => keyspace.range(start..=T::prefix_with(x.as_bytes().as_ref())),
+        Bound::Excluded(x) => keyspace.range(start..T::prefix_with(x.as_bytes().as_ref())),
+    }
+}
+
+pub trait MonotonicTableRowExt: TableRow {
+    fn range<B: RangeBounds<Self::Key>>(
+        keyspace: &fjall::Keyspace,
+        bounds: B,
+    ) -> impl DoubleEndedIterator<Item = Result<(Self::Key, Self)>>;
+
+    fn keys_in_range<B: RangeBounds<Self::Key>>(
+        keyspace: &fjall::Keyspace,
+        bounds: B,
+    ) -> Result<Vec<fjall::UserKey>>;
+}
+
+impl<T: TableRow> MonotonicTableRowExt for T
+where
+    T::Key: MonotonicTableKey,
+{
+    fn range<B: RangeBounds<Self::Key>>(
+        keyspace: &fjall::Keyspace,
+        bounds: B,
+    ) -> impl DoubleEndedIterator<Item = Result<(Self::Key, Self)>> {
+        range_helper::<Self, B>(keyspace, bounds).map(|g| {
+            let (k, v) = g.into_inner()?;
+            let value = Self::from_fjall_value(v)?;
+            let key = Self::key_from_key(k)?;
+            Ok((key, value))
+        })
+    }
+
+    fn keys_in_range<B: RangeBounds<Self::Key>>(
+        keyspace: &fjall::Keyspace,
+        bounds: B,
+    ) -> Result<Vec<fjall::UserKey>> {
+        range_helper::<Self, B>(keyspace, bounds)
+            .map(|g| g.key().map_err(Into::into))
+            .collect::<Result<Vec<UserKey>>>()
+    }
+}
+
+/// Adds convenient methods to fjall's Keyspace to work with TableRow
+pub trait KeyspaceExt {
+    fn ingest_rows<T: TableRow, I: Iterator<Item = T>>(&self, rows: I) -> Result<()>;
+}
+
+impl KeyspaceExt for fjall::Keyspace {
+    fn ingest_rows<T: TableRow, I: Iterator<Item = T>>(&self, rows: I) -> Result<()> {
+        let mut i = self.start_ingestion()?;
+        for row in rows {
+            let (k, v) = row.to_fjall_entry()?;
+            i.write(k, v)?;
+        }
+        i.finish()?;
+        Ok(())
     }
 }
 

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -195,7 +195,7 @@ impl KvStore {
     }
 
     pub fn iter(&self) -> Result<impl Iterator<Item = KvPairRow>> {
-        KvPairRow::iter(&self.tables)
+        KvPairRow::values(&self.tables)
     }
 
     // FIXME(@svix-lucho): needs to be passed now() from the caller!
@@ -223,7 +223,7 @@ impl KvStore {
         let now_ms = now.as_millisecond();
         let mut expired_keys = Vec::new();
 
-        for item in ExpirationRow::iter(&self.tables)? {
+        for item in ExpirationRow::values(&self.tables)? {
             if item.expiration_time.as_millisecond() < now_ms && removed < EXPIRATION_BATCH_SIZE {
                 expired_keys.push(item.key);
                 removed += 1;

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
-use fjall_utils::TableRow;
+use coyote_error::ResultExt;
+use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -59,9 +60,15 @@ impl ExpirationKey {
     }
 }
 
-impl AsRef<[u8]> for ExpirationKey {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
+impl TableKey for ExpirationKey {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.0.as_bytes())
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> coyote_error::Result<Self> {
+        String::from_utf8(bytes.to_owned())
+            .map(Self)
+            .map_err_generic()
     }
 }
 

--- a/crates/stream/src/tables.rs
+++ b/crates/stream/src/tables.rs
@@ -6,7 +6,7 @@ use std::{
 
 use coyote_error::{Error, HttpError, Result};
 use fjall::OwnedWriteBatch;
-use fjall_utils::TableRow;
+use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -325,9 +325,13 @@ impl LeaseRow {
     }
 }
 
-impl AsRef<[u8]> for LeaseKey {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
+impl TableKey for LeaseKey {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(&self.0)
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(Self(bytes.to_owned()))
     }
 }
 

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -1,16 +1,18 @@
 use std::{
+    borrow::Cow,
     fmt::Debug,
     ops::{Bound, RangeBounds},
     path::Path,
 };
 
 use anyhow::Context;
-use byteorder::{BigEndian, ByteOrder};
-use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable, Slice, UserKey};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
+use fjall_utils::{KeyspaceExt, MonotonicTableRowExt, TableRow};
 use openraft::{
     Entry, LogId, OptionalSend, RaftLogId, RaftLogReader, RaftTypeConfig, StorageError, Vote,
     storage::{LogFlushed, RaftLogStorage},
 };
+use serde::{Deserialize, Serialize};
 use tap::{Pipe, Tap, TapFallible};
 use tracing::{Instrument as _, Span};
 
@@ -18,29 +20,9 @@ use super::{NodeId, errors::*, raft::TypeConfig};
 
 // This is an implementation of an openraft Logs store backed by fjall
 
-#[derive(Debug, PartialEq, Clone)]
-enum LogError {
-    KeyDeserializationError,
-}
-
-impl std::error::Error for LogError {
-    fn description(&self) -> &str {
-        "Internal error processing logs"
-    }
-
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
-
-impl std::fmt::Display for LogError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO: fix this
-        write!(f, "{self:?}")
-    }
-}
-
 type StorageResult<T> = Result<T, StorageError<NodeId>>;
+
+type LogEntry = <TypeConfig as RaftTypeConfig>::Entry;
 
 #[derive(Clone)]
 pub struct CoyoteLogs {
@@ -49,40 +31,27 @@ pub struct CoyoteLogs {
     log_keyspace: Keyspace,
 }
 
-type KeyType = [u8; 8];
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+struct Log(LogEntry);
 
-fn index_to_key(index: u64) -> KeyType {
-    let mut buf = [0u8; 8];
-    BigEndian::write_u64(&mut buf, index);
-    buf
-}
+impl TableRow for Log {
+    const TABLE_PREFIX: &str = "log";
+    type Key = u64;
 
-fn key_to_index(key: Slice) -> Result<u64, LogError> {
-    if key.len() != 8 {
-        return Err(LogError::KeyDeserializationError);
-    }
-    Ok(BigEndian::read_u64(&key))
-}
-
-fn range_to_start<RB: RangeBounds<u64>>(range: RB) -> KeyType {
-    match range.start_bound() {
-        Bound::Included(i) => index_to_key(*i),
-        Bound::Excluded(i) => index_to_key(*i + 1),
-        Bound::Unbounded => index_to_key(0),
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Owned(self.0.log_id.index)
     }
 }
 
-impl<C> RaftLogReader<C> for CoyoteLogs
-where
-    C: RaftTypeConfig,
-{
+impl RaftLogReader<TypeConfig> for CoyoteLogs {
     #[tracing::instrument(skip(self))]
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+    ) -> Result<Vec<LogEntry>, StorageError<NodeId>> {
         let output = self
-            .read_log_entries::<C, RB>(range.clone())
+            .read_log_entries::<RB>(range.clone())
             .await
             .map_err(read_logs_err)?;
         let output_keys = output.iter().map(|e| e.get_log_id());
@@ -220,15 +189,7 @@ impl CoyoteLogs {
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             let keys = entries.iter().map(|entry| entry.log_id).collect::<Vec<_>>();
             tracing::trace!(?keys, "appending some entries");
-            let key_vs = entries
-                .into_iter()
-                .map(|entry| (index_to_key(entry.log_id.index), entry));
-            let mut ingest = keyspace.start_ingestion()?;
-            for (id, raw_value) in key_vs {
-                let value = rmp_serde::to_vec(&raw_value)?;
-                ingest.write(id, value)?;
-            }
-            ingest.finish()?;
+            keyspace.ingest_rows(entries.into_iter().map(Log))?;
             Ok(())
         })
         .await??;
@@ -247,12 +208,7 @@ impl CoyoteLogs {
         let log_keyspace = self.log_keyspace.clone();
         let mut tx = self.db.batch().durability(Some(PersistMode::SyncAll));
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let keys: Vec<UserKey> = log_keyspace
-                .range(index_to_key(log_id.index)..)
-                .map(|g| g.key())
-                .collect::<Result<Vec<_>, fjall::Error>>()?;
-            tracing::trace!(?keys, ?log_id, "deleting items after log_id (inclusive)");
-            for key in keys {
+            for key in Log::keys_in_range(&log_keyspace, log_id.index..)? {
                 tx.remove(&log_keyspace, key);
             }
             tx.commit()?;
@@ -268,12 +224,7 @@ impl CoyoteLogs {
         let serialized_log_id = rmp_serde::encode::to_vec(&log_id)?;
         let mut tx = self.db.batch().durability(Some(PersistMode::SyncAll));
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let keys: Vec<UserKey> = log_keyspace
-                .range(..=index_to_key(log_id.index))
-                .map(|g| g.key())
-                .collect::<Result<Vec<_>, fjall::Error>>()?;
-            tracing::trace!(?keys, ?log_id, "deleting items before log_id (inclusive)");
-            for key in keys {
+            for key in Log::keys_in_range(&log_keyspace, ..=log_id.index)? {
                 tx.remove(&log_keyspace, key);
             }
             tx.insert(&meta_keyspace, "last_purged_log_id", serialized_log_id);
@@ -290,21 +241,16 @@ impl CoyoteLogs {
             .get("last_purged_log_id")
             .unwrap()
             .map(|l| rmp_serde::from_slice(&l).unwrap());
-        let first_id = self
-            .log_keyspace
-            .first_key_value()
-            .map(|g| key_to_index(g.key().unwrap()).unwrap());
-        let last_id = self
-            .log_keyspace
-            .last_key_value()
-            .map(|g| key_to_index(g.key().unwrap()).unwrap());
+        let first_id = Log::range(&self.log_keyspace, ..)
+            .next()
+            .map(|l| l.unwrap().0);
+        let last_id = Log::range(&self.log_keyspace, ..)
+            .next_back()
+            .map(|l| l.unwrap().0);
         tracing::trace!(?last_purged_log_id, first_id, last_id, "log metadata");
-        let tx = self.db.snapshot();
-        for guard in tx.iter(&self.log_keyspace) {
-            let (key, value) = guard.into_inner().unwrap();
-            let value: Entry<TypeConfig> = rmp_serde::from_slice(&value).unwrap();
-            let index = key_to_index(key).unwrap();
-            tracing::trace!(?value, ?index, "log");
+        for row in Log::range(&self.log_keyspace, ..) {
+            let (index, value) = row.unwrap();
+            tracing::trace!(?index, ?value, "log");
         }
         tracing::trace!("END LOG TRACE");
     }
@@ -337,14 +283,18 @@ impl CoyoteLogs {
         .await?
     }
 
-    async fn read_log_entries<C, RB>(&mut self, range: RB) -> anyhow::Result<Vec<C::Entry>>
+    async fn read_log_entries<RB>(&mut self, range: RB) -> anyhow::Result<Vec<LogEntry>>
     where
-        C: RaftTypeConfig,
         RB: RangeBounds<u64> + Clone + Debug + OptionalSend,
     {
-        let db = self.db.clone();
         let log_keyspace = self.log_keyspace.clone();
-        let iter_range = range_to_start(range.clone())..;
+        // For some reason, RB isn't specified as Send in the trait, so we can't
+        // use it directly across the boundary. ARGH!
+        let send_range = match range.start_bound() {
+            Bound::Unbounded => 0..,
+            Bound::Included(i) => *i..,
+            Bound::Excluded(i) => (*i + 1)..,
+        };
         // why isn't RB always Send? it's a goddamn range...
         let end = match range.end_bound() {
             Bound::Unbounded => None,
@@ -353,20 +303,16 @@ impl CoyoteLogs {
         };
         tokio::task::spawn_blocking(move || {
             let mut output = vec![];
-            let tx = db.snapshot();
-            for guard in tx.range(&log_keyspace, iter_range) {
-                let (key, value) = guard
-                    .into_inner()
-                    .tap_err(|err| tracing::warn!(?err, "Error reading values from log"))?;
-                let index = key_to_index(key)
-                    .tap_err(|err| tracing::warn!(?err, "Error parsing key from log"))?;
+            for row in Log::range(&log_keyspace, send_range) {
+                let (key, value) =
+                    row.tap_err(|err| tracing::warn!(?err, "Error reading values from log"))?;
                 if let Some(end) = end
-                    && index >= end
+                    && key >= end
                 {
                     break;
                 }
-                let value = rmp_serde::from_slice(&value)?;
-                output.push(value);
+
+                output.push(value.0);
             }
             Ok(output)
         })


### PR DESCRIPTION
This ports the `CoyoteLogs` system to use `fjall-utils::TableRow` for storage, as a precursor for storing multiple logical "tables" in this keyspace (for #35).

To do this, I made pretty substantial refactors for TableRow. Instead of the key being `AsRef<u8>`, there's a dedicated `TableKey` trait with provided impls for `String`, `Vec<u8>`, `Uuid`, and `u64`. There's also a related `MonotonicTableKey` trait for types whose serialized byte format is monotonic with their raw format (currently only implemented for big-endian-serialized u64; might be safe for UUID but I need to confirm how the bytes are ordered in its `.as_bytes()` method); implementing this for your `Key` unlocks some new `range`-related methods. Notably, this trait is not implemented for `String`, since the sorting of strings is not the same as the sorting of their utf8-encoded bytestreams.