### PR TITLE
Disallow use of serde_json::Value

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,4 @@
 disallowed-types = [
     { path = "axum::Json", replacement = "coyote_proto::MsgPackOrJson" },
+    { path = "serde_json::Value", reason = "not compatible with msgpack" },
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ rmpv = "1.3.1"
 rustls = "0.23.31"
 schemars = { version = "1.2.0", features = ["jiff02", "uuid1"] }
 serde = { version = "1.0.184", features = ["derive", "rc"] }
-serde_json = { version = "1.0.74", features = ["arbitrary_precision", "raw_value"] }
+serde_json = { version = "1.0.74", features = ["raw_value"] }
 serde_path_to_error = "0.1.7"
 static_assertions = "1.1"
 stream.path = "crates/stream"

--- a/crates/test-utils/src/test_client.rs
+++ b/crates/test-utils/src/test_client.rs
@@ -205,6 +205,7 @@ impl TestResponse {
 
     #[must_use]
     #[track_caller]
+    #[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
     pub fn json(&self) -> serde_json::Value {
         assert_eq!(
             self.headers().get(header::CONTENT_TYPE),

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -1,4 +1,4 @@
-use serde_json::{Value, json};
+use serde_json::json;
 use test_utils::{
     StatusCode, TestClient, TestResult,
     server::{TestContext, start_server},
@@ -17,7 +17,8 @@ async fn cache_set(client: &TestClient, key: &str, expire_in: u64, value: &str) 
     Ok(())
 }
 
-async fn cache_get(client: &TestClient, key: &str) -> TestResult<Value> {
+#[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
+async fn cache_get(client: &TestClient, key: &str) -> TestResult<serde_json::Value> {
     let response = client
         .post("cache/get")
         .json(json!({

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
-use serde_json::{Value, json};
+use serde_json::json;
 use test_utils::{
     StatusCode, TestClient, TestResult,
     server::{TestContext, start_server},
 };
 
-async fn start(client: &TestClient, key: &str, ttl_seconds: u64) -> TestResult<Value> {
+#[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
+async fn start(client: &TestClient, key: &str, ttl_seconds: u64) -> TestResult<serde_json::Value> {
     let response = client
         .post("idempotency/start")
         .json(json!({

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use jiff::Timestamp;
-use serde_json::{Value, json};
+use serde_json::json;
 use test_utils::{
     StatusCode, TestClient, TestResult,
     server::{TestContext, start_server},
@@ -27,7 +27,8 @@ async fn kv_set(
     Ok(())
 }
 
-async fn kv_get(client: &TestClient, key: &str) -> TestResult<Value> {
+#[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
+async fn kv_get(client: &TestClient, key: &str) -> TestResult<serde_json::Value> {
     let response = client
         .post("kv/get")
         .json(json!({

--- a/tests/it/rate_limiter.rs
+++ b/tests/it/rate_limiter.rs
@@ -1,11 +1,12 @@
 use std::time::Duration;
 
-use serde_json::{Value, json};
+use serde_json::json;
 use test_utils::{
     StatusCode, TestClient, TestResult,
     server::{TestContext, start_server},
 };
 
+#[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
 async fn call_limit_token_bucket(
     client: &TestClient,
     key: &str,
@@ -13,7 +14,7 @@ async fn call_limit_token_bucket(
     capacity: u64,
     refill_amount: u64,
     refill_interval_seconds: u64,
-) -> TestResult<Value> {
+) -> TestResult<serde_json::Value> {
     let response = client
         .post("rate-limiter/limit")
         .json(json!({


### PR DESCRIPTION
I would like to make sure we don't accidentally introduce `serde_json::Value` in any production codepaths (tests are fine, as is OpenAPI spec generation).

Also we were enabling a `serde_json` feature we don't need (for arbitrary precision of numbers, allows lossless JSON to JSON roundtrips of numbers - I don't think msgpack has arbitrary precision numbers though).