### PR TITLE
Run benchmarks on push to main

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -6,3 +6,33 @@ jobs:
   ci:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest-8-cores
+    defaults:
+      run:
+        working-directory: ./benchmarks
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-criterion
+        run: cargo install cargo-criterion
+      - name: Run benchmarks
+        # For some weird reason, it seems to log test output
+        # to stderr:
+        run: cargo criterion --output-format bencher 2>&1 | tee output.txt
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'cargo'
+          output-file-path: ./benchmarks/output.txt
+          external-data-json-path: ./cache/benchmark-data.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          summary-always: true
+          fail-on-alert: true

--- a/benchmarks/benches/kv.rs
+++ b/benchmarks/benches/kv.rs
@@ -12,6 +12,7 @@ use rand::{
 fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGroup<'a, M>) {
     let client = ctx.client;
 
+    group.sample_size(60);
     group.measurement_time(std::time::Duration::from_secs(15));
 
     let mut rng = StdRng::seed_from_u64(0);


### PR DESCRIPTION
This should run benchmarks when stuff is pushed to main. I've been testing on PRs so not entirely sure the permissions are correct for pushes to main, but let's find out. The benchmark results get put into a "Job summary," which shows up as a description on the relevant job in the Github actions.

These benchmarks are very slow, so I've reduced the sample-size for now until we have a better idea of what things look like on repeated runs.

Note: This was previously approved in #113 , but github being laggy and it was merged to a different branch. 