### PR TITLE
cluster: implement log time indexes

### DIFF
--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -237,6 +237,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
             seed_nodes: vec![],
             replication_request_timeout: Duration::from_millis(50),
             startup_discovery_delay: Duration::from_millis(0),
+            log_index_interval: Duration::from_millis(500),
         },
         bootstrap_cfg_path: None,
     }

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -83,3 +83,7 @@ pub(super) fn cluster_election_timeout_max_ms() -> u64 {
 pub(super) fn cluster_auto_initialize() -> bool {
     true
 }
+
+pub(super) fn log_index_interval() -> Duration {
+    Duration::from_mins(10)
+}

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -120,6 +120,13 @@ pub struct ClusterConfiguration {
         default = "defaults::cluster_startup_discovery_delay"
     )]
     pub startup_discovery_delay: Duration,
+
+    #[serde(
+        rename = "log_index_interval_ms",
+        with = "crate::serde::duration::millis",
+        default = "defaults::log_index_interval"
+    )]
+    pub log_index_interval: Duration,
 }
 
 impl Default for ClusterConfiguration {
@@ -321,6 +328,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
                 auto_initialize: cluster_auto_initialize,
                 discovery_timeout: cluster_discovery_timeout,
                 startup_discovery_delay: cluster_startup_discovery_delay,
+                log_index_interval: cluster_log_index_interval,
             },
     } = &mut config;
 
@@ -383,6 +391,9 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
     if let Some(value) = env_var_ms("COYOTE_CLUSTER_STARTUP_DISCOVERY_DELAY_MS")? {
         *cluster_startup_discovery_delay = value;
     };
+    if let Some(value) = env_var_ms("COYOTE_LOG_INDEX_INTERVAL_MS")? {
+        *cluster_log_index_interval = value;
+    }
 
     Ok(Arc::from(config))
 }

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -1,11 +1,14 @@
 use super::{
     handle::{Request, Response},
+    raft::NodeId,
     state_machine::Store,
 };
