### PR TITLE
first pass at multi-db cluster support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "parking_lot",
  "paste",
  "pnet",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ opentelemetry-http.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
+parking_lot.workspace = true
 paste.workspace = true
 pnet.workspace = true
 rand.workspace = true
@@ -165,6 +166,7 @@ opentelemetry-otlp = { version = "0.31.0", default-features = false, features = 
 opentelemetry-proto = { version = "0.31.0", default-features = false, features = ["internal-logs", "gen-tonic", "trace", "with-serde"] }
 opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["metrics", "rt-tokio", "rt-tokio-current-thread", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }
+parking_lot = "0.12"
 paste = "1.0.15"
 percent-encoding = "2.3.2"
 pnet = "0.35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ opentelemetry-otlp = { version = "0.31.0", default-features = false, features = 
 opentelemetry-proto = { version = "0.31.0", default-features = false, features = ["internal-logs", "gen-tonic", "trace", "with-serde"] }
 opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["metrics", "rt-tokio", "rt-tokio-current-thread", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }
-parking_lot = "0.12"
+parking_lot = { version = "0.12", features = ["arc_lock"] }
 paste = "1.0.15"
 percent-encoding = "2.3.2"
 pnet = "0.35"

--- a/crates/coyote-configgroup/src/entities.rs
+++ b/crates/coyote-configgroup/src/entities.rs
@@ -34,7 +34,9 @@ impl Display for Module {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, PartialOrd, Ord,
+)]
 pub enum StorageType {
     #[default]
     Persistent = 0,

--- a/crates/coyote-configgroup/src/lib.rs
+++ b/crates/coyote-configgroup/src/lib.rs
@@ -25,7 +25,8 @@ pub fn group_name(key: &str) -> &str {
 pub struct State {
     db: fjall::Database,
     keyspace: fjall::Keyspace,
-    both_dbs: BothDatabases,
+    // TODO(jbrown|2026-02-20) this needs to live in the SerializedStateMachine, not here
+    pub both_dbs: BothDatabases,
 }
 
 // Yeah this is dumb AF. I don't care

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -1,5 +1,9 @@
+mod readonly_db;
 mod table_row;
 
+pub use self::readonly_db::{
+    ReadableDatabase, ReadableKeyspace, ReadonlyDatabase, ReadonlyKeyspace,
+};
 pub use self::table_row::{
     KeyspaceExt, MonotonicTableKey, MonotonicTableRowExt, TableKey, TableRow, WriteBatchExt,
 };

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -1,11 +1,11 @@
 mod readonly_db;
 mod table_row;
 
-pub use self::readonly_db::{
-    ReadableDatabase, ReadableKeyspace, ReadonlyDatabase, ReadonlyKeyspace,
-};
-pub use self::table_row::{
-    KeyspaceExt, MonotonicTableKey, MonotonicTableRowExt, TableKey, TableRow, WriteBatchExt,
+pub use self::{
+    readonly_db::{ReadableDatabase, ReadableKeyspace, ReadonlyDatabase, ReadonlyKeyspace},
+    table_row::{
+        KeyspaceExt, MonotonicTableKey, MonotonicTableRowExt, TableKey, TableRow, WriteBatchExt,
+    },
 };
 
 /// Useful for verifying all table prefixes for a given keyspace are unique,

--- a/crates/fjall-utils/src/readonly_db.rs
+++ b/crates/fjall-utils/src/readonly_db.rs
@@ -1,0 +1,109 @@
+use fjall::{Database, Keyspace, KeyspaceCreateOptions};
+use std::ops::RangeBounds;
+
+/// A wrapper around a Fjall database that only exposes readonly actions
+pub struct ReadonlyDatabase {
+    inner: Database,
+}
+
+impl ReadonlyDatabase {
+    pub fn new(inner: Database) -> Self {
+        Self { inner }
+    }
+}
+
+pub trait ReadableDatabase {
+    type Keyspace: ReadableKeyspace;
+
+    #[must_use]
+    fn snapshot(&self) -> fjall::Snapshot;
+
+    fn keyspace(&self, name: &str) -> fjall::Result<Self::Keyspace>;
+}
+
+impl ReadableDatabase for Database {
+    type Keyspace = Keyspace;
+
+    fn snapshot(&self) -> fjall::Snapshot {
+        self.snapshot()
+    }
+
+    fn keyspace(&self, name: &str) -> fjall::Result<Self::Keyspace> {
+        self.keyspace(name, KeyspaceCreateOptions::default)
+    }
+}
+
+impl ReadableDatabase for ReadonlyDatabase {
+    type Keyspace = ReadonlyKeyspace;
+
+    fn snapshot(&self) -> fjall::Snapshot {
+        self.inner.snapshot()
+    }
+
+    fn keyspace(&self, name: &str) -> fjall::Result<Self::Keyspace> {
+        self.inner
+            .keyspace(name, KeyspaceCreateOptions::default)
+            .map(|inner| ReadonlyKeyspace { inner })
+    }
+}
+
+pub trait ReadableKeyspace {
+    fn get<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<Option<fjall::UserValue>>;
+
+    fn contains_key<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<bool>;
+
+    fn size_of<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<Option<u32>>;
+
+    fn range<K: AsRef<[u8]>, R: RangeBounds<K>>(&self, range: R) -> fjall::Iter;
+
+    fn prefix<K: AsRef<[u8]>>(&self, prefix: K) -> fjall::Iter;
+}
+
+impl ReadableKeyspace for fjall::Keyspace {
+    fn get<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<Option<fjall::UserValue>> {
+        self.get(key)
+    }
+
+    fn contains_key<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<bool> {
+        self.contains_key(key)
+    }
+
+    fn size_of<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<Option<u32>> {
+        self.size_of(key)
+    }
+
+    fn range<K: AsRef<[u8]>, R: RangeBounds<K>>(&self, range: R) -> fjall::Iter {
+        self.range(range)
+    }
+
+    fn prefix<K: AsRef<[u8]>>(&self, prefix: K) -> fjall::Iter {
+        self.prefix(prefix)
+    }
+}
+
+#[derive(Clone)]
+pub struct ReadonlyKeyspace {
+    inner: Keyspace,
+}
+
+impl ReadableKeyspace for ReadonlyKeyspace {
+    fn get<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<Option<fjall::UserValue>> {
+        self.inner.get(key)
+    }
+
+    fn contains_key<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<bool> {
+        self.inner.contains_key(key)
+    }
+
+    fn size_of<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<Option<u32>> {
+        self.inner.size_of(key)
+    }
+
+    fn range<K: AsRef<[u8]>, R: RangeBounds<K>>(&self, range: R) -> fjall::Iter {
+        self.inner.range(range)
+    }
+
+    fn prefix<K: AsRef<[u8]>>(&self, prefix: K) -> fjall::Iter {
+        self.inner.prefix(prefix)
+    }
+}

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -6,6 +6,7 @@ use std::{
 };
 use uuid::Uuid;
 
+use super::readonly_db::ReadableKeyspace;
 use coyote_error::{Error, Result, ResultExt};
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -109,7 +110,7 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
         rmp_serde::from_slice(&value).map_err(Error::generic)
     }
 
-    fn fetch(keyspace: &fjall::Keyspace, key: &Self::Key) -> Result<Option<Self>> {
+    fn fetch<K: ReadableKeyspace>(keyspace: &K, key: &Self::Key) -> Result<Option<Self>> {
         let key = Self::make_fjall_key(key);
         keyspace.get(&key)?.map(Self::from_fjall_value).transpose()
     }
@@ -136,7 +137,7 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
     }
 
     /// Iterate over all of the key/value pairs in this table, in sorted order
-    fn iter(keyspace: &fjall::Keyspace) -> impl Iterator<Item = Result<(Self::Key, Self)>> {
+    fn iter<K: ReadableKeyspace>(keyspace: &K) -> impl Iterator<Item = Result<(Self::Key, Self)>> {
         let prefix = Self::prefix_with(&[]);
         keyspace.prefix(prefix).map(|g| {
             let (k, v) = g.into_inner()?;
@@ -146,7 +147,7 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
         })
     }
 
-    fn values(keyspace: &fjall::Keyspace) -> Result<impl Iterator<Item = Self>> {
+    fn values<K: ReadableKeyspace>(keyspace: &K) -> Result<impl Iterator<Item = Self>> {
         Ok(keyspace.prefix(Self::TABLE_PREFIX).map(|g| {
             let v = g.value().expect("iter error?");
             Self::from_fjall_value(v).expect("deserialize error?")

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -135,9 +135,10 @@ async fn handle_forwarded_write(
 ) -> Result<MsgPack<ForwardedWriteResponse>, crate::Error> {
     // intentionally do not use state.client_write because we don't want an infinite recursion
     // of forwardings
-    let response = state.raft.client_write(req.request).await.map_err(|e| {
-        crate::Error::generic(format!("Unable to execute forwarded write: {:?}", e))
-    })?;
+    let response =
+        state.raft.client_write(req.request).await.map_err(|e| {
+            crate::Error::generic(format!("Unable to execute forwarded write: {e:?}"))
+        })?;
     let response = ForwardedWriteResponse {
         log_id: response.log_id,
         response: response.data,

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -234,7 +234,7 @@ impl RaftState {
                             .forward_request::<openraft::AnyError>(
                                 super::proto::ForwardedWriteRequest {
                                     source_node_id: self.node_id,
-                                    request: request,
+                                    request,
                                 },
                             )
                             .await

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -69,7 +69,7 @@ impl NetworkClient {
         let start = Instant::now();
         // TODO(jbrown|2026-02-20) handle multiple addresses
         let addrs = self.node.addrs();
-        let Some(addr) = addrs.get(0) else {
+        let Some(addr) = addrs.first() else {
             tracing::warn!(node_id=?self.target, node=?self.node, "node has no valid addresses, cannot send rpc");
             return Err(RPCError::Unreachable(Unreachable::new(
                 &crate::Error::generic("no has no known addresses"),

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -127,11 +127,12 @@ pub async fn initialize_raft(
     let config = Arc::new(config.validate()?);
     let network = super::network::NetworkFactory::new(cfg);
 
-    // TODO: handle ephemeral DB
-    let db = app_state.configgroup_state.db().clone();
+    let db = app_state.configgroup_state.both_dbs.persistent_db.clone();
+    let edb = app_state.configgroup_state.both_dbs.ephemeral_db.clone();
 
     let state_machine =
-        super::state_machine::Store::new(db, cfg.cluster.snapshot_path.clone(), app_state).await?;
+        super::state_machine::Store::new(db, edb, cfg.cluster.snapshot_path.clone(), app_state)
+            .await?;
     let state_machine: StoreHandle = state_machine.into();
     let raft = Raft::new(id, config, network.clone(), logs, state_machine.clone()).await?;
     Ok(RaftState {
@@ -181,10 +182,11 @@ mod tests {
             let cfg = cfg.into();
 
             let db = Database::builder(data_path).open()?;
+            let edb = Database::builder(e_data_path).open()?;
 
             let app_state: AppState = AppState::new(cfg);
 
-            let store = Store::new(db, snapshot_path, app_state).await?;
+            let store = Store::new(db, edb, snapshot_path, app_state).await?;
 
             Ok((workdir, logs, store.into()))
         }

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -3,7 +3,7 @@ use std::{
     io::{Read, Seek, Write},
 };
 
-use super::state_machine::Databases;
+use crate::core::db::Databases;
 use anyhow::Context;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use coyote_configgroup::entities::StorageType;
@@ -230,8 +230,8 @@ mod tests {
 
     use fjall::{Database, KeyspaceCreateOptions, Slice};
 
-    use super::super::state_machine::Databases;
     use super::{load_from_file, serialize_to_file};
+    use crate::core::db::Databases;
     use coyote_configgroup::entities::StorageType;
 
     #[test]

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -274,7 +274,7 @@ mod tests {
         db2e_path.push("db_loaded_ephem/");
         let db2e = Database::builder(db2e_path).open()?;
 
-        let databases = Databases::new(db2.clone(), db2e.clone());
+        let databases = Databases::new(db2.clone(), db2e);
 
         let mut cursor = Cursor::new(out);
 

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -3,8 +3,10 @@ use std::{
     io::{Read, Seek, Write},
 };
 
+use super::state_machine::Databases;
 use anyhow::Context;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use coyote_configgroup::entities::StorageType;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, Readable};
 use serde::{Deserialize, Serialize};
 use zip::{ZipArchive, write::SimpleFileOptions};
@@ -38,8 +40,13 @@ struct Chunk {
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-struct Manifest {
+struct KeyspaceManifest {
     keyspaces: BTreeMap<String, Vec<Chunk>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Manifest {
+    databases: BTreeMap<StorageType, KeyspaceManifest>,
 }
 
 struct KeyspaceSerializer<'a, B: Write + Seek> {
@@ -149,11 +156,9 @@ fn deserialize_keyspace<R: Read + Seek>(
     Ok(())
 }
 
-#[tracing::instrument(skip(db, snapshot, file))]
+#[tracing::instrument(skip_all)]
 pub(crate) fn serialize_to_file<F: Write + Seek>(
-    db: Database,
-    snapshot: fjall::Snapshot,
-    keyspaces: Vec<String>,
+    targets: Vec<(StorageType, Database, fjall::Snapshot, Vec<String>)>,
     file: &mut F,
 ) -> anyhow::Result<()> {
     file.write_all(b"COYOTE01")?;
@@ -162,12 +167,16 @@ pub(crate) fn serialize_to_file<F: Write + Seek>(
 
     let mut manifest = Manifest::default();
 
-    for keyspace_name in keyspaces {
-        tracing::debug!(keyspace=%keyspace_name, "serializing a keyspce");
-        let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
-        let serializer = KeyspaceSerializer::new(&mut zip, &keyspace_name)?;
-        let chunks = serializer.serialize_keyspace(&snapshot, &keyspace)?;
-        manifest.keyspaces.insert(keyspace_name, chunks);
+    for (db_name, db, snapshot, keyspaces) in targets {
+        let mut keyspace_manifests = KeyspaceManifest::default();
+        for keyspace_name in keyspaces {
+            tracing::debug!(keyspace=%keyspace_name, "serializing a keyspce");
+            let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
+            let serializer = KeyspaceSerializer::new(&mut zip, &keyspace_name)?;
+            let chunks = serializer.serialize_keyspace(&snapshot, &keyspace)?;
+            keyspace_manifests.keyspaces.insert(keyspace_name, chunks);
+        }
+        manifest.databases.insert(db_name, keyspace_manifests);
     }
 
     let serialized_manifest = serde_json::to_vec(&manifest)?;
@@ -182,7 +191,7 @@ pub(crate) fn serialize_to_file<F: Write + Seek>(
 }
 
 #[tracing::instrument(skip_all)]
-pub(crate) fn load_from_file<F: Read + Seek>(db: &Database, f: &mut F) -> anyhow::Result<()> {
+pub(crate) fn load_from_file<F: Read + Seek>(dbs: &Databases, f: &mut F) -> anyhow::Result<()> {
     let mut magic = [0u8; 8];
     f.read_exact(&mut magic)?;
     if &magic != b"COYOTE01" {
@@ -197,14 +206,19 @@ pub(crate) fn load_from_file<F: Read + Seek>(db: &Database, f: &mut F) -> anyhow
 
     let manifest: Manifest = serde_json::from_reader(manifest).context("parsing manifest")?;
 
-    for (keyspace_name, chunks) in manifest.keyspaces {
-        tracing::debug!(
-            keyspace_name,
-            num_parts = chunks.len(),
-            "deserializing a keyspace"
-        );
-        let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
-        deserialize_keyspace(&mut z, &keyspace, chunks)?;
+    for (backend_db, keyspaces) in manifest.databases {
+        tracing::debug!(?backend_db, "deserializing a database");
+        let db = dbs.db_for(backend_db);
+
+        for (keyspace_name, chunks) in keyspaces.keyspaces {
+            tracing::debug!(
+                keyspace_name,
+                num_parts = chunks.len(),
+                "deserializing a keyspace"
+            );
+            let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
+            deserialize_keyspace(&mut z, &keyspace, chunks)?;
+        }
     }
 
     Ok(())
@@ -216,7 +230,9 @@ mod tests {
 
     use fjall::{Database, KeyspaceCreateOptions, Slice};
 
-    use crate::core::cluster::serialized_state_machine::{load_from_file, serialize_to_file};
+    use super::super::state_machine::Databases;
+    use super::{load_from_file, serialize_to_file};
+    use coyote_configgroup::entities::StorageType;
 
     #[test]
     fn test_serialize_to_file_round_trip() -> anyhow::Result<()> {
@@ -237,12 +253,14 @@ mod tests {
 
         let mut cursor = Cursor::new(vec![]);
 
-        serialize_to_file(
+        let targets = vec![(
+            StorageType::Persistent,
             db,
             snapshot,
             vec!["keyspace1".to_owned(), "keyspace2".to_owned()],
-            &mut cursor,
-        )?;
+        )];
+
+        serialize_to_file(targets, &mut cursor)?;
 
         let out = cursor.into_inner();
 
@@ -252,9 +270,15 @@ mod tests {
         db2_path.push("db_loaded/");
         let db2 = Database::builder(db2_path).open()?;
 
+        let mut db2e_path = workdir.path().to_path_buf();
+        db2e_path.push("db_loaded_ephem/");
+        let db2e = Database::builder(db2e_path).open()?;
+
+        let databases = Databases::new(db2.clone(), db2e.clone());
+
         let mut cursor = Cursor::new(out);
 
-        load_from_file(&db2, &mut cursor)?;
+        load_from_file(&databases, &mut cursor)?;
 
         let found_keyspaces = db2
             .list_keyspace_names()

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -5,6 +5,7 @@ use std::{
     sync::Arc,
 };
 
+use crate::core::db::Databases;
 use coyote_configgroup::entities::StorageType;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
 use openraft::{
@@ -51,27 +52,6 @@ pub struct StoreHandle(Arc<TokioRwLock<Store>>);
 impl From<Store> for StoreHandle {
     fn from(value: Store) -> Self {
         Self(Arc::new(TokioRwLock::new(value)))
-    }
-}
-
-pub(super) struct Databases {
-    persistent: Database,
-    ephemeral: Database,
-}
-
-impl Databases {
-    pub(super) fn db_for(&self, name: StorageType) -> &Database {
-        match name {
-            StorageType::Persistent => &self.persistent,
-            StorageType::Ephemeral => &self.ephemeral,
-        }
-    }
-
-    pub(super) fn new(persistent: Database, ephemeral: Database) -> Self {
-        Self {
-            persistent,
-            ephemeral,
-        }
     }
 }
 
@@ -133,6 +113,13 @@ impl Store {
         };
         this.load_information().await?;
         Ok(this)
+    }
+
+    /// Get a read lock on the databases and return a handle to them. Intended to be used by the
+    /// applier
+    #[allow(dead_code)]
+    pub(super) fn db_handle(&self) -> impl std::ops::Deref<Target = Databases> {
+        self.databases.read_arc()
     }
 
     pub fn cluster_id(&self) -> Option<&ClusterId> {

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -2,14 +2,16 @@ use std::{
     io::{ErrorKind, Seek, SeekFrom},
     path::{Path, PathBuf},
     pin::Pin,
-    sync::{Arc, RwLock},
+    sync::Arc,
 };
 
+use coyote_configgroup::entities::StorageType;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
 use openraft::{
     EntryPayload, LogId, RaftSnapshotBuilder, RaftTypeConfig, Snapshot, SnapshotMeta,
     StorageIOError, StoredMembership, storage::RaftStateMachine,
 };
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tap::TapFallible;
 use tokio::sync::RwLock as TokioRwLock;
@@ -52,9 +54,30 @@ impl From<Store> for StoreHandle {
     }
 }
 
+pub(super) struct Databases {
+    persistent: Database,
+    ephemeral: Database,
+}
+
+impl Databases {
+    pub(super) fn db_for(&self, name: StorageType) -> &Database {
+        match name {
+            StorageType::Persistent => &self.persistent,
+            StorageType::Ephemeral => &self.ephemeral,
+        }
+    }
+
+    pub(super) fn new(persistent: Database, ephemeral: Database) -> Self {
+        Self {
+            persistent,
+            ephemeral,
+        }
+    }
+}
+
 pub struct Store {
     pub(super) state: AppState,
-    db: Database,
+    databases: Arc<RwLock<Databases>>,
     snapshot_directory: PathBuf,
     meta_keyspace: Keyspace,
     snapshot_idx: u64,
@@ -84,7 +107,8 @@ const METADATA_KEYSPACE: &str = "_raft_metadata";
 
 impl Store {
     pub async fn new(
-        db: Database,
+        persistent_db: Database,
+        ephemeral_db: Database,
         snapshot_directory: PathBuf,
         app_state: AppState,
     ) -> anyhow::Result<Self> {
@@ -93,9 +117,11 @@ impl Store {
         {
             return Err(e.into());
         }
-        let meta_keyspace = db.keyspace(METADATA_KEYSPACE, KeyspaceCreateOptions::default)?;
+        let meta_keyspace =
+            persistent_db.keyspace(METADATA_KEYSPACE, KeyspaceCreateOptions::default)?;
+        let databases = Databases::new(persistent_db, ephemeral_db);
         let mut this = Self {
-            db,
+            databases: Arc::new(RwLock::new(databases)),
             state: app_state,
             snapshot_directory,
             meta_keyspace,
@@ -142,11 +168,12 @@ impl Store {
 
     #[tracing::instrument(skip(self))]
     async fn load_information(&mut self) -> anyhow::Result<()> {
-        let db = self.db.clone();
+        let handle = self.databases.clone();
         let keyspace = self.meta_keyspace.clone();
 
         let (last_applied_log_id, last_membership, last_snapshot, cluster_id) =
             tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+                let db = &handle.read().persistent;
                 let snapshot = db.snapshot();
                 let last_applied_log_id =
                     Self::try_read_field(&snapshot, &keyspace, "last_applied_log_id").ok();
@@ -173,7 +200,7 @@ impl Store {
             .map(|s| s.meta.snapshot_idx())
             .unwrap_or(0);
         self.cluster_id = cluster_id;
-        *self.last_snapshot.write().unwrap() = last_snapshot;
+        *self.last_snapshot.write() = last_snapshot;
         Ok(())
     }
 
@@ -182,7 +209,7 @@ impl Store {
         meta: SnapshotMeta<NodeId, Node>,
         snapshot_path: PathBuf,
     ) -> anyhow::Result<()> {
-        let db = self.db.clone();
+        let handle = self.databases.clone();
         let keyspace = self.meta_keyspace.clone();
         self.snapshot_idx = std::cmp::max(self.snapshot_idx + 1, meta.snapshot_idx());
         let data = LastSnapshot {
@@ -192,12 +219,13 @@ impl Store {
         tracing::trace!(last_snapshot=?data, "setting last_snapshot");
         let serialized = rmp_serde::to_vec_named(&data)?;
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let db = &handle.read().persistent;
             keyspace.insert("last_snapshot", serialized)?;
             db.persist(fjall::PersistMode::SyncAll)?;
             Ok(())
         })
         .await??;
-        *self.last_snapshot.write().unwrap() = Some(data);
+        *self.last_snapshot.write() = Some(data);
         Ok(())
     }
 
@@ -206,11 +234,16 @@ impl Store {
             last_applied_log_id=?self.last_applied_log_id,
             last_membership=?self.last_membership,
             "storing id values");
-        let mut tx = self.db.batch().durability(Some(PersistMode::Buffer));
+        let handle = self.databases.clone();
         let keyspace = self.meta_keyspace.clone();
         let last_applied_log_id = rmp_serde::encode::to_vec_named(&self.last_applied_log_id)?;
         let last_membership = rmp_serde::encode::to_vec_named(&self.last_membership)?;
         tokio::task::spawn_blocking(move || {
+            let mut tx = handle
+                .read()
+                .persistent
+                .batch()
+                .durability(Some(PersistMode::Buffer));
             tx.insert(&keyspace, "last_applied_log_id", last_applied_log_id);
             tx.insert(&keyspace, "last_membership", last_membership);
             tx.commit()?;
@@ -244,9 +277,12 @@ impl Store {
     ) -> anyhow::Result<()> {
         tracing::debug!("starting snapshot installation");
         let mut f = snapshot.file.into_std().await;
-        let db = self.db.clone();
-        tokio::task::spawn_blocking(move || serialized_state_machine::load_from_file(&db, &mut f))
-            .await??;
+        let handle = self.databases.clone();
+        tokio::task::spawn_blocking(move || {
+            let databases = handle.write();
+            serialized_state_machine::load_from_file(&databases, &mut f)
+        })
+        .await??;
         self.last_applied_log_id = meta.last_log_id;
         self.last_membership = meta.last_membership.clone();
         self.record_ids_().await?;
@@ -323,7 +359,7 @@ impl Store {
         &mut self,
     ) -> StorageResult<Option<openraft::Snapshot<TypeConfig>>> {
         // clone to avoid holding a lock over an await point
-        let last_snapshot = self.last_snapshot.read().unwrap().clone();
+        let last_snapshot = self.last_snapshot.read().clone();
         if let Some(last_snapshot) = last_snapshot {
             tracing::trace!(?last_snapshot, "found last_snapshot");
             let f = tokio::fs::File::open(&last_snapshot.path)
@@ -358,18 +394,40 @@ impl Store {
             snapshot_id,
         };
 
-        let keyspaces = self
-            .db
-            .list_keyspace_names()
-            .into_iter()
-            .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
-            .map(|s| s.to_string())
-            .collect();
+        let handle = self.databases.clone();
 
-        let snapshot =
-            StoredSnapshot::new(&meta, &self.snapshot_directory, self.db.clone(), keyspaces)
-                .await
-                .map_err(write_snapshot_err)?;
+        fn list_keyspaces(db: &Database) -> Vec<String> {
+            db.list_keyspace_names()
+                .into_iter()
+                .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
+                .map(|s| s.to_string())
+                .collect()
+        }
+
+        let targets = tokio::task::spawn_blocking(move || {
+            let dbs = handle.write();
+
+            vec![
+                (
+                    StorageType::Persistent,
+                    dbs.persistent.clone(),
+                    dbs.persistent.snapshot(),
+                    list_keyspaces(&dbs.persistent),
+                ),
+                (
+                    StorageType::Ephemeral,
+                    dbs.ephemeral.clone(),
+                    dbs.ephemeral.snapshot(),
+                    list_keyspaces(&dbs.ephemeral),
+                ),
+            ]
+        })
+        .await
+        .map_err(|err| write_snapshot_err(anyhow::anyhow!(err)))?;
+
+        let snapshot = StoredSnapshot::new(&meta, &self.snapshot_directory, targets)
+            .await
+            .map_err(write_snapshot_err)?;
 
         self.set_last_snapshot_(meta.clone(), snapshot.path.clone())
             .await
@@ -457,17 +515,15 @@ impl StoredSnapshot {
     async fn new(
         metadata: &SnapshotMeta<NodeId, Node>,
         directory: &Path,
-        database: Database,
-        keyspaces: Vec<String>,
+        targets: Vec<(StorageType, Database, fjall::Snapshot, Vec<String>)>,
     ) -> anyhow::Result<Self> {
         let file_name = format!("coyote-{}", metadata.snapshot_id);
         let path = directory.with_file_name(file_name);
         let path_c = path.clone();
         let file = tokio::task::spawn_blocking(move || -> anyhow::Result<std::fs::File> {
-            let snapshot = database.snapshot();
             tracing::info!(path=%path_c.display(), "writing snapshot");
             let mut f = std::fs::File::create(path_c)?;
-            serialized_state_machine::serialize_to_file(database, snapshot, keyspaces, &mut f)?;
+            serialized_state_machine::serialize_to_file(targets, &mut f)?;
             f.seek(SeekFrom::Start(0))?;
             Ok(f)
         })

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1,0 +1,71 @@
+use coyote_configgroup::entities::StorageType;
+use fjall::Database;
+use fjall_utils::ReadonlyDatabase;
+
+/// A handle to both of the databases. Should only ever be accessed while holding
+/// a read lock on the raft StateMachine
+pub struct Databases {
+    pub(super) persistent: Database,
+    pub(super) ephemeral: Database,
+}
+
+impl Databases {
+    /// Construct a new handle from raw fjall databases
+    pub fn new(persistent: Database, ephemeral: Database) -> Self {
+        Self {
+            persistent,
+            ephemeral,
+        }
+    }
+
+    /// Get a handle to the particular database for a given StorageType
+    pub fn db_for(&self, storage_type: StorageType) -> &Database {
+        match storage_type {
+            StorageType::Persistent => &self.persistent,
+            StorageType::Ephemeral => &self.ephemeral,
+        }
+    }
+
+    /// Construct a `ReadonlyDatabases` handle from this handle
+    pub fn readonly(&self) -> ReadonlyDatabases {
+        ReadonlyDatabases {
+            inner: Databases {
+                persistent: self.persistent.clone(),
+                ephemeral: self.ephemeral.clone(),
+            },
+        }
+    }
+}
+
+/// A handle to readonly versions of both databases
+pub struct ReadonlyDatabases {
+    inner: Databases,
+}
+
+impl Clone for ReadonlyDatabases {
+    fn clone(&self) -> Self {
+        self.inner.readonly()
+    }
+}
+
+pub trait ReadonlyConnection {
+    fn db_for(&self, storage_type: StorageType) -> ReadonlyDatabase;
+}
+
+impl ReadonlyConnection for Databases {
+    fn db_for(&self, storage_type: StorageType) -> ReadonlyDatabase {
+        match storage_type {
+            StorageType::Persistent => ReadonlyDatabase::new(self.persistent.clone()),
+            StorageType::Ephemeral => ReadonlyDatabase::new(self.ephemeral.clone()),
+        }
+    }
+}
+
+impl ReadonlyConnection for ReadonlyDatabases {
+    fn db_for(&self, storage_type: StorageType) -> ReadonlyDatabase {
+        match storage_type {
+            StorageType::Persistent => ReadonlyDatabase::new(self.inner.persistent.clone()),
+            StorageType::Ephemeral => ReadonlyDatabase::new(self.inner.ephemeral.clone()),
+        }
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 pub mod cluster;
+pub mod db;
 pub mod otel_spans;
 pub mod retry;
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,10 @@ use uuid::Uuid;
 
 use crate::{
     cfg::{Configuration, DatabaseConfig},
-    core::cluster::RaftState,
-    core::db::{Databases, ReadonlyDatabases},
+    core::{
+        cluster::RaftState,
+        db::{Databases, ReadonlyDatabases},
+    },
 };
 use coyote_cache::CacheStore;
 use coyote_idempotency::IdempotencyStore;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ use uuid::Uuid;
 use crate::{
     cfg::{Configuration, DatabaseConfig},
     core::cluster::RaftState,
+    core::db::{Databases, ReadonlyDatabases},
 };
 use coyote_cache::CacheStore;
 use coyote_idempotency::IdempotencyStore;
@@ -115,6 +116,8 @@ pub struct AppState {
 
     stream_state: stream::State,
     configgroup_state: coyote_configgroup::State,
+    #[allow(dead_code)]
+    ro_dbs: ReadonlyDatabases,
 }
 
 async fn run_interserver(
@@ -160,6 +163,8 @@ impl AppState {
         let persistent_db = DatabaseConfig::persistent(&cfg.persistent_db).expect("persistent db");
         let ephemeral_db = DatabaseConfig::ephemeral(&cfg.ephemeral_db).expect("ephemeral db");
 
+        let ro_dbs = Databases::new(persistent_db.clone(), ephemeral_db.clone()).readonly();
+
         let configgroup_state = coyote_configgroup::State::init(BothDatabases {
             persistent_db: persistent_db.clone(),
             ephemeral_db,
@@ -176,6 +181,7 @@ impl AppState {
             ),
             stream_state,
             configgroup_state,
+            ro_dbs,
         }
     }
 


### PR DESCRIPTION
This is the first (and less likely to conflict) PR related to supporting both the ephemeral and the persistent databases in replication.

It stores references to both of these behind an RwLock inside the StateMachine, and when creating/restoring snapshots, holds a write lock on that RwLock.

This also builds out the infrastructure for providing read-only views across the databases.

In a future set of PRs, I'm going to be expanding on this to make it so that instead of the DBs living in `coyote_configgroup`, they live in the state machine and get _borred_ by coyote_configgroup; for `ReadonlyDatabases` we don't need to hold the rwlock at all (which is why that object impls Clone), but for `Databases` we do.

Part of #77