### PR TITLE
Cluster: support having hostnames in seed_nodes.

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use coyote::{cfg::LogLevel, core::cluster::proto::HealthResponse};
+use coyote::{cfg::{LogLevel, SeedNode}, core::cluster::proto::HealthResponse};
 use coyote_client::{CoyoteClient, CoyoteOptions};
 use openraft::ServerState;
 use std::sync::{Arc, Once};
@@ -112,7 +112,7 @@ pub fn setup_cluster(num_servers: usize) -> BenchmarkContext {
             (server, workdir)
         });
 
-        seed_nodes.push(server.repl_addr);
+        seed_nodes.push(SeedNode::from(server.repl_addr));
         servers.push(server);
         workdirs.push(workdir);
     }

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -50,6 +50,72 @@ impl DatabaseConfig {
     }
 }
 
+/// A cluster seed node address with an optional port.
+///
+/// Accepts `hostname:port` or just `hostname` (port defaults to the cluster listen port).
+/// Hostnames are resolved via DNS when a [`SocketAddr`] is needed.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SeedNode {
+    pub host: String,
+    pub port: Option<u16>,
+}
+
+impl SeedNode {
+    pub fn effective_port(&self) -> u16 {
+        self.port.unwrap_or_else(|| defaults::cluster_listen_address().port())
+    }
+
+    pub async fn resolve(&self) -> anyhow::Result<SocketAddr> {
+        let port = self.effective_port();
+        let addr_str = format!("{}:{}", self.host, port);
+        tokio::net::lookup_host(addr_str)
+            .await?
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("could not resolve seed node {}:{}", self.host, port))
+    }
+}
+
+impl fmt::Display for SeedNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.host, self.effective_port())
+    }
+}
+
+impl FromStr for SeedNode {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((host, port_str)) = s.rsplit_once(':') {
+            if let Ok(port) = port_str.parse::<u16>() {
+                return Ok(SeedNode {
+                    host: host.to_owned(),
+                    port: Some(port),
+                });
+            }
+        }
+        Ok(SeedNode {
+            host: s.to_owned(),
+            port: None,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for SeedNode {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Ok(s.parse().unwrap())
+    }
+}
+
+impl From<SocketAddr> for SeedNode {
+    fn from(addr: SocketAddr) -> Self {
+        SeedNode {
+            host: addr.ip().to_string(),
+            port: Some(addr.port()),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct ClusterConfiguration {
     /// The address to listen on for replication
@@ -99,7 +165,7 @@ pub struct ClusterConfiguration {
     pub election_timeout_max_ms: u64,
 
     #[serde(default)]
-    pub seed_nodes: Vec<SocketAddr>,
+    pub seed_nodes: Vec<SeedNode>,
 
     /// Automatically initialize the cluster on bootup if we can't discover any
     /// peers and we don't have any existing state. If you initialize all peers

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -50,7 +50,8 @@ impl Discovery {
     }
 
     async fn poll_seeds(&self) -> (Option<SocketAddr>, BTreeMap<SocketAddr, DiscoverResponse>) {
-        let mut responses = self.cfg.cluster.seed_nodes.iter().copied().map(|s| async move {
+        // Poll all seed nodes concurrently, keeping SeedNode only for display/URL purposes.
+        let seed_responses: Vec<_> = self.cfg.cluster.seed_nodes.iter().cloned().map(|s| async move {
                     let url_string = format!("http://{s}/repl/discover");
                     let url = match Url::parse(&url_string) {
                         Ok(url) => url,
@@ -77,14 +78,26 @@ impl Discovery {
                 }).pipe(stream::iter)
                 .buffer_unordered(CONCURRENT_FETCHES)
                 .filter_map(futures_util::future::ready)
-                .collect::<BTreeMap<_, _>>()
+                .collect()
                 .await;
-        let my_addr = responses
-            .iter()
-            .find(|(_k, v)| v.node_id == self.my_node_id)
-            .map(|(k, _)| k.to_owned());
-        if let Some(addr) = &my_addr {
-            responses.remove(addr);
+
+        // Resolve all hostnames to IPs once here at cluster startup; everything
+        // downstream works with SocketAddr only.
+        let mut my_addr = None;
+        let mut responses = BTreeMap::new();
+        for (seed, response) in seed_responses {
+            match seed.resolve().await {
+                Ok(addr) => {
+                    if response.node_id == self.my_node_id {
+                        my_addr = Some(addr);
+                    } else {
+                        responses.insert(addr, response);
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(?err, "could not resolve seed node {seed}, skipping");
+                }
+            }
         }
         (my_addr, responses)
     }


### PR DESCRIPTION
This PR only resolves hostnames from the original config, but doesn't resolve hostnames when shared, nor does it allow it.

Partially fixes #199, though there are still open questions.

TBH, I feel like the other solutions suggested in #199 are better.