### PR TITLE
Wire up Stream.append with Raft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,9 +4576,11 @@ version = "0.0.1"
 dependencies = [
  "coyote-configgroup",
  "coyote-error",
+ "coyote-operations",
  "fjall",
  "fjall-utils",
  "jiff",
+ "paste",
  "rmp-serde",
  "schemars 1.2.0",
  "serde",

--- a/Claude.md
+++ b/Claude.md
@@ -1,6 +1,5 @@
 # Rules
 
-* When adding dependencies, add them in alphabetical order.
 * Before making any Rust code changes, disable the rust-analyzer extension to prevent server crashes:
   ```bash
   code --disable-extension rust-lang.rust-analyzer
@@ -16,4 +15,3 @@
 * Code guidelines
   * Keep mutation or state manipulation as isolated as possible
   * Keep functions short and simple. If a function is too long, split it into shorter, self documenting functions.
-* If any changes are made to `src/v1/endpoints/*`, run `cargo codegen` when done to update the client library code.

--- a/crates/stream/Cargo.toml
+++ b/crates/stream/Cargo.toml
@@ -8,9 +8,11 @@ rust-version.workspace = true
 [dependencies]
 coyote-configgroup.workspace = true
 coyote-error.workspace = true
+coyote-operations.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true
 jiff.workspace = true
+paste.workspace = true
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/stream/src/operations/append_to_stream.rs
+++ b/crates/stream/src/operations/append_to_stream.rs
@@ -1,12 +1,12 @@
-use coyote_configgroup::entities::ConfigGroupId;
-use coyote_error::Result;
-use jiff::Timestamp;
-
+use super::{AppendResponse, StreamRequest};
 use crate::{
     State,
     entities::{MsgId, MsgIn},
     tables::{MsgRow, msg_row_key},
 };
+use coyote_configgroup::entities::ConfigGroupId;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
 
 pub struct AppendToStream {
     group_id: ConfigGroupId,
@@ -18,7 +18,11 @@ pub struct AppendToStreamOutput {
 }
 
 impl AppendToStream {
-    pub fn new(state: &State, group_id: ConfigGroupId, msgs: Vec<MsgIn>) -> Result<Self> {
+    pub fn new(
+        state: &State,
+        group_id: ConfigGroupId,
+        msgs: Vec<MsgIn>,
+    ) -> coyote_error::Result<Self> {
         let offset = MsgRow::get_next_msg_id_in_stream(state, group_id)?;
         let created_at = Timestamp::now();
 
@@ -45,10 +49,7 @@ impl AppendToStream {
         Ok(Self { group_id, msgs })
     }
 
-    // FIXME(@svix-gabriel) - I'm trying to adhere mostly to the API mentioned in the HA rfc (https://github.com/svix/rfc/pull/30/files#diff-1f8e708b840474d3072b1c965eb090a3e30b26e8b7036c6e0ae47ef36ffb09abR54)
-    // However for expediency, I don't want to wait for the relevant traits to be added in order to have something working.
-    // It should be straightforward (famous last words) to translate this method to the Operations trait once it's in place.
-    pub fn apply_operation(self, state: &State) -> Result<AppendToStreamOutput> {
+    pub fn apply_operation(self, state: &State) -> coyote_error::Result<AppendToStreamOutput> {
         let mut batch = state.db.batch();
 
         let msg_ids = self.msgs.iter().map(|(id, _msg)| *id).collect();
@@ -62,5 +63,38 @@ impl AppendToStream {
         batch.commit()?;
 
         Ok(AppendToStreamOutput { msg_ids })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppendOperation {
+    pub(crate) group_id: ConfigGroupId,
+    pub(crate) msgs: Vec<MsgIn>,
+}
+
+impl AppendOperation {
+    pub fn new(group_id: ConfigGroupId, msgs: Vec<MsgIn>) -> Self {
+        Self { group_id, msgs }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppendResponseData {
+    pub msg_ids: Vec<MsgId>,
+}
+
+impl AppendOperation {
+    fn apply_real(self, state: &State) -> coyote_operations::Result<AppendResponseData> {
+        let op = AppendToStream::new(state, self.group_id, self.msgs)?;
+        let out = op.apply_operation(state)?;
+        Ok(AppendResponseData {
+            msg_ids: out.msg_ids,
+        })
+    }
+}
+
+impl StreamRequest for AppendOperation {
+    fn apply(self, state: &State) -> AppendResponse {
+        AppendResponse(self.apply_real(state))
     }
 }

--- a/crates/stream/src/operations/mod.rs
+++ b/crates/stream/src/operations/mod.rs
@@ -8,3 +8,16 @@ mod redrive;
 pub use self::{ack::*, append_to_stream::*, fetch::*, fetch_locking::*};
 pub use dlq::*;
 pub use redrive::*;
+
+use crate::State;
+use serde::{Deserialize, Serialize};
+
+use coyote_operations::raft_module_operations;
+
+raft_module_operations!(
+    StreamRequest,
+    StreamOperation {
+        Append(AppendOperation) -> AppendResponseData,
+    },
+    state = &State,
+);

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -27,6 +27,7 @@ pub(super) async fn apply_request(
             let mut store = state_machine.state.get_cache_store_by_key(req.key_name())?;
             Response::Cache(req.apply(&mut store))
         }
+        Request::Stream(req) => Response::Stream(req.apply(&state_machine.state.stream_state)),
         Request::ClusterInternal(req) => Response::ClusterInternal(req.apply(state_machine).await?),
     })
 }

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -39,6 +39,7 @@ pub enum Request {
     RateLimiter(coyote_rate_limiter::operations::RateLimiterOperation),
     Idempotency(coyote_idempotency::operations::IdempotencyOperation),
     Cache(coyote_cache::operations::CacheOperation),
+    Stream(stream::operations::StreamOperation),
 }
 
 impl From<coyote_kv::operations::KvOperation> for Request {
@@ -65,6 +66,12 @@ impl From<coyote_cache::operations::CacheOperation> for Request {
     }
 }
 
+impl From<stream::operations::StreamOperation> for Request {
+    fn from(value: stream::operations::StreamOperation) -> Self {
+        Request::Stream(value)
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Response {
     Blank,
@@ -73,6 +80,7 @@ pub enum Response {
     RateLimiter(coyote_rate_limiter::operations::Response),
     Idempotency(coyote_idempotency::operations::Response),
     Cache(coyote_cache::operations::Response),
+    Stream(stream::operations::Response),
 }
 
 impl TryFrom<Response> for coyote_kv::operations::Response {
@@ -114,6 +122,17 @@ impl TryFrom<Response> for coyote_cache::operations::Response {
     fn try_from(value: Response) -> Result<Self, Self::Error> {
         match value {
             Response::Cache(v) => Ok(v),
+            _ => Err(ResponseParseError::InvalidVariant),
+        }
+    }
+}
+
+impl TryFrom<Response> for stream::operations::Response {
+    type Error = ResponseParseError;
+
+    fn try_from(value: Response) -> Result<Self, Self::Error> {
+        match value {
+            Response::Stream(v) => Ok(v),
             _ => Err(ResponseParseError::InvalidVariant),
         }
     }

--- a/src/v1/endpoints/stream.rs
+++ b/src/v1/endpoints/stream.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use aide::axum::{ApiRouter, routing::post_with};
-use axum::extract::State;
+use axum::{Extension, extract::State};
 use coyote_configgroup::{
     entities::StreamConfig, operations::create_configgroup::CreateConfigGroupOutput,
 };
 use coyote_derive::aide_annotate;
-use coyote_error::Result;
+use coyote_error::{Result, ResultExt};
 use coyote_proto::MsgPackOrJson;
 use jiff::Timestamp;
 use schemars::JsonSchema;
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use stream::entities::{ConsumerGroup, MsgId, MsgIn, MsgOut, StreamName};
 use validator::Validate;
 
-use crate::{AppState, v1::utils::openapi_tag};
+use crate::{AppState, core::cluster::RaftState, v1::utils::openapi_tag};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct CreateStreamIn {
@@ -103,29 +103,15 @@ struct AppendToStreamOut {
 #[aide_annotate(op_id = "v1.stream.append")]
 async fn append_to_stream(
     State(state): State<AppState>,
+    Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<AppendToStreamIn>,
 ) -> Result<MsgPackOrJson<AppendToStreamOut>> {
-    /*
-    FIXME(@svix-gabriel)
-
-    This is missing a few important things
-        1. We haven't setup thread-per-core, so this could go to any thread.
-        2. We haven't setup quorum/raft stuff yet, so there's no consensus.
-
-    I didn't want to let either of these things block developing stream,
-    so in practice the structure of this handler will look different once those two pieces are in place.
-    */
-
     let group = state.get_stream(&data.name)?;
-    let stream_state = state.stream_state;
-    let out = tokio::task::spawn_blocking(move || {
-        let op = stream::operations::AppendToStream::new(&stream_state, group.id, data.msgs)?;
-        op.apply_operation(&stream_state)
-    })
-    .await??;
+    let operation = stream::operations::AppendOperation::new(group.id, data.msgs);
+    let response = repl.client_write(operation).await.map_err_generic()?.0?;
 
     Ok(MsgPackOrJson(AppendToStreamOut {
-        msg_ids: out.msg_ids,
+        msg_ids: response.msg_ids,
     }))
 }
 


### PR DESCRIPTION
Split off from a larger change because it was getting too big.

This wires up `stream.append` with Raft.

Other endpoints done in separate PRs