+use openraft::LogId;
 
 pub(super) async fn apply_request(
     request: Request,
     state_machine: &mut Store,
+    log_id: LogId<NodeId>,
 ) -> anyhow::Result<Response> {
     Ok(match request {
         Request::Kv(req) => {
@@ -44,6 +47,8 @@ pub(super) async fn apply_request(
             };
             Response::Stream(req.apply(state))
         }
-        Request::ClusterInternal(req) => Response::ClusterInternal(req.apply(state_machine).await?),
+        Request::ClusterInternal(req) => {
+            Response::ClusterInternal(req.apply(state_machine, log_id).await?)
+        }
     })
 }

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -1,0 +1,189 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use super::{Node, NodeId, handle::RaftState};
+use crate::cfg::Configuration;
+use openraft::error::{ClientWriteError, RaftError};
+use tokio::task::JoinSet;
+
+trait BackgroundJob {
+    async fn run_on_leader(self) -> anyhow::Result<()>;
+}
+
+struct RecordLogTimestamps {
+    cfg: Configuration,
+    handle: RaftState,
+}
+
+impl BackgroundJob for RecordLogTimestamps {
+    async fn run_on_leader(self) -> anyhow::Result<()> {
+        let mut ticker = tokio::time::interval(self.cfg.cluster.log_index_interval);
+        loop {
+            tracing::debug!("recording log timestamps");
+            let now = jiff::Timestamp::now();
+            self.handle
+                .raft
+                .client_write(super::handle::Request::ClusterInternal(
+                    super::operations::InternalRequest::RecordLogTimestamp(now),
+                ))
+                .await?;
+            ticker.tick().await;
+        }
+    }
+}
+
+struct BackgroundJobRunner {
+    jobs: JoinSet<anyhow::Result<()>>,
+}
+
+fn is_forward_to_leader_err(e: &anyhow::Error) -> bool {
+    if let Some(raft_err) = e.downcast_ref::<RaftError<NodeId, ClientWriteError<NodeId, Node>>>() {
+        raft_err.forward_to_leader().is_some()
+    } else {
+        false
+    }
+}
+
+impl BackgroundJobRunner {
+    fn spawn_all(cfg: Configuration, handle: RaftState) -> Self {
+        let mut jobs = JoinSet::new();
+        jobs.spawn(RecordLogTimestamps { cfg, handle }.run_on_leader());
+        Self { jobs }
+    }
+
+    async fn stop_all(mut self) -> anyhow::Result<()> {
+        self.jobs.abort_all();
+        while let Some(job) = self.jobs.join_next().await {
+            match job {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    if is_forward_to_leader_err(&e) {
+                        tracing::trace!("some worker died with forward-to-leader, who cares");
+                    } else {
+                        return Err(e);
+                    }
+                }
+                Err(e) if e.is_cancelled() => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Generate a channel of all leadership changes in the raft cluster
+async fn leadership_changes(handle: RaftState) -> tokio::sync::broadcast::Receiver<Option<NodeId>> {
+    // this is racy (because it could change multiple times in between calls to `.wait`), so we
+    // back it up by polling
+    const POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+    let shutdown = crate::shutting_down_token();
+    let (tx, rx) = tokio::sync::broadcast::channel(10);
+    tokio::spawn(async move {
+        let last_leader = Arc::new(Mutex::new(None));
+        while shutdown
+            .run_until_cancelled(handle.raft.wait(Some(POLL_INTERVAL)).metrics(
+                |m| {
+                    let mut l = last_leader.lock().unwrap();
+                    if m.current_leader != *l {
+                        *l = m.current_leader;
+                        if tx.send(m.current_leader).is_err() {
+                            return true;
+                        }
+                        true
+                    } else {
+                        false
+                    }
+                },
+                "metrics to change",
+            ))
+            .await
+            .is_some()
+        {}
+    });
+    rx
+}
+
+/// Wait until the current node becomes the leader (or we shutdown)
+async fn wait_until_leader(
+    me: NodeId,
+    mut chan: tokio::sync::broadcast::Receiver<Option<NodeId>>,
+) -> bool {
+    let shutdown = crate::shutting_down_token();
+    loop {
+        let Some(value) = shutdown.run_until_cancelled(chan.recv()).await else {
+            return false;
+        };
+        match value {
+            Ok(Some(node)) if node == me => {
+                tracing::debug!("I believe I am the leader! Spawning background tasks");
+                return true;
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                tracing::debug!("shutdown detected");
+                return false;
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(super) async fn run_background_jobs_on_leader(
+    cfg: Configuration,
+    handle: RaftState,
+) -> anyhow::Result<()> {
+    let shutdown = crate::shutting_down_token();
+    let mut chan = leadership_changes(handle.clone()).await;
+    while wait_until_leader(handle.node_id, chan.resubscribe()).await {
+        let mut runner = BackgroundJobRunner::spawn_all(cfg.clone(), handle.clone());
+        loop {
+            tokio::select! {
+                new_leader = chan.recv() => {
+                    match new_leader {
+                        Ok(new_leader) if new_leader == Some(handle.node_id) => {
+                            // we might receive ourselves several times
+                        },
+                        Ok(new_leader) => {
+                            tracing::debug!(?new_leader, "No longer the leader");
+                            break;
+                        },
+                        Err(err) => {
+                            tracing::warn!(?err, "leader detection died");
+                            break;
+                        }
+                    }
+                },
+                _ = shutdown.cancelled() => {
+                    tracing::debug!("shutting down");
+                    break;
+                },
+                res = runner.jobs.join_next() => {
+                    if let Some(res) = res {
+                        tracing::debug!("a background job ended unexpectedly");
+                        match res {
+                            Ok(Ok(_)) => {},
+                            Ok(Err(e)) => {
+                                if is_forward_to_leader_err(&e) {
+                                    tracing::debug!("failed a write because we are not the leader");
+                                    break;
+                                } else {
+                                    runner.stop_all().await?;
+                                    return Err(e);
+                                }
+                            }
+                            Err(e) => {
+                                if !e.is_cancelled() {
+                                    return Err(e.into());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        runner.stop_all().await?;
+    }
+    Ok(())
+}

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -6,6 +6,7 @@ use super::{
     operations::{InternalRequest, InternalResponse},
     raft::{NodeId, Raft},
 };
+use anyhow::{Context, Result};
 use coyote_operations::{OperationRequest, OperationResponse};
 use openraft::RaftNetworkFactory;
 use serde::{Deserialize, Serialize};
@@ -89,6 +90,12 @@ impl From<coyote_kv::operations::CreateKvOp> for Request {
 impl From<stream_deprecated::operations::StreamOperation> for Request {
     fn from(value: stream_deprecated::operations::StreamOperation) -> Self {
         Request::Stream(value)
+    }
+}
+
+impl From<super::operations::InternalRequest> for Request {
+    fn from(value: super::operations::InternalRequest) -> Self {
+        Self::ClusterInternal(value)
     }
 }
 
@@ -194,6 +201,17 @@ impl TryFrom<Response> for stream_deprecated::operations::Response {
     }
 }
 
+impl TryFrom<Response> for super::operations::InternalResponse {
+    type Error = ResponseParseError;
+
+    fn try_from(value: Response) -> Result<Self, Self::Error> {
+        match value {
+            Response::ClusterInternal(v) => Ok(v),
+            _ => Err(ResponseParseError::InvalidVariant),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct RaftState {
     pub raft: Raft,
@@ -262,13 +280,14 @@ impl RaftState {
         Ok(resp)
     }
 
-    pub async fn run_discovery_if_necessary(&self, cfg: Configuration) -> anyhow::Result<()> {
+    pub async fn run_discovery_if_necessary(&self, cfg: Configuration) -> Result<()> {
         let has_cluster = self
             .raft
             .with_raft_state(|s| {
                 s.committed.is_some() || s.membership_state.effective().nodes().count() > 0
             })
-            .await?;
+            .await
+            .context("reading cluster state")?;
         if has_cluster {
             tracing::debug!("node already has cluster information; skipping discovery");
         } else {

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -8,6 +8,7 @@ use std::{
 use anyhow::Context;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
 use fjall_utils::{MonotonicTableRowExt, TableRow};
+use jiff::Timestamp;
 use openraft::{
     Entry, LogId, OptionalSend, RaftLogId, RaftLogReader, RaftTypeConfig, StorageError, Vote,
     storage::{LogFlushed, RaftLogStorage},
@@ -41,6 +42,21 @@ impl TableRow for Log {
 
     fn get_key(&self) -> Cow<'_, Self::Key> {
         Cow::Owned(self.0.log_id.index)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct LogIndex {
+    unix_timestamp_millis: u64,
+    log_id: u64,
+}
+
+impl TableRow for LogIndex {
+    const TABLE_PREFIX: &str = "timestamps";
+    type Key = u64;
+
+    fn get_key(&self) -> Cow<'_, Self::Key> {
+        Cow::Owned(self.unix_timestamp_millis)
     }
 }
 
@@ -143,7 +159,7 @@ impl RaftLogStorage<TypeConfig> for CoyoteLogs {
 }
 
 impl CoyoteLogs {
-    pub async fn new(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+    pub fn new(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let db = Database::builder(path).worker_threads(1).open()?;
         let log_keyspace = db.keyspace("cluster:logs", KeyspaceCreateOptions::default)?;
         let meta_keyspace = db.keyspace("cluster:meta", KeyspaceCreateOptions::default)?;
@@ -152,6 +168,24 @@ impl CoyoteLogs {
             log_keyspace,
             meta_keyspace,
         })
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub(crate) async fn record_log_timestamp(
+        &self,
+        timestamp: Timestamp,
+        log_index: u64,
+    ) -> anyhow::Result<()> {
+        let rec = LogIndex {
+            unix_timestamp_millis: timestamp.as_millisecond() as u64,
+            log_id: log_index,
+        };
+        tracing::debug!(?rec, "recording log/timestamp checkpoint");
+        let (k, v) = rec.to_fjall_entry()?;
+        let keyspace = self.log_keyspace.clone();
+        tokio::task::spawn_blocking(move || -> fjall::Result<()> { keyspace.insert(k, v) })
+            .await??;
+        Ok(())
     }
 
     /// Get the NodeId (or, if we don't have one, make a new one)
@@ -284,6 +318,7 @@ impl CoyoteLogs {
             })
         })
         .await?
+        .tap(|state| tracing::trace!(?state, "read initial log state"))
     }
 
     async fn read_log_entries<RB>(&mut self, range: RB) -> anyhow::Result<Vec<LogEntry>>
@@ -367,5 +402,112 @@ impl CoyoteLogs {
             Ok(committed)
         })
         .await?
+    }
+
+    /// Return the highest log index that we know occurred before the given timestamp,
+    pub async fn log_index_before(&self, ts: Timestamp) -> anyhow::Result<Option<u64>> {
+        let log_keyspace = self.log_keyspace.clone();
+        let range = ..(ts.as_millisecond() as u64);
+        tokio::task::spawn_blocking(move || {
+            if let Some(row) = LogIndex::range(&log_keyspace, range).next_back() {
+                Ok(Some(row?.1.log_id))
+            } else {
+                Ok(None)
+            }
+        })
+        .await?
+    }
+
+    /// Return the highest log index that we know occurred at or after the given timestamp,
+    pub async fn log_index_after(&self, ts: Timestamp) -> anyhow::Result<Option<u64>> {
+        let log_keyspace = self.log_keyspace.clone();
+        let range = (ts.as_millisecond() as u64)..;
+        tokio::task::spawn_blocking(move || {
+            if let Some(row) = LogIndex::range(&log_keyspace, range).next() {
+                Ok(Some(row?.1.log_id))
+            } else {
+                Ok(None)
+            }
+        })
+        .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CoyoteLogs;
+    use jiff::{Span, Timestamp};
+    use tempfile::TempDir;
+    use test_utils::TestResult;
+
+    struct TestContext {
+        _workdir: TempDir,
+        logs: CoyoteLogs,
+    }
+
+    impl TestContext {
+        fn new() -> Self {
+            let workdir = tempfile::tempdir().unwrap();
+            let logs = CoyoteLogs::new(&workdir).unwrap();
+            Self {
+                _workdir: workdir,
+                logs,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_log_timestamps() -> TestResult {
+        let context = TestContext::new();
+        let now = Timestamp::now();
+        context
+            .logs
+            .record_log_timestamp(now - Span::new().hours(1), 1)
+            .await?;
+        context
+            .logs
+            .record_log_timestamp(now - Span::new().minutes(30), 10)
+            .await?;
+        context
+            .logs
+            .record_log_timestamp(now - Span::new().minutes(1), 20)
+            .await?;
+
+        assert_eq!(
+            context
+                .logs
+                .log_index_before(now - Span::new().hours(1))
+                .await?,
+            None
+        );
+        assert_eq!(
+            context
+                .logs
+                .log_index_before(now - Span::new().seconds(3599))
+                .await?,
+            Some(1)
+        );
+        assert_eq!(
+            context
+                .logs
+                .log_index_before(now + Span::new().seconds(1))
+                .await?,
+            Some(20)
+        );
+        assert_eq!(
+            context
+                .logs
+                .log_index_after(now - Span::new().hours(1))
+                .await?,
+            Some(1)
+        );
+        assert_eq!(
+            context
+                .logs
+                .log_index_after(now + Span::new().seconds(1))
+                .await?,
+            None
+        );
+        Ok(())
     }
 }

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -2,6 +2,7 @@ use openraft::RaftTypeConfig;
 
 mod app;
 mod applier;
+mod background;
 mod discovery;
 mod errors;
 mod handle;

--- a/src/core/cluster/operations.rs
+++ b/src/core/cluster/operations.rs
@@ -1,11 +1,13 @@
 use crate::core::cluster::state_machine::ClusterId;
 
-use super::state_machine::Store;
+use super::{raft::NodeId, state_machine::Store};
+use openraft::LogId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum InternalRequest {
     SetClusterId(ClusterId),
+    RecordLogTimestamp(jiff::Timestamp),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -14,9 +16,19 @@ pub enum InternalResponse {
 }
 
 impl InternalRequest {
-    pub(super) async fn apply(self, state_machine: &mut Store) -> anyhow::Result<InternalResponse> {
+    pub(super) async fn apply(
+        self,
+        state_machine: &mut Store,
+        log_id: LogId<NodeId>,
+    ) -> anyhow::Result<InternalResponse> {
         match self {
             Self::SetClusterId(uuid) => state_machine.set_cluster_id(uuid).await?,
+            Self::RecordLogTimestamp(timestamp) => {
+                state_machine
+                    .logs
+                    .record_log_timestamp(timestamp, log_id.index)
+                    .await?
+            }
         }
         Ok(InternalResponse::Ok)
     }

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Instant};
 
+use anyhow::Context;
 use openraft::error::{InitializeError, RaftError};
 use serde::{Deserialize, Serialize};
 use tap::TapFallible;
@@ -115,8 +116,11 @@ pub async fn initialize_raft(
     cfg: &Configuration,
     app_state: AppState,
 ) -> anyhow::Result<RaftState> {
-    let mut logs = super::CoyoteLogs::new(&cfg.cluster.log_path).await?;
-    let id = logs.get_node_id().await?;
+    let mut logs = super::CoyoteLogs::new(&cfg.cluster.log_path).context("setting up log store")?;
+    let id = logs
+        .get_node_id()
+        .await
+        .context("reading node ID from logs")?;
     let config = openraft::Config {
         heartbeat_interval: cfg.cluster.heartbeat_interval_ms,
         election_timeout_min: cfg.cluster.election_timeout_min_ms,
@@ -124,23 +128,46 @@ pub async fn initialize_raft(
         cluster_name: cfg.cluster.name.clone(),
         ..Default::default()
     };
-    let config = Arc::new(config.validate()?);
+    let config = Arc::new(config.validate().context("configuring openraft")?);
     let network = super::network::NetworkFactory::new(cfg);
 
     let db = app_state.configgroup_state.both_dbs.persistent_db.clone();
     let edb = app_state.configgroup_state.both_dbs.ephemeral_db.clone();
 
-    let state_machine =
-        super::state_machine::Store::new(db, edb, cfg.cluster.snapshot_path.clone(), app_state)
-            .await?;
+    let state_machine = super::state_machine::Store::new(
+        db,
+        edb,
+        cfg.cluster.snapshot_path.clone(),
+        app_state,
+        logs.clone(),
+    )
+    .await?;
     let state_machine: StoreHandle = state_machine.into();
-    let raft = Raft::new(id, config, network.clone(), logs, state_machine.clone()).await?;
-    Ok(RaftState {
+    let raft = Raft::new(id, config, network.clone(), logs, state_machine.clone())
+        .await
+        .context("initializing openraft")?;
+    let handle = RaftState {
         raft,
         node_id: id,
         state_machine,
         network,
-    })
+    };
+    tokio::spawn({
+        let handle = handle.clone();
+        let cfg = cfg.clone();
+        async move {
+            if let Err(err) =
+                super::background::run_background_jobs_on_leader(cfg.clone(), handle.clone()).await
+            {
+                tracing::error!(
+                    ?err,
+                    "raft administrative process died; shutting everything down"
+                );
+                crate::start_shut_down()
+            }
+        }
+    });
+    Ok(handle)
 }
 
 #[cfg(test)]
@@ -166,7 +193,7 @@ mod tests {
             let workdir = tempfile::tempdir()?;
             let mut log_path = workdir.path().to_path_buf();
             log_path.push("logs");
-            let logs = CoyoteLogs::new(log_path).await?;
+            let logs = CoyoteLogs::new(log_path)?;
 
             let mut data_path = workdir.path().to_path_buf();
             data_path.push("data");
@@ -186,7 +213,7 @@ mod tests {
 
             let app_state: AppState = AppState::new(cfg);
 
-            let store = Store::new(db, edb, snapshot_path, app_state).await?;
+            let store = Store::new(db, edb, snapshot_path, app_state, logs.clone()).await?;
 
             Ok((workdir, logs, store.into()))
         }

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 use super::{
     errors::*,
     handle::Response,
+    logs::CoyoteLogs,
     raft::{Node, TypeConfig},
     serialized_state_machine,
 };
@@ -82,6 +83,7 @@ pub struct Store {
     last_membership: StoredMembership<NodeId, Node>,
     last_snapshot: Arc<RwLock<Option<LastSnapshot>>>,
     cluster_id: Option<ClusterId>,
+    pub(super) logs: CoyoteLogs,
 }
 
 trait SnapshotIdx {
@@ -108,6 +110,7 @@ impl Store {
         ephemeral_db: Database,
         snapshot_directory: PathBuf,
         app_state: AppState,
+        logs: CoyoteLogs,
     ) -> anyhow::Result<Self> {
         if let Err(e) = tokio::fs::create_dir_all(&snapshot_directory).await
             && e.kind() != ErrorKind::AlreadyExists
@@ -137,6 +140,7 @@ impl Store {
             last_applied_log_id: None,
             last_membership: Default::default(),
             cluster_id: None,
+            logs,
         };
         this.load_information().await?;
         Ok(this)
@@ -323,7 +327,7 @@ impl Store {
                 }
                 EntryPayload::Normal(req) => {
                     tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
-                    let reply = match super::applier::apply_request(req, self).await {
+                    let reply = match super::applier::apply_request(req, self, item.log_id).await {
                         Ok(o) => o,
                         Err(e) => {
                             tracing::error!("failed to apply raft log");


### PR DESCRIPTION
This starts periodically recording a timestamp->log_index map on every node, for use in future log pruning. It's not consumed by anything other than tests yet.

The functionality to run background tasks on the leader feels fragile to me, but it's a starting point I guess.

Fixes #35.