### PR TITLE
Mark client code as `linguist-generated`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+clients/rust/src/api/** linguist-generated
+clients/rust/src/models/** linguist-generated
+clients/cli/src/cmds/api/** linguist-generated
+clients/go/apis.go linguist-generated
+clients/go/models.go linguist-generated
+clients/go/internal/apis/** linguist-generated
+clients/go/internal/models/** linguist-generated
+clients/javascript/src/client.ts linguist-generated
+clients/javascript/src/apis/** linguist-generated
+clients/javascript/src/models/** linguist-generated


### PR DESCRIPTION
This marks all of the autogenerated client code as `linguist-generated`, which [according to github](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github), will do two things:
1. Ignore these files when computing language statistics
2. By default, hide these files in diffs

I don't care about (1). but I am strongly motivated by (2). It's annoying to review a PR that is (nominally) 3000+ LoC diff, only to see that 2500 of those lines are autogenerated client code, that I have to go through and manually "mark as viewed" in the github diff viewer.

Curious to hear people's thoughts on this.