### PR TITLE
ci: Add coverage tracking

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,6 +11,9 @@ test-threads = 16
 fail-fast = false
 default-filter = 'all()'
 
+[profile.ci.junit]
+path = "junit.xml"
+
 [[profile.ci.overrides]]
 filter = 'test(~openraft_slow)'
 slow-timeout = { period = "60s", terminate-after = 1}

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,7 @@ fail-fast = true
 slow-timeout = { period = "120s", terminate-after = 4 }
 
 [profile.ci]
+test-threads = 16
 fail-fast = false
 default-filter = 'all()'
 

--- a/.github/test-report.sh
+++ b/.github/test-report.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+cargo llvm-cov nextest --profile ci --no-clean
+status=$?
+
+if [[ $status -eq 0 ]]; then
+    cargo llvm-cov report --html
+    mv target/llvm-cov/html ./coverage-html
+    coverage_percentage=$(cargo llvm-cov report --json | jq '.data[].totals.lines.percent')
+    if [[ -n "$GITHUB_OUTPUT" ]]; then
+        printf 'coverage_percent=%.2f\n' "$coverage_percentage" >> "$GITHUB_OUTPUT"
+    fi
+fi
+
+mv target/nextest/ci/junit.xml ./junit.xml
+exit $status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,16 +59,48 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       RUST_LOG: debug
-      "COYOTE:LOG_LEVEL": debug
+      "COYOTE_LOG_LEVEL": debug
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@cargo-nextest
-      - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: just test --profile ci
+      - name: Run tests
+        id: test
+        run: bash .github/test-report.sh
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        if: github.ref != 'refs/heads/main'
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Test Coverage:'
+      - name: Create comment
+        if: github.ref != 'refs/heads/main' && steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: 'Test Coverage: ${{ steps.test.outputs.coverage_percent }}%'
+      - name: Update comment
+        if: github.ref != 'refs/heads/main' && steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: 'Test Coverage: ${{ steps.test.outputs.coverage_percent }}%'
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test-report
+          path: |
+            ./junit.xml
+            ./coverage-html
+          retention-days: 7
   check-codegen:
     name: Check openapi.json and SDK freshness
     runs-on: ubuntu-24.04

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -4,6 +4,9 @@ on:
     branches: ['*']
 jobs:
   ci:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/ci.yml
     secrets: inherit
   lint-openapi:

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -86,7 +86,7 @@ async fn test_kv_set_and_get() -> TestResult {
         expires_at
             .as_millisecond()
             .abs_diff(expected.as_millisecond())
-            < 5 // tolerance
+            < 50 // tolerance
     );
 
     Ok(())


### PR DESCRIPTION
Closes https://github.com/svix/coyote-private/issues/143.

It's super basic for now. I think if we want something more advanced, we should probably use coveralls.io, but this should be an okay starting point for moving to that too.

A full coverage report in HTML form + junit test report from nextest are available as an artifact.