### PR TITLE
API changes in rate limiter, kv and idempotency modules

### DIFF
--- a/clients/cli/src/cmds/api/idempotency.rs
+++ b/clients/cli/src/cmds/api/idempotency.rs
@@ -1,0 +1,56 @@
+// this file is @generated
+use clap::{Args, Subcommand};
+use coyote_client::CoyoteClient;
+
+#[derive(Args, Clone)]
+pub struct IdempotencyAbortOptions {
+    #[arg(long)]
+    pub idempotency_key: Option<String>,
+}
+
+impl From<IdempotencyAbortOptions> for coyote_client::api::IdempotencyAbortOptions {
+    fn from(value: IdempotencyAbortOptions) -> Self {
+        let IdempotencyAbortOptions { idempotency_key } = value;
+        Self { idempotency_key }
+    }
+}
+
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true, flatten_help = true)]
+pub struct IdempotencyArgs {
+    #[command(subcommand)]
+    pub command: IdempotencyCommands,
+}
+
+#[derive(Subcommand)]
+pub enum IdempotencyCommands {
+    /// Abandon an idempotent request (remove lock without saving response)
+    Abort {
+        idempotency_abort_in: crate::json::JsonOf<coyote_client::models::IdempotencyAbortIn>,
+        #[clap(flatten)]
+        options: IdempotencyAbortOptions,
+    },
+}
+
+impl IdempotencyCommands {
+    pub async fn exec(
+        self,
+        client: &CoyoteClient,
+        color_mode: colored_json::ColorMode,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::Abort {
+                idempotency_abort_in,
+                options,
+            } => {
+                let resp = client
+                    .idempotency()
+                    .abort(idempotency_abort_in.into_inner(), Some(options.into()))
+                    .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/clients/cli/src/cmds/api/mod.rs
+++ b/clients/cli/src/cmds/api/mod.rs
@@ -1,11 +1,12 @@
 // this file is @generated
 mod cache;
+mod health;
 mod idempotency;
 mod kv;
 mod rate_limiter;
 mod stream;
 
 pub(crate) use self::{
-    cache::CacheArgs, idempotency::IdempotencyArgs, kv::KvArgs, rate_limiter::RateLimiterArgs,
-    stream::StreamArgs,
+    cache::CacheArgs, health::HealthArgs, idempotency::IdempotencyArgs, kv::KvArgs,
+    rate_limiter::RateLimiterArgs, stream::StreamArgs,
 };

--- a/clients/cli/src/cmds/api/mod.rs
+++ b/clients/cli/src/cmds/api/mod.rs
@@ -1,11 +1,11 @@
 // this file is @generated
 mod cache;
-mod health;
+mod idempotency;
 mod kv;
 mod rate_limiter;
 mod stream;
 
 pub(crate) use self::{
-    cache::CacheArgs, health::HealthArgs, kv::KvArgs, rate_limiter::RateLimiterArgs,
+    cache::CacheArgs, idempotency::IdempotencyArgs, kv::KvArgs, rate_limiter::RateLimiterArgs,
     stream::StreamArgs,
 };

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -6,7 +6,7 @@ use concolor_clap::{Color, ColorChoice};
 use coyote_client::{CoyoteClient, CoyoteOptions};
 
 use self::{
-    cmds::api::{CacheArgs, HealthArgs, KvArgs, RateLimiterArgs, StreamArgs},
+    cmds::api::{CacheArgs, IdempotencyArgs, KvArgs, RateLimiterArgs, StreamArgs},
     config::Config,
 };
 
@@ -61,6 +61,7 @@ impl Cli {
 #[derive(Subcommand)]
 enum RootCommands {
     Cache(CacheArgs),
+    Idempotency(IdempotencyArgs),
     Kv(KvArgs),
     RateLimit(RateLimiterArgs),
     Stream(StreamArgs),
@@ -100,6 +101,10 @@ async fn main() -> Result<()> {
 
         // Remote API calls
         RootCommands::Cache(args) => {
+            let client = get_client(&cfg?)?;
+            args.command.exec(&client, color_mode).await?;
+        }
+        RootCommands::Idempotency(args) => {
             let client = get_client(&cfg?)?;
             args.command.exec(&client, color_mode).await?;
         }

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -6,7 +6,7 @@ use concolor_clap::{Color, ColorChoice};
 use coyote_client::{CoyoteClient, CoyoteOptions};
 
 use self::{
-    cmds::api::{CacheArgs, IdempotencyArgs, KvArgs, RateLimiterArgs, StreamArgs},
+    cmds::api::{CacheArgs, HealthArgs, IdempotencyArgs, KvArgs, RateLimiterArgs, StreamArgs},
     config::Config,
 };
 

--- a/clients/rust/src/api/idempotency.rs
+++ b/clients/rust/src/api/idempotency.rs
@@ -1,0 +1,32 @@
+// this file is @generated
+use crate::{Configuration, error::Result, models::*};
+
+#[derive(Default)]
+pub struct IdempotencyAbortOptions {
+    pub idempotency_key: Option<String>,
+}
+
+pub struct Idempotency<'a> {
+    cfg: &'a Configuration,
+}
+
+impl<'a> Idempotency<'a> {
+    pub(super) fn new(cfg: &'a Configuration) -> Self {
+        Self { cfg }
+    }
+
+    /// Abandon an idempotent request (remove lock without saving response)
+    pub async fn abort(
+        &self,
+        idempotency_abort_in: IdempotencyAbortIn,
+        options: Option<IdempotencyAbortOptions>,
+    ) -> Result<IdempotencyAbortOut> {
+        let IdempotencyAbortOptions { idempotency_key } = options.unwrap_or_default();
+
+        crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/abort")
+            .with_optional_header_param("idempotency-key", idempotency_key)
+            .with_body_param(idempotency_abort_in)
+            .execute(self.cfg)
+            .await
+    }
+}

--- a/clients/rust/src/api/mod.rs
+++ b/clients/rust/src/api/mod.rs
@@ -2,6 +2,7 @@
 use crate::CoyoteClient;
 
 mod cache;
+mod health;
 mod idempotency;
 mod kv;
 mod rate_limiter;
@@ -9,6 +10,7 @@ mod stream;
 
 pub use self::{
     cache::{Cache, CacheDeleteOptions, CacheGetOptions, CacheSetOptions},
+    health::Health,
     idempotency::{Idempotency, IdempotencyAbortOptions},
     kv::{Kv, KvDeleteOptions, KvGetOptions, KvSetOptions},
     rate_limiter::{RateLimiter, RateLimiterGetRemainingOptions, RateLimiterLimitOptions},
@@ -22,9 +24,15 @@ impl CoyoteClient {
     pub fn cache(&self) -> Cache<'_> {
         Cache::new(&self.cfg)
     }
+
+    pub fn health(&self) -> Health<'_> {
+        Health::new(&self.cfg)
+    }
+
     pub fn idempotency(&self) -> Idempotency<'_> {
         Idempotency::new(&self.cfg)
     }
+
     pub fn kv(&self) -> Kv<'_> {
         Kv::new(&self.cfg)
     }

--- a/clients/rust/src/api/mod.rs
+++ b/clients/rust/src/api/mod.rs
@@ -2,14 +2,14 @@
 use crate::CoyoteClient;
 
 mod cache;
-mod health;
+mod idempotency;
 mod kv;
 mod rate_limiter;
 mod stream;
 
 pub use self::{
     cache::{Cache, CacheDeleteOptions, CacheGetOptions, CacheSetOptions},
-    health::Health,
+    idempotency::{Idempotency, IdempotencyAbortOptions},
     kv::{Kv, KvDeleteOptions, KvGetOptions, KvSetOptions},
     rate_limiter::{RateLimiter, RateLimiterGetRemainingOptions, RateLimiterLimitOptions},
     stream::{
@@ -22,11 +22,9 @@ impl CoyoteClient {
     pub fn cache(&self) -> Cache<'_> {
         Cache::new(&self.cfg)
     }
-
-    pub fn health(&self) -> Health<'_> {
-        Health::new(&self.cfg)
+    pub fn idempotency(&self) -> Idempotency<'_> {
+        Idempotency::new(&self.cfg)
     }
-
     pub fn kv(&self) -> Kv<'_> {
         Kv::new(&self.cfg)
     }

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -125,7 +125,7 @@ mod tests {
         let client = CoyoteClient::new(String::new(), None);
         let cache_api = client.cache();
         let fut = cache_api.set(
-            CacheSetIn::new(0, "key".to_owned(), "value".to_owned()),
+            CacheSetIn::new("key".to_owned(), 0, "value".as_bytes().to_vec()),
             None,
         );
         require_send_sync(fut);

--- a/clients/rust/src/models/cache_get_out.rs
+++ b/clients/rust/src/models/cache_get_out.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct CacheGetOut {
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires: Option<jiff::Timestamp>,
+    pub expiry: Option<jiff::Timestamp>,
 
     pub key: String,
 
@@ -16,7 +16,7 @@ pub struct CacheGetOut {
 impl CacheGetOut {
     pub fn new(key: String, value: Vec<u8>) -> Self {
         Self {
-            expires: None,
+            expiry: None,
             key,
             value,
         }

--- a/clients/rust/src/models/cache_get_out.rs
+++ b/clients/rust/src/models/cache_get_out.rs
@@ -6,17 +6,17 @@ use serde::{Deserialize, Serialize};
 pub struct CacheGetOut {
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<jiff::Timestamp>,
+    pub expires: Option<jiff::Timestamp>,
 
     pub key: String,
 
-    pub value: String,
+    pub value: Vec<u8>,
 }
 
 impl CacheGetOut {
-    pub fn new(key: String, value: String) -> Self {
+    pub fn new(key: String, value: Vec<u8>) -> Self {
         Self {
-            expires_at: None,
+            expires: None,
             key,
             value,
         }

--- a/clients/rust/src/models/cache_set_in.rs
+++ b/clients/rust/src/models/cache_set_in.rs
@@ -4,20 +4,16 @@ use serde::{Deserialize, Serialize};
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CacheSetIn {
-    /// Time to live in milliseconds
-    pub expire_in: u64,
-
     pub key: String,
 
-    pub value: String,
+    /// Time to live in milliseconds
+    pub ttl: u64,
+
+    pub value: Vec<u8>,
 }
 
 impl CacheSetIn {
-    pub fn new(expire_in: u64, key: String, value: String) -> Self {
-        Self {
-            expire_in,
-            key,
-            value,
-        }
+    pub fn new(key: String, ttl: u64, value: Vec<u8>) -> Self {
+        Self { key, ttl, value }
     }
 }

--- a/clients/rust/src/models/idempotency_abort_in.rs
+++ b/clients/rust/src/models/idempotency_abort_in.rs
@@ -1,0 +1,14 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IdempotencyAbortIn {
+    pub key: String,
+}
+
+impl IdempotencyAbortIn {
+    pub fn new(key: String) -> Self {
+        Self { key }
+    }
+}

--- a/clients/rust/src/models/idempotency_abort_out.rs
+++ b/clients/rust/src/models/idempotency_abort_out.rs
@@ -1,0 +1,12 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IdempotencyAbortOut {}
+
+impl IdempotencyAbortOut {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/clients/rust/src/models/kv_get_out.rs
+++ b/clients/rust/src/models/kv_get_out.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct KvGetOut {
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires: Option<jiff::Timestamp>,
+    pub expiry: Option<jiff::Timestamp>,
 
     pub key: String,
 
@@ -16,7 +16,7 @@ pub struct KvGetOut {
 impl KvGetOut {
     pub fn new(key: String, value: Vec<u8>) -> Self {
         Self {
-            expires: None,
+            expiry: None,
             key,
             value,
         }

--- a/clients/rust/src/models/kv_get_out.rs
+++ b/clients/rust/src/models/kv_get_out.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct KvGetOut {
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<jiff::Timestamp>,
+    pub expires: Option<jiff::Timestamp>,
 
     pub key: String,
 
@@ -16,7 +16,7 @@ pub struct KvGetOut {
 impl KvGetOut {
     pub fn new(key: String, value: Vec<u8>) -> Self {
         Self {
-            expires_at: None,
+            expires: None,
             key,
             value,
         }

--- a/clients/rust/src/models/kv_set_in.rs
+++ b/clients/rust/src/models/kv_set_in.rs
@@ -9,11 +9,11 @@ pub struct KvSetIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub behavior: Option<OperationBehavior>,
 
+    pub key: String,
+
     /// Time to live in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expire_in: Option<u64>,
-
-    pub key: String,
+    pub ttl: Option<u64>,
 
     pub value: Vec<u8>,
 }
@@ -22,8 +22,8 @@ impl KvSetIn {
     pub fn new(key: String, value: Vec<u8>) -> Self {
         Self {
             behavior: None,
-            expire_in: None,
             key,
+            ttl: None,
             value,
         }
     }

--- a/clients/rust/src/models/mod.rs
+++ b/clients/rust/src/models/mod.rs
@@ -19,6 +19,8 @@ mod dlq_in;
 mod dlq_out;
 mod fetch_from_stream_in;
 mod fetch_from_stream_out;
+mod idempotency_abort_in;
+mod idempotency_abort_out;
 mod kv_delete_in;
 mod kv_delete_out;
 mod kv_get_in;
@@ -28,8 +30,7 @@ mod kv_set_out;
 mod msg_in;
 mod msg_out;
 mod operation_behavior;
-mod ping_out;
-mod rate_limit_result;
+mod rate_limit_status;
 mod rate_limiter_check_in;
 mod rate_limiter_check_out;
 mod rate_limiter_fixed_window_config;
@@ -58,6 +59,8 @@ pub use self::{
     dlq_out::DlqOut,
     fetch_from_stream_in::FetchFromStreamIn,
     fetch_from_stream_out::FetchFromStreamOut,
+    idempotency_abort_in::IdempotencyAbortIn,
+    idempotency_abort_out::IdempotencyAbortOut,
     kv_delete_in::KvDeleteIn,
     kv_delete_out::KvDeleteOut,
     kv_get_in::KvGetIn,
@@ -67,8 +70,7 @@ pub use self::{
     msg_in::MsgIn,
     msg_out::MsgOut,
     operation_behavior::OperationBehavior,
-    ping_out::PingOut,
-    rate_limit_result::RateLimitResult,
+    rate_limit_status::RateLimitStatus,
     rate_limiter_check_in::{RateLimiterCheckIn, RateLimiterCheckInConfig},
     rate_limiter_check_out::RateLimiterCheckOut,
     rate_limiter_fixed_window_config::RateLimiterFixedWindowConfig,

--- a/clients/rust/src/models/mod.rs
+++ b/clients/rust/src/models/mod.rs
@@ -30,6 +30,7 @@ mod kv_set_out;
 mod msg_in;
 mod msg_out;
 mod operation_behavior;
+mod ping_out;
 mod rate_limit_status;
 mod rate_limiter_check_in;
 mod rate_limiter_check_out;
@@ -70,6 +71,7 @@ pub use self::{
     msg_in::MsgIn,
     msg_out::MsgOut,
     operation_behavior::OperationBehavior,
+    ping_out::PingOut,
     rate_limit_status::RateLimitStatus,
     rate_limiter_check_in::{RateLimiterCheckIn, RateLimiterCheckInConfig},
     rate_limiter_check_out::RateLimiterCheckOut,

--- a/clients/rust/src/models/rate_limit_status.rs
+++ b/clients/rust/src/models/rate_limit_status.rs
@@ -5,18 +5,18 @@ use serde::{Deserialize, Serialize};
 
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-pub enum RateLimitResult {
-    #[serde(rename = "OK")]
+pub enum RateLimitStatus {
+    #[serde(rename = "ok")]
     Ok,
-    #[serde(rename = "BLOCK")]
+    #[serde(rename = "block")]
     Block,
 }
 
-impl fmt::Display for RateLimitResult {
+impl fmt::Display for RateLimitStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let value = match self {
-            Self::Ok => "OK",
-            Self::Block => "BLOCK",
+            Self::Ok => "ok",
+            Self::Block => "block",
         };
         f.write_str(value)
     }

--- a/clients/rust/src/models/rate_limiter_check_in.rs
+++ b/clients/rust/src/models/rate_limiter_check_in.rs
@@ -11,9 +11,9 @@ use super::{
 pub struct RateLimiterCheckIn {
     pub key: String,
 
-    /// Number of units to consume (default: 1)
+    /// Number of tokens to consume (default: 1)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub units: Option<u64>,
+    pub tokens: Option<u64>,
 
     #[serde(flatten)]
     pub config: RateLimiterCheckInConfig,

--- a/clients/rust/src/models/rate_limiter_check_out.rs
+++ b/clients/rust/src/models/rate_limiter_check_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-use super::rate_limit_result::RateLimitResult;
+use super::rate_limit_status::RateLimitStatus;
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9,20 +9,20 @@ pub struct RateLimiterCheckOut {
     /// Number of tokens remaining
     pub remaining: u64,
 
-    /// Whether the request is allowed
-    pub result: RateLimitResult,
-
     /// Seconds until enough tokens are available (only present when allowed is false)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after: Option<u64>,
+
+    /// Whether the request is allowed
+    pub status: RateLimitStatus,
 }
 
 impl RateLimiterCheckOut {
-    pub fn new(remaining: u64, result: RateLimitResult) -> Self {
+    pub fn new(remaining: u64, status: RateLimitStatus) -> Self {
         Self {
             remaining,
-            result,
             retry_after: None,
+            status,
         }
     }
 }

--- a/clients/rust/src/models/rate_limiter_fixed_window_config.rs
+++ b/clients/rust/src/models/rate_limiter_fixed_window_config.rs
@@ -8,14 +8,14 @@ pub struct RateLimiterFixedWindowConfig {
     pub max_requests: u64,
 
     /// Window size in seconds
-    pub window_size_seconds: u64,
+    pub window_size: u64,
 }
 
 impl RateLimiterFixedWindowConfig {
-    pub fn new(max_requests: u64, window_size_seconds: u64) -> Self {
+    pub fn new(max_requests: u64, window_size: u64) -> Self {
         Self {
             max_requests,
-            window_size_seconds,
+            window_size,
         }
     }
 }

--- a/clients/rust/src/models/rate_limiter_token_bucket_config.rs
+++ b/clients/rust/src/models/rate_limiter_token_bucket_config.rs
@@ -11,15 +11,16 @@ pub struct RateLimiterTokenBucketConfig {
     pub refill_amount: u64,
 
     /// Interval in seconds between refills (minimum 1 second)
-    pub refill_interval_seconds: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refill_interval: Option<u64>,
 }
 
 impl RateLimiterTokenBucketConfig {
-    pub fn new(capacity: u64, refill_amount: u64, refill_interval_seconds: u64) -> Self {
+    pub fn new(capacity: u64, refill_amount: u64) -> Self {
         Self {
             capacity,
             refill_amount,
-            refill_interval_seconds,
+            refill_interval: None,
         }
     }
 }

--- a/crates/idempotency/src/lib.rs
+++ b/crates/idempotency/src/lib.rs
@@ -153,20 +153,23 @@ mod tests {
         let mut store = SetupFixture::new()?.store;
         let value = vec![1, 2, 3];
         let result = store.try_start("test", 10)?;
-        assert_eq!(result, None);
-
-        let result = store.try_start("test", 10);
-        assert!(result.is_err());
-
-        store.abandon("test")?;
+        assert_eq!(result, IdempotencyStartResult::Started);
 
         let result = store.try_start("test", 10)?;
-        assert_eq!(result, None);
+        assert_eq!(result, IdempotencyStartResult::Locked);
+
+        store.abort("test")?;
+
+        let result = store.try_start("test", 10)?;
+        assert_eq!(result, IdempotencyStartResult::Started);
 
         store.complete("test", value.clone(), 10)?;
 
         let result = store.try_start("test", 10)?;
-        assert_eq!(result, Some(value));
+        assert_eq!(
+            result,
+            IdempotencyStartResult::Completed { response: value }
+        );
         Ok(())
     }
 
@@ -179,12 +182,15 @@ mod tests {
         store.complete("test", value.clone(), 10)?;
 
         let result = store.try_start("test", 10)?;
-        assert_eq!(result, Some(value));
+        assert_eq!(
+            result,
+            IdempotencyStartResult::Completed { response: value }
+        );
 
-        // Can abandon a request without starting it first
-        store.abandon("test2")?;
+        // Can abort a request without starting it first
+        store.abort("test2")?;
         let result2 = store.try_start("test2", 10)?;
-        assert_eq!(result2, None);
+        assert_eq!(result2, IdempotencyStartResult::Started);
 
         Ok(())
     }
@@ -199,14 +205,14 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         let result = store.try_start("test", 1)?;
-        assert_eq!(result, None);
+        assert_eq!(result, IdempotencyStartResult::Started);
 
         store.complete("test", value, 1)?;
 
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         let result = store.try_start("test", 1)?;
-        assert_eq!(result, None);
+        assert_eq!(result, IdempotencyStartResult::Started);
 
         Ok(())
     }

--- a/crates/idempotency/src/lib.rs
+++ b/crates/idempotency/src/lib.rs
@@ -11,7 +11,7 @@
 
 use std::time::Duration;
 
-use coyote_error::{Error, HttpError, Result};
+use coyote_error::Result;
 use coyote_kv::{KvModel, KvStore, OperationBehavior};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,14 @@ enum IdempotencyState {
     /// Request is in progress (locked)
     InProgress,
     /// Request completed successfully with a response
+    Completed { response: Vec<u8> },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum IdempotencyStartResult {
+    Started,
+    Locked,
     Completed { response: Vec<u8> },
 }
 
@@ -48,11 +56,7 @@ impl IdempotencyStore {
     }
 
     /// Try to acquire the lock for a request.
-    /// Returns:
-    /// - Ok(None) if lock was acquired (request should proceed)
-    /// - Ok(Some(response)) if request was already completed (return cached response)
-    /// - Err if request is already in progress (conflict)
-    pub fn try_start(&mut self, key: &str, ttl_seconds: u64) -> Result<Option<Vec<u8>>> {
+    pub fn try_start(&mut self, key: &str, ttl_seconds: u64) -> Result<IdempotencyStartResult> {
         let now = Timestamp::now();
         let expires_at = now + Duration::from_secs(ttl_seconds);
 
@@ -64,21 +68,18 @@ impl IdempotencyStore {
                     expires_at: Some(expires_at),
                 };
                 self.kv.set(key, &kv_model, OperationBehavior::Insert)?;
-                Ok(None)
+                Ok(IdempotencyStartResult::Started)
             }
             Some(kv_model) => {
                 let state: IdempotencyState = kv_model.value.into();
                 match state {
                     IdempotencyState::InProgress => {
                         // Still in progress by another request
-                        Err(Error::http(HttpError::conflict(
-                            Some("Request is already in progress".into()),
-                            None,
-                        )))
+                        Ok(IdempotencyStartResult::Locked)
                     }
                     IdempotencyState::Completed { response } => {
                         // Return cached response
-                        Ok(Some(response))
+                        Ok(IdempotencyStartResult::Completed { response })
                     }
                 }
             }
@@ -100,7 +101,7 @@ impl IdempotencyStore {
     }
 
     /// Abandon a request (remove the lock without saving response)
-    pub fn abandon(&mut self, key: &str) -> Result<()> {
+    pub fn abort(&mut self, key: &str) -> Result<()> {
         self.kv.delete(key)
     }
 }

--- a/crates/idempotency/src/lib.rs
+++ b/crates/idempotency/src/lib.rs
@@ -58,14 +58,14 @@ impl IdempotencyStore {
     /// Try to acquire the lock for a request.
     pub fn try_start(&mut self, key: &str, ttl_seconds: u64) -> Result<IdempotencyStartResult> {
         let now = Timestamp::now();
-        let expires_at = now + Duration::from_secs(ttl_seconds);
+        let expiry = now + Duration::from_secs(ttl_seconds);
 
         match self.kv.get(key)? {
             None => {
                 // No existing entry - acquire lock
                 let kv_model = KvModel {
                     value: IdempotencyState::InProgress.into(),
-                    expires_at: Some(expires_at),
+                    expiry: Some(expiry),
                 };
                 self.kv.set(key, &kv_model, OperationBehavior::Insert)?;
                 Ok(IdempotencyStartResult::Started)
@@ -89,11 +89,11 @@ impl IdempotencyStore {
     /// Complete a request with a successful response
     pub fn complete(&mut self, key: &str, response: Vec<u8>, ttl_seconds: u64) -> Result<()> {
         let now = Timestamp::now();
-        let expires_at = now + Duration::from_secs(ttl_seconds);
+        let expiry = now + Duration::from_secs(ttl_seconds);
 
         let kv_model = KvModel {
             value: IdempotencyState::Completed { response }.into(),
-            expires_at: Some(expires_at),
+            expiry: Some(expiry),
         };
         self.kv.set(key, &kv_model, OperationBehavior::Upsert)?;
 

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -23,14 +23,14 @@ use crate::{
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct KvModel {
-    pub expires_at: Option<Timestamp>,
+    pub expiry: Option<Timestamp>,
     pub value: Vec<u8>,
 }
 
 impl From<KvPairRow> for KvModel {
     fn from(row: KvPairRow) -> Self {
         Self {
-            expires_at: row.expires_at,
+            expiry: row.expiry,
             value: row.value,
         }
     }
@@ -79,14 +79,14 @@ impl KvStore {
         }
     }
 
-    fn update_lru(&mut self, key: &str, expires_at: Option<Timestamp>) {
+    fn update_lru(&mut self, key: &str, expiry: Option<Timestamp>) {
         match self.lru.raw_entry_mut().from_key(key) {
             RawEntryMut::Occupied(mut occupied) => {
                 occupied.to_back();
-                *occupied.get_mut() = expires_at;
+                *occupied.get_mut() = expiry;
             }
             RawEntryMut::Vacant(vacant) => {
-                vacant.insert(key.to_string(), expires_at);
+                vacant.insert(key.to_string(), expiry);
             }
         }
     }
@@ -101,12 +101,12 @@ impl KvStore {
             return Ok(None);
         };
 
-        if data.expires_at.is_some_and(|exp| exp < Timestamp::now()) {
+        if data.expiry.is_some_and(|exp| exp < Timestamp::now()) {
             let _ = self.delete(key);
             return Ok(None);
         }
 
-        self.update_lru(key, data.expires_at);
+        self.update_lru(key, data.expiry);
 
         Ok(Some(data.into()))
     }
@@ -117,19 +117,19 @@ impl KvStore {
         let row = KvPairRow {
             key: key.to_string(),
             value: model.value.clone(),
-            expires_at: model.expires_at,
+            expiry: model.expiry,
         };
 
         batch.insert_row(&self.tables, &row)?;
 
-        if let Some(expires_at) = model.expires_at {
-            let expiration_row = ExpirationRow::new(expires_at, key.to_string());
+        if let Some(expiry) = model.expiry {
+            let expiration_row = ExpirationRow::new(expiry, key.to_string());
             batch.insert_row(&self.tables, &expiration_row)?;
         }
 
         batch.commit()?;
 
-        self.update_lru(key, model.expires_at);
+        self.update_lru(key, model.expiry);
 
         Ok(())
     }
@@ -176,8 +176,8 @@ impl KvStore {
 
         if let Some(data) = KvPairRow::fetch(&self.tables, &key.to_string())? {
             // Delete from the expiration keyspace
-            if let Some(expires_at) = data.expires_at {
-                let r = ExpirationRow::new(expires_at, key.to_string());
+            if let Some(expiry) = data.expiry {
+                let r = ExpirationRow::new(expiry, key.to_string());
                 batch.remove_row::<ExpirationRow>(&self.tables, r.get_key().as_ref())?;
             }
             batch.remove_row::<KvPairRow>(&self.tables, &key.to_string())?;
@@ -224,10 +224,10 @@ impl KvStore {
         let mut expired_keys = Vec::new();
 
         for item in ExpirationRow::values(&self.tables)? {
-            if item.expiration_time.as_millisecond() < now_ms && removed < EXPIRATION_BATCH_SIZE {
+            if item.expiry.as_millisecond() < now_ms && removed < EXPIRATION_BATCH_SIZE {
                 expired_keys.push(item.key);
                 removed += 1;
-            } else if item.expiration_time.as_millisecond() >= now_ms {
+            } else if item.expiry.as_millisecond() >= now_ms {
                 // expiration rows are ordered, so we can break early
                 break;
             }
@@ -385,7 +385,7 @@ mod tests {
 
         let key = "test:key1";
         let model = KvModel {
-            expires_at: None,
+            expiry: None,
             value: b"hello world".to_vec(),
         };
 
@@ -396,7 +396,7 @@ mod tests {
         assert!(retrieved.is_some());
         let retrieved = retrieved.unwrap();
         assert_eq!(retrieved.value, b"hello world");
-        assert_eq!(retrieved.expires_at, None);
+        assert_eq!(retrieved.expiry, None);
 
         assert!(!key_exists(&mut store, "nonexistent:key"));
     }
@@ -409,7 +409,7 @@ mod tests {
         let res = store.set(
             "key1",
             &KvModel {
-                expires_at: None,
+                expiry: None,
                 value: b"key1 updated".to_vec(),
             },
             OperationBehavior::Update,
@@ -420,7 +420,7 @@ mod tests {
         let res = store.set(
             "key1",
             &KvModel {
-                expires_at: None,
+                expiry: None,
                 value: b"key1 inserted".to_vec(),
             },
             OperationBehavior::Insert,
@@ -433,7 +433,7 @@ mod tests {
         let res = store.set(
             "key1",
             &KvModel {
-                expires_at: None,
+                expiry: None,
                 value: b"another value".to_vec(),
             },
             OperationBehavior::Insert,
@@ -448,7 +448,7 @@ mod tests {
         let res = store.set(
             "key1",
             &KvModel {
-                expires_at: None,
+                expiry: None,
                 value: b"key1 upserted".to_vec(),
             },
             OperationBehavior::Upsert,
@@ -467,13 +467,13 @@ mod tests {
 
         let key = "overwrite:key";
         let model1 = KvModel {
-            expires_at: None,
+            expiry: None,
             value: b"first value".to_vec(),
         };
         store.set(key, &model1, OperationBehavior::Upsert).unwrap();
 
         let model2 = KvModel {
-            expires_at: None,
+            expiry: None,
             value: b"second value".to_vec(),
         };
         store.set(key, &model2, OperationBehavior::Upsert).unwrap();
@@ -489,7 +489,7 @@ mod tests {
         let mut store = setup.store;
 
         let expired_model = KvModel {
-            expires_at: Some(Timestamp::now().checked_sub(1.hour()).unwrap()),
+            expiry: Some(Timestamp::now().checked_sub(1.hour()).unwrap()),
             value: b"expired data".to_vec(),
         };
         store
@@ -501,21 +501,21 @@ mod tests {
             (
                 "expired:key:1",
                 KvModel {
-                    expires_at: Some(now.checked_sub(3.hour()).unwrap()),
+                    expiry: Some(now.checked_sub(3.hour()).unwrap()),
                     value: b"expired data 1".to_vec(),
                 },
             ),
             (
                 "expired:key:2",
                 KvModel {
-                    expires_at: Some(now.checked_sub(2.hour()).unwrap()),
+                    expiry: Some(now.checked_sub(2.hour()).unwrap()),
                     value: b"expired data 2".to_vec(),
                 },
             ),
             (
                 "expired:key:3",
                 KvModel {
-                    expires_at: Some(now.checked_sub(1.second()).unwrap()), // really close to now
+                    expiry: Some(now.checked_sub(1.second()).unwrap()), // really close to now
                     value: b"expired data 3".to_vec(),
                 },
             ),
@@ -526,7 +526,7 @@ mod tests {
         }
 
         let valid_model = KvModel {
-            expires_at: Some(now.checked_add(1.hour()).unwrap()),
+            expiry: Some(now.checked_add(1.hour()).unwrap()),
             value: b"valid data".to_vec(),
         };
         let valid_key = "valid:key";
@@ -535,7 +535,7 @@ mod tests {
             .unwrap();
 
         let permanent_model = KvModel {
-            expires_at: None,
+            expiry: None,
             value: b"permanent data".to_vec(),
         };
         let permanent_key = "permanent:key";
@@ -563,11 +563,11 @@ mod tests {
         assert_eq!(permanent.unwrap().value, b"permanent data");
     }
 
-    fn insert_key(kv: &mut KvStore, key: &str, expires_at: Option<Timestamp>) {
+    fn insert_key(kv: &mut KvStore, key: &str, expiry: Option<Timestamp>) {
         kv.set(
             key,
             &KvModel {
-                expires_at,
+                expiry,
                 value: key.as_bytes().to_vec(),
             },
             OperationBehavior::Upsert,

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -15,7 +15,7 @@ static_assertions::const_assert!(fjall_utils::are_all_unique(&[
 pub struct KvPairRow {
     pub key: String,
     pub value: Vec<u8>,
-    pub expires_at: Option<Timestamp>,
+    pub expiry: Option<Timestamp>,
 }
 
 impl TableRow for KvPairRow {
@@ -29,7 +29,7 @@ impl TableRow for KvPairRow {
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct ExpirationRow {
-    pub expiration_time: Timestamp,
+    pub expiry: Timestamp,
     pub key: String,
 
     #[serde(skip)]
@@ -37,10 +37,10 @@ pub(crate) struct ExpirationRow {
 }
 
 impl ExpirationRow {
-    pub(crate) fn new(expiration_time: Timestamp, key: String) -> Self {
+    pub(crate) fn new(expiry: Timestamp, key: String) -> Self {
         Self {
-            computed_key: ExpirationKey::from(expiration_time, key.clone()),
-            expiration_time,
+            computed_key: ExpirationKey::from(expiry, key.clone()),
+            expiry,
             key,
         }
     }

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -25,7 +25,8 @@ pub struct RateLimiter {
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone, JsonSchema)]
-pub enum RateLimitResult {
+#[serde(rename_all = "snake_case")]
+pub enum RateLimitStatus {
     OK,
     BLOCK,
 }
@@ -49,7 +50,7 @@ impl RateLimiter {
         identifier: &str,
         delta: u64,
         algorithm: RateLimitConfig,
-    ) -> Result<(RateLimitResult, u64, Option<Duration>)> {
+    ) -> Result<(RateLimitStatus, u64, Option<Duration>)> {
         self.limit_inner(now, identifier, delta, algorithm, true)
     }
 
@@ -60,7 +61,7 @@ impl RateLimiter {
         delta: u64,
         algorithm: RateLimitConfig,
         update: bool,
-    ) -> Result<(RateLimitResult, u64, Option<Duration>)> {
+    ) -> Result<(RateLimitStatus, u64, Option<Duration>)> {
         match algorithm {
             RateLimitConfig::FixedWindow(fw_config) => {
                 let window_start = fw_config.get_window_start(now);
@@ -85,10 +86,10 @@ impl RateLimiter {
                     state.count = max_tokens;
                     let window_end = window_start + fw_config.size;
                     let time_until_reset = window_end.duration_since(now).try_into().unwrap();
-                    (0, RateLimitResult::BLOCK, Some(time_until_reset))
+                    (0, RateLimitStatus::BLOCK, Some(time_until_reset))
                 } else {
                     state.count += delta;
-                    (max_tokens - state.count, RateLimitResult::OK, None)
+                    (max_tokens - state.count, RateLimitStatus::OK, None)
                 };
 
                 if update {
@@ -117,7 +118,7 @@ impl RateLimiter {
                     let retry_after = (filled_per_millis - capacity).div_ceil(delta);
 
                     return Ok((
-                        RateLimitResult::BLOCK,
+                        RateLimitStatus::BLOCK,
                         capacity,
                         Some(Duration::from_millis(retry_after)),
                     ));
@@ -130,7 +131,7 @@ impl RateLimiter {
                     TokenBucketState::insert(&self.tables, &bucket)?;
                 }
 
-                Ok((RateLimitResult::OK, bucket.tokens, None))
+                Ok((RateLimitStatus::OK, bucket.tokens, None))
             }
         }
     }
@@ -145,7 +146,7 @@ impl RateLimiter {
             self.limit_inner(now, identifier, 1, algorithm, false)?;
 
         // We 'simulated' consuming 1 token, so we add it back to get the actual remaining capacity
-        let actual_remaining = if matches!(result, RateLimitResult::OK) {
+        let actual_remaining = if matches!(result, RateLimitStatus::OK) {
             remaining + 1
         } else {
             remaining
@@ -222,19 +223,19 @@ mod tests {
 
             let mut clock = Timestamp::UNIX_EPOCH;
             let (result, remaining, retry_after) = limiter.limit(clock, id, 3, config()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 2);
             assert_eq!(retry_after, None);
 
             clock += Duration::from_millis(500);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 2, config()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, None);
 
             clock += Duration::from_millis(400);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
-            assert!(matches!(result, RateLimitResult::BLOCK));
+            assert!(matches!(result, RateLimitStatus::BLOCK));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, Some(Duration::from_millis(100)));
 
@@ -245,7 +246,7 @@ mod tests {
             // Resets at t=1000ms
             clock += Duration::from_millis(100);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 4);
             assert_eq!(retry_after, None);
 
@@ -283,17 +284,17 @@ mod tests {
 
             let clock = Timestamp::now();
             let (result, remaining, retry_after) = limiter.limit(clock, id, 3, config()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 2);
             assert_eq!(retry_after, None);
 
             let (result, remaining, retry_after) = limiter.limit(clock, id, 2, config()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, None);
 
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
-            assert!(matches!(result, RateLimitResult::BLOCK));
+            assert!(matches!(result, RateLimitStatus::BLOCK));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, Some(Duration::from_millis(100)));
         }
@@ -306,7 +307,7 @@ mod tests {
             let mut clock = Timestamp::now();
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 5, config_refill_2()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, None);
 
@@ -324,7 +325,7 @@ mod tests {
 
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 2, config_refill_2()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 3);
             assert_eq!(retry_after, None);
         }
@@ -346,21 +347,21 @@ mod tests {
 
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 2, make_config()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 4);
             assert_eq!(retry_after, None);
 
             clock += Duration::from_secs(2);
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 1, make_config()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 3);
             assert_eq!(retry_after, None);
 
             clock += Duration::from_secs(3);
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 1, make_config()).unwrap();
-            assert!(matches!(result, RateLimitResult::OK));
+            assert!(matches!(result, RateLimitStatus::OK));
             assert_eq!(remaining, 4); // 4 (previous) + 2 (refill) - 1 (consumed)
             assert_eq!(retry_after, None);
         }

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -27,8 +27,8 @@ pub struct RateLimiter {
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum RateLimitStatus {
-    OK,
-    BLOCK,
+    Ok,
+    Block,
 }
 
 impl RateLimiter {
@@ -86,10 +86,10 @@ impl RateLimiter {
                     state.count = max_tokens;
                     let window_end = window_start + fw_config.size;
                     let time_until_reset = window_end.duration_since(now).try_into().unwrap();
-                    (0, RateLimitStatus::BLOCK, Some(time_until_reset))
+                    (0, RateLimitStatus::Block, Some(time_until_reset))
                 } else {
                     state.count += delta;
-                    (max_tokens - state.count, RateLimitStatus::OK, None)
+                    (max_tokens - state.count, RateLimitStatus::Ok, None)
                 };
 
                 if update {
@@ -118,7 +118,7 @@ impl RateLimiter {
                     let retry_after = (filled_per_millis - capacity).div_ceil(delta);
 
                     return Ok((
-                        RateLimitStatus::BLOCK,
+                        RateLimitStatus::Block,
                         capacity,
                         Some(Duration::from_millis(retry_after)),
                     ));
@@ -131,7 +131,7 @@ impl RateLimiter {
                     TokenBucketState::insert(&self.tables, &bucket)?;
                 }
 
-                Ok((RateLimitStatus::OK, bucket.tokens, None))
+                Ok((RateLimitStatus::Ok, bucket.tokens, None))
             }
         }
     }
@@ -146,7 +146,7 @@ impl RateLimiter {
             self.limit_inner(now, identifier, 1, algorithm, false)?;
 
         // We 'simulated' consuming 1 token, so we add it back to get the actual remaining capacity
-        let actual_remaining = if matches!(result, RateLimitStatus::OK) {
+        let actual_remaining = if matches!(result, RateLimitStatus::Ok) {
             remaining + 1
         } else {
             remaining
@@ -223,19 +223,19 @@ mod tests {
 
             let mut clock = Timestamp::UNIX_EPOCH;
             let (result, remaining, retry_after) = limiter.limit(clock, id, 3, config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 2);
             assert_eq!(retry_after, None);
 
             clock += Duration::from_millis(500);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 2, config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, None);
 
             clock += Duration::from_millis(400);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::BLOCK));
+            assert!(matches!(result, RateLimitStatus::Block));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, Some(Duration::from_millis(100)));
 
@@ -246,7 +246,7 @@ mod tests {
             // Resets at t=1000ms
             clock += Duration::from_millis(100);
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 4);
             assert_eq!(retry_after, None);
 
@@ -284,17 +284,17 @@ mod tests {
 
             let clock = Timestamp::now();
             let (result, remaining, retry_after) = limiter.limit(clock, id, 3, config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 2);
             assert_eq!(retry_after, None);
 
             let (result, remaining, retry_after) = limiter.limit(clock, id, 2, config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, None);
 
             let (result, remaining, retry_after) = limiter.limit(clock, id, 1, config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::BLOCK));
+            assert!(matches!(result, RateLimitStatus::Block));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, Some(Duration::from_millis(100)));
         }
@@ -307,7 +307,7 @@ mod tests {
             let mut clock = Timestamp::now();
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 5, config_refill_2()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 0);
             assert_eq!(retry_after, None);
 
@@ -325,7 +325,7 @@ mod tests {
 
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 2, config_refill_2()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 3);
             assert_eq!(retry_after, None);
         }
@@ -347,21 +347,21 @@ mod tests {
 
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 2, make_config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 4);
             assert_eq!(retry_after, None);
 
             clock += Duration::from_secs(2);
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 1, make_config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 3);
             assert_eq!(retry_after, None);
 
             clock += Duration::from_secs(3);
             let (result, remaining, retry_after) =
                 limiter.limit(clock, id, 1, make_config()).unwrap();
-            assert!(matches!(result, RateLimitStatus::OK));
+            assert!(matches!(result, RateLimitStatus::Ok));
             assert_eq!(remaining, 4); // 4 (previous) + 2 (refill) - 1 (consumed)
             assert_eq!(retry_after, None);
         }

--- a/crates/rate-limiter/src/operations/limit.rs
+++ b/crates/rate-limiter/src/operations/limit.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use super::{LimitResponse, RateLimiterRequest};
-use crate::{RateLimitConfig, RateLimitResult};
+use crate::{RateLimitConfig, RateLimitStatus};
 use coyote_operations::Result;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -10,16 +10,16 @@ use serde::{Deserialize, Serialize};
 pub struct LimitOperation {
     pub(crate) key: String,
     pub(crate) now: Timestamp,
-    pub(crate) units: u64,
+    pub(crate) tokens: u64,
     pub(crate) method: RateLimitConfig,
 }
 
 impl LimitOperation {
-    pub fn new(key: String, now: Timestamp, units: u64, method: RateLimitConfig) -> Self {
+    pub fn new(key: String, now: Timestamp, tokens: u64, method: RateLimitConfig) -> Self {
         Self {
             key,
             now,
-            units,
+            tokens,
             method,
         }
     }
@@ -27,17 +27,17 @@ impl LimitOperation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LimitResponseData {
-    pub result: RateLimitResult,
+    pub status: RateLimitStatus,
     pub remaining: u64,
     pub retry_after: Option<Duration>,
 }
 
 impl LimitOperation {
     fn apply_real(self, state: &crate::RateLimiter) -> Result<LimitResponseData> {
-        let (result, remaining, retry_after) =
-            state.limit(self.now, &self.key, self.units, self.method)?;
+        let (status, remaining, retry_after) =
+            state.limit(self.now, &self.key, self.tokens, self.method)?;
         Ok(LimitResponseData {
-            result,
+            status,
             remaining,
             retry_after,
         })

--- a/openapi.json
+++ b/openapi.json
@@ -517,14 +517,14 @@
         ]
       }
     },
-    "/api/v1/idempotency/abandon": {
+    "/api/v1/idempotency/abort": {
       "post": {
         "tags": [
           "Idempotency"
         ],
-        "summary": "Idempotency Abandon",
+        "summary": "Idempotency Abort",
         "description": "Abandon an idempotent request (remove lock without saving response)",
-        "operationId": "v1.idempotency.abandon",
+        "operationId": "v1.idempotency.abort",
         "parameters": [
           {
             "in": "header",
@@ -540,7 +540,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/IdempotencyAbandonIn"
+                "$ref": "#/components/schemas/IdempotencyAbortIn"
               }
             }
           },
@@ -552,7 +552,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IdempotencyAbandonOut"
+                  "$ref": "#/components/schemas/IdempotencyAbortOut"
                 }
               }
             }
@@ -1095,14 +1095,20 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$",
             "example": "some_key"
           },
-          "expires_at": {
+          "expires": {
             "description": "Time of expiry",
             "type": "string",
             "format": "date-time",
             "nullable": true
           },
           "value": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0,
+              "maximum": 255
+            }
           }
         },
         "required": [
@@ -1119,19 +1125,25 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$",
             "example": "some_key"
           },
-          "expire_in": {
+          "ttl": {
             "description": "Time to live in milliseconds",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "value": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0,
+              "maximum": 255
+            }
           }
         },
         "required": [
           "key",
-          "expire_in",
+          "ttl",
           "value"
         ]
       },
@@ -1264,7 +1276,7 @@
           "msgs"
         ]
       },
-      "IdempotencyAbandonIn": {
+      "IdempotencyAbortIn": {
         "type": "object",
         "properties": {
           "key": {
@@ -1278,7 +1290,7 @@
           "key"
         ]
       },
-      "IdempotencyAbandonOut": {
+      "IdempotencyAbortOut": {
         "type": "object"
       },
       "IdempotencyCompleteIn": {
@@ -1300,7 +1312,7 @@
               "maximum": 255
             }
           },
-          "ttl_seconds": {
+          "ttl": {
             "description": "TTL in seconds for the cached response",
             "type": "integer",
             "format": "uint64",
@@ -1310,7 +1322,7 @@
         "required": [
           "key",
           "response",
-          "ttl_seconds"
+          "ttl"
         ]
       },
       "IdempotencyCompleteOut": {
@@ -1325,7 +1337,7 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$",
             "example": "some_key"
           },
-          "ttl_seconds": {
+          "ttl": {
             "description": "TTL in seconds for the lock/response",
             "type": "integer",
             "format": "uint64",
@@ -1334,13 +1346,28 @@
         },
         "required": [
           "key",
-          "ttl_seconds"
+          "ttl"
         ]
       },
       "IdempotencyStartOut": {
         "oneOf": [
           {
             "description": "Lock acquired, request should proceed",
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "started"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "description": "Request is already in progress (locked)",
             "type": "object",
             "properties": {
               "status": {
@@ -1429,7 +1456,7 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$",
             "example": "some_key"
           },
-          "expires_at": {
+          "expires": {
             "description": "Time of expiry",
             "type": "string",
             "format": "date-time",
@@ -1459,7 +1486,7 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$",
             "example": "some_key"
           },
-          "expire_in": {
+          "ttl": {
             "description": "Time to live in milliseconds",
             "type": "integer",
             "format": "uint64",
@@ -1566,11 +1593,11 @@
           "ok"
         ]
       },
-      "RateLimitResult": {
+      "RateLimitStatus": {
         "type": "string",
         "enum": [
-          "OK",
-          "BLOCK"
+          "ok",
+          "block"
         ]
       },
       "RateLimiterCheckIn": {
@@ -1582,8 +1609,8 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$",
             "example": "some_key"
           },
-          "units": {
-            "description": "Number of units to consume (default: 1)",
+          "tokens": {
+            "description": "Number of tokens to consume (default: 1)",
             "type": "integer",
             "format": "uint64",
             "minimum": 0,
@@ -1635,9 +1662,9 @@
       "RateLimiterCheckOut": {
         "type": "object",
         "properties": {
-          "result": {
+          "status": {
             "description": "Whether the request is allowed",
-            "$ref": "#/components/schemas/RateLimitResult"
+            "$ref": "#/components/schemas/RateLimitStatus"
           },
           "remaining": {
             "description": "Number of tokens remaining",
@@ -1654,14 +1681,14 @@
           }
         },
         "required": [
-          "result",
+          "status",
           "remaining"
         ]
       },
       "RateLimiterFixedWindowConfig": {
         "type": "object",
         "properties": {
-          "window_size_seconds": {
+          "window_size": {
             "description": "Window size in seconds",
             "type": "integer",
             "format": "uint64",
@@ -1675,7 +1702,7 @@
           }
         },
         "required": [
-          "window_size_seconds",
+          "window_size",
           "max_requests"
         ]
       },
@@ -1767,17 +1794,17 @@
             "format": "uint64",
             "minimum": 1
           },
-          "refill_interval_seconds": {
+          "refill_interval": {
             "description": "Interval in seconds between refills (minimum 1 second)",
             "type": "integer",
             "format": "uint64",
-            "minimum": 1
+            "minimum": 1,
+            "default": 1
           }
         },
         "required": [
           "capacity",
-          "refill_amount",
-          "refill_interval_seconds"
+          "refill_amount"
         ]
       },
       "RedriveIn": {

--- a/openapi.json
+++ b/openapi.json
@@ -1095,7 +1095,7 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$",
             "example": "some_key"
           },
-          "expires": {
+          "expiry": {
             "description": "Time of expiry",
             "type": "string",
             "format": "date-time",
@@ -1456,7 +1456,7 @@
             "pattern": "^[a-zA-Z0-9\\-_.]+$",
             "example": "some_key"
           },
-          "expires": {
+          "expiry": {
             "description": "Time of expiry",
             "type": "string",
             "format": "date-time",

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -28,19 +28,18 @@ pub struct CacheSetIn {
     pub key: EntityKey,
 
     /// Time to live in milliseconds
-    pub expire_in: u64,
+    pub ttl: u64,
 
-    // FIXME: change to Bytes
-    pub value: String,
+    pub value: Vec<u8>,
 }
 
 impl CacheSetIn {
     fn into_model(self) -> CacheModel {
-        let expires_at = Timestamp::now() + Duration::from_millis(self.expire_in);
+        let expires = Timestamp::now() + Duration::from_millis(self.ttl);
 
         CacheModel {
-            expires_at: Some(expires_at),
-            value: self.value.into_bytes(),
+            expires: Some(expires),
+            value: self.value,
         }
     }
 }
@@ -60,18 +59,17 @@ pub struct CacheGetOut {
     pub key: EntityKey,
 
     /// Time of expiry
-    pub expires_at: Option<Timestamp>,
+    pub expires: Option<Timestamp>,
 
-    // FIXME: change to Bytes
-    pub value: String,
+    pub value: Vec<u8>,
 }
 
 impl CacheGetOut {
     fn from_model(key: EntityKey, model: CacheModel) -> Self {
         Self {
             key,
-            expires_at: model.expires_at,
-            value: String::from_utf8_lossy(&model.value).into_owned(),
+            expires: model.expires,
+            value: model.value,
         }
     }
 }

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -35,10 +35,10 @@ pub struct CacheSetIn {
 
 impl CacheSetIn {
     fn into_model(self) -> CacheModel {
-        let expires = Timestamp::now() + Duration::from_millis(self.ttl);
+        let expiry = Timestamp::now() + Duration::from_millis(self.ttl);
 
         CacheModel {
-            expires: Some(expires),
+            expiry: Some(expiry),
             value: self.value,
         }
     }
@@ -59,7 +59,7 @@ pub struct CacheGetOut {
     pub key: EntityKey,
 
     /// Time of expiry
-    pub expires: Option<Timestamp>,
+    pub expiry: Option<Timestamp>,
 
     pub value: Vec<u8>,
 }
@@ -68,7 +68,7 @@ impl CacheGetOut {
     fn from_model(key: EntityKey, model: CacheModel) -> Self {
         Self {
             key,
-            expires: model.expires,
+            expiry: model.expiry,
             value: model.value,
         }
     }

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -4,6 +4,7 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::extract::State;
 use coyote_derive::aide_annotate;
+use coyote_idempotency::IdempotencyStartResult;
 use coyote_proto::MsgPackOrJson;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -25,16 +26,30 @@ pub struct IdempotencyStartIn {
 
     /// TTL in seconds for the lock/response
     #[validate(range(min = 1))]
-    pub ttl_seconds: u64,
+    pub ttl: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum IdempotencyStartOut {
     /// Lock acquired, request should proceed
+    Started,
+    /// Request is already in progress (locked)
     Locked,
     /// Request was already completed, cached response returned
     Completed { response: Vec<u8> },
+}
+
+impl From<IdempotencyStartResult> for IdempotencyStartOut {
+    fn from(result: IdempotencyStartResult) -> Self {
+        match result {
+            IdempotencyStartResult::Started => IdempotencyStartOut::Started,
+            IdempotencyStartResult::Locked => IdempotencyStartOut::Locked,
+            IdempotencyStartResult::Completed { response } => {
+                IdempotencyStartOut::Completed { response }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -47,20 +62,20 @@ pub struct IdempotencyCompleteIn {
 
     /// TTL in seconds for the cached response
     #[validate(range(min = 1))]
-    pub ttl_seconds: u64,
+    pub ttl: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct IdempotencyCompleteOut {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
-pub struct IdempotencyAbandonIn {
+pub struct IdempotencyAbortIn {
     #[validate(nested)]
     pub key: EntityKey,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-pub struct IdempotencyAbandonOut {}
+pub struct IdempotencyAbortOut {}
 
 // ============================================================================
 // API Endpoints
@@ -75,10 +90,8 @@ async fn idempotency_start(
     let key_str = data.key.to_string();
 
     let mut idempotency_store = state.get_idempotency_store_by_key(&key_str)?;
-    match idempotency_store.try_start(&key_str, data.ttl_seconds)? {
-        None => Ok(MsgPackOrJson(IdempotencyStartOut::Locked)),
-        Some(response) => Ok(MsgPackOrJson(IdempotencyStartOut::Completed { response })),
-    }
+    let result = idempotency_store.try_start(&key_str, data.ttl)?;
+    Ok(MsgPackOrJson(result.into()))
 }
 
 /// Complete an idempotent request with a response
@@ -90,23 +103,23 @@ async fn idempotency_complete(
     let key_str = data.key.to_string();
 
     let mut idempotency_store = state.get_idempotency_store_by_key(&key_str)?;
-    idempotency_store.complete(&key_str, data.response, data.ttl_seconds)?;
+    idempotency_store.complete(&key_str, data.response, data.ttl)?;
 
     Ok(MsgPackOrJson(IdempotencyCompleteOut {}))
 }
 
 /// Abandon an idempotent request (remove lock without saving response)
-#[aide_annotate(op_id = "v1.idempotency.abandon")]
-async fn idempotency_abandon(
+#[aide_annotate(op_id = "v1.idempotency.abort")]
+async fn idempotency_abort(
     State(state): State<AppState>,
-    MsgPackOrJson(data): MsgPackOrJson<IdempotencyAbandonIn>,
-) -> Result<MsgPackOrJson<IdempotencyAbandonOut>> {
+    MsgPackOrJson(data): MsgPackOrJson<IdempotencyAbortIn>,
+) -> Result<MsgPackOrJson<IdempotencyAbortOut>> {
     let key_str = data.key.to_string();
 
     let mut idempotency_store = state.get_idempotency_store_by_key(&key_str)?;
-    idempotency_store.abandon(&key_str)?;
+    idempotency_store.abort(&key_str)?;
 
-    Ok(MsgPackOrJson(IdempotencyAbandonOut {}))
+    Ok(MsgPackOrJson(IdempotencyAbortOut {}))
 }
 
 // ============================================================================
@@ -128,8 +141,8 @@ pub fn router() -> ApiRouter<AppState> {
             &tag,
         )
         .api_route_with(
-            "/idempotency/abandon",
-            post_with(idempotency_abandon, idempotency_abandon_operation),
+            "/idempotency/abort",
+            post_with(idempotency_abort, idempotency_abort_operation),
             &tag,
         )
 }

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -34,7 +34,7 @@ pub struct KvSetIn {
 
     /// Time to live in milliseconds
     #[validate(range(min = 1))]
-    pub expire_in: Option<u64>,
+    pub ttl: Option<u64>,
 
     #[serde(default)]
     pub behavior: OperationBehavior,
@@ -46,7 +46,7 @@ impl KvSetIn {
     fn into_model(self) -> KvModel {
         let KvSetIn {
             key: _,
-            expire_in,
+            ttl: expire_in,
             value,
             behavior: _,
         } = self;
@@ -73,7 +73,7 @@ pub struct KvGetOut {
     pub key: Arc<EntityKey>,
 
     /// Time of expiry
-    pub expires_at: Option<Timestamp>,
+    pub expires: Option<Timestamp>,
 
     pub value: Vec<u8>,
 }
@@ -82,7 +82,7 @@ impl KvGetOut {
     fn from_model(key: Arc<EntityKey>, model: KvModel) -> Self {
         Self {
             key,
-            expires_at: model.expires_at,
+            expires: model.expires_at,
             value: model.value,
         }
     }

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -51,10 +51,9 @@ impl KvSetIn {
             behavior: _,
         } = self;
 
-        let expires_at =
-            expire_in.map(|expire_in| Timestamp::now() + Duration::from_millis(expire_in));
+        let expiry = expire_in.map(|expire_in| Timestamp::now() + Duration::from_millis(expire_in));
 
-        KvModel { expires_at, value }
+        KvModel { expiry, value }
     }
 }
 
@@ -73,7 +72,7 @@ pub struct KvGetOut {
     pub key: Arc<EntityKey>,
 
     /// Time of expiry
-    pub expires: Option<Timestamp>,
+    pub expiry: Option<Timestamp>,
 
     pub value: Vec<u8>,
 }
@@ -82,7 +81,7 @@ impl KvGetOut {
     fn from_model(key: Arc<EntityKey>, model: KvModel) -> Self {
         Self {
             key,
-            expires: model.expires_at,
+            expiry: model.expiry,
             value: model.value,
         }
     }

--- a/src/v1/endpoints/rate_limiter.rs
+++ b/src/v1/endpoints/rate_limiter.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 // Re-export types that are used in AppState
-use coyote_rate_limiter::{FixedWindow, RateLimitConfig, RateLimitResult, TokenBucket};
+use coyote_rate_limiter::{FixedWindow, RateLimitConfig, RateLimitStatus, TokenBucket};
 
 // FIXME(@svix-lucho): Not fully convinced about 'method' and 'config'
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -122,7 +122,7 @@ fn default_tokens() -> u64 {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RateLimiterCheckOut {
     /// Whether the request is allowed
-    pub result: RateLimitResult,
+    pub status: RateLimitStatus,
 
     /// Number of tokens remaining
     pub remaining: u64,
@@ -167,7 +167,7 @@ async fn rate_limiter_limit(
     let response = repl.client_write(operation).await.map_err_generic()?.0?;
 
     Ok(MsgPackOrJson(RateLimiterCheckOut {
-        result: response.result,
+        status: response.status,
         remaining: response.remaining,
         retry_after: response
             .retry_after

--- a/src/v1/endpoints/rate_limiter.rs
+++ b/src/v1/endpoints/rate_limiter.rs
@@ -56,7 +56,7 @@ impl From<RateLimiterTokenBucketConfig> for TokenBucket {
         TokenBucket {
             bucket_size: val.capacity,
             refill_rate: val.refill_amount,
-            refill_interval: Duration::from_secs(val.refill_interval_seconds),
+            refill_interval: Duration::from_secs(val.refill_interval),
         }
     }
 }
@@ -64,7 +64,7 @@ impl From<RateLimiterTokenBucketConfig> for TokenBucket {
 impl From<RateLimiterFixedWindowConfig> for FixedWindow {
     fn from(val: RateLimiterFixedWindowConfig) -> Self {
         FixedWindow {
-            size: Duration::from_secs(val.window_size_seconds),
+            size: Duration::from_secs(val.window_size),
             tokens: val.max_requests,
         }
     }
@@ -73,7 +73,7 @@ impl From<RateLimiterFixedWindowConfig> for FixedWindow {
 pub struct RateLimiterFixedWindowConfig {
     /// Window size in seconds
     #[validate(range(min = 1))]
-    pub window_size_seconds: u64,
+    pub window_size: u64,
 
     /// Maximum number of requests allowed within the window
     #[validate(range(min = 1))]
@@ -92,7 +92,12 @@ pub struct RateLimiterTokenBucketConfig {
 
     /// Interval in seconds between refills (minimum 1 second)
     #[validate(range(min = 1))]
-    pub refill_interval_seconds: u64,
+    #[serde(default = "default_interval")]
+    pub refill_interval: u64,
+}
+
+fn default_interval() -> u64 {
+    1
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -100,9 +105,9 @@ pub struct RateLimiterCheckIn {
     #[validate(nested)]
     pub key: EntityKey,
 
-    /// Number of units to consume (default: 1)
-    #[serde(default = "default_units")]
-    pub units: u64,
+    /// Number of tokens to consume (default: 1)
+    #[serde(default = "default_tokens")]
+    pub tokens: u64,
 
     /// Rate limiter configuration
     #[validate(nested)]
@@ -110,7 +115,7 @@ pub struct RateLimiterCheckIn {
     pub method: RateLimiterMethod,
 }
 
-fn default_units() -> u64 {
+fn default_tokens() -> u64 {
     1
 }
 
@@ -155,7 +160,7 @@ async fn rate_limiter_limit(
     MsgPackOrJson(data): MsgPackOrJson<RateLimiterCheckIn>,
 ) -> Result<MsgPackOrJson<RateLimiterCheckOut>> {
     let key = data.key.0.clone();
-    let units = data.units;
+    let units = data.tokens;
     let method = data.method.into();
 
     let operation = RateLimiter::limit_operation(key, units, method);

--- a/src/v1/modules/cache.rs
+++ b/src/v1/modules/cache.rs
@@ -30,7 +30,7 @@ impl CacheStore {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct CacheModel {
-    pub expires: Option<Timestamp>,
+    pub expiry: Option<Timestamp>,
 
     pub value: Vec<u8>,
 }
@@ -39,7 +39,7 @@ impl From<CacheModel> for KvModel {
     fn from(model: CacheModel) -> Self {
         KvModel {
             value: model.value,
-            expires_at: model.expires,
+            expiry: model.expiry,
         }
     }
 }
@@ -48,7 +48,7 @@ impl From<KvModel> for CacheModel {
     fn from(model: KvModel) -> Self {
         CacheModel {
             value: model.value,
-            expires: model.expires_at,
+            expiry: model.expiry,
         }
     }
 }

--- a/src/v1/modules/cache.rs
+++ b/src/v1/modules/cache.rs
@@ -30,7 +30,7 @@ impl CacheStore {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct CacheModel {
-    pub expires_at: Option<Timestamp>,
+    pub expires: Option<Timestamp>,
 
     pub value: Vec<u8>,
 }
@@ -39,7 +39,7 @@ impl From<CacheModel> for KvModel {
     fn from(model: CacheModel) -> Self {
         KvModel {
             value: model.value,
-            expires_at: model.expires_at,
+            expires_at: model.expires,
         }
     }
 }
@@ -48,7 +48,7 @@ impl From<KvModel> for CacheModel {
     fn from(model: KvModel) -> Self {
         CacheModel {
             value: model.value,
-            expires_at: model.expires_at,
+            expires: model.expires_at,
         }
     }
 }

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -44,7 +44,7 @@ async fn test_cache_set_and_get() -> TestResult {
 
     assert_eq!(response["key"], "test-key-1");
     assert_eq!(response["value"], json!("test-value-123".as_bytes()));
-    assert!(response["expires"].is_string());
+    assert!(response["expiry"].is_string());
 
     Ok(())
 }

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -9,8 +9,8 @@ async fn cache_set(client: &TestClient, key: &str, expire_in: u64, value: &str) 
         .post("cache/set")
         .json(json!({
             "key": key,
-            "expire_in": expire_in,
-            "value": value
+            "ttl": expire_in,
+            "value": value.as_bytes()
         }))
         .await?
         .expect(StatusCode::OK);
@@ -43,8 +43,8 @@ async fn test_cache_set_and_get() -> TestResult {
     let response = cache_get(&client, "test-key-1").await?;
 
     assert_eq!(response["key"], "test-key-1");
-    assert_eq!(response["value"], "test-value-123");
-    assert!(response["expires_at"].is_string());
+    assert_eq!(response["value"], json!("test-value-123".as_bytes()));
+    assert!(response["expires"].is_string());
 
     Ok(())
 }
@@ -60,7 +60,7 @@ async fn test_cache_set_get_and_delete() -> TestResult {
     cache_set(&client, "test-key-2", 30000, "another-value").await?;
 
     let response = cache_get(&client, "test-key-2").await?;
-    assert_eq!(response["value"], "another-value");
+    assert_eq!(response["value"], json!("another-value".as_bytes()));
 
     let delete_response = client
         .post("cache/delete")

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -12,7 +12,7 @@ async fn start(client: &TestClient, key: &str, ttl_seconds: u64) -> TestResult<s
         .post("idempotency/start")
         .json(json!({
             "key": key,
-            "ttl_seconds": ttl_seconds
+            "ttl": ttl_seconds
         }))
         .await?
         .expect(StatusCode::OK)
@@ -31,7 +31,7 @@ async fn complete(
         .json(json!({
             "key": key,
             "response": response.as_bytes(),
-            "ttl_seconds": ttl_seconds
+            "ttl": ttl_seconds
         }))
         .await?
         .expect(StatusCode::OK);
@@ -40,7 +40,7 @@ async fn complete(
 
 async fn abandon(client: &TestClient, key: &str) -> TestResult<()> {
     client
-        .post("idempotency/abandon")
+        .post("idempotency/abort")
         .json(json!({
             "key": key
         }))
@@ -58,19 +58,21 @@ async fn test_idempotency_start_and_complete() -> TestResult {
     } = start_server().await;
 
     let response = start(&client, "k1", 60).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     start(&client, "k2", 60).await?;
 
-    // start again should conflict
-    client
+    // start again should return locked
+    let response = client
         .post("idempotency/start")
         .json(json!({
             "key": "k2",
-            "ttl_seconds": 60
+            "ttl": 60
         }))
         .await?
-        .expect(StatusCode::CONFLICT);
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(response["status"], "locked");
 
     start(&client, "k3", 60).await?;
     complete(&client, "k3", "v1", 60).await?;
@@ -83,7 +85,7 @@ async fn test_idempotency_start_and_complete() -> TestResult {
     start(&client, "k4", 60).await?;
     abandon(&client, "k4").await?;
     let response = start(&client, "k4", 60).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     start(&client, "k5", 60).await?;
     complete(&client, "k5", "v2", 60).await?;
@@ -104,14 +106,14 @@ async fn test_idempotency_start_and_complete() -> TestResult {
     abandon(&client, "k6").await?;
 
     let response = start(&client, "k6", 60).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     start(&client, "k7", 60).await?;
     complete(&client, "k7", "v1", 60).await?;
     // can abandon after completing
     abandon(&client, "k7").await?;
     let response = start(&client, "k7", 60).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     Ok(())
 }
@@ -129,7 +131,7 @@ async fn test_idempotency_abandon() -> TestResult {
     // can abandon after completing
     abandon(&client, "k1").await?;
     let response = start(&client, "k1", 1).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     // can abandon before starting
     abandon(&client, "k2").await?;
@@ -138,7 +140,7 @@ async fn test_idempotency_abandon() -> TestResult {
     // can abandon before completing
     abandon(&client, "k3").await?;
     let response = start(&client, "k3", 1).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     Ok(())
 }
@@ -155,20 +157,20 @@ async fn test_idempotency_expiration() -> TestResult {
     start(&client, "k1", 1).await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
     let response = start(&client, "k1", 1).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     // start again after expired (completed)
     complete(&client, "k2", "v1", 1).await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
     let response = start(&client, "k2", 1).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     // complete TTL shorter than start
     start(&client, "k4", 60).await?;
     complete(&client, "k4", "v1", 1).await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
     let response = start(&client, "k4", 60).await?;
-    assert_eq!(response["status"], "locked");
+    assert_eq!(response["status"], "started");
 
     // complete TTL longer than start
     start(&client, "k5", 1).await?;
@@ -193,7 +195,7 @@ async fn test_idempotency_validation() -> TestResult {
         .post("idempotency/start")
         .json(json!({
             "key": "k",
-            "ttl_seconds": 0
+            "ttl": 0
         }))
         .await?
         .expect(StatusCode::UNPROCESSABLE_ENTITY);

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -18,7 +18,7 @@ async fn kv_set(
         .post("kv/set")
         .json(json!({
             "key": key,
-            "expire_in": expire_in,
+            "ttl": expire_in,
             "value": value.as_bytes(),
             "behavior": behavior
         }))
@@ -66,7 +66,7 @@ async fn test_kv_set_and_get() -> TestResult {
 
     assert_eq!(response["key"], "kv-key-1");
     assert_eq!(response["value"], json!("kv-value-456".as_bytes()));
-    assert!(response["expires_at"].is_null());
+    assert!(response["expires"].is_null());
 
     let expires_in = 1000;
     let now = Timestamp::now();
@@ -80,7 +80,7 @@ async fn test_kv_set_and_get() -> TestResult {
     .await?;
     let response = kv_get(&client, "kv-key-1").await?;
 
-    let expires_at: Timestamp = serde_json::from_value(response["expires_at"].clone()).unwrap();
+    let expires_at: Timestamp = serde_json::from_value(response["expires"].clone()).unwrap();
     let expected = now + Duration::from_millis(expires_in);
     assert!(
         expires_at
@@ -110,7 +110,7 @@ async fn test_kv_set_with_insert_and_delete() -> TestResult {
 
     let response = kv_get(&client, "kv-key-2").await?;
     assert_eq!(response["value"], json!("permanent-value".as_bytes()));
-    assert_eq!(response["expires_at"], json!(null));
+    assert_eq!(response["expires"], json!(null));
 
     let delete_response = client
         .post("kv/delete")
@@ -158,20 +158,20 @@ async fn test_kv_update_expiration() -> TestResult {
     kv_set(&client, "kv4", Some(2000), "v4", "upsert").await?;
 
     let response = kv_get(&client, "kv4").await?;
-    let expires_at = response["expires_at"].as_str().unwrap();
+    let expires_at = response["expires"].as_str().unwrap();
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     let response = kv_get(&client, "kv4").await?;
     assert_eq!(response["value"], json!("v4".as_bytes()));
-    assert_eq!(response["expires_at"], expires_at);
+    assert_eq!(response["expires"], expires_at);
 
     kv_set(&client, "kv5", Some(3000), "v5", "upsert").await?;
     kv_set(&client, "kv5", Some(500), "v5", "upsert").await?;
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    kv_not_found(&client, "test-key-3").await?;
+    kv_not_found(&client, "kv5").await?;
 
     // Test updating expired key
     kv_set(&client, "kv6", Some(500), "v6", "upsert").await?;
@@ -255,7 +255,7 @@ async fn test_kv_validation() -> TestResult {
         .json(json!({
             "key": "kv-key-3",
             "value": "test".as_bytes(),
-            "expire_in": 0,
+            "ttl": 0,
             "behavior": "upsert"
         }))
         .await?
@@ -266,7 +266,7 @@ async fn test_kv_validation() -> TestResult {
         .json(json!({
             "key": "kv-key-3",
             "value": "test".as_bytes(),
-            "expire_in": -1,
+            "ttl": -1,
             "behavior": "upsert"
         }))
         .await?

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -66,7 +66,7 @@ async fn test_kv_set_and_get() -> TestResult {
 
     assert_eq!(response["key"], "kv-key-1");
     assert_eq!(response["value"], json!("kv-value-456".as_bytes()));
-    assert!(response["expires"].is_null());
+    assert!(response["expiry"].is_null());
 
     let expires_in = 1000;
     let now = Timestamp::now();
@@ -80,7 +80,7 @@ async fn test_kv_set_and_get() -> TestResult {
     .await?;
     let response = kv_get(&client, "kv-key-1").await?;
 
-    let expires_at: Timestamp = serde_json::from_value(response["expires"].clone()).unwrap();
+    let expires_at: Timestamp = serde_json::from_value(response["expiry"].clone()).unwrap();
     let expected = now + Duration::from_millis(expires_in);
     assert!(
         expires_at
@@ -110,7 +110,7 @@ async fn test_kv_set_with_insert_and_delete() -> TestResult {
 
     let response = kv_get(&client, "kv-key-2").await?;
     assert_eq!(response["value"], json!("permanent-value".as_bytes()));
-    assert_eq!(response["expires"], json!(null));
+    assert_eq!(response["expiry"], json!(null));
 
     let delete_response = client
         .post("kv/delete")
@@ -158,13 +158,13 @@ async fn test_kv_update_expiration() -> TestResult {
     kv_set(&client, "kv4", Some(2000), "v4", "upsert").await?;
 
     let response = kv_get(&client, "kv4").await?;
-    let expires_at = response["expires"].as_str().unwrap();
+    let expires_at = response["expiry"].as_str().unwrap();
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     let response = kv_get(&client, "kv4").await?;
     assert_eq!(response["value"], json!("v4".as_bytes()));
-    assert_eq!(response["expires"], expires_at);
+    assert_eq!(response["expiry"], expires_at);
 
     kv_set(&client, "kv5", Some(3000), "v5", "upsert").await?;
     kv_set(&client, "kv5", Some(500), "v5", "upsert").await?;

--- a/tests/it/msgpack.rs
+++ b/tests/it/msgpack.rs
@@ -9,8 +9,8 @@ use test_utils::{
 #[derive(Serialize)]
 struct CacheSetIn<'a> {
     key: &'a str,
-    expire_in: u32,
-    value: &'a str,
+    ttl: u32,
+    value: &'a [u8],
 }
 
 #[derive(Serialize)]
@@ -31,8 +31,8 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
         .header("accept", "application/json")
         .msgpack(CacheSetIn {
             key: "test-key-1",
-            expire_in: 60000,
-            value: "test-value-123",
+            ttl: 60000,
+            value: b"test-value-123",
         })
         .await?
         .expect(StatusCode::OK);
@@ -46,8 +46,8 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
         .json();
 
     assert_eq!(response["key"], "test-key-1");
-    assert_eq!(response["value"], "test-value-123");
-    assert!(response["expires_at"].is_string());
+    assert_eq!(response["value"], json!(b"test-value-123"));
+    assert!(response["expires"].is_string());
 
     Ok(())
 }
@@ -55,9 +55,9 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
 #[derive(Deserialize)]
 struct CacheGetOut {
     key: String,
-    value: String,
+    value: Vec<u8>,
     #[allow(unused)]
-    expires_at: String,
+    expires: Option<String>,
 }
 
 #[tokio::test]
@@ -72,8 +72,8 @@ async fn test_cache_set_and_get_msgpack_out() -> TestResult {
         .post("cache/set")
         .json(json!({
             "key": "test-key-1",
-            "expire_in": 60000,
-            "value": "test-value-123",
+            "ttl": 60000,
+            "value": "test-value-123".as_bytes(),
         }))
         .await?
         .expect(StatusCode::OK);
@@ -93,7 +93,7 @@ async fn test_cache_set_and_get_msgpack_out() -> TestResult {
 
     let response_body: CacheGetOut = rmp_serde::from_slice(response.body())?;
     assert_eq!(response_body.key, "test-key-1");
-    assert_eq!(response_body.value, "test-value-123");
+    assert_eq!(response_body.value, b"test-value-123");
 
     Ok(())
 }

--- a/tests/it/msgpack.rs
+++ b/tests/it/msgpack.rs
@@ -47,7 +47,7 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
 
     assert_eq!(response["key"], "test-key-1");
     assert_eq!(response["value"], json!(b"test-value-123"));
-    assert!(response["expires"].is_string());
+    assert!(response["expiry"].is_string());
 
     Ok(())
 }
@@ -57,7 +57,7 @@ struct CacheGetOut {
     key: String,
     value: Vec<u8>,
     #[allow(unused)]
-    expires: Option<String>,
+    expiry: Option<String>,
 }
 
 #[tokio::test]

--- a/tests/it/rate_limiter.rs
+++ b/tests/it/rate_limiter.rs
@@ -19,12 +19,12 @@ async fn call_limit_token_bucket(
         .post("rate-limiter/limit")
         .json(json!({
             "key": key,
-            "units": units,
+            "tokens": units,
             "method": "token_bucket",
             "config": {
                 "capacity": capacity,
                 "refill_amount": refill_amount,
-                "refill_interval_seconds": refill_interval_seconds
+                "refill_interval": refill_interval_seconds
             }
         }))
         .await?
@@ -45,11 +45,11 @@ async fn call_limit_fixed_window(
         .post("rate-limiter/limit")
         .json(json!({
             "key": key,
-            "units": units,
+            "tokens": units,
             "method": "fixed_window",
             "config": {
                 "max_requests": max_requests,
-                "window_size_seconds": window_size_seconds
+                "window_size": window_size_seconds
             }
         }))
         .await?
@@ -78,7 +78,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
         refill_interval,
     )
     .await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 4);
     assert_eq!(response["retry_after"], json!(null));
 
@@ -91,7 +91,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
         refill_interval,
     )
     .await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 2);
     assert_eq!(response["retry_after"], json!(null));
 
@@ -104,7 +104,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
         refill_interval,
     )
     .await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 0);
     assert_eq!(response["retry_after"], json!(null));
 
@@ -117,7 +117,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
         refill_interval,
     )
     .await?;
-    assert_eq!(response["result"], "BLOCK");
+    assert_eq!(response["status"], "block");
     assert_eq!(response["remaining"], 0);
     assert!(response["retry_after"].is_number());
 
@@ -131,7 +131,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
             "config": {
                 "capacity": capacity,
                 "refill_amount": refill_amount,
-                "refill_interval_seconds": refill_interval
+                "refill_interval": refill_interval
             }
         }))
         .await?
@@ -156,25 +156,25 @@ async fn test_rate_limiter_limit_fixed_window() -> TestResult {
 
     let response =
         call_limit_fixed_window(&client, "rl-key-1", 1, max_requests, window_size_seconds).await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 4);
     assert_eq!(response["retry_after"], json!(null));
 
     let response =
         call_limit_fixed_window(&client, "rl-key-1", 2, max_requests, window_size_seconds).await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 2);
     assert_eq!(response["retry_after"], json!(null));
 
     let response =
         call_limit_fixed_window(&client, "rl-key-1", 2, max_requests, window_size_seconds).await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 0);
     assert_eq!(response["retry_after"], json!(null));
 
     let response =
         call_limit_fixed_window(&client, "rl-key-1", 1, max_requests, window_size_seconds).await?;
-    assert_eq!(response["result"], "BLOCK");
+    assert_eq!(response["status"], "block");
     assert_eq!(response["remaining"], 0);
     assert!(response["retry_after"].is_number());
 
@@ -187,7 +187,7 @@ async fn test_rate_limiter_limit_fixed_window() -> TestResult {
             "method": "fixed_window",
             "config": {
                 "max_requests": max_requests,
-                "window_size_seconds": window_size_seconds
+                "window_size": window_size_seconds
             }
         }))
         .await?
@@ -211,26 +211,26 @@ async fn test_rate_limiter_change_algorithm() -> TestResult {
 
     let response =
         call_limit_fixed_window(&client, "rl-key-1", 1, max_requests, window_size_seconds).await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 4);
     assert_eq!(response["retry_after"], json!(null));
 
     // Calling limit with the same key but a different algorithm behaves as a different key
     let response = call_limit_token_bucket(&client, "rl-key-1", 1, 5, 1, 1).await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 4);
     assert_eq!(response["retry_after"], json!(null));
 
     // Change algorithm parameters
     let response = call_limit_token_bucket(&client, "rl-key-1", 1, 10, 4, 2).await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 3);
     assert_eq!(response["retry_after"], json!(null));
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     let response = call_limit_token_bucket(&client, "rl-key-1", 1, 10, 4, 2).await?;
-    assert_eq!(response["result"], "OK");
+    assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 6); // 3 (previous) + 4 (refill) - 1 (consumed)
     assert_eq!(response["retry_after"], json!(null));
 
@@ -280,10 +280,10 @@ async fn test_rate_limiter_refill_interval() -> TestResult {
                 "key": "rl-key-1",
                 "method": "token_bucket",
                 "config": {
-                    "capacity": capacity,
-                    "refill_amount": refill_amount,
-                    "refill_interval_seconds": refill_interval
-                }
+                "capacity": capacity,
+                "refill_amount": refill_amount,
+                "refill_interval": refill_interval
+            }
         }))
         .await?
         .expect(StatusCode::OK)

--- a/tests/it/rate_limiter.rs
+++ b/tests/it/rate_limiter.rs
@@ -153,27 +153,28 @@ async fn test_rate_limiter_limit_fixed_window() -> TestResult {
     } = start_server().await;
     let max_requests = 5;
     let window_size_seconds = 1;
+    let key = "rl-key-fixed-window";
 
     let response =
-        call_limit_fixed_window(&client, "rl-key-1", 1, max_requests, window_size_seconds).await?;
+        call_limit_fixed_window(&client, key, 1, max_requests, window_size_seconds).await?;
     assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 4);
     assert_eq!(response["retry_after"], json!(null));
 
     let response =
-        call_limit_fixed_window(&client, "rl-key-1", 2, max_requests, window_size_seconds).await?;
+        call_limit_fixed_window(&client, key, 2, max_requests, window_size_seconds).await?;
     assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 2);
     assert_eq!(response["retry_after"], json!(null));
 
     let response =
-        call_limit_fixed_window(&client, "rl-key-1", 2, max_requests, window_size_seconds).await?;
+        call_limit_fixed_window(&client, key, 2, max_requests, window_size_seconds).await?;
     assert_eq!(response["status"], "ok");
     assert_eq!(response["remaining"], 0);
     assert_eq!(response["retry_after"], json!(null));
 
     let response =
-        call_limit_fixed_window(&client, "rl-key-1", 1, max_requests, window_size_seconds).await?;
+        call_limit_fixed_window(&client, key, 1, max_requests, window_size_seconds).await?;
     assert_eq!(response["status"], "block");
     assert_eq!(response["remaining"], 0);
     assert!(response["retry_after"].is_number());
@@ -183,7 +184,7 @@ async fn test_rate_limiter_limit_fixed_window() -> TestResult {
     let response = client
         .post("rate-limiter/get-remaining")
         .json(json!({
-            "key": "rl-key-1",
+            "key": key,
             "method": "fixed_window",
             "config": {
                 "max_requests": max_requests,


### PR DESCRIPTION
Some improvements based on Tom's feedback on https://github.com/svix/coyote-private/pull/116

Summary:
- Rename `expire_in` to `ttl`
- Remove units in field names
- Rename idempotency/abandon to idempotency/abort
- Use consistent casing in enums (snake_case)
- Return `Vec<u8>` instead of `String` in cache
- Add one more status to idempotency instead of returning an HTTP error when the key is locked
- A few other misc field renames