### PR TITLE
cluster: introduce a new wrapper for storing static key/value pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,7 @@ dependencies = [
  "fjall",
  "rmp-serde",
  "serde",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/fjall-utils/Cargo.toml
+++ b/crates/fjall-utils/Cargo.toml
@@ -12,6 +12,7 @@ coyote-error.workspace = true
 fjall.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [lints]

--- a/crates/fjall-utils/src/fixed_key.rs
+++ b/crates/fjall-utils/src/fixed_key.rs
@@ -1,0 +1,62 @@
+use std::marker::PhantomData;
+
+use crate::ReadableKeyspace;
+use coyote_error::{Error, Result, ResultExt};
+
+use serde::{Serialize, de::DeserializeOwned};
+
+/// This is a useful wrapper for key/value pairs stored in a fjall keyspace
+/// whose key and type are statically known; data is always serialized as msgpack
+pub struct FjallFixedKey<T: Serialize + DeserializeOwned + 'static> {
+    key: &'static str,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Serialize + DeserializeOwned + 'static> FjallFixedKey<T> {
+    pub const fn new(key: &'static str) -> Self {
+        Self {
+            key,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn get<K: ReadableKeyspace>(&self, keyspace: &K) -> Result<Option<T>> {
+        keyspace
+            .get(self.key)?
+            .map(|v| rmp_serde::from_slice(&v).map_err_generic())
+            .transpose()
+            .map_err(|err| {
+                tracing::warn!(key = self.key, ?err, "error deserializing key from DB");
+                Error::generic(err)
+            })
+    }
+
+    pub fn store(&self, keyspace: &fjall::Keyspace, value: &T) -> coyote_error::Result<()> {
+        let serialized = rmp_serde::encode::to_vec_named(&value).map_err_generic()?;
+        keyspace.insert(self.key, serialized).map_err_generic()
+    }
+
+    pub fn remove(&self, keyspace: &fjall::Keyspace) -> coyote_error::Result<()> {
+        keyspace.remove(self.key).map_err_generic()
+    }
+
+    pub fn store_tx(
+        &self,
+        tx: &mut fjall::OwnedWriteBatch,
+        keyspace: &fjall::Keyspace,
+        value: &T,
+    ) -> coyote_error::Result<()> {
+        let serialized = rmp_serde::encode::to_vec_named(&value).map_err_generic()?;
+        tx.insert(keyspace, self.key, serialized);
+        Ok(())
+    }
+
+    pub fn remove_tx(
+        &self,
+        tx: &mut fjall::OwnedWriteBatch,
+        keyspace: &fjall::Keyspace,
+    ) -> coyote_error::Result<()> {
+        tx.remove(keyspace, self.key);
+        Ok(())
+    }
+}

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -1,7 +1,9 @@
+mod fixed_key;
 mod readonly_db;
 mod table_row;
 
 pub use self::{
+    fixed_key::FjallFixedKey,
     readonly_db::{ReadableDatabase, ReadableKeyspace, ReadonlyDatabase, ReadonlyKeyspace},
     table_row::{
         KeyspaceExt, MonotonicTableKey, MonotonicTableRowExt, TableKey, TableRow, WriteBatchExt,

--- a/crates/fjall-utils/src/readonly_db.rs
+++ b/crates/fjall-utils/src/readonly_db.rs
@@ -86,6 +86,12 @@ pub struct ReadonlyKeyspace {
     inner: Keyspace,
 }
 
+impl From<Keyspace> for ReadonlyKeyspace {
+    fn from(inner: Keyspace) -> Self {
+        Self { inner }
+    }
+}
+
 impl ReadableKeyspace for ReadonlyKeyspace {
     fn get<K: AsRef<[u8]>>(&self, key: K) -> fjall::Result<Option<fjall::UserValue>> {
         self.inner.get(key)

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -6,15 +6,15 @@ use std::{
 };
 
 use anyhow::Context;
-use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
-use fjall_utils::{MonotonicTableRowExt, TableRow};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
+use fjall_utils::{FjallFixedKey, MonotonicTableRowExt, TableRow};
 use jiff::Timestamp;
 use openraft::{
     Entry, LogId, OptionalSend, RaftLogId, RaftLogReader, RaftTypeConfig, StorageError, Vote,
     storage::{LogFlushed, RaftLogStorage},
 };
 use serde::{Deserialize, Serialize};
-use tap::{Pipe, Tap, TapFallible};
+use tap::{Pipe, Tap, TapFallible, TapOptional};
 use tracing::{Instrument as _, Span};
 
 use super::{NodeId, errors::*, raft::TypeConfig};
@@ -158,6 +158,11 @@ impl RaftLogStorage<TypeConfig> for CoyoteLogs {
     }
 }
 
+static NODE_ID: FjallFixedKey<NodeId> = FjallFixedKey::new("node_id");
+static LAST_PURGED_LOG_ID: FjallFixedKey<LogId<NodeId>> = FjallFixedKey::new("last_purged_log_id");
+static VOTE: FjallFixedKey<Vote<NodeId>> = FjallFixedKey::new("vote");
+static COMMITTED: FjallFixedKey<Option<LogId<NodeId>>> = FjallFixedKey::new("committed");
+
 impl CoyoteLogs {
     pub fn new(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let db = Database::builder(path).worker_threads(1).open()?;
@@ -190,21 +195,17 @@ impl CoyoteLogs {
 
     /// Get the NodeId (or, if we don't have one, make a new one)
     pub async fn get_node_id(&mut self) -> anyhow::Result<NodeId> {
-        let meta_keyspace = self.meta_keyspace.clone();
         let db = self.db.clone();
+        let meta_keyspace = self.meta_keyspace.clone();
         tokio::task::spawn_blocking(move || {
-            if let Some(raw_node_id) = meta_keyspace
-                .get("node_id")
-                .context("fetching node ID from logs database")?
-            {
-                let node_id = rmp_serde::from_slice(&raw_node_id)?;
+            if let Some(node_id) = NODE_ID.get(&meta_keyspace)? {
                 tracing::debug!(?node_id, "starting up with existing node ID");
                 node_id
             } else {
                 let node_id = NodeId::generate();
                 tracing::info!(?node_id, "generated a new node ID");
-                meta_keyspace
-                    .insert("node_id", rmp_serde::to_vec(&node_id)?)
+                NODE_ID
+                    .store(&meta_keyspace, &node_id)
                     .context("saving node ID to logs database")?;
                 db.persist(PersistMode::SyncAll)?;
                 node_id
@@ -260,13 +261,12 @@ impl CoyoteLogs {
     async fn purge_entries_(&self, log_id: LogId<NodeId>) -> anyhow::Result<()> {
         let meta_keyspace = self.meta_keyspace.clone();
         let log_keyspace = self.log_keyspace.clone();
-        let serialized_log_id = rmp_serde::encode::to_vec(&log_id)?;
         let mut tx = self.db.batch().durability(Some(PersistMode::SyncAll));
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             for key in Log::keys_in_range(&log_keyspace, ..=log_id.index)? {
                 tx.remove(&log_keyspace, key);
             }
-            tx.insert(&meta_keyspace, "last_purged_log_id", serialized_log_id);
+            LAST_PURGED_LOG_ID.store_tx(&mut tx, &meta_keyspace, &log_id)?;
             tx.commit()?;
             Ok(())
         })
@@ -275,11 +275,7 @@ impl CoyoteLogs {
 
     fn trace_logs(&self) {
         tracing::trace!("BEGINNING LOG TRACE");
-        let last_purged_log_id: Option<LogId<NodeId>> = self
-            .meta_keyspace
-            .get("last_purged_log_id")
-            .unwrap()
-            .map(|l| rmp_serde::from_slice(&l).unwrap());
+        let last_purged_log_id = LAST_PURGED_LOG_ID.get(&self.meta_keyspace);
         let first_id = Log::range(&self.log_keyspace, ..)
             .next()
             .map(|l| l.unwrap().0);
@@ -295,17 +291,10 @@ impl CoyoteLogs {
     }
 
     async fn get_log_state_(&mut self) -> anyhow::Result<openraft::LogState<TypeConfig>> {
-        let db = self.db.clone();
         let log_keyspace = self.log_keyspace.clone();
         let meta_keyspace = self.meta_keyspace.clone();
         tokio::task::spawn_blocking(move || {
-            let tx = db.snapshot();
-            let last_purged_log_id =
-                if let Some(value) = tx.get(&meta_keyspace, "last_purged_log_id")? {
-                    Some(rmp_serde::from_slice(&value)?)
-                } else {
-                    None
-                };
+            let last_purged_log_id = LAST_PURGED_LOG_ID.get(&meta_keyspace)?;
             let last_log_id =
                 if let Some(Ok(last_guard)) = Log::range(&log_keyspace, ..).next_back() {
                     Some(last_guard.1.0.log_id)
@@ -362,8 +351,7 @@ impl CoyoteLogs {
         let db = self.db.clone();
         let meta_keyspace = self.meta_keyspace.clone();
         tokio::task::spawn_blocking(move || {
-            let serialized = rmp_serde::to_vec(&vote)?;
-            meta_keyspace.insert("vote", serialized)?;
+            VOTE.store(&meta_keyspace, &vote)?;
             db.persist(PersistMode::SyncAll)?;
             Ok(())
         })
@@ -371,35 +359,31 @@ impl CoyoteLogs {
     }
 
     async fn read_vote_(&self) -> anyhow::Result<Option<Vote<NodeId>>> {
-        let Some(raw) = self.meta_keyspace.get("vote")? else {
+        let keyspace = self.meta_keyspace.clone();
+        let Some(vote) = tokio::task::spawn_blocking(move || VOTE.get(&keyspace)).await?? else {
             tracing::trace!("couldn't find a vote");
             return Ok(None);
         };
-        let vote = rmp_serde::from_slice(&raw)?;
-        tracing::trace!(?vote, "reading a vote");
+        tracing::trace!(?vote, "read a vote");
         Ok(Some(vote))
     }
 
     async fn save_committed_(&self, committed: Option<LogId<NodeId>>) -> anyhow::Result<()> {
         let meta_keyspace = self.meta_keyspace.clone();
         tracing::trace!(?committed, "saving committed state");
-        tokio::task::spawn_blocking(move || {
-            let serialized = rmp_serde::to_vec(&committed)?;
-            meta_keyspace.insert("committed", serialized)?;
-            Ok(())
-        })
-        .await?
+        tokio::task::spawn_blocking(move || COMMITTED.store(&meta_keyspace, &committed))
+            .await?
+            .context("saving committed state")
     }
 
     async fn read_committed_(&self) -> anyhow::Result<Option<LogId<NodeId>>> {
         let meta_keyspace = self.meta_keyspace.clone();
         tokio::task::spawn_blocking(move || {
-            let committed = meta_keyspace
-                .get("committed")?
-                .map(|c| rmp_serde::from_slice(&c))
-                .transpose()?;
-            tracing::trace!(?committed, "read committed state");
-            Ok(committed)
+            COMMITTED
+                .get(&meta_keyspace)?
+                .tap_some(|committed| tracing::trace!(?committed, "read committed state"))
+                .flatten()
+                .pipe(Ok)
         })
         .await?
     }

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -8,14 +8,15 @@ use std::{
 use crate::core::db::Databases;
 use anyhow::Context;
 use coyote_configgroup::entities::StorageType;
-use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
+use fjall_utils::{FjallFixedKey, ReadonlyKeyspace};
 use openraft::{
     EntryPayload, LogId, RaftSnapshotBuilder, RaftTypeConfig, Snapshot, SnapshotMeta,
     StorageIOError, StoredMembership, storage::RaftStateMachine,
 };
 use parking_lot::RwLock;
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use tap::TapFallible;
+use serde::{Deserialize, Serialize};
+use tap::TapOptional;
 use tokio::sync::RwLock as TokioRwLock;
 use uuid::Uuid;
 
@@ -78,6 +79,7 @@ pub struct Store {
     stores: Arc<RwLock<Stores>>,
     snapshot_directory: PathBuf,
     meta_keyspace: Keyspace,
+    readonly_meta_keyspace: ReadonlyKeyspace,
     snapshot_idx: u64,
     last_applied_log_id: Option<LogId<NodeId>>,
     last_membership: StoredMembership<NodeId, Node>,
@@ -103,6 +105,13 @@ impl SnapshotIdx for SnapshotMeta<NodeId, Node> {
 }
 
 const METADATA_KEYSPACE: &str = "_raft_metadata";
+
+static LAST_APPLIED_LOG_ID: FjallFixedKey<LogId<NodeId>> =
+    FjallFixedKey::new("last_applied_log_id");
+static LAST_SNAPSHOT: FjallFixedKey<LastSnapshot> = FjallFixedKey::new("last_snapshot");
+static LAST_MEMBERSHIP: FjallFixedKey<StoredMembership<NodeId, Node>> =
+    FjallFixedKey::new("last_membership");
+static CLUSTER_UUID: FjallFixedKey<ClusterId> = FjallFixedKey::new("cluster_uuid");
 
 impl Store {
     pub async fn new(
@@ -134,6 +143,7 @@ impl Store {
             stores: Arc::new(RwLock::new(stores)),
             state: app_state,
             snapshot_directory,
+            readonly_meta_keyspace: ReadonlyKeyspace::from(meta_keyspace.clone()),
             meta_keyspace,
             last_snapshot: Arc::new(RwLock::new(None)),
             snapshot_idx: 0,
@@ -157,8 +167,7 @@ impl Store {
     pub(super) async fn set_cluster_id(&mut self, id: ClusterId) -> anyhow::Result<()> {
         let keyspace = self.meta_keyspace.clone();
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let serialized = rmp_serde::to_vec(&id)?;
-            keyspace.insert("cluster_uuid", serialized)?;
+            CLUSTER_UUID.store(&keyspace, &id)?;
             Ok(())
         })
         .await??;
@@ -166,39 +175,19 @@ impl Store {
         Ok(())
     }
 
-    fn try_read_field<T: DeserializeOwned>(
-        snapshot: &fjall::Snapshot,
-        keyspace: &Keyspace,
-        key: &str,
-    ) -> anyhow::Result<T> {
-        if let Some(raw_data) = snapshot.get(keyspace, key)? {
-            rmp_serde::from_slice(&raw_data).map_err(|err| {
-                tracing::warn!(?key, ?err, "error deserializing key from meta keyspace");
-                err.into()
-            })
-        } else {
-            anyhow::bail!("no such key {key:?}");
-        }
-    }
-
     #[tracing::instrument(skip(self))]
     async fn load_information(&mut self) -> anyhow::Result<()> {
-        let handle = self.stores.clone();
-        let keyspace = self.meta_keyspace.clone();
+        let keyspace = self.readonly_meta_keyspace.clone();
 
         let (last_applied_log_id, last_membership, last_snapshot, cluster_id) =
             tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-                let db = &handle.read().databases.persistent;
-                let snapshot = db.snapshot();
-                let last_applied_log_id =
-                    Self::try_read_field(&snapshot, &keyspace, "last_applied_log_id").ok();
-                let last_membership = Self::try_read_field(&snapshot, &keyspace, "last_membership")
-                    .tap_err(|_| tracing::trace!("found no last membership in the database!"))
+                let last_applied_log_id = LAST_APPLIED_LOG_ID.get(&keyspace)?;
+                let last_membership = LAST_MEMBERSHIP
+                    .get(&keyspace)?
+                    .tap_none(|| tracing::trace!("found no last membership in the database!"))
                     .unwrap_or_default();
-                let last_snapshot =
-                    Self::try_read_field::<LastSnapshot>(&snapshot, &keyspace, "last_snapshot")
-                        .ok();
-                let cluster_id = Self::try_read_field(&snapshot, &keyspace, "cluster_uuid").ok();
+                let last_snapshot = LAST_SNAPSHOT.get(&keyspace)?;
+                let cluster_id = CLUSTER_UUID.get(&keyspace)?;
 
                 Ok((
                     last_applied_log_id,
@@ -232,12 +221,11 @@ impl Store {
             path: snapshot_path,
         };
         tracing::trace!(last_snapshot=?data, "setting last_snapshot");
-        let serialized = rmp_serde::to_vec_named(&data)?;
-        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let data = tokio::task::spawn_blocking(move || -> anyhow::Result<LastSnapshot> {
             let db = &handle.read().databases.persistent;
-            keyspace.insert("last_snapshot", serialized)?;
+            LAST_SNAPSHOT.store(&keyspace, &data)?;
             db.persist(fjall::PersistMode::SyncAll)?;
-            Ok(())
+            Ok(data)
         })
         .await??;
         *self.last_snapshot.write() = Some(data);
@@ -250,9 +238,9 @@ impl Store {
             last_membership=?self.last_membership,
             "storing id values");
         let handle = self.stores.clone();
-        let keyspace = self.meta_keyspace.clone();
-        let last_applied_log_id = rmp_serde::encode::to_vec_named(&self.last_applied_log_id)?;
-        let last_membership = rmp_serde::encode::to_vec_named(&self.last_membership)?;
+        let meta_keyspace = self.meta_keyspace.clone();
+        let last_applied_log_id = self.last_applied_log_id;
+        let last_membership = self.last_membership.clone();
         tokio::task::spawn_blocking(move || {
             let mut tx = handle
                 .read()
@@ -260,8 +248,12 @@ impl Store {
                 .persistent
                 .batch()
                 .durability(Some(PersistMode::Buffer));
-            tx.insert(&keyspace, "last_applied_log_id", last_applied_log_id);
-            tx.insert(&keyspace, "last_membership", last_membership);
+            if let Some(log_id) = &last_applied_log_id {
+                LAST_APPLIED_LOG_ID.store_tx(&mut tx, &meta_keyspace, log_id)?;
+            } else {
+                LAST_APPLIED_LOG_ID.remove_tx(&mut tx, &meta_keyspace)?;
+            }
+            LAST_MEMBERSHIP.store_tx(&mut tx, &meta_keyspace, &last_membership)?;
             tx.commit()?;
             Ok(())
         })


### PR DESCRIPTION
I didn't like the nunber of places that the logs and state metadata systems were directly reading to and writing from fjall, so this introduces a new helper struct for statically-known key/value pairs.