### PR TITLE
cluster: change node representation to be extensible

### DIFF
--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -143,7 +143,7 @@ async fn discover(
                 .membership_state
                 .committed()
                 .nodes()
-                .map(|(nid, n)| (*nid, n.addr.parse().unwrap()))
+                .map(|(nid, n)| (*nid, n.addrs()))
                 .collect(),
         })
         .await
@@ -167,10 +167,17 @@ async fn add_learner(
     MsgPack(request): MsgPack<AddLearnerRequest>,
 ) -> impl IntoResponse {
     let url = format!("http://{}/repl/raft/vote", request.address);
-    let Ok(Some(addr)) = Uri::try_from(url).map(|v| v.authority().map(|a| a.to_string())) else {
+    let Ok(Some(authority)) = Uri::try_from(url).map(|v| v.authority().map(|a| a.to_string()))
+    else {
         return internal_error("invalid address");
     };
-    let node = Node { addr };
+    let Ok(addr) = authority.parse::<std::net::SocketAddr>() else {
+        return internal_error(format!(
+            "unable to get socketaddr for authority {authority}"
+        ));
+    };
+    tracing::debug!(?authority, ?addr, "looked up learner");
+    let node = Node::new(addr);
     rpc_response(state.raft.add_learner(request.node_id, node, true).await)
 }
 
@@ -200,9 +207,8 @@ async fn initialize(
     let addr = match detect_address(&app_state.cfg) {
         Ok(a) => a,
         Err(_e) => return internal_error("could not find any valid addresses"),
-    }
-    .to_string();
-    let my_node = Node { addr };
+    };
+    let my_node = Node::new(addr);
     let nodes = [(state.node_id, my_node)]
         .into_iter()
         .collect::<BTreeMap<_, _>>();

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -66,7 +66,14 @@ impl NetworkClient {
         Resp: DeserializeOwned,
     {
         let start = Instant::now();
-        let addr = self.node.addr.as_str();
+        // TODO(jbrown|2026-02-20) handle multiple addresses
+        let addrs = self.node.addrs();
+        let Some(addr) = addrs.get(0) else {
+            tracing::warn!(node_id=?self.target, node=?self.node, "node has no valid addresses, cannot send rpc");
+            return Err(RPCError::Unreachable(Unreachable::new(
+                &crate::Error::generic("no has no known addresses"),
+            )));
+        };
         let url = format!("http://{addr}/{path}");
         tracing::trace!(url, target=?self.target, "sending internal RPC");
 

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -16,7 +16,7 @@ use super::raft::NodeId;
 pub(super) struct DiscoverClusterResponse {
     pub cluster_name: String,
     pub cluster_id: Option<ClusterId>,
-    pub known_peers: BTreeMap<NodeId, SocketAddr>,
+    pub known_peers: BTreeMap<NodeId, Vec<SocketAddr>>,
     pub state: ServerState,
     pub last_committed_log_id: Option<LogId<NodeId>>,
 }

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -1,9 +1,6 @@
-use std::{collections::BTreeMap, sync::Arc, time::Instant};
+use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Instant};
 
-use openraft::{
-    BasicNode,
-    error::{InitializeError, RaftError},
-};
+use openraft::error::{InitializeError, RaftError};
 use serde::{Deserialize, Serialize};
 use tap::TapFallible;
 use uuid::Uuid;
@@ -21,8 +18,25 @@ use crate::{
     },
 };
 
-// TODO: is BasicNode enough for us?
-pub(super) type Node = BasicNode;
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum Node {
+    #[default]
+    NoAddress,
+    SingleHomed(SocketAddr),
+}
+
+impl Node {
+    pub fn new(s: SocketAddr) -> Self {
+        Self::SingleHomed(s)
+    }
+
+    pub fn addrs(&self) -> Vec<SocketAddr> {
+        match self {
+            Self::NoAddress => vec![],
+            Self::SingleHomed(s) => vec![*s],
+        }
+    }
+}
 
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash, Serialize, Deserialize,


### PR DESCRIPTION
Fixes #158. The goal is to be able to change the node type without breaking everyone's databases in the future.