### PR TITLE
go: Add missing Coyote constructor function

### DIFF
--- a/clients/go/client.go
+++ b/clients/go/client.go
@@ -1,6 +1,7 @@
 package coyote
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -17,4 +18,33 @@ type CoyoteOptions struct {
 
 type Coyote struct {
 	inner coyote_proto.HttpClient
+}
+
+func New(token string, options *CoyoteOptions) (*Coyote, error) {
+	httpClient := coyote_proto.DefaultHttpClient("http://localhost:8050")
+
+	if options != nil {
+		if options.ServerUrl != nil {
+			httpClient.BaseURL = options.ServerUrl.String()
+		}
+
+		if options.RetrySchedule != nil {
+			if len(*options.RetrySchedule) > 5 {
+				return nil, fmt.Errorf("number of retries must not exceed 5")
+			}
+			httpClient.RetrySchedule = *options.RetrySchedule
+		}
+
+		if options.HTTPClient != nil {
+			httpClient.HTTPClient = options.HTTPClient
+		}
+
+		httpClient.Debug = options.Debug
+	}
+
+	httpClient.DefaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", token)
+	httpClient.DefaultHeaders["User-Agent"] = "coyote-sdks/0.0.1/go"
+
+	client := Coyote{httpClient}
+	return &client, nil
 }

--- a/clients/go/internal/apis/cache.go
+++ b/clients/go/internal/apis/cache.go
@@ -34,7 +34,7 @@ type CacheDeleteOptions struct {
 }
 
 // Cache Set
-func (cache *Cache) Set(
+func (cache Cache) Set(
 	ctx context.Context,
 	cacheSetIn coyote_models.CacheSetIn,
 	o *CacheSetOptions,
@@ -60,7 +60,7 @@ func (cache *Cache) Set(
 }
 
 // Cache Get
-func (cache *Cache) Get(
+func (cache Cache) Get(
 	ctx context.Context,
 	cacheGetIn coyote_models.CacheGetIn,
 	o *CacheGetOptions,
@@ -86,7 +86,7 @@ func (cache *Cache) Get(
 }
 
 // Get cache group
-func (cache *Cache) GetGroup(
+func (cache Cache) GetGroup(
 	ctx context.Context,
 	cacheGetGroupIn coyote_models.CacheGetGroupIn,
 	o *CacheGetGroupOptions,
@@ -112,7 +112,7 @@ func (cache *Cache) GetGroup(
 }
 
 // Cache Delete
-func (cache *Cache) Delete(
+func (cache Cache) Delete(
 	ctx context.Context,
 	cacheDeleteIn coyote_models.CacheDeleteIn,
 	o *CacheDeleteOptions,

--- a/clients/go/internal/apis/health.go
+++ b/clients/go/internal/apis/health.go
@@ -18,7 +18,7 @@ func NewHealth(client *coyote_proto.HttpClient) Health {
 }
 
 // Verify the server is up and running.
-func (health *Health) Ping(
+func (health Health) Ping(
 	ctx context.Context,
 ) (*coyote_models.PingOut, error) {
 	return coyote_proto.ExecuteRequest[any, coyote_models.PingOut](

--- a/clients/go/internal/apis/idempotency.go
+++ b/clients/go/internal/apis/idempotency.go
@@ -26,7 +26,7 @@ type IdempotencyGetGroupOptions struct {
 }
 
 // Abandon an idempotent request (remove lock without saving response)
-func (idempotency *Idempotency) Abort(
+func (idempotency Idempotency) Abort(
 	ctx context.Context,
 	idempotencyAbortIn coyote_models.IdempotencyAbortIn,
 	o *IdempotencyAbortOptions,
@@ -52,7 +52,7 @@ func (idempotency *Idempotency) Abort(
 }
 
 // Get idempotency group
-func (idempotency *Idempotency) GetGroup(
+func (idempotency Idempotency) GetGroup(
 	ctx context.Context,
 	idempotencyGetGroupIn coyote_models.IdempotencyGetGroupIn,
 	o *IdempotencyGetGroupOptions,

--- a/clients/go/internal/apis/kv.go
+++ b/clients/go/internal/apis/kv.go
@@ -34,7 +34,7 @@ type KvDeleteOptions struct {
 }
 
 // KV Set
-func (kv *Kv) Set(
+func (kv Kv) Set(
 	ctx context.Context,
 	kvSetIn coyote_models.KvSetIn,
 	o *KvSetOptions,
@@ -60,7 +60,7 @@ func (kv *Kv) Set(
 }
 
 // KV Get
-func (kv *Kv) Get(
+func (kv Kv) Get(
 	ctx context.Context,
 	kvGetIn coyote_models.KvGetIn,
 	o *KvGetOptions,
@@ -86,7 +86,7 @@ func (kv *Kv) Get(
 }
 
 // Get KV store
-func (kv *Kv) GetGroup(
+func (kv Kv) GetGroup(
 	ctx context.Context,
 	kvGetGroupIn coyote_models.KvGetGroupIn,
 	o *KvGetGroupOptions,
@@ -112,7 +112,7 @@ func (kv *Kv) GetGroup(
 }
 
 // KV Delete
-func (kv *Kv) Delete(
+func (kv Kv) Delete(
 	ctx context.Context,
 	kvDeleteIn coyote_models.KvDeleteIn,
 	o *KvDeleteOptions,

--- a/clients/go/internal/apis/rate_limiter.go
+++ b/clients/go/internal/apis/rate_limiter.go
@@ -26,7 +26,7 @@ type RateLimiterGetRemainingOptions struct {
 }
 
 // Rate Limiter Check and Consume
-func (rateLimiter *RateLimiter) Limit(
+func (rateLimiter RateLimiter) Limit(
 	ctx context.Context,
 	rateLimiterCheckIn coyote_models.RateLimiterCheckIn,
 	o *RateLimiterLimitOptions,
@@ -52,7 +52,7 @@ func (rateLimiter *RateLimiter) Limit(
 }
 
 // Rate Limiter Get Remaining
-func (rateLimiter *RateLimiter) GetRemaining(
+func (rateLimiter RateLimiter) GetRemaining(
 	ctx context.Context,
 	rateLimiterGetRemainingIn coyote_models.RateLimiterGetRemainingIn,
 	o *RateLimiterGetRemainingOptions,

--- a/clients/go/internal/apis/stream.go
+++ b/clients/go/internal/apis/stream.go
@@ -54,7 +54,7 @@ type StreamRedriveOptions struct {
 }
 
 // Upserts a new Stream with the given name.
-func (stream *Stream) Create(
+func (stream Stream) Create(
 	ctx context.Context,
 	createStreamIn coyote_models.CreateStreamIn,
 	o *StreamCreateOptions,
@@ -80,7 +80,7 @@ func (stream *Stream) Create(
 }
 
 // Get stream with given name.
-func (stream *Stream) Get(
+func (stream Stream) Get(
 	ctx context.Context,
 	getStreamIn coyote_models.GetStreamIn,
 	o *StreamGetOptions,
@@ -106,7 +106,7 @@ func (stream *Stream) Get(
 }
 
 // Appends messages to the stream.
-func (stream *Stream) Append(
+func (stream Stream) Append(
 	ctx context.Context,
 	appendToStreamIn coyote_models.AppendToStreamIn,
 	o *StreamAppendOptions,
@@ -136,7 +136,7 @@ func (stream *Stream) Append(
 // Unlike `stream.fetch-locking`, this does not block other consumers within the same consumer group from reading
 // messages from the Stream. The consumer will still take an exclusive lock on the messages fetched, and that lock is held
 // until the visibility timeout expires, or the messages are acked.
-func (stream *Stream) Fetch(
+func (stream Stream) Fetch(
 	ctx context.Context,
 	fetchFromStreamIn coyote_models.FetchFromStreamIn,
 	o *StreamFetchOptions,
@@ -165,7 +165,7 @@ func (stream *Stream) Fetch(
 //
 // This call prevents other consumers within the same consumer group from reading from the stream
 // until either the visibility timeout expires, or the last message in the batch is acknowledged.
-func (stream *Stream) FetchLocking(
+func (stream Stream) FetchLocking(
 	ctx context.Context,
 	fetchFromStreamIn coyote_models.FetchFromStreamIn,
 	o *StreamFetchLockingOptions,
@@ -191,7 +191,7 @@ func (stream *Stream) FetchLocking(
 }
 
 // Acks the messages for the consumer group, allowing more messages to be consumed.
-func (stream *Stream) AckRange(
+func (stream Stream) AckRange(
 	ctx context.Context,
 	ackMsgRangeIn coyote_models.AckMsgRangeIn,
 	o *StreamAckRangeOptions,
@@ -217,7 +217,7 @@ func (stream *Stream) AckRange(
 }
 
 // Acks a single message.
-func (stream *Stream) Ack(
+func (stream Stream) Ack(
 	ctx context.Context,
 	ack coyote_models.Ack,
 	o *StreamAckOptions,
@@ -243,7 +243,7 @@ func (stream *Stream) Ack(
 }
 
 // Moves a message to the dead letter queue.
-func (stream *Stream) Dlq(
+func (stream Stream) Dlq(
 	ctx context.Context,
 	dlqIn coyote_models.DlqIn,
 	o *StreamDlqOptions,
@@ -269,7 +269,7 @@ func (stream *Stream) Dlq(
 }
 
 // Redrives messages from the dead letter queue back to the stream.
-func (stream *Stream) Redrive(
+func (stream Stream) Redrive(
 	ctx context.Context,
 	redriveIn coyote_models.RedriveIn,
 	o *StreamRedriveOptions,

--- a/clients/go/internal/proto/http_client.go
+++ b/clients/go/internal/proto/http_client.go
@@ -26,7 +26,7 @@ type HttpClient struct {
 	Debug          bool
 }
 
-func DefaultSvixHttpClient(defaultBaseUrl string) HttpClient {
+func DefaultHttpClient(defaultBaseUrl string) HttpClient {
 	// Disable HTTP/2.0
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	tr.ForceAttemptHTTP2 = false

--- a/codegen/templates/go/api_resource.go.jinja
+++ b/codegen/templates/go/api_resource.go.jinja
@@ -72,7 +72,7 @@ type {{ opt_struct_name }} struct {
 	{% endif -%}
 // Deprecated: {{ op.name | to_upper_camel_case }} is deprecated.
 	{% endif -%}
-func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_camel_case }}(
+func ({{ resource_self_name }} {{ resource_type_name }}) {{ op.name | to_upper_camel_case }}(
 	ctx context.Context,
 
 	{#- path parameters #}


### PR DESCRIPTION
That's what I get for not testing the SDK initially (#142) - one where you can't even instantiate the client object.