### PR TITLE
gha: only run vacuum-action if we changed openapi.json

### DIFF
--- a/.github/workflows/lint-openapi.yml
+++ b/.github/workflows/lint-openapi.yml
@@ -1,0 +1,28 @@
+name: Lint OpenAPI
+on:
+  workflow_dispatch:
+  workflow_call:
+jobs:
+  lint-openapi:
+    name: Lint openapi.json
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - id: changed-files
+        uses: tj-actions/changed-files@v47.0.4
+        with:
+          files: "openapi.json"
+      - uses: pb33f/vacuum-action@v2
+        if: steps.changed-files.outputs.test_any_changed == 'true'
+        with:
+          openapi_path: openapi.json
+          ruleset: .vacuum.yaml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # raise this as time goes on and we fix some stuff
+          minimum_score: 0
+      - run: |
+          echo "succeed even if we skipped vacuum-action"
+          exit 0

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -10,20 +10,11 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
   lint-openapi:
-    name: Lint openapi.json
-    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pb33f/vacuum-action@v2
-        with:
-          openapi_path: openapi.json
-          ruleset: .vacuum.yaml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # raise this as time goes on and we fix some stuff
-          minimum_score: 0
+    uses: ./.github/workflows/lint-openapi.yml
+    secrets: inherit
   ci-required-checks:
     name: CI Required Checks
     runs-on: ubuntu-24.04


### PR DESCRIPTION
I don't like seeing the big post from vacuum if I didn't touch the openapi spec.