### PR TITLE
Add OpenAPI linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: just test --profile ci
   check-codegen:
-    name: Check openapi.json and SDKs
+    name: Check openapi.json and SDK freshness
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -6,3 +6,18 @@ jobs:
   ci:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
+  lint-openapi:
+    name: Lint openapi.json
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pb33f/vacuum-action@v2
+        with:
+          openapi_path: openapi.json
+          ruleset: .vacuum.yaml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # raise this as time goes on and we fix some stuff
+          minimum_score: 50

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .TODO.md
 logs
 .data/
+
+# vacuum HTML report
+/report.html

--- a/.vacuum.yaml
+++ b/.vacuum.yaml
@@ -1,0 +1,715 @@
+rules:
+  # custom rules
+  snake-case-properties:
+    category:
+      id: schemas
+    description: Schema property names should use snake_case for consistency.
+    given: $.components.schemas.*.properties
+    id: snake-case-properties
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: casing
+      functionOptions:
+        type: snake
+    type: style
+  pascal-case-schemas:
+    category:
+      id: schemas
+    description: Schema names should use PascalCase for consistency.
+    given: $.components.schemas
+    id: pascal-case-components
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: casing
+      functionOptions:
+        type: pascal
+    type: style
+  # rules from recommended ruleset
+  component-description:
+    category:
+      id: descriptions
+    description: Component description check
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Components are the inputs and outputs of a specification. A user needs to be able to understand each component and what it does. Descriptions are critical to understanding components. Add a description!
+    id: component-description
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: oasComponentDescriptions
+    type: validation
+  description-duplication:
+    category:
+      id: descriptions
+    description: Description duplication check
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Descriptions are only useful, if they are meaningful. If a description is meaningful, then it won't be something you copy and paste. Please don't duplicate descriptions, make them deliberate and meaningful.
+    id: description-duplication
+    recommended: true
+    severity: info
+    then:
+      function: oasDescriptionDuplication
+    type: validation
+  duplicate-paths:
+    category:
+      id: operations
+    description: Paths cannot be duplicated; only the last definition will be kept.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Duplicate path definitions found in your OpenAPI specification. In YAML, duplicate keys are allowed, but only the last occurrence is used. This means earlier path definitions are silently ignored, which can lead to missing API endpoints in your specification.
+    id: duplicate-paths
+    recommended: true
+    severity: error
+    then:
+      function: duplicatePaths
+    type: validation
+  duplicated-entry-in-enum:
+    category:
+      id: schemas
+    description: Enum values must not have duplicate entry
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Enums need to be unique, you can't duplicate them in the same definition. Please remove the duplicate value.
+    id: duplicated-entry-in-enum
+    recommended: true
+    severity: error
+    then:
+      function: duplicatedEnum
+    type: validation
+  info-description:
+    category:
+      id: information
+    description: Info section is missing a description
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: The 'info' section is missing a description, surely you want people to know what this spec is all about, right?
+    id: info-description
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: infoDescription
+    type: validation
+  info-license-spdx:
+    category:
+      id: information
+    description: License section cannot contain both an identifier and a URL, they are mutually exclusive.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: A license can contain either a URL or an SPDX identifier, but not both, They are mutually exclusive and cannot both be present. Choose one or the other
+    id: info-license-spdx
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: infoLicenseURLSPDX
+    type: validation
+  no-ambiguous-paths:
+    category:
+      id: operations
+    description: Paths need to resolve unambiguously from one another
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Paths must all resolve unambiguously, they can't be confused with one another (/{id}/ambiguous and /ambiguous/{id} are the same thing. Make sure every path and the variables used are unique and do conflict with one another. Check the ordering of variables and the naming of path segments.
+    id: no-ambiguous-paths
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: noAmbiguousPaths
+    type: validation
+  no-eval-in-markdown:
+    category:
+      description: Validation rules make sure that certain characters or patterns have not been used that may cause issues when rendering in different types of applications.
+      id: validation
+      name: Validation
+    description: Markdown descriptions must not have `eval()` statements'
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Remove all references to 'eval()' in the description. These can be used by malicious actors to embed code in contracts that is then executed when read by a browser.
+    id: no-eval-in-markdown
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: noEvalDescription
+      functionOptions:
+        pattern: eval\(
+    type: validation
+  no-request-body:
+    category:
+      id: operations
+    description: HTTP GET and DELETE should not accept request bodies
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Remove 'requestBody' from HTTP GET and DELETE methods
+    id: no-request-body
+    recommended: true
+    severity: warn
+    then:
+      function: noRequestBody
+    type: style
+  no-script-tags-in-markdown:
+    category:
+      description: Validation rules make sure that certain characters or patterns have not been used that may cause issues when rendering in different types of applications.
+      id: validation
+      name: Validation
+    description: Markdown descriptions must not have `<script>` tags'
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Remove all references to '<script>' tags from the description. These can be used by malicious actors to load remote code if the spec is being parsed by a browser.
+    id: no-script-tags-in-markdown
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: noEvalDescription
+      functionOptions:
+        pattern: <script
+    type: validation
+  no-unnecessary-combinator:
+    category:
+      id: schemas
+    description: Schema combinators (allOf, anyOf, oneOf) with only one item should be replaced with the item directly.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Schema combinators (allOf, anyOf, oneOf) with only a single item are unnecessary and should be replaced with the item directly for cleaner, more readable schemas.
+    id: no-unnecessary-combinator
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: oasUnnecessaryCombinator
+    type: style
+  nullable-enum-contains-null:
+    category:
+      id: schemas
+    description: Nullable enums must explicitly include null in the enum array
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: 'When a schema is marked as nullable (using ''nullable: true'' in OpenAPI 3.0 or ''type: [<type>, "null"]'' in OpenAPI 3.1), and also defines an enum array, the enum must explicitly contain a null value (without quotes). Simply marking the schema as nullable is not enough - the null value must be listed in the enum array. Add null (unquoted) to your enum array, for example: enum: [active, inactive, null]'
+    id: nullable-enum-contains-null
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: nullableEnum
+    type: validation
+  oas-missing-type:
+    category:
+      id: schemas
+    description: All schemas and their properties should have a type field (unless using enum, const, or a composition)
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: 'Add a `type` field to all schemas and properties. Valid types are: string, number, integer, boolean, array, object, or null.'
+    id: oas-missing-type
+    recommended: true
+    severity: info
+    then:
+      function: missingType
+    type: validation
+  oas-schema-check:
+    category:
+      id: schemas
+    description: All document schemas must have a valid type defined
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Make sure each schema has a value type defined. Without a type, the schema is useless
+    id: oas-schema-check
+    recommended: true
+    severity: error
+    then:
+      function: schemaTypeCheck
+    type: validation
+  oas3-api-servers:
+    category:
+      description: Validation rules make sure that certain characters or patterns have not been used that may cause issues when rendering in different types of applications.
+      id: validation
+      name: Validation
+    description: Check for valid API servers definition
+    formats:
+      - oas3
+    given: $
+    howToFix: Ensure server URIs are correct and valid, check the schemes, ensure descriptions are complete.
+    id: oas3-api-servers
+    recommended: true
+    severity: warn
+    then:
+      function: oasAPIServers
+    type: validation
+  oas3-example-external-check:
+    category:
+      description: Examples help consumers understand how API calls should look. They are really important for automated tooling for mocking and testing. These rules check examples have been added to component schemas, parameters and operations. These rules also check that examples match the schema and types provided.
+      id: examples
+      name: Examples
+    description: Examples cannot use both `value` and `externalValue` together.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Examples are critical for consumers to be able to understand schemas and models defined by the spec. Without examples, developers can't understand the type of data the API will return in real life. Examples are turned into mocks and can provide a rich testing capability for APIs. Add detailed examples everywhere!
+    id: oas3-example-external-check
+    recommended: true
+    severity: warn
+    then:
+      function: oasExampleExternal
+    type: validation
+  oas3-missing-example:
+    category:
+      description: Examples help consumers understand how API calls should look. They are really important for automated tooling for mocking and testing. These rules check examples have been added to component schemas, parameters and operations. These rules also check that examples match the schema and types provided.
+      id: examples
+      name: Examples
+    description: Ensure everything that can have an example, contains one
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Examples are critical for consumers to be able to understand schemas and models defined by the spec. Without examples, developers can't understand the type of data the API will return in real life. Examples are turned into mocks and can provide a rich testing capability for APIs. Add detailed examples everywhere!
+    id: oas3-missing-example
+    recommended: true
+    severity: warn
+    then:
+      function: oasExampleMissing
+    type: validation
+  oas3-no-$ref-siblings:
+    category:
+      id: schemas
+    description: '`$ref` values cannot be placed next to other properties, except `description` and `summary`'
+    formats:
+      - oas3_1
+    given: $
+    howToFix: $ref values must not be placed next to sibling nodes, except `description` and `summary` nodes.  This is wrong. remove all additional siblings!
+    id: oas3-no-$ref-siblings
+    recommended: true
+    severity: error
+    then:
+      function: oasRefSiblings
+    type: validation
+  oas3-operation-security-defined:
+    category:
+      description: Security plays a central role in RESTful APIs. These rules make sure that the correct definitions have been used and put in the right places.
+      id: security
+      name: Security
+    description: '`security` values must match a scheme defined in components.securitySchemes'
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: When defining security values for operations, you need to ensure they match the globally defined security schemes. Check $.components.securitySchemes to make sure your values align.
+    id: oas3-operation-security-defined
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: oasOpSecurityDefined
+      functionOptions:
+        schemesPath: $.components.securitySchemes
+    type: validation
+  oas3-parameter-description:
+    category:
+      id: descriptions
+    description: Parameter description checks
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: All parameters should have a description. Descriptions are critical to understanding how an API works correctly. Please add a description to all parameters.
+    id: oas3-parameter-description
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: oasParamDescriptions
+    type: style
+  # disabled temporarily until codegen is adjusted
+  # oas3-schema:
+  #     category:
+  #         id: schemas
+  #     description: OpenAPI 3+ specification is invalid
+  #     formats:
+  #         - oas3
+  #         - oas3_1
+  #         - oas3_2
+  #     given: $
+  #     howToFix: The schema isn't valid OpenAPI 3. Check the errors for more details
+  #     id: oas3-schema
+  #     recommended: true
+  #     severity: error
+  #     then:
+  #         function: oasDocumentSchema
+  #     type: validation
+  oas3-unused-component:
+    category:
+      id: schemas
+    description: Check for unused components and bad references
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Unused components / definitions are generally the result of the OpenAPI contract being updated without considering references. Another reference could have been updated, or an operation changed that no longer references this component. Remove this component from the spec, or re-link to it from another component or operation to fix the problem.
+    id: oas3-unused-component
+    recommended: true
+    severity: warn
+    then:
+      function: oasUnusedComponent
+    type: validation
+  oas3-valid-schema-example:
+    category:
+      description: Examples help consumers understand how API calls should look. They are really important for automated tooling for mocking and testing. These rules check examples have been added to component schemas, parameters and operations. These rules also check that examples match the schema and types provided.
+      id: examples
+      name: Examples
+    description: If an example has been used, check the schema is valid
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Examples are critical for consumers to be able to understand schemas and models defined by the spec. Without examples, developers can't understand the type of data the API will return in real life. Examples are turned into mocks and can provide a rich testing capability for APIs. Add detailed examples everywhere!
+    id: oas3-valid-schema-example
+    recommended: true
+    severity: warn
+    then:
+      function: oasExampleSchema
+    type: validation
+  operation-description:
+    category:
+      id: descriptions
+    description: Operation description checks
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: All operations must have a description. Descriptions explain how the operation works, and how users should use it and what to expect. Operation descriptions make up the bulk of API documentation. so please, add a description!
+    id: operation-description
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: oasDescriptions
+      functionOptions:
+        minWords: "1"
+    type: validation
+  operation-operationId:
+    category:
+      id: operations
+    description: Every operation must contain an `operationId`.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Every single operation needs an operationId. It's a critical requirement to be able to identify each individual operation uniquely. Please add an operationId to the operation.
+    id: operation-operationId
+    recommended: true
+    severity: error
+    then:
+      function: oasOpId
+    type: validation
+  operation-operationId-unique:
+    category:
+      id: operations
+    description: Every operation must have unique `operationId`.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $.paths
+    howToFix: An operationId needs to be unique, there can't be any duplicates in the document, you can't re-use them. Make sure the ID used for this operation is unique.
+    id: operation-operationId-unique
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: oasOpIdUnique
+    type: validation
+  operation-operationId-valid-in-url:
+    category:
+      id: operations
+    description: OperationId must use URL friendly characters
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $.paths[*][*]
+    howToFix: An operationId is critical to correct code generation and operation identification. The operationId should really be designed in a way to make it friendly when used as part of a URL. Remove non-standard URL characters.
+    id: operation-operationId-valid-in-url
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      field: operationId
+      function: pattern
+      functionOptions:
+        match: ^[A-Za-z0-9-._~:/?#\[\]@!\$&'()*+,;=]*$
+    type: validation
+  operation-parameters:
+    category:
+      id: operations
+    description: Operation parameters are unique and non-repeating.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $.paths
+    howToFix: Make sure that all the operation parameters are unique and non-repeating, don't duplicate names, don't re-use parameter names in the same operation.
+    id: operation-parameters
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: oasOpParams
+    type: validation
+  operation-success-response:
+    category:
+      id: operations
+    description: Operation must have at least one `2xx` or a `3xx` response.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Make sure that your operation returns a 'success' response via 2xx or 3xx response code. An API consumer will always expect a success response
+    id: operation-success-response
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      field: responses
+      function: oasOpSuccessResponse
+    type: style
+  operation-tag-defined:
+    category:
+      description: Tags are used as meta-data for operations. They are mainly used by tooling as a taxonomy mechanism to build navigation, search and more. Tags are important as they help consumers navigate the contract when using documentation, testing, code generation or analysis tools.
+      id: tags
+      name: Tags
+    description: Operation tags must be defined in global tags.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: This tag has not been defined in the global scope, you should always ensure that any tags used in operations, are defined globally in the root 'tags' definition.
+    id: operation-tag-defined
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: oasTagDefined
+    type: validation
+  operation-tags:
+    category:
+      description: Tags are used as meta-data for operations. They are mainly used by tooling as a taxonomy mechanism to build navigation, search and more. Tags are important as they help consumers navigate the contract when using documentation, testing, code generation or analysis tools.
+      id: tags
+      name: Tags
+    description: Operation `tags` are missing/empty
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Operations use tags to define the domain(s) they are apart of. Generally a single tag per operation is used, however some tools use multiple tags. The point is that you need tags! Add some tags to the operation that match the globally available ones.
+    id: operation-tags
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: oasOperationTags
+    type: validation
+  path-declarations-must-exist:
+    category:
+      id: operations
+    description: Path parameter declarations must not be empty ex. `/api/{}` is invalid
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $.paths
+    howToFix: Paths define the endpoint for operations. Without paths, there is no API. You need to add 'paths' to the root of the specification.
+    id: path-declarations-must-exist
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: '{}'
+    type: validation
+  path-item-refs:
+    category:
+      id: operations
+    description: Path items should not use references ($ref) values. They are technically not allowed.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Path items should not use references for defining operations. It's technically allowed, but not great style
+    id: path-item-refs
+    recommended: true
+    severity: info
+    then:
+      function: pathItemReferences
+    type: validation
+  path-keys-no-trailing-slash:
+    category:
+      id: operations
+    description: Path must not end with a slash
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $.paths
+    howToFix: Paths should not end with a trailing slash, it can confuse tooling and isn't valid as a path Remove the trailing slash from the path.
+    id: path-keys-no-trailing-slash
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: .+\/$
+    type: validation
+  path-not-include-query:
+    category:
+      id: operations
+    description: Path must not include query string
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $.paths
+    howToFix: Query strings are defined as parameters for an operation, they should not be included in the path Please remove it and correctly define as a parameter.
+    id: path-not-include-query
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: \?
+    type: validation
+  path-params:
+    category:
+      id: operations
+    description: Path parameters must be defined and valid.
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+    given: $
+    howToFix: Path parameters need to match up with the parameters defined for the path, or in an operation that sits under that path. Make sure variable names match up and are defined correctly.
+    id: path-params
+    recommended: true
+    resolved: true
+    severity: error
+    then:
+      function: oasPathParam
+    type: validation
+  paths-kebab-case:
+    category:
+      id: operations
+    description: Path segments must only use kebab-case (no underscores or uppercase)
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Path segments should not contain any uppercase letters, punctuation or underscores. The only valid way to separate words in a segment, is to use a hyphen '-'. The elements that are violating the rule are highlighted in the violation description. These are the elements that need to change.
+    id: paths-kebab-case
+    recommended: true
+    severity: warn
+    then:
+      function: pathsKebabCase
+    type: validation
+  typed-enum:
+    category:
+      id: schemas
+    description: Enum values must respect the specified type
+    formats:
+      - oas3
+      - oas3_1
+      - oas3_2
+      - oas2
+    given: $
+    howToFix: Enum values lock down the number of variable inputs a parameter or schema can have. The problem here is that the Enum defined, does not match the specified type. Fix the type!
+    id: typed-enum
+    recommended: true
+    resolved: true
+    severity: warn
+    then:
+      function: typedEnum
+    type: validation

--- a/clients/cli/src/cmds/api/health.rs
+++ b/clients/cli/src/cmds/api/health.rs
@@ -1,0 +1,33 @@
+// this file is @generated
+use clap::{Args, Subcommand};
+use coyote_client::CoyoteClient;
+
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true, flatten_help = true)]
+pub struct HealthArgs {
+    #[command(subcommand)]
+    pub command: HealthCommands,
+}
+
+#[derive(Subcommand)]
+pub enum HealthCommands {
+    /// Verify the server is up and running.
+    Ping {},
+}
+
+impl HealthCommands {
+    pub async fn exec(
+        self,
+        client: &CoyoteClient,
+        color_mode: colored_json::ColorMode,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::Ping {} => {
+                let resp = client.health().ping().await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/clients/cli/src/cmds/api/mod.rs
+++ b/clients/cli/src/cmds/api/mod.rs
@@ -1,9 +1,11 @@
 // this file is @generated
 mod cache;
+mod health;
 mod kv;
 mod rate_limiter;
 mod stream;
 
 pub(crate) use self::{
-    cache::CacheArgs, kv::KvArgs, rate_limiter::RateLimiterArgs, stream::StreamArgs,
+    cache::CacheArgs, health::HealthArgs, kv::KvArgs, rate_limiter::RateLimiterArgs,
+    stream::StreamArgs,
 };

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -6,7 +6,7 @@ use concolor_clap::{Color, ColorChoice};
 use coyote_client::{CoyoteClient, CoyoteOptions};
 
 use self::{
-    cmds::api::{CacheArgs, KvArgs, RateLimiterArgs, StreamArgs},
+    cmds::api::{CacheArgs, HealthArgs, KvArgs, RateLimiterArgs, StreamArgs},
     config::Config,
 };
 
@@ -64,6 +64,7 @@ enum RootCommands {
     Kv(KvArgs),
     RateLimit(RateLimiterArgs),
     Stream(StreamArgs),
+    Health(HealthArgs),
     /// Get the version of the Svix CLI
     Version,
     /// Generate the autocompletion script for the specified shell
@@ -112,6 +113,10 @@ async fn main() -> Result<()> {
             args.command.exec(&client, color_mode).await?;
         }
         RootCommands::Stream(args) => {
+            let client = get_client(&cfg?)?;
+            args.command.exec(&client, color_mode).await?;
+        }
+        RootCommands::Health(args) => {
             let client = get_client(&cfg?)?;
             args.command.exec(&client, color_mode).await?;
         }

--- a/clients/rust/src/api/health.rs
+++ b/clients/rust/src/api/health.rs
@@ -1,0 +1,19 @@
+// this file is @generated
+use crate::{Configuration, error::Result, models::*};
+
+pub struct Health<'a> {
+    cfg: &'a Configuration,
+}
+
+impl<'a> Health<'a> {
+    pub(super) fn new(cfg: &'a Configuration) -> Self {
+        Self { cfg }
+    }
+
+    /// Verify the server is up and running.
+    pub async fn ping(&self) -> Result<PingOut> {
+        crate::request::Request::new(http::Method::GET, "/api/v1/health/ping")
+            .execute(self.cfg)
+            .await
+    }
+}

--- a/clients/rust/src/api/mod.rs
+++ b/clients/rust/src/api/mod.rs
@@ -2,12 +2,14 @@
 use crate::CoyoteClient;
 
 mod cache;
+mod health;
 mod kv;
 mod rate_limiter;
 mod stream;
 
 pub use self::{
     cache::{Cache, CacheDeleteOptions, CacheGetOptions, CacheSetOptions},
+    health::Health,
     kv::{Kv, KvDeleteOptions, KvGetOptions, KvSetOptions},
     rate_limiter::{RateLimiter, RateLimiterGetRemainingOptions, RateLimiterLimitOptions},
     stream::{
@@ -20,12 +22,19 @@ impl CoyoteClient {
     pub fn cache(&self) -> Cache<'_> {
         Cache::new(&self.cfg)
     }
+
+    pub fn health(&self) -> Health<'_> {
+        Health::new(&self.cfg)
+    }
+
     pub fn kv(&self) -> Kv<'_> {
         Kv::new(&self.cfg)
     }
+
     pub fn rate_limiter(&self) -> RateLimiter<'_> {
         RateLimiter::new(&self.cfg)
     }
+
     pub fn stream(&self) -> Stream<'_> {
         Stream::new(&self.cfg)
     }

--- a/clients/rust/src/models/mod.rs
+++ b/clients/rust/src/models/mod.rs
@@ -28,6 +28,7 @@ mod kv_set_out;
 mod msg_in;
 mod msg_out;
 mod operation_behavior;
+mod ping_out;
 mod rate_limit_result;
 mod rate_limiter_check_in;
 mod rate_limiter_check_out;
@@ -66,6 +67,7 @@ pub use self::{
     msg_in::MsgIn,
     msg_out::MsgOut,
     operation_behavior::OperationBehavior,
+    ping_out::PingOut,
     rate_limit_result::RateLimitResult,
     rate_limiter_check_in::{RateLimiterCheckIn, RateLimiterCheckInConfig},
     rate_limiter_check_out::RateLimiterCheckOut,

--- a/clients/rust/src/models/ping_out.rs
+++ b/clients/rust/src/models/ping_out.rs
@@ -1,0 +1,14 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PingOut {
+    pub ok: bool,
+}
+
+impl PingOut {
+    pub fn new(ok: bool) -> Self {
+        Self { ok }
+    }
+}

--- a/codegen/templates/rust/api_summary.rs.jinja
+++ b/codegen/templates/rust/api_summary.rs.jinja
@@ -39,5 +39,6 @@ impl CoyoteClient {
         pub fn {{ resource.name | to_snake_case }}(&self) -> {{ resource_type_name }}<'_> {
             {{ resource_type_name }}::new(&self.cfg)
         }
+
     {% endfor -%}
 }

--- a/openapi.json
+++ b/openapi.json
@@ -15,6 +15,9 @@
         "tags": [
           "Health"
         ],
+        "summary": "Ping",
+        "description": "Verify the server is up and running.",
+        "operationId": "v1.health.ping",
         "responses": {
           "200": {
             "description": "",
@@ -26,24 +29,12 @@
               }
             }
           }
