### PR TITLE
Allow spaces in comma-separated env vars

### DIFF
--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -414,7 +414,11 @@ where
     T: FromStr<Err: fmt::Display>,
 {
     env_var_parse(name, |value| {
-        value.split(',').map(FromStr::from_str).collect()
+        value
+            .split(',')
+            .map(str::trim_ascii)
+            .map(FromStr::from_str)
+            .collect()
     })
 }
 


### PR DESCRIPTION
Ref. https://svixhq.slack.com/archives/C0A72988962/p1772031729060049?thread_ts=1772030894.921029&cid=C0A72988962