### PR TITLE
Change `ConsumerGroup` from type alias to validated type

### DIFF
--- a/crates/stream/src/entities.rs
+++ b/crates/stream/src/entities.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt, ops::Deref};
 
 use coyote_configgroup::entities::ConfigGroupName;
 use jiff::Timestamp;
@@ -10,7 +10,6 @@ use validator::Validate;
 // We absolutely can (and should) use more robust types.
 pub type StreamName = ConfigGroupName;
 pub type MsgId = u64;
-pub type ConsumerGroup = String;
 pub type MsgHeaders = HashMap<String, String>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -26,4 +25,91 @@ pub struct MsgOut {
     pub payload: Vec<u8>,
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,
+}
+
+/// A validated consumer group identifier.
+///
+/// Must be at most 64 bytes and only contain ASCII alphanumeric characters, `_`, or `-`.
+///
+/// NOTE(@svix-gabriel) - the validation here is completely arbitrary right now. If you have a
+/// compelling reason to change it (the length, forbidden characters, etc.) just make the change.
+/// No need to make a ticket or tag me in slack or anything.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct ConsumerGroup(String);
+
+impl ConsumerGroup {
+    const MAX_LEN: usize = 64;
+
+    fn validate_str(s: &str) -> Result<(), &'static str> {
+        if s.len() > Self::MAX_LEN {
+            return Err("consumer group name must be at most 64 bytes");
+        }
+        if !s
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+        {
+            return Err(
+                "consumer group name must only contain alphanumeric characters, '_', and '-'",
+            );
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<String> for ConsumerGroup {
+    type Error = &'static str;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::validate_str(&s)?;
+        Ok(Self(s))
+    }
+}
+
+impl TryFrom<&str> for ConsumerGroup {
+    type Error = &'static str;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::validate_str(s)?;
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl Deref for ConsumerGroup {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ConsumerGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConsumerGroup {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::validate_str(&s).map_err(serde::de::Error::custom)?;
+        Ok(ConsumerGroup(s))
+    }
+}
+
+impl JsonSchema for ConsumerGroup {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        String::schema_name()
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
+    }
 }

--- a/crates/stream/src/tables.rs
+++ b/crates/stream/src/tables.rs
@@ -491,7 +491,7 @@ mod tests {
         let group_id = ConfigGroupId::new_v4();
         let lease = LeaseRow {
             group_id,
-            cg: "cg1".to_string(),
+            cg: "cg1".try_into().unwrap(),
             block_start: 1,
             block_end: 5,
             leased_at: ts(0),
@@ -512,7 +512,7 @@ mod tests {
         let group_id = ConfigGroupId::new_v4();
         let lease = LeaseRow {
             group_id,
-            cg: "cg1".to_string(),
+            cg: "cg1".try_into().unwrap(),
             block_start: 1,
             block_end: 5,
             leased_at: ts(0),
@@ -532,7 +532,7 @@ mod tests {
         let group_id = ConfigGroupId::new_v4();
         let lease = LeaseRow {
             group_id,
-            cg: "cg1".to_string(),
+            cg: "cg1".try_into().unwrap(),
             block_start: 1,
             block_end: 5,
             leased_at: ts(0),
@@ -553,7 +553,7 @@ mod tests {
         let leases = vec![
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 1,
                 block_end: 5,
                 leased_at: ts(0),
@@ -563,7 +563,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 6,
                 block_end: 10,
                 leased_at: ts(0),
@@ -573,7 +573,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 20,
                 block_end: 25,
                 leased_at: ts(0),
@@ -595,7 +595,7 @@ mod tests {
         let leases = vec![
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 1,
                 block_end: 5,
                 leased_at: ts(0),
@@ -605,7 +605,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 6,
                 block_end: 10,
                 leased_at: ts(0),
@@ -627,7 +627,7 @@ mod tests {
         let leases = vec![
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 1,
                 block_end: 5,
                 leased_at: ts(10),
@@ -637,7 +637,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 6,
                 block_end: 10,
                 leased_at: ts(15),
@@ -664,7 +664,7 @@ mod tests {
         let leases = vec![
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 1,
                 block_end: 7,
                 leased_at: ts(10),
@@ -674,7 +674,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 5,
                 block_end: 12,
                 leased_at: ts(15),
@@ -700,7 +700,7 @@ mod tests {
         let leases = vec![
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 1,
                 block_end: 5,
                 leased_at: ts(10),
@@ -710,7 +710,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 10,
                 block_end: 15,
                 leased_at: ts(15),
@@ -732,7 +732,7 @@ mod tests {
         let leases = vec![
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 1,
                 block_end: 5,
                 leased_at: ts(10),
@@ -742,7 +742,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 6,
                 block_end: 10,
                 leased_at: ts(15),
@@ -752,7 +752,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 11,
                 block_end: 15,
                 leased_at: ts(18),
@@ -779,7 +779,7 @@ mod tests {
         let leases = vec![
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 1,
                 block_end: 5,
                 leased_at: ts(0),
@@ -789,7 +789,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 6,
                 block_end: 10,
                 leased_at: ts(0),
@@ -799,7 +799,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 20,
                 block_end: 25,
                 leased_at: ts(0),
@@ -809,7 +809,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 26,
                 block_end: 30,
                 leased_at: ts(0),
@@ -835,7 +835,7 @@ mod tests {
         let leases = vec![
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 1,
                 block_end: 5,
                 leased_at: ts(10),
@@ -845,7 +845,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 6,
                 block_end: 10,
                 leased_at: ts(15),
@@ -855,7 +855,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 50,
                 block_end: 55,
                 leased_at: ts(10),
@@ -865,7 +865,7 @@ mod tests {
             },
             LeaseRow {
                 group_id,
-                cg: ConsumerGroup::from("cg1".to_string()),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 56,
                 block_end: 60,
                 leased_at: ts(15),
@@ -970,7 +970,7 @@ mod tests {
         fn lease(group_id: ConfigGroupId, block_start: MsgId, block_end: MsgId) -> LeaseRow {
             LeaseRow {
                 group_id,
-                cg: "test-cg".to_string(),
+                cg: "test-cg".try_into().unwrap(),
                 block_start,
                 block_end,
                 leased_at: ts(0),
@@ -1254,7 +1254,7 @@ mod tests {
             // Create a DLQ lease for message 3
             let dlq_lease = LeaseRow {
                 group_id,
-                cg: "test-cg".to_string(),
+                cg: "test-cg".try_into().unwrap(),
                 block_start: 3,
                 block_end: 3,
                 leased_at: ts(0),
@@ -1277,7 +1277,7 @@ mod tests {
             let group_id = ConfigGroupId::new_v4();
             let dlq_lease = LeaseRow {
                 group_id,
-                cg: "cg1".to_string(),
+                cg: "cg1".try_into().unwrap(),
                 block_start: 3,
                 block_end: 3,
                 leased_at: ts(0),
@@ -1299,7 +1299,7 @@ mod tests {
             let leases = vec![
                 LeaseRow {
                     group_id,
-                    cg: "cg1".to_string(),
+                    cg: "cg1".try_into().unwrap(),
                     block_start: 1,
                     block_end: 3,
                     leased_at: ts(0),
@@ -1309,7 +1309,7 @@ mod tests {
                 },
                 LeaseRow {
                     group_id,
-                    cg: "cg1".to_string(),
+                    cg: "cg1".try_into().unwrap(),
                     block_start: 4,
                     block_end: 6,
                     leased_at: ts(5),
@@ -1337,7 +1337,7 @@ mod tests {
             let leases = vec![
                 LeaseRow {
                     group_id,
-                    cg: "cg1".to_string(),
+                    cg: "cg1".try_into().unwrap(),
                     block_start: 1,
                     block_end: 3,
                     leased_at: ts(0),
@@ -1347,7 +1347,7 @@ mod tests {
                 },
                 LeaseRow {
                     group_id,
-                    cg: "cg1".to_string(),
+                    cg: "cg1".try_into().unwrap(),
                     block_start: 10,
                     block_end: 12,
                     leased_at: ts(5),


### PR DESCRIPTION
Planned to do this for a while.

The validations we run on the ConsumerGroup are completely arbitrary right now. I just picked something that seemed reasonable at first glance. It's trivial to change in the future.