### PR TITLE
Rewrite bootstrap config loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,6 @@ dependencies = [
  "assert_matches",
  "axum",
  "byteorder",
- "config",
  "coyote-cache",
  "coyote-client",
  "coyote-configgroup",
@@ -884,6 +883,7 @@ dependencies = [
  "url",
  "uuid",
  "validator",
+ "yaml_serde",
  "zip",
 ]
 
@@ -4606,6 +4606,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5285,6 +5291,19 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.10.0",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a7f5270edc6fab0529a772a772b3e505dfd883a8de5cc5b464e35fabe586411"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ anyerror.workspace = true
 anyhow.workspace = true
 axum.workspace = true
 byteorder.workspace = true
-config.workspace = true
 coyote-cache.workspace = true
 coyote-configgroup.workspace = true
 coyote-derive.workspace = true
@@ -74,6 +73,7 @@ tracing-subscriber = { workspace = true, features = ["json"] }
 url.workspace = true
 uuid.workspace = true
 validator.workspace = true
+yaml_serde.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
@@ -198,6 +198,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["a
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.19.0", features = ["v7", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
+yaml_serde = "0.10.3"
 zip = "7"
 
 [workspace.lints.rust]

--- a/bootstrap.default.yaml
+++ b/bootstrap.default.yaml
@@ -1,9 +1,0 @@
-kv:
-  default:
-    storage_type: persistent
-cache:
-  default:
-    storage_type: persistent
-idempotency:
-  default:
-    storage_type: persistent

--- a/crates/coyote-configgroup/src/entities.rs
+++ b/crates/coyote-configgroup/src/entities.rs
@@ -34,8 +34,9 @@ impl Display for Module {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum StorageType {
+    #[default]
     Persistent = 0,
     Ephemeral = 1,
 }

--- a/crates/coyote-configgroup/src/operations/create_configgroup.rs
+++ b/crates/coyote-configgroup/src/operations/create_configgroup.rs
@@ -16,7 +16,8 @@ use crate::{
 pub struct CreateConfigGroup<C: ModuleConfig> {
     timestamp: Timestamp,
     name: String,
-    storage_type: Option<StorageType>,
+    #[serde(default)]
+    storage_type: StorageType,
     max_storage_bytes: Option<NonZeroU64>,
     config: C,
 }
@@ -37,7 +38,7 @@ impl<C: ModuleConfig> CreateConfigGroup<C> {
     pub fn new(
         name: String,
         config: C,
-        storage_type: Option<StorageType>,
+        storage_type: StorageType,
         max_storage_bytes: Option<NonZeroU64>,
     ) -> Self {
         Self {
@@ -54,7 +55,7 @@ impl<C: ModuleConfig> CreateConfigGroup<C> {
         let keyspace = state.keyspace();
         let configgroup = match ConfigGroup::<C>::fetch(keyspace, &self.name)? {
             Some(mut configgroup) => {
-                configgroup.storage_type = self.storage_type.unwrap_or(StorageType::Persistent);
+                configgroup.storage_type = self.storage_type;
                 configgroup.updated_at = self.timestamp;
                 configgroup.max_storage_bytes = self.max_storage_bytes;
                 configgroup.config = self.config;
@@ -65,7 +66,7 @@ impl<C: ModuleConfig> CreateConfigGroup<C> {
                 ConfigGroup {
                     id,
                     name: self.name,
-                    storage_type: self.storage_type.unwrap_or(StorageType::Persistent),
+                    storage_type: self.storage_type,
                     max_storage_bytes: self.max_storage_bytes,
                     created_at: self.timestamp,
                     updated_at: self.timestamp,

--- a/crates/stream/src/operations/create_stream.rs
+++ b/crates/stream/src/operations/create_stream.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 
 use super::{CreateStreamResponse, StreamRaftState, StreamRequest};
-use coyote_configgroup::entities::StreamConfig;
+use coyote_configgroup::entities::{StorageType, StreamConfig};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -34,7 +34,7 @@ impl CreateStreamOperation {
             StreamConfig {
                 retention_period_seconds: self.retention_period_seconds,
             },
-            None,
+            StorageType::default(),
             self.max_byte_size,
         );
         let out = op.apply_operation(configgroup_state)?;

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,8 +1,11 @@
-use std::{collections::HashMap, num::NonZeroU64};
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    fs::File,
+    num::NonZeroU64,
+};
 
 use crate::cfg::{Configuration as AppConfig, DatabaseConfig};
 use anyhow::Context;
-use config::ConfigBuilder;
 use coyote_configgroup::{
     BothDatabases,
     entities::{
@@ -12,9 +15,6 @@ use coyote_configgroup::{
     operations::create_configgroup::CreateConfigGroup,
 };
 use serde::Deserialize;
-use tap::Pipe;
-
-const DEFAULTS: &str = include_str!("../bootstrap.default.yaml");
 
 trait IntoModuleConfig {
     type Output: ModuleConfig;
@@ -76,7 +76,7 @@ impl<C: IntoModuleConfig> ConfigGroupIn<C> {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct KeyValueConfigIn {}
 
 impl IntoModuleConfig for KeyValueConfigIn {
@@ -87,7 +87,7 @@ impl IntoModuleConfig for KeyValueConfigIn {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct IdempotencyConfigIn {}
 
 impl IntoModuleConfig for IdempotencyConfigIn {
@@ -98,7 +98,7 @@ impl IntoModuleConfig for IdempotencyConfigIn {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct CacheConfigIn {
     pub eviction_policy: Option<EvictionPolicyIn>,
 }
@@ -128,7 +128,7 @@ impl IntoModuleConfig for StreamConfigIn {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct BootstrapConfig {
     cache: Option<HashMap<String, ConfigGroupIn<CacheConfigIn>>>,
     idempotency: Option<HashMap<String, ConfigGroupIn<IdempotencyConfigIn>>>,
@@ -138,20 +138,52 @@ struct BootstrapConfig {
 
 impl BootstrapConfig {
     fn load(config_path: Option<&str>) -> anyhow::Result<BootstrapConfig> {
-        let config = config::Config::builder()
-            .add_source(config::File::from_str(DEFAULTS, config::FileFormat::Yaml))
-            .pipe(|config: ConfigBuilder<_>| {
-                if let Some(path) = config_path {
-                    config.add_source(config::File::with_name(path))
-                } else {
-                    config
-                }
-            })
-            .build()?;
+        let mut config = match config_path {
+            Some(path) => {
+                let config_file = File::open(path).context("opening bootstrap config")?;
+                yaml_serde::from_reader(config_file).context("parsing bootstrap config")?
+            }
+            None => BootstrapConfig::default(),
+        };
 
-        let config: BootstrapConfig = config
-            .try_deserialize::<BootstrapConfig>()
-            .context("failed to load bootstrap configuration")?;
+        // Configure default config group for cache, if not part of the config file
+        if let Entry::Vacant(v) = config
+            .cache
+            .get_or_insert_default()
+            .entry("default".to_owned())
+        {
+            v.insert(ConfigGroupIn {
+                storage_type: Some(StorageTypeIn::Persistent),
+                max_storage_bytes: None,
+                config: CacheConfigIn::default(),
+            });
+        }
+
+        // Configure default config group for idempotency, if not part of the config file
+        if let Entry::Vacant(v) = config
+            .idempotency
+            .get_or_insert_default()
+            .entry("default".to_owned())
+        {
+            v.insert(ConfigGroupIn {
+                storage_type: Some(StorageTypeIn::Persistent),
+                max_storage_bytes: None,
+                config: IdempotencyConfigIn::default(),
+            });
+        }
+
+        // Configure default config group for kv, if not part of the config file
+        if let Entry::Vacant(v) = config
+            .kv
+            .get_or_insert_default()
+            .entry("default".to_owned())
+        {
+            v.insert(ConfigGroupIn {
+                storage_type: Some(StorageTypeIn::Persistent),
+                max_storage_bytes: None,
+                config: KeyValueConfigIn::default(),
+            });
+        }
 
         Ok(config)
     }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -56,9 +56,10 @@ impl From<EvictionPolicyIn> for EvictionPolicy {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct ConfigGroupIn<C> {
-    pub storage_type: Option<StorageTypeIn>,
+    #[serde(default)]
+    pub storage_type: StorageTypeIn,
     pub max_storage_bytes: Option<NonZeroU64>,
 
     #[serde(flatten)]
@@ -70,7 +71,7 @@ impl<C: IntoModuleConfig> ConfigGroupIn<C> {
         CreateConfigGroup::new(
             name,
             self.config.into_module_config(),
-            self.storage_type.map(|x| x.into()),
+            self.storage_type.into(),
             self.max_storage_bytes,
         )
     }
@@ -152,11 +153,7 @@ impl BootstrapConfig {
             .get_or_insert_default()
             .entry("default".to_owned())
         {
-            v.insert(ConfigGroupIn {
-                storage_type: Some(StorageTypeIn::Persistent),
-                max_storage_bytes: None,
-                config: CacheConfigIn::default(),
-            });
+            v.insert(ConfigGroupIn::default());
         }
 
         // Configure default config group for idempotency, if not part of the config file
@@ -165,11 +162,7 @@ impl BootstrapConfig {
             .get_or_insert_default()
             .entry("default".to_owned())
         {
-            v.insert(ConfigGroupIn {
-                storage_type: Some(StorageTypeIn::Persistent),
-                max_storage_bytes: None,
-                config: IdempotencyConfigIn::default(),
-            });
+            v.insert(ConfigGroupIn::default());
         }
 
         // Configure default config group for kv, if not part of the config file
@@ -178,11 +171,7 @@ impl BootstrapConfig {
             .get_or_insert_default()
             .entry("default".to_owned())
         {
-            v.insert(ConfigGroupIn {
-                storage_type: Some(StorageTypeIn::Persistent),
-                max_storage_bytes: None,
-                config: KeyValueConfigIn::default(),
-            });
+            v.insert(ConfigGroupIn::default());
         }
 
         Ok(config)

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -147,7 +147,6 @@ impl BootstrapConfig {
                     config
                 }
             })
-            .add_source(config::Environment::with_prefix("COYOTE"))
             .build()?;
 
         let config: BootstrapConfig = config


### PR DESCRIPTION
- Remove loading bootstrap config from env vars (never intended; closes https://github.com/svix/coyote-private/issues/124)
- Use `serde-yaml` instead of `config` crate for parsing yaml file (and move defaults into code, hope you don't mind)
- Drop `Option<_>` around StorageType[In] because `None` and `::Persistent` have the same meaning