### PR TITLE
codegen: Remove support for query parameters / header options structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]

--- a/benchmarks/benches/kv.rs
+++ b/benchmarks/benches/kv.rs
@@ -30,7 +30,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             || (test_key.clone(), test_val.clone()),
             |(key, val)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(KvSetIn::new(key, val), None))
+                    std::hint::black_box(client.kv().set(KvSetIn::new(key, val)))
                         .await
                         .unwrap();
                 })
@@ -49,7 +49,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(KvSetIn::new(k, v), None))
+                    std::hint::black_box(client.kv().set(KvSetIn::new(k, v)))
                         .await
                         .unwrap();
                 })
@@ -68,7 +68,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(KvSetIn::new(k, v), None))
+                    std::hint::black_box(client.kv().set(KvSetIn::new(k, v)))
                         .await
                         .unwrap();
                 })
@@ -87,7 +87,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(KvSetIn::new(k, v), None))
+                    std::hint::black_box(client.kv().set(KvSetIn::new(k, v)))
                         .await
                         .unwrap();
                 })
@@ -101,7 +101,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
         std::hint::black_box(
             client
                 .kv()
-                .set(KvSetIn::new(test_key.clone(), test_val.clone()), None),
+                .set(KvSetIn::new(test_key.clone(), test_val.clone())),
         )
         .await
         .unwrap();
@@ -112,7 +112,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             || test_key.clone(),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().get(KvGetIn::new(key), None))
+                    std::hint::black_box(client.kv().get(KvGetIn::new(key)))
                         .await
                         .unwrap();
                 })
@@ -126,10 +126,10 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             || (test_key.clone(), test_key.clone(), test_val.clone()),
             |(key1, key2, test_val)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(KvSetIn::new(key1, test_val), None))
+                    std::hint::black_box(client.kv().set(KvSetIn::new(key1, test_val)))
                         .await
                         .unwrap();
-                    std::hint::black_box(client.kv().delete(KvDeleteIn::new(key2), None))
+                    std::hint::black_box(client.kv().delete(KvDeleteIn::new(key2)))
                         .await
                         .unwrap();
                 })

--- a/clients/cli/src/cmds/api/cache.rs
+++ b/clients/cli/src/cmds/api/cache.rs
@@ -2,58 +2,6 @@
 use clap::{Args, Subcommand};
 use coyote_client::CoyoteClient;
 