-        }
-      },
-      "head": {
-        "tags": [
-          "Health"
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PingOut"
-                }
-              }
-            }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
           }
-        }
+        ]
       }
     },
     "/api/v1/cache/set": {

--- a/src/v1/endpoints/health.rs
+++ b/src/v1/endpoints/health.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use aide::axum::{ApiRouter, routing::get};
+use aide::axum::{ApiRouter, routing::get_with};
+use coyote_derive::aide_annotate;
 use coyote_proto::MsgPackOrJson;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -13,6 +14,8 @@ pub struct PingOut {
     pub ok: bool,
 }
 
+/// Verify the server is up and running.
+#[aide_annotate(op_id = "v1.health.ping")]
 async fn ping() -> Result<MsgPackOrJson<PingOut>> {
     Ok(MsgPackOrJson(PingOut { ok: true }))
 }
@@ -20,5 +23,5 @@ async fn ping() -> Result<MsgPackOrJson<PingOut>> {
 pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Health");
 
-    ApiRouter::new().api_route_with("/health/ping", get(ping).head(ping), &tag)
+    ApiRouter::new().api_route_with("/health/ping", get_with(ping, ping_operation), &tag)
 }


### PR DESCRIPTION
Should the health route be `POST` like everything else? I didn't change it for now.

There are two recommended vacuum checks I removed:
- Properties should be camelCase (added properties must be snake_case instead)
- Paths should not contain request verbs (we intentionally don't do regular CRUD style)