### PR TITLE
server: use non-colon form of env vars in development.env

### DIFF
--- a/development.env
+++ b/development.env
@@ -1,3 +1,3 @@
 # Example .env file for development
-COYOTE:JWT_SECRET=x
-COYOTE:LOG_LEVEL=trace
+COYOTE_JWT_SECRET=x
+COYOTE_LOG_LEVEL=trace


### PR DESCRIPTION
these have been broken since commit bfecef7a0d5204f0326da54d8a6ff0f616d311f7