-#[derive(Args, Clone)]
-pub struct CacheSetOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<CacheSetOptions> for coyote_client::api::CacheSetOptions {
-    fn from(value: CacheSetOptions) -> Self {
-        let CacheSetOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct CacheGetOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<CacheGetOptions> for coyote_client::api::CacheGetOptions {
-    fn from(value: CacheGetOptions) -> Self {
-        let CacheGetOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct CacheGetGroupOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<CacheGetGroupOptions> for coyote_client::api::CacheGetGroupOptions {
-    fn from(value: CacheGetGroupOptions) -> Self {
-        let CacheGetGroupOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct CacheDeleteOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<CacheDeleteOptions> for coyote_client::api::CacheDeleteOptions {
-    fn from(value: CacheDeleteOptions) -> Self {
-        let CacheDeleteOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct CacheArgs {
@@ -66,26 +14,18 @@ pub enum CacheCommands {
     /// Cache Set
     Set {
         cache_set_in: crate::json::JsonOf<coyote_client::models::CacheSetIn>,
-        #[clap(flatten)]
-        options: CacheSetOptions,
     },
     /// Cache Get
     Get {
         cache_get_in: crate::json::JsonOf<coyote_client::models::CacheGetIn>,
-        #[clap(flatten)]
-        options: CacheGetOptions,
     },
     /// Get cache group
     GetGroup {
         cache_get_group_in: crate::json::JsonOf<coyote_client::models::CacheGetGroupIn>,
-        #[clap(flatten)]
-        options: CacheGetGroupOptions,
     },
     /// Cache Delete
     Delete {
         cache_delete_in: crate::json::JsonOf<coyote_client::models::CacheDeleteIn>,
-        #[clap(flatten)]
-        options: CacheDeleteOptions,
     },
 }
 
@@ -96,44 +36,23 @@ impl CacheCommands {
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {
-            Self::Set {
-                cache_set_in,
-                options,
-            } => {
+            Self::Set { cache_set_in } => {
+                let resp = client.cache().set(cache_set_in.into_inner()).await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Get { cache_get_in } => {
+                let resp = client.cache().get(cache_get_in.into_inner()).await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::GetGroup { cache_get_group_in } => {
                 let resp = client
                     .cache()
-                    .set(cache_set_in.into_inner(), Some(options.into()))
+                    .get_group(cache_get_group_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::Get {
-                cache_get_in,
-                options,
-            } => {
-                let resp = client
-                    .cache()
-                    .get(cache_get_in.into_inner(), Some(options.into()))
-                    .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
-            }
-            Self::GetGroup {
-                cache_get_group_in,
-                options,
-            } => {
-                let resp = client
-                    .cache()
-                    .get_group(cache_get_group_in.into_inner(), Some(options.into()))
-                    .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
-            }
-            Self::Delete {
-                cache_delete_in,
-                options,
-            } => {
-                let resp = client
-                    .cache()
-                    .delete(cache_delete_in.into_inner(), Some(options.into()))
-                    .await?;
+            Self::Delete { cache_delete_in } => {
+                let resp = client.cache().delete(cache_delete_in.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
         }

--- a/clients/cli/src/cmds/api/idempotency.rs
+++ b/clients/cli/src/cmds/api/idempotency.rs
@@ -2,32 +2,6 @@
 use clap::{Args, Subcommand};
 use coyote_client::CoyoteClient;
 
-#[derive(Args, Clone)]
-pub struct IdempotencyAbortOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<IdempotencyAbortOptions> for coyote_client::api::IdempotencyAbortOptions {
-    fn from(value: IdempotencyAbortOptions) -> Self {
-        let IdempotencyAbortOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct IdempotencyGetGroupOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<IdempotencyGetGroupOptions> for coyote_client::api::IdempotencyGetGroupOptions {
-    fn from(value: IdempotencyGetGroupOptions) -> Self {
-        let IdempotencyGetGroupOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct IdempotencyArgs {
@@ -40,14 +14,10 @@ pub enum IdempotencyCommands {
     /// Abandon an idempotent request (remove lock without saving response)
     Abort {
         idempotency_abort_in: crate::json::JsonOf<coyote_client::models::IdempotencyAbortIn>,
-        #[clap(flatten)]
-        options: IdempotencyAbortOptions,
     },
     /// Get idempotency group
     GetGroup {
         idempotency_get_group_in: crate::json::JsonOf<coyote_client::models::IdempotencyGetGroupIn>,
-        #[clap(flatten)]
-        options: IdempotencyGetGroupOptions,
     },
 }
 
@@ -60,21 +30,19 @@ impl IdempotencyCommands {
         match self {
             Self::Abort {
                 idempotency_abort_in,
-                options,
             } => {
                 let resp = client
                     .idempotency()
-                    .abort(idempotency_abort_in.into_inner(), Some(options.into()))
+                    .abort(idempotency_abort_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
             Self::GetGroup {
                 idempotency_get_group_in,
-                options,
             } => {
                 let resp = client
                     .idempotency()
-                    .get_group(idempotency_get_group_in.into_inner(), Some(options.into()))
+                    .get_group(idempotency_get_group_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }

--- a/clients/cli/src/cmds/api/kv.rs
+++ b/clients/cli/src/cmds/api/kv.rs
@@ -2,58 +2,6 @@
 use clap::{Args, Subcommand};
 use coyote_client::CoyoteClient;
 
-#[derive(Args, Clone)]
-pub struct KvSetOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<KvSetOptions> for coyote_client::api::KvSetOptions {
-    fn from(value: KvSetOptions) -> Self {
-        let KvSetOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct KvGetOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<KvGetOptions> for coyote_client::api::KvGetOptions {
-    fn from(value: KvGetOptions) -> Self {
-        let KvGetOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct KvGetGroupOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<KvGetGroupOptions> for coyote_client::api::KvGetGroupOptions {
-    fn from(value: KvGetGroupOptions) -> Self {
-        let KvGetGroupOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct KvDeleteOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<KvDeleteOptions> for coyote_client::api::KvDeleteOptions {
-    fn from(value: KvDeleteOptions) -> Self {
-        let KvDeleteOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct KvArgs {
@@ -66,26 +14,18 @@ pub enum KvCommands {
     /// KV Set
     Set {
         kv_set_in: crate::json::JsonOf<coyote_client::models::KvSetIn>,
-        #[clap(flatten)]
-        options: KvSetOptions,
     },
     /// KV Get
     Get {
         kv_get_in: crate::json::JsonOf<coyote_client::models::KvGetIn>,
-        #[clap(flatten)]
-        options: KvGetOptions,
     },
     /// Get KV store
     GetGroup {
         kv_get_group_in: crate::json::JsonOf<coyote_client::models::KvGetGroupIn>,
-        #[clap(flatten)]
-        options: KvGetGroupOptions,
     },
     /// KV Delete
     Delete {
         kv_delete_in: crate::json::JsonOf<coyote_client::models::KvDeleteIn>,
-        #[clap(flatten)]
-        options: KvDeleteOptions,
     },
 }
 
@@ -96,38 +36,20 @@ impl KvCommands {
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {
-            Self::Set { kv_set_in, options } => {
-                let resp = client
-                    .kv()
-                    .set(kv_set_in.into_inner(), Some(options.into()))
-                    .await?;
+            Self::Set { kv_set_in } => {
+                let resp = client.kv().set(kv_set_in.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::Get { kv_get_in, options } => {
-                let resp = client
-                    .kv()
-                    .get(kv_get_in.into_inner(), Some(options.into()))
-                    .await?;
+            Self::Get { kv_get_in } => {
+                let resp = client.kv().get(kv_get_in.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::GetGroup {
-                kv_get_group_in,
-                options,
-            } => {
-                let resp = client
-                    .kv()
-                    .get_group(kv_get_group_in.into_inner(), Some(options.into()))
-                    .await?;
+            Self::GetGroup { kv_get_group_in } => {
+                let resp = client.kv().get_group(kv_get_group_in.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::Delete {
-                kv_delete_in,
-                options,
-            } => {
-                let resp = client
-                    .kv()
-                    .delete(kv_delete_in.into_inner(), Some(options.into()))
-                    .await?;
+            Self::Delete { kv_delete_in } => {
+                let resp = client.kv().delete(kv_delete_in.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
         }

--- a/clients/cli/src/cmds/api/rate_limiter.rs
+++ b/clients/cli/src/cmds/api/rate_limiter.rs
@@ -2,32 +2,6 @@
 use clap::{Args, Subcommand};
 use coyote_client::CoyoteClient;
 
-#[derive(Args, Clone)]
-pub struct RateLimiterLimitOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<RateLimiterLimitOptions> for coyote_client::api::RateLimiterLimitOptions {
-    fn from(value: RateLimiterLimitOptions) -> Self {
-        let RateLimiterLimitOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct RateLimiterGetRemainingOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<RateLimiterGetRemainingOptions> for coyote_client::api::RateLimiterGetRemainingOptions {
-    fn from(value: RateLimiterGetRemainingOptions) -> Self {
-        let RateLimiterGetRemainingOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct RateLimiterArgs {
@@ -40,15 +14,11 @@ pub enum RateLimiterCommands {
     /// Rate Limiter Check and Consume
     Limit {
         rate_limiter_check_in: crate::json::JsonOf<coyote_client::models::RateLimiterCheckIn>,
-        #[clap(flatten)]
-        options: RateLimiterLimitOptions,
     },
     /// Rate Limiter Get Remaining
     GetRemaining {
         rate_limiter_get_remaining_in:
             crate::json::JsonOf<coyote_client::models::RateLimiterGetRemainingIn>,
-        #[clap(flatten)]
-        options: RateLimiterGetRemainingOptions,
     },
 }
 
@@ -61,24 +31,19 @@ impl RateLimiterCommands {
         match self {
             Self::Limit {
                 rate_limiter_check_in,
-                options,
             } => {
                 let resp = client
                     .rate_limiter()
-                    .limit(rate_limiter_check_in.into_inner(), Some(options.into()))
+                    .limit(rate_limiter_check_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
             Self::GetRemaining {
                 rate_limiter_get_remaining_in,
-                options,
             } => {
                 let resp = client
                     .rate_limiter()
-                    .get_remaining(
-                        rate_limiter_get_remaining_in.into_inner(),
-                        Some(options.into()),
-                    )
+                    .get_remaining(rate_limiter_get_remaining_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }

--- a/clients/cli/src/cmds/api/stream.rs
+++ b/clients/cli/src/cmds/api/stream.rs
@@ -2,123 +2,6 @@
 use clap::{Args, Subcommand};
 use coyote_client::CoyoteClient;
 
-#[derive(Args, Clone)]
-pub struct StreamCreateOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamCreateOptions> for coyote_client::api::StreamCreateOptions {
-    fn from(value: StreamCreateOptions) -> Self {
-        let StreamCreateOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct StreamGetOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamGetOptions> for coyote_client::api::StreamGetOptions {
-    fn from(value: StreamGetOptions) -> Self {
-        let StreamGetOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct StreamAppendOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamAppendOptions> for coyote_client::api::StreamAppendOptions {
-    fn from(value: StreamAppendOptions) -> Self {
-        let StreamAppendOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct StreamFetchOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamFetchOptions> for coyote_client::api::StreamFetchOptions {
-    fn from(value: StreamFetchOptions) -> Self {
-        let StreamFetchOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct StreamFetchLockingOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamFetchLockingOptions> for coyote_client::api::StreamFetchLockingOptions {
-    fn from(value: StreamFetchLockingOptions) -> Self {
-        let StreamFetchLockingOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct StreamAckRangeOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamAckRangeOptions> for coyote_client::api::StreamAckRangeOptions {
-    fn from(value: StreamAckRangeOptions) -> Self {
-        let StreamAckRangeOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct StreamAckOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamAckOptions> for coyote_client::api::StreamAckOptions {
-    fn from(value: StreamAckOptions) -> Self {
-        let StreamAckOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct StreamDlqOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamDlqOptions> for coyote_client::api::StreamDlqOptions {
-    fn from(value: StreamDlqOptions) -> Self {
-        let StreamDlqOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
-#[derive(Args, Clone)]
-pub struct StreamRedriveOptions {
-    #[arg(long)]
-    pub idempotency_key: Option<String>,
-}
-
-impl From<StreamRedriveOptions> for coyote_client::api::StreamRedriveOptions {
-    fn from(value: StreamRedriveOptions) -> Self {
-        let StreamRedriveOptions { idempotency_key } = value;
-        Self { idempotency_key }
-    }
-}
-
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct StreamArgs {
@@ -131,20 +14,14 @@ pub enum StreamCommands {
     /// Upserts a new Stream with the given name.
     Create {
         create_stream_in: crate::json::JsonOf<coyote_client::models::CreateStreamIn>,
-        #[clap(flatten)]
-        options: StreamCreateOptions,
     },
     /// Get stream with given name.
     Get {
         get_stream_in: crate::json::JsonOf<coyote_client::models::GetStreamIn>,
-        #[clap(flatten)]
-        options: StreamGetOptions,
     },
     /// Appends messages to the stream.
     Append {
         append_to_stream_in: crate::json::JsonOf<coyote_client::models::AppendToStreamIn>,
-        #[clap(flatten)]
-        options: StreamAppendOptions,
     },
     /// Fetches messages from the stream, while allowing concurrent access from other consumers in the same group.
     ///
@@ -153,8 +30,6 @@ pub enum StreamCommands {
     /// until the visibility timeout expires, or the messages are acked.
     Fetch {
         fetch_from_stream_in: crate::json::JsonOf<coyote_client::models::FetchFromStreamIn>,
-        #[clap(flatten)]
-        options: StreamFetchOptions,
     },
     /// Fetches messages from the stream, locking over the consumer group.
     ///
@@ -162,32 +37,22 @@ pub enum StreamCommands {
     /// until either the visibility timeout expires, or the last message in the batch is acknowledged.
     FetchLocking {
         fetch_from_stream_in: crate::json::JsonOf<coyote_client::models::FetchFromStreamIn>,
-        #[clap(flatten)]
-        options: StreamFetchLockingOptions,
     },
     /// Acks the messages for the consumer group, allowing more messages to be consumed.
     AckRange {
         ack_msg_range_in: crate::json::JsonOf<coyote_client::models::AckMsgRangeIn>,
-        #[clap(flatten)]
-        options: StreamAckRangeOptions,
     },
     /// Acks a single message.
     Ack {
         ack: crate::json::JsonOf<coyote_client::models::Ack>,
-        #[clap(flatten)]
-        options: StreamAckOptions,
     },
     /// Moves a message to the dead letter queue.
     Dlq {
         dlq_in: crate::json::JsonOf<coyote_client::models::DlqIn>,
-        #[clap(flatten)]
-        options: StreamDlqOptions,
     },
     /// Redrives messages from the dead letter queue back to the stream.
     Redrive {
         redrive_in: crate::json::JsonOf<coyote_client::models::RedriveIn>,
-        #[clap(flatten)]
-        options: StreamRedriveOptions,
     },
 }
 
@@ -198,88 +63,61 @@ impl StreamCommands {
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {
-            Self::Create {
-                create_stream_in,
-                options,
-            } => {
+            Self::Create { create_stream_in } => {
                 let resp = client
                     .stream()
-                    .create(create_stream_in.into_inner(), Some(options.into()))
+                    .create(create_stream_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::Get {
-                get_stream_in,
-                options,
-            } => {
-                let resp = client
-                    .stream()
-                    .get(get_stream_in.into_inner(), Some(options.into()))
-                    .await?;
+            Self::Get { get_stream_in } => {
+                let resp = client.stream().get(get_stream_in.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
             Self::Append {
                 append_to_stream_in,
-                options,
             } => {
                 let resp = client
                     .stream()
-                    .append(append_to_stream_in.into_inner(), Some(options.into()))
+                    .append(append_to_stream_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
             Self::Fetch {
                 fetch_from_stream_in,
-                options,
             } => {
                 let resp = client
                     .stream()
-                    .fetch(fetch_from_stream_in.into_inner(), Some(options.into()))
+                    .fetch(fetch_from_stream_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
             Self::FetchLocking {
                 fetch_from_stream_in,
-                options,
             } => {
                 let resp = client
                     .stream()
-                    .fetch_locking(fetch_from_stream_in.into_inner(), Some(options.into()))
+                    .fetch_locking(fetch_from_stream_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::AckRange {
-                ack_msg_range_in,
-                options,
-            } => {
+            Self::AckRange { ack_msg_range_in } => {
                 let resp = client
                     .stream()
-                    .ack_range(ack_msg_range_in.into_inner(), Some(options.into()))
+                    .ack_range(ack_msg_range_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::Ack { ack, options } => {
-                let resp = client
-                    .stream()
-                    .ack(ack.into_inner(), Some(options.into()))
-                    .await?;
+            Self::Ack { ack } => {
+                let resp = client.stream().ack(ack.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::Dlq { dlq_in, options } => {
-                let resp = client
-                    .stream()
-                    .dlq(dlq_in.into_inner(), Some(options.into()))
-                    .await?;
+            Self::Dlq { dlq_in } => {
+                let resp = client.stream().dlq(dlq_in.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::Redrive {
-                redrive_in,
-                options,
-            } => {
-                let resp = client
-                    .stream()
-                    .redrive(redrive_in.into_inner(), Some(options.into()))
-                    .await?;
+            Self::Redrive { redrive_in } => {
+                let resp = client.stream().redrive(redrive_in.into_inner()).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
         }

--- a/clients/go/internal/apis/cache.go
+++ b/clients/go/internal/apis/cache.go
@@ -17,36 +17,11 @@ func NewCache(client *coyote_proto.HttpClient) Cache {
 	return Cache{client}
 }
 
-type CacheSetOptions struct {
-	IdempotencyKey *string
-}
-
-type CacheGetOptions struct {
-	IdempotencyKey *string
-}
-
-type CacheGetGroupOptions struct {
-	IdempotencyKey *string
-}
-
-type CacheDeleteOptions struct {
-	IdempotencyKey *string
-}
-
 // Cache Set
 func (cache *Cache) Set(
 	ctx context.Context,
 	cacheSetIn coyote_models.CacheSetIn,
-	o *CacheSetOptions,
 ) (*coyote_models.CacheSetOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.CacheSetIn, coyote_models.CacheSetOut](
 		ctx,
 		cache.client,
@@ -54,7 +29,7 @@ func (cache *Cache) Set(
 		"/api/v1/cache/set",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&cacheSetIn,
 	)
 }
@@ -63,16 +38,7 @@ func (cache *Cache) Set(
 func (cache *Cache) Get(
 	ctx context.Context,
 	cacheGetIn coyote_models.CacheGetIn,
-	o *CacheGetOptions,
 ) (*coyote_models.CacheGetOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.CacheGetIn, coyote_models.CacheGetOut](
 		ctx,
 		cache.client,
@@ -80,7 +46,7 @@ func (cache *Cache) Get(
 		"/api/v1/cache/get",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&cacheGetIn,
 	)
 }
@@ -89,16 +55,7 @@ func (cache *Cache) Get(
 func (cache *Cache) GetGroup(
 	ctx context.Context,
 	cacheGetGroupIn coyote_models.CacheGetGroupIn,
-	o *CacheGetGroupOptions,
 ) (*coyote_models.CacheGetGroupOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.CacheGetGroupIn, coyote_models.CacheGetGroupOut](
 		ctx,
 		cache.client,
@@ -106,7 +63,7 @@ func (cache *Cache) GetGroup(
 		"/api/v1/cache/get-group",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&cacheGetGroupIn,
 	)
 }
@@ -115,16 +72,7 @@ func (cache *Cache) GetGroup(
 func (cache *Cache) Delete(
 	ctx context.Context,
 	cacheDeleteIn coyote_models.CacheDeleteIn,
-	o *CacheDeleteOptions,
 ) (*coyote_models.CacheDeleteOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.CacheDeleteIn, coyote_models.CacheDeleteOut](
 		ctx,
 		cache.client,
@@ -132,7 +80,7 @@ func (cache *Cache) Delete(
 		"/api/v1/cache/delete",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&cacheDeleteIn,
 	)
 }

--- a/clients/go/internal/apis/cache.go
+++ b/clients/go/internal/apis/cache.go
@@ -29,7 +29,6 @@ func (cache *Cache) Set(
 		"/api/v1/cache/set",
 		nil,
 		nil,
-		nil,
 		&cacheSetIn,
 	)
 }
@@ -44,7 +43,6 @@ func (cache *Cache) Get(
 		cache.client,
 		"POST",
 		"/api/v1/cache/get",
-		nil,
 		nil,
 		nil,
 		&cacheGetIn,
@@ -63,7 +61,6 @@ func (cache *Cache) GetGroup(
 		"/api/v1/cache/get-group",
 		nil,
 		nil,
-		nil,
 		&cacheGetGroupIn,
 	)
 }
@@ -78,7 +75,6 @@ func (cache *Cache) Delete(
 		cache.client,
 		"POST",
 		"/api/v1/cache/delete",
-		nil,
 		nil,
 		nil,
 		&cacheDeleteIn,

--- a/clients/go/internal/apis/health.go
+++ b/clients/go/internal/apis/health.go
@@ -29,6 +29,5 @@ func (health *Health) Ping(
 		nil,
 		nil,
 		nil,
-		nil,
 	)
 }

--- a/clients/go/internal/apis/idempotency.go
+++ b/clients/go/internal/apis/idempotency.go
@@ -17,28 +17,11 @@ func NewIdempotency(client *coyote_proto.HttpClient) Idempotency {
 	return Idempotency{client}
 }
 
-type IdempotencyAbortOptions struct {
-	IdempotencyKey *string
-}
-
-type IdempotencyGetGroupOptions struct {
-	IdempotencyKey *string
-}
-
 // Abandon an idempotent request (remove lock without saving response)
 func (idempotency *Idempotency) Abort(
 	ctx context.Context,
 	idempotencyAbortIn coyote_models.IdempotencyAbortIn,
-	o *IdempotencyAbortOptions,
 ) (*coyote_models.IdempotencyAbortOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.IdempotencyAbortIn, coyote_models.IdempotencyAbortOut](
 		ctx,
 		idempotency.client,
@@ -46,7 +29,7 @@ func (idempotency *Idempotency) Abort(
 		"/api/v1/idempotency/abort",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&idempotencyAbortIn,
 	)
 }
@@ -55,16 +38,7 @@ func (idempotency *Idempotency) Abort(
 func (idempotency *Idempotency) GetGroup(
 	ctx context.Context,
 	idempotencyGetGroupIn coyote_models.IdempotencyGetGroupIn,
-	o *IdempotencyGetGroupOptions,
 ) (*coyote_models.IdempotencyGetGroupOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.IdempotencyGetGroupIn, coyote_models.IdempotencyGetGroupOut](
 		ctx,
 		idempotency.client,
@@ -72,7 +46,7 @@ func (idempotency *Idempotency) GetGroup(
 		"/api/v1/idempotency/get-group",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&idempotencyGetGroupIn,
 	)
 }

--- a/clients/go/internal/apis/idempotency.go
+++ b/clients/go/internal/apis/idempotency.go
@@ -29,7 +29,6 @@ func (idempotency *Idempotency) Abort(
 		"/api/v1/idempotency/abort",
 		nil,
 		nil,
-		nil,
 		&idempotencyAbortIn,
 	)
 }
@@ -44,7 +43,6 @@ func (idempotency *Idempotency) GetGroup(
 		idempotency.client,
 		"POST",
 		"/api/v1/idempotency/get-group",
-		nil,
 		nil,
 		nil,
 		&idempotencyGetGroupIn,

--- a/clients/go/internal/apis/kv.go
+++ b/clients/go/internal/apis/kv.go
@@ -17,36 +17,11 @@ func NewKv(client *coyote_proto.HttpClient) Kv {
 	return Kv{client}
 }
 
-type KvSetOptions struct {
-	IdempotencyKey *string
-}
-
-type KvGetOptions struct {
-	IdempotencyKey *string
-}
-
-type KvGetGroupOptions struct {
-	IdempotencyKey *string
-}
-
-type KvDeleteOptions struct {
-	IdempotencyKey *string
-}
-
 // KV Set
 func (kv *Kv) Set(
 	ctx context.Context,
 	kvSetIn coyote_models.KvSetIn,
-	o *KvSetOptions,
 ) (*coyote_models.KvSetOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.KvSetIn, coyote_models.KvSetOut](
 		ctx,
 		kv.client,
@@ -54,7 +29,7 @@ func (kv *Kv) Set(
 		"/api/v1/kv/set",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&kvSetIn,
 	)
 }
@@ -63,16 +38,7 @@ func (kv *Kv) Set(
 func (kv *Kv) Get(
 	ctx context.Context,
 	kvGetIn coyote_models.KvGetIn,
-	o *KvGetOptions,
 ) (*coyote_models.KvGetOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.KvGetIn, coyote_models.KvGetOut](
 		ctx,
 		kv.client,
@@ -80,7 +46,7 @@ func (kv *Kv) Get(
 		"/api/v1/kv/get",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&kvGetIn,
 	)
 }
@@ -89,16 +55,7 @@ func (kv *Kv) Get(
 func (kv *Kv) GetGroup(
 	ctx context.Context,
 	kvGetGroupIn coyote_models.KvGetGroupIn,
-	o *KvGetGroupOptions,
 ) (*coyote_models.KvGetGroupOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.KvGetGroupIn, coyote_models.KvGetGroupOut](
 		ctx,
 		kv.client,
@@ -106,7 +63,7 @@ func (kv *Kv) GetGroup(
 		"/api/v1/kv/get-group",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&kvGetGroupIn,
 	)
 }
@@ -115,16 +72,7 @@ func (kv *Kv) GetGroup(
 func (kv *Kv) Delete(
 	ctx context.Context,
 	kvDeleteIn coyote_models.KvDeleteIn,
-	o *KvDeleteOptions,
 ) (*coyote_models.KvDeleteOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.KvDeleteIn, coyote_models.KvDeleteOut](
 		ctx,
 		kv.client,
@@ -132,7 +80,7 @@ func (kv *Kv) Delete(
 		"/api/v1/kv/delete",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&kvDeleteIn,
 	)
 }

--- a/clients/go/internal/apis/kv.go
+++ b/clients/go/internal/apis/kv.go
@@ -29,7 +29,6 @@ func (kv *Kv) Set(
 		"/api/v1/kv/set",
 		nil,
 		nil,
-		nil,
 		&kvSetIn,
 	)
 }
@@ -44,7 +43,6 @@ func (kv *Kv) Get(
 		kv.client,
 		"POST",
 		"/api/v1/kv/get",
-		nil,
 		nil,
 		nil,
 		&kvGetIn,
@@ -63,7 +61,6 @@ func (kv *Kv) GetGroup(
 		"/api/v1/kv/get-group",
 		nil,
 		nil,
-		nil,
 		&kvGetGroupIn,
 	)
 }
@@ -78,7 +75,6 @@ func (kv *Kv) Delete(
 		kv.client,
 		"POST",
 		"/api/v1/kv/delete",
-		nil,
 		nil,
 		nil,
 		&kvDeleteIn,

--- a/clients/go/internal/apis/rate_limiter.go
+++ b/clients/go/internal/apis/rate_limiter.go
@@ -29,7 +29,6 @@ func (rateLimiter *RateLimiter) Limit(
 		"/api/v1/rate-limiter/limit",
 		nil,
 		nil,
-		nil,
 		&rateLimiterCheckIn,
 	)
 }
@@ -44,7 +43,6 @@ func (rateLimiter *RateLimiter) GetRemaining(
 		rateLimiter.client,
 		"POST",
 		"/api/v1/rate-limiter/get-remaining",
-		nil,
 		nil,
 		nil,
 		&rateLimiterGetRemainingIn,

--- a/clients/go/internal/apis/rate_limiter.go
+++ b/clients/go/internal/apis/rate_limiter.go
@@ -17,28 +17,11 @@ func NewRateLimiter(client *coyote_proto.HttpClient) RateLimiter {
 	return RateLimiter{client}
 }
 
-type RateLimiterLimitOptions struct {
-	IdempotencyKey *string
-}
-
-type RateLimiterGetRemainingOptions struct {
-	IdempotencyKey *string
-}
-
 // Rate Limiter Check and Consume
 func (rateLimiter *RateLimiter) Limit(
 	ctx context.Context,
 	rateLimiterCheckIn coyote_models.RateLimiterCheckIn,
-	o *RateLimiterLimitOptions,
 ) (*coyote_models.RateLimiterCheckOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.RateLimiterCheckIn, coyote_models.RateLimiterCheckOut](
 		ctx,
 		rateLimiter.client,
@@ -46,7 +29,7 @@ func (rateLimiter *RateLimiter) Limit(
 		"/api/v1/rate-limiter/limit",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&rateLimiterCheckIn,
 	)
 }
@@ -55,16 +38,7 @@ func (rateLimiter *RateLimiter) Limit(
 func (rateLimiter *RateLimiter) GetRemaining(
 	ctx context.Context,
 	rateLimiterGetRemainingIn coyote_models.RateLimiterGetRemainingIn,
-	o *RateLimiterGetRemainingOptions,
 ) (*coyote_models.RateLimiterGetRemainingOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.RateLimiterGetRemainingIn, coyote_models.RateLimiterGetRemainingOut](
 		ctx,
 		rateLimiter.client,
@@ -72,7 +46,7 @@ func (rateLimiter *RateLimiter) GetRemaining(
 		"/api/v1/rate-limiter/get-remaining",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&rateLimiterGetRemainingIn,
 	)
 }

--- a/clients/go/internal/apis/stream.go
+++ b/clients/go/internal/apis/stream.go
@@ -17,56 +17,11 @@ func NewStream(client *coyote_proto.HttpClient) Stream {
 	return Stream{client}
 }
 
-type StreamCreateOptions struct {
-	IdempotencyKey *string
-}
-
-type StreamGetOptions struct {
-	IdempotencyKey *string
-}
-
-type StreamAppendOptions struct {
-	IdempotencyKey *string
-}
-
-type StreamFetchOptions struct {
-	IdempotencyKey *string
-}
-
-type StreamFetchLockingOptions struct {
-	IdempotencyKey *string
-}
-
-type StreamAckRangeOptions struct {
-	IdempotencyKey *string
-}
-
-type StreamAckOptions struct {
-	IdempotencyKey *string
-}
-
-type StreamDlqOptions struct {
-	IdempotencyKey *string
-}
-
-type StreamRedriveOptions struct {
-	IdempotencyKey *string
-}
-
 // Upserts a new Stream with the given name.
 func (stream *Stream) Create(
 	ctx context.Context,
 	createStreamIn coyote_models.CreateStreamIn,
-	o *StreamCreateOptions,
 ) (*coyote_models.CreateStreamOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.CreateStreamIn, coyote_models.CreateStreamOut](
 		ctx,
 		stream.client,
@@ -74,7 +29,7 @@ func (stream *Stream) Create(
 		"/api/v1/stream/create",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&createStreamIn,
 	)
 }
@@ -83,16 +38,7 @@ func (stream *Stream) Create(
 func (stream *Stream) Get(
 	ctx context.Context,
 	getStreamIn coyote_models.GetStreamIn,
-	o *StreamGetOptions,
 ) (*coyote_models.GetStreamOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.GetStreamIn, coyote_models.GetStreamOut](
 		ctx,
 		stream.client,
@@ -100,7 +46,7 @@ func (stream *Stream) Get(
 		"/api/v1/stream/get-group",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&getStreamIn,
 	)
 }
@@ -109,16 +55,7 @@ func (stream *Stream) Get(
 func (stream *Stream) Append(
 	ctx context.Context,
 	appendToStreamIn coyote_models.AppendToStreamIn,
-	o *StreamAppendOptions,
 ) (*coyote_models.AppendToStreamOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.AppendToStreamIn, coyote_models.AppendToStreamOut](
 		ctx,
 		stream.client,
@@ -126,7 +63,7 @@ func (stream *Stream) Append(
 		"/api/v1/stream/append",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&appendToStreamIn,
 	)
 }
@@ -139,16 +76,7 @@ func (stream *Stream) Append(
 func (stream *Stream) Fetch(
 	ctx context.Context,
 	fetchFromStreamIn coyote_models.FetchFromStreamIn,
-	o *StreamFetchOptions,
 ) (*coyote_models.FetchFromStreamOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.FetchFromStreamIn, coyote_models.FetchFromStreamOut](
 		ctx,
 		stream.client,
@@ -156,7 +84,7 @@ func (stream *Stream) Fetch(
 		"/api/v1/stream/fetch",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&fetchFromStreamIn,
 	)
 }
@@ -168,16 +96,7 @@ func (stream *Stream) Fetch(
 func (stream *Stream) FetchLocking(
 	ctx context.Context,
 	fetchFromStreamIn coyote_models.FetchFromStreamIn,
-	o *StreamFetchLockingOptions,
 ) (*coyote_models.FetchFromStreamOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.FetchFromStreamIn, coyote_models.FetchFromStreamOut](
 		ctx,
 		stream.client,
@@ -185,7 +104,7 @@ func (stream *Stream) FetchLocking(
 		"/api/v1/stream/fetch-locking",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&fetchFromStreamIn,
 	)
 }
@@ -194,16 +113,7 @@ func (stream *Stream) FetchLocking(
 func (stream *Stream) AckRange(
 	ctx context.Context,
 	ackMsgRangeIn coyote_models.AckMsgRangeIn,
-	o *StreamAckRangeOptions,
 ) (*coyote_models.AckMsgRangeOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.AckMsgRangeIn, coyote_models.AckMsgRangeOut](
 		ctx,
 		stream.client,
@@ -211,7 +121,7 @@ func (stream *Stream) AckRange(
 		"/api/v1/stream/ack-range",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&ackMsgRangeIn,
 	)
 }
@@ -220,16 +130,7 @@ func (stream *Stream) AckRange(
 func (stream *Stream) Ack(
 	ctx context.Context,
 	ack coyote_models.Ack,
-	o *StreamAckOptions,
 ) (*coyote_models.AckOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.Ack, coyote_models.AckOut](
 		ctx,
 		stream.client,
@@ -237,7 +138,7 @@ func (stream *Stream) Ack(
 		"/api/v1/stream/ack",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&ack,
 	)
 }
@@ -246,16 +147,7 @@ func (stream *Stream) Ack(
 func (stream *Stream) Dlq(
 	ctx context.Context,
 	dlqIn coyote_models.DlqIn,
-	o *StreamDlqOptions,
 ) (*coyote_models.DlqOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.DlqIn, coyote_models.DlqOut](
 		ctx,
 		stream.client,
@@ -263,7 +155,7 @@ func (stream *Stream) Dlq(
 		"/api/v1/stream/dlq",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&dlqIn,
 	)
 }
@@ -272,16 +164,7 @@ func (stream *Stream) Dlq(
 func (stream *Stream) Redrive(
 	ctx context.Context,
 	redriveIn coyote_models.RedriveIn,
-	o *StreamRedriveOptions,
 ) (*coyote_models.RedriveOut, error) {
-	headerMap := map[string]string{}
-	var err error
-	if o != nil {
-		coyote_proto.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coyote_proto.ExecuteRequest[coyote_models.RedriveIn, coyote_models.RedriveOut](
 		ctx,
 		stream.client,
@@ -289,7 +172,7 @@ func (stream *Stream) Redrive(
 		"/api/v1/stream/redrive-dlq",
 		nil,
 		nil,
-		headerMap,
+		nil,
 		&redriveIn,
 	)
 }

--- a/clients/go/internal/apis/stream.go
+++ b/clients/go/internal/apis/stream.go
@@ -29,7 +29,6 @@ func (stream *Stream) Create(
 		"/api/v1/stream/create",
 		nil,
 		nil,
-		nil,
 		&createStreamIn,
 	)
 }
@@ -46,7 +45,6 @@ func (stream *Stream) Get(
 		"/api/v1/stream/get-group",
 		nil,
 		nil,
-		nil,
 		&getStreamIn,
 	)
 }
@@ -61,7 +59,6 @@ func (stream *Stream) Append(
 		stream.client,
 		"POST",
 		"/api/v1/stream/append",
-		nil,
 		nil,
 		nil,
 		&appendToStreamIn,
@@ -84,7 +81,6 @@ func (stream *Stream) Fetch(
 		"/api/v1/stream/fetch",
 		nil,
 		nil,
-		nil,
 		&fetchFromStreamIn,
 	)
 }
@@ -104,7 +100,6 @@ func (stream *Stream) FetchLocking(
 		"/api/v1/stream/fetch-locking",
 		nil,
 		nil,
-		nil,
 		&fetchFromStreamIn,
 	)
 }
@@ -119,7 +114,6 @@ func (stream *Stream) AckRange(
 		stream.client,
 		"POST",
 		"/api/v1/stream/ack-range",
-		nil,
 		nil,
 		nil,
 		&ackMsgRangeIn,
@@ -138,7 +132,6 @@ func (stream *Stream) Ack(
 		"/api/v1/stream/ack",
 		nil,
 		nil,
-		nil,
 		&ack,
 	)
 }
@@ -155,7 +148,6 @@ func (stream *Stream) Dlq(
 		"/api/v1/stream/dlq",
 		nil,
 		nil,
-		nil,
 		&dlqIn,
 	)
 }
@@ -170,7 +162,6 @@ func (stream *Stream) Redrive(
 		stream.client,
 		"POST",
 		"/api/v1/stream/redrive-dlq",
-		nil,
 		nil,
 		nil,
 		&redriveIn,

--- a/clients/go/internal/proto/http_client.go
+++ b/clients/go/internal/proto/http_client.go
@@ -11,7 +11,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -51,17 +50,13 @@ func ExecuteRequest[ReqBody any, ResBody any](
 	method string,
 	path string,
 	pathParams map[string]string,
-	queryParams map[string]string,
 	headerParams map[string]string,
 	jsonBody *ReqBody,
 ) (*ResBody, error) {
+	urlStr := client.BaseURL + replacePathKeys(path, pathParams)
 
-	urlWithPath := client.BaseURL + replacePathKeys(path, pathParams)
-	urlStr, err := addQueryParams(urlWithPath, queryParams)
-	if err != nil {
-		return nil, err
-	}
 	var req *http.Request
+	var err error
 	if jsonBody != nil {
 		encodedBody, err := json.Marshal(jsonBody)
 		if err != nil {
@@ -77,7 +72,6 @@ func ExecuteRequest[ReqBody any, ResBody any](
 		if err != nil {
 			return nil, err
 		}
-
 	}
 
 	req.Header.Set("svix-req-id", strconv.FormatUint(rand.Uint64(), 10))
@@ -179,21 +173,6 @@ func replacePathKeys(path string, pathParams map[string]string) string {
 		path = strings.ReplaceAll(path, placeholder, value)
 	}
 	return path
-}
-
-func addQueryParams(baseURL string, params map[string]string) (string, error) {
-	parsedURL, err := url.Parse(baseURL)
-	if err != nil {
-		return "", err
-	}
-
-	query := parsedURL.Query()
-	for key, value := range params {
-		query.Add(key, value)
-	}
-
-	parsedURL.RawQuery = query.Encode()
-	return parsedURL.String(), nil
 }
 
 func SerializeParamToMap(key string, val interface{}, d map[string]string, err *error) {

--- a/clients/javascript/src/apis/cache.ts
+++ b/clients/javascript/src/apis/cache.ts
@@ -34,33 +34,15 @@ import {
 } from '../models/cacheSetOut';
 import { HttpMethod, CoyoteRequest, CoyoteRequestContext } from "../request";
 
-export interface CacheSetOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface CacheGetOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface CacheGetGroupOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface CacheDeleteOptions {
-        idempotencyKey?: string;
-        }
-
-    export class Cache {
+export class Cache {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Cache Set */
         public set(
             cacheSetIn: CacheSetIn,
-            options?: CacheSetOptions,
             ): Promise<CacheSetOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/set");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     CacheSetInSerializer._toJsonObject(
                         cacheSetIn,
@@ -78,11 +60,9 @@ export interface CacheSetOptions {
     /** Cache Get */
         public get(
             cacheGetIn: CacheGetIn,
-            options?: CacheGetOptions,
             ): Promise<CacheGetOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/get");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     CacheGetInSerializer._toJsonObject(
                         cacheGetIn,
@@ -100,11 +80,9 @@ export interface CacheSetOptions {
     /** Get cache group */
         public getGroup(
             cacheGetGroupIn: CacheGetGroupIn,
-            options?: CacheGetGroupOptions,
             ): Promise<CacheGetGroupOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/get-group");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     CacheGetGroupInSerializer._toJsonObject(
                         cacheGetGroupIn,
@@ -122,11 +100,9 @@ export interface CacheSetOptions {
     /** Cache Delete */
         public delete(
             cacheDeleteIn: CacheDeleteIn,
-            options?: CacheDeleteOptions,
             ): Promise<CacheDeleteOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/delete");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     CacheDeleteInSerializer._toJsonObject(
                         cacheDeleteIn,

--- a/clients/javascript/src/apis/idempotency.ts
+++ b/clients/javascript/src/apis/idempotency.ts
@@ -18,25 +18,15 @@ import {
 } from '../models/idempotencyGetGroupOut';
 import { HttpMethod, CoyoteRequest, CoyoteRequestContext } from "../request";
 
-export interface IdempotencyAbortOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface IdempotencyGetGroupOptions {
-        idempotencyKey?: string;
-        }
-
-    export class Idempotency {
+export class Idempotency {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Abandon an idempotent request (remove lock without saving response) */
         public abort(
             idempotencyAbortIn: IdempotencyAbortIn,
-            options?: IdempotencyAbortOptions,
             ): Promise<IdempotencyAbortOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/abort");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     IdempotencyAbortInSerializer._toJsonObject(
                         idempotencyAbortIn,
@@ -54,11 +44,9 @@ export interface IdempotencyAbortOptions {
     /** Get idempotency group */
         public getGroup(
             idempotencyGetGroupIn: IdempotencyGetGroupIn,
-            options?: IdempotencyGetGroupOptions,
             ): Promise<IdempotencyGetGroupOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/get-group");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     IdempotencyGetGroupInSerializer._toJsonObject(
                         idempotencyGetGroupIn,

--- a/clients/javascript/src/apis/kv.ts
+++ b/clients/javascript/src/apis/kv.ts
@@ -34,33 +34,15 @@ import {
 } from '../models/kvSetOut';
 import { HttpMethod, CoyoteRequest, CoyoteRequestContext } from "../request";
 
-export interface KvSetOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface KvGetOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface KvGetGroupOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface KvDeleteOptions {
-        idempotencyKey?: string;
-        }
-
-    export class Kv {
+export class Kv {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** KV Set */
         public set(
             kvSetIn: KvSetIn,
-            options?: KvSetOptions,
             ): Promise<KvSetOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/set");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     KvSetInSerializer._toJsonObject(
                         kvSetIn,
@@ -78,11 +60,9 @@ export interface KvSetOptions {
     /** KV Get */
         public get(
             kvGetIn: KvGetIn,
-            options?: KvGetOptions,
             ): Promise<KvGetOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/get");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     KvGetInSerializer._toJsonObject(
                         kvGetIn,
@@ -100,11 +80,9 @@ export interface KvSetOptions {
     /** Get KV store */
         public getGroup(
             kvGetGroupIn: KvGetGroupIn,
-            options?: KvGetGroupOptions,
             ): Promise<KvGetGroupOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/get-group");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     KvGetGroupInSerializer._toJsonObject(
                         kvGetGroupIn,
@@ -122,11 +100,9 @@ export interface KvSetOptions {
     /** KV Delete */
         public delete(
             kvDeleteIn: KvDeleteIn,
-            options?: KvDeleteOptions,
             ): Promise<KvDeleteOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/delete");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     KvDeleteInSerializer._toJsonObject(
                         kvDeleteIn,

--- a/clients/javascript/src/apis/rateLimiter.ts
+++ b/clients/javascript/src/apis/rateLimiter.ts
@@ -18,25 +18,15 @@ import {
 } from '../models/rateLimiterGetRemainingOut';
 import { HttpMethod, CoyoteRequest, CoyoteRequestContext } from "../request";
 
-export interface RateLimiterLimitOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface RateLimiterGetRemainingOptions {
-        idempotencyKey?: string;
-        }
-
-    export class RateLimiter {
+export class RateLimiter {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Rate Limiter Check and Consume */
         public limit(
             rateLimiterCheckIn: RateLimiterCheckIn,
-            options?: RateLimiterLimitOptions,
             ): Promise<RateLimiterCheckOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limiter/limit");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     RateLimiterCheckInSerializer._toJsonObject(
                         rateLimiterCheckIn,
@@ -54,11 +44,9 @@ export interface RateLimiterLimitOptions {
     /** Rate Limiter Get Remaining */
         public getRemaining(
             rateLimiterGetRemainingIn: RateLimiterGetRemainingIn,
-            options?: RateLimiterGetRemainingOptions,
             ): Promise<RateLimiterGetRemainingOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limiter/get-remaining");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     RateLimiterGetRemainingInSerializer._toJsonObject(
                         rateLimiterGetRemainingIn,

--- a/clients/javascript/src/apis/stream.ts
+++ b/clients/javascript/src/apis/stream.ts
@@ -66,53 +66,15 @@ import {
 } from '../models/redriveOut';
 import { HttpMethod, CoyoteRequest, CoyoteRequestContext } from "../request";
 
-export interface StreamCreateOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface StreamGetOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface StreamAppendOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface StreamFetchOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface StreamFetchLockingOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface StreamAckRangeOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface StreamAckOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface StreamDlqOptions {
-        idempotencyKey?: string;
-        }
-
-    export interface StreamRedriveOptions {
-        idempotencyKey?: string;
-        }
-
-    export class Stream {
+export class Stream {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Upserts a new Stream with the given name. */
         public create(
             createStreamIn: CreateStreamIn,
-            options?: StreamCreateOptions,
             ): Promise<CreateStreamOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/create");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     CreateStreamInSerializer._toJsonObject(
                         createStreamIn,
@@ -130,11 +92,9 @@ export interface StreamCreateOptions {
     /** Get stream with given name. */
         public get(
             getStreamIn: GetStreamIn,
-            options?: StreamGetOptions,
             ): Promise<GetStreamOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/get-group");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     GetStreamInSerializer._toJsonObject(
                         getStreamIn,
@@ -152,11 +112,9 @@ export interface StreamCreateOptions {
     /** Appends messages to the stream. */
         public append(
             appendToStreamIn: AppendToStreamIn,
-            options?: StreamAppendOptions,
             ): Promise<AppendToStreamOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/append");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     AppendToStreamInSerializer._toJsonObject(
                         appendToStreamIn,
@@ -180,11 +138,9 @@ export interface StreamCreateOptions {
 */
         public fetch(
             fetchFromStreamIn: FetchFromStreamIn,
-            options?: StreamFetchOptions,
             ): Promise<FetchFromStreamOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/fetch");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     FetchFromStreamInSerializer._toJsonObject(
                         fetchFromStreamIn,
@@ -207,11 +163,9 @@ export interface StreamCreateOptions {
 */
         public fetchLocking(
             fetchFromStreamIn: FetchFromStreamIn,
-            options?: StreamFetchLockingOptions,
             ): Promise<FetchFromStreamOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/fetch-locking");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     FetchFromStreamInSerializer._toJsonObject(
                         fetchFromStreamIn,
@@ -229,11 +183,9 @@ export interface StreamCreateOptions {
     /** Acks the messages for the consumer group, allowing more messages to be consumed. */
         public ackRange(
             ackMsgRangeIn: AckMsgRangeIn,
-            options?: StreamAckRangeOptions,
             ): Promise<AckMsgRangeOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/ack-range");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     AckMsgRangeInSerializer._toJsonObject(
                         ackMsgRangeIn,
@@ -251,11 +203,9 @@ export interface StreamCreateOptions {
     /** Acks a single message. */
         public ack(
             ack: Ack,
-            options?: StreamAckOptions,
             ): Promise<AckOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/ack");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     AckSerializer._toJsonObject(
                         ack,
@@ -273,11 +223,9 @@ export interface StreamCreateOptions {
     /** Moves a message to the dead letter queue. */
         public dlq(
             dlqIn: DlqIn,
-            options?: StreamDlqOptions,
             ): Promise<DlqOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/dlq");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     DlqInSerializer._toJsonObject(
                         dlqIn,
@@ -295,11 +243,9 @@ export interface StreamCreateOptions {
     /** Redrives messages from the dead letter queue back to the stream. */
         public redrive(
             redriveIn: RedriveIn,
-            options?: StreamRedriveOptions,
             ): Promise<RedriveOut> {
             const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/stream/redrive-dlq");
 
-            request.setHeaderParam("idempotency-key", options?.idempotencyKey);
             request.setBody(
                     RedriveInSerializer._toJsonObject(
                         redriveIn,

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -33,7 +33,6 @@ tokio.workspace = true
 tower-service.workspace = true
 tracing.workspace = true
 url.workspace = true
-uuid.workspace = true
 
 [lints]
 workspace = true

--- a/clients/rust/src/api/cache.rs
+++ b/clients/rust/src/api/cache.rs
@@ -1,26 +1,6 @@
 // this file is @generated
 use crate::{Configuration, error::Result, models::*};
 
-#[derive(Default)]
-pub struct CacheSetOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct CacheGetOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct CacheGetGroupOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct CacheDeleteOptions {
-    pub idempotency_key: Option<String>,
-}
-
 pub struct Cache<'a> {
     cfg: &'a Configuration,
 }
@@ -31,60 +11,32 @@ impl<'a> Cache<'a> {
     }
 
     /// Cache Set
-    pub async fn set(
-        &self,
-        cache_set_in: CacheSetIn,
-        options: Option<CacheSetOptions>,
-    ) -> Result<CacheSetOut> {
-        let CacheSetOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn set(&self, cache_set_in: CacheSetIn) -> Result<CacheSetOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/cache/set")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(cache_set_in)
             .execute(self.cfg)
             .await
     }
 
     /// Cache Get
-    pub async fn get(
-        &self,
-        cache_get_in: CacheGetIn,
-        options: Option<CacheGetOptions>,
-    ) -> Result<CacheGetOut> {
-        let CacheGetOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn get(&self, cache_get_in: CacheGetIn) -> Result<CacheGetOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/cache/get")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(cache_get_in)
             .execute(self.cfg)
             .await
     }
 
     /// Get cache group
-    pub async fn get_group(
-        &self,
-        cache_get_group_in: CacheGetGroupIn,
-        options: Option<CacheGetGroupOptions>,
-    ) -> Result<CacheGetGroupOut> {
-        let CacheGetGroupOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn get_group(&self, cache_get_group_in: CacheGetGroupIn) -> Result<CacheGetGroupOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/cache/get-group")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(cache_get_group_in)
             .execute(self.cfg)
             .await
     }
 
     /// Cache Delete
-    pub async fn delete(
-        &self,
-        cache_delete_in: CacheDeleteIn,
-        options: Option<CacheDeleteOptions>,
-    ) -> Result<CacheDeleteOut> {
-        let CacheDeleteOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn delete(&self, cache_delete_in: CacheDeleteIn) -> Result<CacheDeleteOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/cache/delete")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(cache_delete_in)
             .execute(self.cfg)
             .await

--- a/clients/rust/src/api/idempotency.rs
+++ b/clients/rust/src/api/idempotency.rs
@@ -1,16 +1,6 @@
 // this file is @generated
 use crate::{Configuration, error::Result, models::*};
 
-#[derive(Default)]
-pub struct IdempotencyAbortOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct IdempotencyGetGroupOptions {
-    pub idempotency_key: Option<String>,
-}
-
 pub struct Idempotency<'a> {
     cfg: &'a Configuration,
 }
@@ -24,12 +14,8 @@ impl<'a> Idempotency<'a> {
     pub async fn abort(
         &self,
         idempotency_abort_in: IdempotencyAbortIn,
-        options: Option<IdempotencyAbortOptions>,
     ) -> Result<IdempotencyAbortOut> {
-        let IdempotencyAbortOptions { idempotency_key } = options.unwrap_or_default();
-
         crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/abort")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(idempotency_abort_in)
             .execute(self.cfg)
             .await
@@ -39,12 +25,8 @@ impl<'a> Idempotency<'a> {
     pub async fn get_group(
         &self,
         idempotency_get_group_in: IdempotencyGetGroupIn,
-        options: Option<IdempotencyGetGroupOptions>,
     ) -> Result<IdempotencyGetGroupOut> {
-        let IdempotencyGetGroupOptions { idempotency_key } = options.unwrap_or_default();
-
         crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/get-group")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(idempotency_get_group_in)
             .execute(self.cfg)
             .await

--- a/clients/rust/src/api/kv.rs
+++ b/clients/rust/src/api/kv.rs
@@ -1,26 +1,6 @@
 // this file is @generated
 use crate::{Configuration, error::Result, models::*};
 
-#[derive(Default)]
-pub struct KvSetOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct KvGetOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct KvGetGroupOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct KvDeleteOptions {
-    pub idempotency_key: Option<String>,
-}
-
 pub struct Kv<'a> {
     cfg: &'a Configuration,
 }
@@ -31,52 +11,32 @@ impl<'a> Kv<'a> {
     }
 
     /// KV Set
-    pub async fn set(&self, kv_set_in: KvSetIn, options: Option<KvSetOptions>) -> Result<KvSetOut> {
-        let KvSetOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn set(&self, kv_set_in: KvSetIn) -> Result<KvSetOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/kv/set")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(kv_set_in)
             .execute(self.cfg)
             .await
     }
 
     /// KV Get
-    pub async fn get(&self, kv_get_in: KvGetIn, options: Option<KvGetOptions>) -> Result<KvGetOut> {
-        let KvGetOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn get(&self, kv_get_in: KvGetIn) -> Result<KvGetOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/kv/get")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(kv_get_in)
             .execute(self.cfg)
             .await
     }
 
     /// Get KV store
-    pub async fn get_group(
-        &self,
-        kv_get_group_in: KvGetGroupIn,
-        options: Option<KvGetGroupOptions>,
-    ) -> Result<KvGetGroupOut> {
-        let KvGetGroupOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn get_group(&self, kv_get_group_in: KvGetGroupIn) -> Result<KvGetGroupOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/kv/get-group")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(kv_get_group_in)
             .execute(self.cfg)
             .await
     }
 
     /// KV Delete
-    pub async fn delete(
-        &self,
-        kv_delete_in: KvDeleteIn,
-        options: Option<KvDeleteOptions>,
-    ) -> Result<KvDeleteOut> {
-        let KvDeleteOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn delete(&self, kv_delete_in: KvDeleteIn) -> Result<KvDeleteOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/kv/delete")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(kv_delete_in)
             .execute(self.cfg)
             .await

--- a/clients/rust/src/api/mod.rs
+++ b/clients/rust/src/api/mod.rs
@@ -9,16 +9,8 @@ mod rate_limiter;
 mod stream;
 
 pub use self::{
-    cache::{Cache, CacheDeleteOptions, CacheGetGroupOptions, CacheGetOptions, CacheSetOptions},
-    health::Health,
-    idempotency::{Idempotency, IdempotencyAbortOptions, IdempotencyGetGroupOptions},
-    kv::{Kv, KvDeleteOptions, KvGetGroupOptions, KvGetOptions, KvSetOptions},
-    rate_limiter::{RateLimiter, RateLimiterGetRemainingOptions, RateLimiterLimitOptions},
-    stream::{
-        Stream, StreamAckOptions, StreamAckRangeOptions, StreamAppendOptions, StreamCreateOptions,
-        StreamDlqOptions, StreamFetchLockingOptions, StreamFetchOptions, StreamGetOptions,
-        StreamRedriveOptions,
-    },
+    cache::Cache, health::Health, idempotency::Idempotency, kv::Kv, rate_limiter::RateLimiter,
+    stream::Stream,
 };
 
 impl CoyoteClient {

--- a/clients/rust/src/api/rate_limiter.rs
+++ b/clients/rust/src/api/rate_limiter.rs
@@ -1,16 +1,6 @@
 // this file is @generated
 use crate::{Configuration, error::Result, models::*};
 
-#[derive(Default)]
-pub struct RateLimiterLimitOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct RateLimiterGetRemainingOptions {
-    pub idempotency_key: Option<String>,
-}
-
 pub struct RateLimiter<'a> {
     cfg: &'a Configuration,
 }
@@ -24,12 +14,8 @@ impl<'a> RateLimiter<'a> {
     pub async fn limit(
         &self,
         rate_limiter_check_in: RateLimiterCheckIn,
-        options: Option<RateLimiterLimitOptions>,
     ) -> Result<RateLimiterCheckOut> {
-        let RateLimiterLimitOptions { idempotency_key } = options.unwrap_or_default();
-
         crate::request::Request::new(http::Method::POST, "/api/v1/rate-limiter/limit")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(rate_limiter_check_in)
             .execute(self.cfg)
             .await
@@ -39,12 +25,8 @@ impl<'a> RateLimiter<'a> {
     pub async fn get_remaining(
         &self,
         rate_limiter_get_remaining_in: RateLimiterGetRemainingIn,
-        options: Option<RateLimiterGetRemainingOptions>,
     ) -> Result<RateLimiterGetRemainingOut> {
-        let RateLimiterGetRemainingOptions { idempotency_key } = options.unwrap_or_default();
-
         crate::request::Request::new(http::Method::POST, "/api/v1/rate-limiter/get-remaining")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(rate_limiter_get_remaining_in)
             .execute(self.cfg)
             .await

--- a/clients/rust/src/api/stream.rs
+++ b/clients/rust/src/api/stream.rs
@@ -1,51 +1,6 @@
 // this file is @generated
 use crate::{Configuration, error::Result, models::*};
 
-#[derive(Default)]
-pub struct StreamCreateOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct StreamGetOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct StreamAppendOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct StreamFetchOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct StreamFetchLockingOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct StreamAckRangeOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct StreamAckOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct StreamDlqOptions {
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Default)]
-pub struct StreamRedriveOptions {
-    pub idempotency_key: Option<String>,
-}
-
 pub struct Stream<'a> {
     cfg: &'a Configuration,
 }
@@ -56,45 +11,24 @@ impl<'a> Stream<'a> {
     }
 
     /// Upserts a new Stream with the given name.
-    pub async fn create(
-        &self,
-        create_stream_in: CreateStreamIn,
-        options: Option<StreamCreateOptions>,
-    ) -> Result<CreateStreamOut> {
-        let StreamCreateOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn create(&self, create_stream_in: CreateStreamIn) -> Result<CreateStreamOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/create")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(create_stream_in)
             .execute(self.cfg)
             .await
     }
 
     /// Get stream with given name.
-    pub async fn get(
-        &self,
-        get_stream_in: GetStreamIn,
-        options: Option<StreamGetOptions>,
-    ) -> Result<GetStreamOut> {
-        let StreamGetOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn get(&self, get_stream_in: GetStreamIn) -> Result<GetStreamOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/get-group")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(get_stream_in)
             .execute(self.cfg)
             .await
     }
 
     /// Appends messages to the stream.
-    pub async fn append(
-        &self,
-        append_to_stream_in: AppendToStreamIn,
-        options: Option<StreamAppendOptions>,
-    ) -> Result<AppendToStreamOut> {
-        let StreamAppendOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn append(&self, append_to_stream_in: AppendToStreamIn) -> Result<AppendToStreamOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/append")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(append_to_stream_in)
             .execute(self.cfg)
             .await
@@ -108,12 +42,8 @@ impl<'a> Stream<'a> {
     pub async fn fetch(
         &self,
         fetch_from_stream_in: FetchFromStreamIn,
-        options: Option<StreamFetchOptions>,
     ) -> Result<FetchFromStreamOut> {
-        let StreamFetchOptions { idempotency_key } = options.unwrap_or_default();
-
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/fetch")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(fetch_from_stream_in)
             .execute(self.cfg)
             .await
@@ -126,64 +56,40 @@ impl<'a> Stream<'a> {
     pub async fn fetch_locking(
         &self,
         fetch_from_stream_in: FetchFromStreamIn,
-        options: Option<StreamFetchLockingOptions>,
     ) -> Result<FetchFromStreamOut> {
-        let StreamFetchLockingOptions { idempotency_key } = options.unwrap_or_default();
-
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/fetch-locking")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(fetch_from_stream_in)
             .execute(self.cfg)
             .await
     }
 
     /// Acks the messages for the consumer group, allowing more messages to be consumed.
-    pub async fn ack_range(
-        &self,
-        ack_msg_range_in: AckMsgRangeIn,
-        options: Option<StreamAckRangeOptions>,
-    ) -> Result<AckMsgRangeOut> {
-        let StreamAckRangeOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn ack_range(&self, ack_msg_range_in: AckMsgRangeIn) -> Result<AckMsgRangeOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/ack-range")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(ack_msg_range_in)
             .execute(self.cfg)
             .await
     }
 
     /// Acks a single message.
-    pub async fn ack(&self, ack: Ack, options: Option<StreamAckOptions>) -> Result<AckOut> {
-        let StreamAckOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn ack(&self, ack: Ack) -> Result<AckOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/ack")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(ack)
             .execute(self.cfg)
             .await
     }
 
     /// Moves a message to the dead letter queue.
-    pub async fn dlq(&self, dlq_in: DlqIn, options: Option<StreamDlqOptions>) -> Result<DlqOut> {
-        let StreamDlqOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn dlq(&self, dlq_in: DlqIn) -> Result<DlqOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/dlq")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(dlq_in)
             .execute(self.cfg)
             .await
     }
 
     /// Redrives messages from the dead letter queue back to the stream.
-    pub async fn redrive(
-        &self,
-        redrive_in: RedriveIn,
-        options: Option<StreamRedriveOptions>,
-    ) -> Result<RedriveOut> {
-        let StreamRedriveOptions { idempotency_key } = options.unwrap_or_default();
-
+    pub async fn redrive(&self, redrive_in: RedriveIn) -> Result<RedriveOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/stream/redrive-dlq")
-            .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(redrive_in)
             .execute(self.cfg)
             .await

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -124,10 +124,11 @@ mod tests {
 
         let client = CoyoteClient::new(String::new(), None);
         let cache_api = client.cache();
-        let fut = cache_api.set(
-            CacheSetIn::new("key".to_owned(), 0, "value".as_bytes().to_vec()),
-            None,
-        );
+        let fut = cache_api.set(CacheSetIn::new(
+            "key".to_owned(),
+            0,
+            "value".as_bytes().to_vec(),
+        ));
         require_send_sync(fut);
     }
 }

--- a/clients/rust/src/request.rs
+++ b/clients/rust/src/request.rs
@@ -51,17 +51,6 @@ impl Request {
         self
     }
 
-    pub(crate) fn with_optional_header_param(
-        mut self,
-        basename: &'static str,
-        param: Option<String>,
-    ) -> Self {
-        if let Some(value) = param {
-            self.header_params.insert(basename, value);
-        }
-        self
-    }
-
     pub(crate) async fn execute<T: DeserializeOwned>(
         self,
         conf: &Configuration,
@@ -78,13 +67,8 @@ impl Request {
         }
     }
 
-    async fn execute_with_backoff(mut self, conf: &Configuration) -> Result<Option<Bytes>, Error> {
+    async fn execute_with_backoff(self, conf: &Configuration) -> Result<Option<Bytes>, Error> {
         let no_return_type = self.no_return_type;
-        if self.method == http::Method::POST && !self.header_params.contains_key("idempotency-key")
-        {
-            self.header_params
-                .insert("idempotency-key", format!("auto_{}", uuid::Uuid::now_v7()));
-        }
 
         const MAX_BACKOFF: Duration = Duration::from_secs(5);
 

--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -12,68 +12,6 @@ use clap::{Args, Subcommand};
 use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}Args;
 {% endfor %}
 
-{% for op in resource.operations -%}
-    {% if (op.query_params | length > 0) or (op.header_params | length > 0) -%}
-        {% set param_struct_type_name -%}
-            {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options
-        {%- endset -%}
-
-        #[derive(Args, Clone)]
-        pub struct {{ param_struct_type_name }} {
-            {% for p in op.query_params -%}
-                {% set ty = p.type.to_rust() -%}
-                {% if not p.required %}{% set ty %}Option<{{ ty }}>{% endset %}{% endif -%}
-                {% if p.description is defined -%}
-                    {{ p.description | to_doc_comment(style="rust") }}
-                {% endif -%}
-                #[arg(long)]
-                pub {{ p.name | to_snake_case }}: {{ ty }},
-            {% endfor %}
-            {% for p in op.header_params -%}
-                {% set ty = "String" -%}
-                {% if not p.required %}{% set ty %}Option<{{ ty }}>{% endset %}{% endif %}
-                {% if p.description is defined -%}
-                    {{ p.description | to_doc_comment(style="rust") }}
-                {% endif -%}
-                #[arg(long)]
-                pub {{ p.name | to_snake_case }}: {{ ty }},
-            {% endfor -%}
-        }
-
-        impl From<{{ param_struct_type_name }}> for coyote_client::api::{{ param_struct_type_name }} {
-            fn from(
-                value: {{ param_struct_type_name }},
-            ) -> Self {
-                let {{ param_struct_type_name }} {
-                    {% for p in op.query_params -%}
-                        {{ p.name | to_snake_case }},
-                    {% endfor -%}
-                    {% for p in op.header_params -%}
-                        {{ p.name | to_snake_case }},
-                    {% endfor -%}
-                } = value;
-                Self {
-                    {% for p in op.query_params -%}
-                        {% if p.type.is_datetime() -%}
-                            {{ p.name | to_snake_case }}:
-                            {%- if p.required %}
-                            {{ p.name | to_snake_case }}.to_rfc3339(),
-                            {%- else %}
-                            {{ p.name | to_snake_case }}.map(|dt| dt.to_rfc3339()),
-                            {% endif -%}
-                        {% else -%}
-                            {{ p.name | to_snake_case }},
-                        {% endif -%}
-                    {% endfor -%}
-                    {% for p in op.header_params -%}
-                        {{ p.name | to_snake_case }},
-                    {% endfor -%}
-                }
-            }
-        }
-    {% endif %}
-{% endfor %}
-
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct {{ resource_type_name }}Args {
@@ -109,12 +47,6 @@ pub enum {{ resource_type_name }}Commands {
                 {{ op.request_body_schema_name | to_snake_case }}:
                 {% if op.request_body_all_optional %}Option<{{ ty }}>{% else %}{{ ty }}{% endif %},
             {% endif -%}
-
-            {# query / header parameters -#}
-            {% if has_params -%}
-            #[clap(flatten)]
-            options: {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options,
-            {% endif -%}
         },
     {% endfor %}
 }
@@ -145,9 +77,6 @@ impl {{ resource_type_name }}Commands {
                     {% if op.request_body_schema_name is defined -%}
                         {{ op.request_body_schema_name | to_snake_case }},
                     {% endif -%}
-
-                    {# query / header parameters -#}
-                    {% if has_params %}options,{% endif -%}
                 } => {
                     {% if op.deprecated -%}
                         #[allow(deprecated)]
@@ -177,18 +106,6 @@ impl {{ resource_type_name }}Commands {
                                     .unwrap_or_default()
                                 {% endif -%}
                                     .into_inner(),
-                            {% endif -%}
-
-                            {# query parameters -#}
-                            {% if has_params %}
-                                {% set has_required_params =
-                                    (op.query_params | selectattr("required") | length > 0) or
-                                    (op.header_params | selectattr("required") | length > 0) -%}
-                                {%- if has_required_params -%}
-                                    options.into(),
-                                {% else -%}
-                                    Some(options.into()),
-                                {% endif -%}
                             {% endif -%}
                         )
                         .await?;

--- a/codegen/templates/go/api_resource.go.jinja
+++ b/codegen/templates/go/api_resource.go.jinja
@@ -25,29 +25,10 @@ func New{{ resource_type_name }}(client *coyote_proto.HttpClient) {{ resource_ty
 	return {{ resource_type_name }}{client}
 }
 
-{% for op in resource.operations -%}
-	{% if op | has_query_or_header_params -%}
-	{% set opt_struct_name %}{{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options{% endset %}
-type {{ opt_struct_name }} struct {
-		{% for p in op.query_params -%}
-			{% set p_ty = p.type.to_go() -%}
-			{% if p.type.is_schema_ref() -%}
-				{% set p_ty %}coyote_models.{{ p.type.to_go() }}{% endset %}
-			{% endif -%}
-			{% if p.description is defined -%}
-	{{ p.description | to_doc_comment(style="go") }}
-			{% endif -%}
-	{# all types in *Options structs are optional -#}
-	{{ p.name | to_upper_camel_case }} *{{ p_ty }}
-		{% endfor -%}
-		{% for p in op.header_params -%}
-	{{ p.name | to_upper_camel_case }} *string
-		{% endfor -%}
-}
-	{% endif -%}
-{% endfor -%}
-
 {% for op in resource.operations %}
+	{% if op.query_params | length > 0 -%}
+		{% do panic("we don't do query parameters in this API") %}
+	{% endif -%}
 	{% if op.request_body_schema_name is defined -%}
 		{% set request_body_param = op.request_body_schema_name | to_lower_camel_case -%}
 	{% endif -%}
@@ -84,14 +65,7 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 	{% if op.request_body_schema_name is defined -%}
 		{{ request_body_param }} coyote_models.{{ op.request_body_schema_name }},
 	{% endif -%}
-
-	{% if op | has_query_or_header_params -%}
-		o *{{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options,
-	{% endif -%}
-
 ) {{ func_ret_type }} {
-	{% set used_err = false -%}
-
 	{# path params -#}
 	{% if op.path_params | length > 0 -%}
 	pathMap := map[string]string{
@@ -101,40 +75,8 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 	}
 	{% endif -%}
 
-	{% if op.id == "v1.application.create" -%}
-	queryMap := map[string]string{
-		"get_if_exists": "false",
-	}
-	{% elif op.query_params | length > 0 -%}
-	queryMap := map[string]string{}
-	{% endif -%}
-
-	{% if op.header_params | length >0 -%}
+	{% if op.header_params | length > 0 -%}
 	headerMap := map[string]string{}
-	{% endif -%}
-
-	{% if op | has_query_or_header_params -%}
-	{% set used_err = true -%}
-	var err error
-	if o != nil {
-		{# header params -#}
-		{% if op.header_params | length > 0 -%}
-			{% for p in op.header_params -%}
-		coyote_proto.SerializeParamToMap("{{ p.name }}", o.{{ p.name | to_upper_camel_case }}, headerMap, &err)
-			{% endfor -%}
-		{% endif -%}
-
-		{# query params -#}
-		{% if op.query_params | length >0 -%}
-			{% for p in op.query_params -%}
-		coyote_proto.SerializeParamToMap("{{ p.name }}", o.{{ p.name | to_upper_camel_case }}, queryMap, &err)
-			{% endfor -%}
-		{% endif -%}
-
-		if err != nil {
-			return {% if has_return %}nil,{% endif %} err
-		}
-	}
 	{% endif -%}
 
 	{# make template ugly, but generated code nice -#}
@@ -144,7 +86,7 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 	{% else -%}
 		{% set generic_ret_type -%}any,{{ ret_type }}{% endset -%}
 	{% endif -%}
-	{% if has_return %}return {% else %} _,err {% if not used_err%}:{% endif%}= {% endif %}coyote_proto.ExecuteRequest[{{ generic_ret_type }}](
+	{% if has_return %}return {% else %} _, err := {% endif %}coyote_proto.ExecuteRequest[{{ generic_ret_type }}](
 		ctx,
 		{{ resource_self_name }}.client,
 		"{{ op.method | upper }}",
@@ -152,13 +94,6 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 		{# path params -#}
 		{% if op.path_params | length > 0 -%}
 		pathMap,
-		{% else -%}
-		nil,
-		{% endif -%}
-
-		{#- query params -#}
-		{% if op.query_params | length > 0 or op.id == "v1.application.create" -%}
-		queryMap,
 		{% else -%}
 		nil,
 		{% endif -%}

--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -13,30 +13,6 @@ import { {{ sub.name | to_upper_camel_case}} } from './{{ sub.name | to_lower_ca
 {% endfor -%}
 import { HttpMethod, CoyoteRequest, CoyoteRequestContext } from "../request";
 
-{% for op in resource.operations -%}
-    {% if op | has_query_or_header_params -%}
-    export interface {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options {
-        {% for p in op.query_params -%}
-            {% if p.description is defined -%}
-                {{ p.description | to_doc_comment(style="js") }}
-            {% endif -%}
-            {% set field_ty = p.type.to_js() -%}
-            {% if p.name == "iterator" %}{% set field_ty = "string | null" %}{% endif -%}
-            {% if p.type.is_datetime() %}{% set field_ty = "Date | null"%}{% endif -%}
-            {{ p.name | to_lower_camel_case }}{% if not p.required %}?{% endif %}: {{ field_ty }};
-        {% endfor -%}
-        {% for p in op.header_params -%}
-            {% if p.description is defined -%}
-                {{ p.description | to_doc_comment(style="js") }}
-            {% endif -%}
-            {% set field_ty = "string" -%}
-            {{ p.name | to_lower_camel_case }}{% if not p.required %}?{% endif %}: {{ field_ty }};
-        {% endfor -%}
-    }
-
-    {% endif -%}
-{% endfor -%}
-
 export class {{ resource_type_name }} {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
@@ -63,33 +39,12 @@ export class {{ resource_type_name }} {
                 {{ field_name }}: {{ op.request_body_schema_name }},
             {% endif -%}
 
-            {# query parameters -#}
-            {% if op | has_query_or_header_params -%}
-                {% set field_ty -%}
-                    {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options
-                {%- endset -%}
-                options{% if not op | has_required_query_or_header_params %}?{% endif %}: {{ field_ty }},
-            {% endif -%}
         ): Promise<{{ response_type }}> {
             const request = new CoyoteRequest(HttpMethod.{{ op.method | upper }}, "{{ op.path }}");
 
             {# path parameters -#}
             {% for p in op.path_params -%}
                 request.setPathParam("{{ p }}", {{ p | to_lower_camel_case }});
-            {% endfor -%}
-
-            {# query parameters -#}
-            {% if op.query_params | length > 0 -%}
-            request.setQueryParams({
-                {% for p in op.query_params -%}
-                "{{ p.name }}": options{% if not p.required %}?{% endif %}.{{ p.name | to_lower_camel_case }},
-                {% endfor -%}
-            });
-            {% endif -%}
-
-            {# header parameters -#}
-            {% for p in op.header_params -%}
-                request.setHeaderParam("{{ p.name }}", options?.{{ p.name | to_lower_camel_case }});
             {% endfor -%}
 
             {# body parameter -#}

--- a/codegen/templates/rust/api_resource.rs.jinja
+++ b/codegen/templates/rust/api_resource.rs.jinja
@@ -14,32 +14,6 @@ use super::{
     {%- endfor %}
 };
 
-{% for op in resource.operations -%}
-    {% if op | has_query_or_header_params %}
-    {% if not op | has_required_query_or_header_params -%}
-        #[derive(Default)]
-    {% endif -%}
-    pub struct {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options {
-        {% for p in op.query_params -%}
-            {% set ty = p.type.to_rust() -%}
-            {% if not p.required %}{% set ty %}Option<{{ ty }}>{% endset %}{% endif %}
-            {% if p.description is defined -%}
-                {{ p.description | to_doc_comment(style="rust") }}
-            {% endif -%}
-            pub {{ p.name | to_snake_case }}: {{ ty }},
-        {% endfor -%}
-        {% for p in op.header_params -%}
-            {% set ty = "String" -%}
-            {% if not p.required %}{% set ty %}Option<{{ ty }}>{% endset %}{% endif %}
-            {% if p.description is defined -%}
-                {{ p.description | to_doc_comment(style="rust") }}
-            {% endif -%}
-            pub {{ p.name | to_snake_case }}: {{ ty }},
-        {% endfor -%}
-    }
-    {% endif %}
-{% endfor -%}
-
 pub struct {{ resource_type_name }}<'a> {
     cfg: &'a Configuration,
 }
@@ -58,7 +32,9 @@ impl<'a> {{ resource_type_name }}<'a> {
     {% endfor -%}
 
     {% for op in resource.operations %}
-    {% set has_params = op | has_query_or_header_params -%}
+    {% if op.query_params | length > 0 -%}
+        {% do panic("we don't do query parameters in this API") %}
+    {% endif -%}
     {% if op.description is defined -%}
         {{ op.description | to_doc_comment(style="rust") }}
     {% endif -%}
@@ -77,44 +53,12 @@ impl<'a> {{ resource_type_name }}<'a> {
         {% if op.request_body_schema_name is defined -%}
             {{ op.request_body_schema_name | to_snake_case }}: {{ op.request_body_schema_name }},
         {% endif -%}
-
-        {# query / header parameter struct -#}
-        {% if has_params -%}
-            {% set param_struct_name -%}
-                {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options
-            {%- endset -%}
-            {% set has_required_params = op | has_required_query_or_header_params -%}
-            {%- if has_required_params -%}
-                options: {{ param_struct_name }},
-            {%- else -%}
-                options: Option<{{ param_struct_name }}>,
-            {%- endif -%}
-        {% endif -%}
     ) -> Result<{{ op.response_body_schema_name | default("()") | replace("_", "") }}> {
-        {% if has_params -%}
-            {# unpack query / header parameter struct -#}
-            let {{ param_struct_name }} {
-                {% for p in op.query_params %}{{ p.name | to_snake_case }},{% endfor %}
-                {% for p in op.header_params %}{{ p.name | to_snake_case }},{% endfor %}
-            } = options
-            {%- if not has_required_params %}.unwrap_or_default(){% endif -%}
-            ;
-        {% endif -%}
-
         {# make the request #}
         crate::request::Request::new(http::Method::{{ op.method | upper }}, "{{ op.path }}")
 
         {% for p in op.path_params -%}
             .with_path_param("{{ p }}", {{ p }})
-        {% endfor -%}
-
-        {% for p in op.query_params -%}
-            {% if p.required -%}
-                .with_query_param
-            {%- else -%}
-                .with_optional_query_param
-            {%- endif -%}
-            ("{{ p.name }}", {{ p.name | to_snake_case }})
         {% endfor -%}
 
         {% for p in op.header_params -%}

--- a/openapi.json
+++ b/openapi.json
@@ -45,17 +45,6 @@
         "summary": "Cache Set",
         "description": "Cache Set",
         "operationId": "v1.cache.set",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -93,17 +82,6 @@
         "summary": "Cache Get",
         "description": "Cache Get",
         "operationId": "v1.cache.get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -141,17 +119,6 @@
         "summary": "Cache Get Group",
         "description": "Get cache group",
         "operationId": "v1.cache.get_group",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -189,17 +156,6 @@
         "summary": "Cache Del",
         "description": "Cache Delete",
         "operationId": "v1.cache.delete",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -237,17 +193,6 @@
         "summary": "Kv Set",
         "description": "KV Set",
         "operationId": "v1.kv.set",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -285,17 +230,6 @@
         "summary": "Kv Get",
         "description": "KV Get",
         "operationId": "v1.kv.get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -333,17 +267,6 @@
         "summary": "Kv Get Group",
         "description": "Get KV store",
         "operationId": "v1.kv.get_group",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -381,17 +304,6 @@
         "summary": "Kv Del",
         "description": "KV Delete",
         "operationId": "v1.kv.delete",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -429,17 +341,6 @@
         "summary": "Rate Limiter Limit",
         "description": "Rate Limiter Check and Consume",
         "operationId": "v1.rate_limiter.limit",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -477,17 +378,6 @@
         "summary": "Rate Limiter Get Remaining",
         "description": "Rate Limiter Get Remaining",
         "operationId": "v1.rate_limiter.get_remaining",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -525,17 +415,6 @@
         "summary": "Idempotency Start",
         "description": "Start an idempotent request",
         "operationId": "v1.idempotency.start",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -573,17 +452,6 @@
         "summary": "Idempotency Complete",
         "description": "Complete an idempotent request with a response",
         "operationId": "v1.idempotency.complete",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -621,17 +489,6 @@
         "summary": "Idempotency Abort",
         "description": "Abandon an idempotent request (remove lock without saving response)",
         "operationId": "v1.idempotency.abort",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -669,17 +526,6 @@
         "summary": "Idempotency Get Group",
         "description": "Get idempotency group",
         "operationId": "v1.idempotency.get_group",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -717,17 +563,6 @@
         "summary": "Create Stream",
         "description": "Upserts a new Stream with the given name.",
         "operationId": "v1.stream.create",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -765,17 +600,6 @@
         "summary": "Get Stream",
         "description": "Get stream with given name.",
         "operationId": "v1.stream.get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -813,17 +637,6 @@
         "summary": "Append To Stream",
         "description": "Appends messages to the stream.",
         "operationId": "v1.stream.append",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -861,17 +674,6 @@
         "summary": "Fetch From Stream",
         "description": "Fetches messages from the stream, while allowing concurrent access from other consumers in the same group.\n\nUnlike `stream.fetch-locking`, this does not block other consumers within the same consumer group from reading\nmessages from the Stream. The consumer will still take an exclusive lock on the messages fetched, and that lock is held\nuntil the visibility timeout expires, or the messages are acked.",
         "operationId": "v1.stream.fetch",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -909,17 +711,6 @@
         "summary": "Locking Fetch From Stream",
         "description": "Fetches messages from the stream, locking over the consumer group.\n\nThis call prevents other consumers within the same consumer group from reading from the stream\nuntil either the visibility timeout expires, or the last message in the batch is acknowledged.",
         "operationId": "v1.stream.fetch-locking",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -957,17 +748,6 @@
         "summary": "Ack Range",
         "description": "Acks the messages for the consumer group, allowing more messages to be consumed.",
         "operationId": "v1.stream.ack-range",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1005,17 +785,6 @@
         "summary": "Ack",
         "description": "Acks a single message.",
         "operationId": "v1.stream.ack",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1053,17 +822,6 @@
         "summary": "Dlq",
         "description": "Moves a message to the dead letter queue.",
         "operationId": "v1.stream.dlq",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1101,17 +859,6 @@
         "summary": "Redrive",
         "description": "Redrives messages from the dead letter queue back to the stream.",
         "operationId": "v1.stream.redrive",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "idempotency-key",
-            "description": "The request's idempotency key",
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/core/otel_spans.rs
+++ b/src/core/otel_spans.rs
@@ -66,11 +66,6 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             .is_valid()
             .then(|| span_context.trace_id().to_string());
 
-        let idempotency_key = request
-            .headers()
-            .get("idempotency-key")
-            .and_then(|v| v.to_str().ok());
-
         let span = tracing::error_span!(
             "HTTP request",
             grpc.code = Empty,
@@ -87,7 +82,6 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             otel.status_code = Empty,
             request_id,
             trace_id,
-            idempotency_key,
             org_id = tracing::field::Empty,
             app_id = tracing::field::Empty,
         );

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,5 +1,4 @@
-use aide::openapi::{self, OpenApi, Parameter, ReferenceOr};
-use schemars::JsonSchema;
+use aide::openapi::{self, OpenApi};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -99,53 +98,6 @@ fn sort_schemas_by_name(openapi: &mut OpenApi) {
     }
 }
 
-/// Adds the `Idempotency-Key` header parameter to all `POST` operations in the schema.
-fn add_idempotency_to_post(openapi: &mut OpenApi) {
-    // The header's value can be any valid string
-    let string_schema = aide::generate::in_context(|ctx| String::json_schema(&mut ctx.schema));
-
-    let s = openapi::SchemaObject {
-        json_schema: string_schema,
-        external_docs: None,
-        example: None,
-    };
-
-    let idempotency_key_data = openapi::ParameterData {
-        name: "idempotency-key".to_string(),
-        description: Some("The request's idempotency key".to_string()),
-        required: false,
-        deprecated: None,
-        format: openapi::ParameterSchemaOrContent::Schema(s),
-        example: None,
-        examples: indexmap::indexmap! {},
-        explode: None,
-        extensions: indexmap::indexmap! {},
-    };
-
-    if let Some(paths) = &mut openapi.paths {
-        for (_, op) in &mut paths.paths {
-            match op {
-                openapi::ReferenceOr::Reference { reference, .. } => {
-                    // References to operations should never appear in our
-                    // schema since all our operations are unique, and we
-                    // don't reference any 3rd party/external operations.
-                    tracing::warn!(
-                        "Unexpected operation reference encountered in OpenAPI schema: {reference}"
-                    );
-                }
-                openapi::ReferenceOr::Item(op) => {
-                    if let Some(post) = &mut op.post {
-                        post.parameters.push(ReferenceOr::Item(Parameter::Header {
-                            parameter_data: idempotency_key_data.clone(),
-                            style: openapi::HeaderStyle::Simple,
-                        }));
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// Remove schemas from `components.schemas` of the spec which are under normal
 /// circumstances not referenced. At the moment these are struct schemas used
 /// by query parameters and path placeholders.
@@ -211,7 +163,6 @@ pub fn add_security_scheme(
 pub fn postprocess_spec(openapi: &mut OpenApi) {
     let hacks = [
         sort_schemas_by_name,
-        add_idempotency_to_post,
         flatten_weird_nested_ref,
         remove_unneeded_schemas,
     ];


### PR DESCRIPTION
We don't use query parameters, and once we add header parameters like trace-id, they will almost certainly not use an extra options struct like we have in the Svix API.