### PR TITLE
Adjust sleep times in tests to reduce flakyness

### DIFF
--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -154,13 +154,13 @@ async fn test_kv_update_expiration() -> TestResult {
     } = start_server().await;
 
     // Test updating expiration time
-    kv_set(&client, "kv4", Some(500), "v4", "upsert").await?;
-    kv_set(&client, "kv4", Some(2000), "v4", "upsert").await?;
+    kv_set(&client, "kv4", Some(1500), "v4", "upsert").await?;
+    kv_set(&client, "kv4", Some(3000), "v4", "upsert").await?;
 
     let response = kv_get(&client, "kv4").await?;
     let expires_at = response["expiry"].as_str().unwrap();
 
-    tokio::time::sleep(Duration::from_millis(1000)).await;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
 
     let response = kv_get(&client, "kv4").await?;
     assert_eq!(response["value"], json!("v4".as_bytes()));
@@ -174,14 +174,14 @@ async fn test_kv_update_expiration() -> TestResult {
     kv_not_found(&client, "kv5").await?;
 
     // Test updating expired key
-    kv_set(&client, "kv6", Some(500), "v6", "upsert").await?;
-    kv_set(&client, "kv6", Some(100), "v6", "insert").await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    kv_set(&client, "kv6", Some(1000), "v6", "upsert").await?;
+    kv_set(&client, "kv6", Some(500), "v6", "insert").await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     let response = kv_get(&client, "kv6").await?;
     assert_eq!(response["value"], json!("v6".as_bytes()));
 
-    tokio::time::sleep(Duration::from_millis(400)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     kv_set(&client, "kv6", Some(500), "v6", "update").await?;
     kv_not_found(&client, "kv6").await?;

--- a/tests/it/rate_limiter.rs
+++ b/tests/it/rate_limiter.rs
@@ -152,7 +152,7 @@ async fn test_rate_limiter_limit_fixed_window() -> TestResult {
         ..
     } = start_server().await;
     let max_requests = 5;
-    let window_size_seconds = 1;
+    let window_size_seconds = 3;
     let key = "rl-key-fixed-window";
 
     let response =
@@ -179,7 +179,7 @@ async fn test_rate_limiter_limit_fixed_window() -> TestResult {
     assert_eq!(response["remaining"], 0);
     assert!(response["retry_after"].is_number());
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
 
     let response = client
         .post("rate-limiter/get-remaining")


### PR DESCRIPTION
These 2 tests were failing locally, I think because we set expirations/reset to be 1s and it made them a bit tight. When running the whole test suite locally, they were too slow and failed. 

I tried this a bunch of times and this seems to fix them.