### PR TITLE
cluster: allow adding peers with hostnames instead of SocketAddrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "addr"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
+dependencies = [
+ "psl",
+ "psl-types",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +838,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "coyote"
 version = "0.0.1"
 dependencies = [
+ "addr",
  "aide 0.16.0-alpha.2",
  "anyerror",
  "anyhow",
@@ -3120,6 +3131,21 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29b38f74e543deb5a2efcedb975b8695b65af607d96201e2266222ca99874bd"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "ptr_meta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ignored = [
 openapi = []
 
 [dependencies]
+addr.workspace = true
 aide.workspace = true
 anyerror.workspace = true
 anyhow.workspace = true
@@ -110,6 +111,7 @@ version = "0.0.1"
 rust-version = "1.91"
 
 [workspace.dependencies]
+addr = "0.15"
 aide = { version = "=0.16.0-alpha.2", features = ["axum", "axum-json", "axum-query", "macros"] }
 anyerror = { version = "0.1.13", features = ["anyhow"] }
 anyhow = "1.0.56"

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -112,7 +112,7 @@ pub fn setup_cluster(num_servers: usize) -> BenchmarkContext {
             (server, workdir)
         });
 
-        seed_nodes.push(server.repl_addr);
+        seed_nodes.push(server.repl_addr.into());
         servers.push(server);
         workdirs.push(workdir);
     }

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -223,7 +223,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         opentelemetry_service_name: "coyote-test".to_string(),
         environment: Environment::Dev,
         cluster: ClusterConfiguration {
-            my_address: Some(cluster_addr.into()),
+            advertised_address: None,
             listen_address: cluster_addr,
             name: "coyote-test".to_string(),
             snapshot_path,

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -202,6 +202,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
     let snapshot_path = workdir.join("snapshots");
 
     let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+    let cluster_addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
 
     ConfigurationInner {
         listen_address: addr,
@@ -222,7 +223,8 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         opentelemetry_service_name: "coyote-test".to_string(),
         environment: Environment::Dev,
         cluster: ClusterConfiguration {
-            listen_address: addr,
+            my_address: Some(cluster_addr.into()),
+            listen_address: cluster_addr,
             name: "coyote-test".to_string(),
             snapshot_path,
             log_path,

--- a/example-configs/three-node-cluster/run.sh
+++ b/example-configs/three-node-cluster/run.sh
@@ -35,10 +35,6 @@ if [[ -t 1 ]]; then
     OFF="$(printf "\e[0m")"
 fi
 
-for instance in first second third; do
-    "./prefix-output.sh" "[${TAG}$instance${OFF}]" cargo run -- --config-path "${instance}.toml" bootstrap
-done
-
 ./prefix-output.sh "[${TAG}first${OFF}] " cargo run -- --config-path ./first.toml server &
 FIRST=$!
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -22,6 +22,78 @@ mod defaults;
 
 pub type Configuration = Arc<ConfigurationInner>;
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PeerAddr {
+    SocketAddr(SocketAddr),
+    HostnameAndPort { hostname: String, port: u16 },
+}
+
+impl PeerAddr {
+    pub fn as_base_url(&self) -> url::Url {
+        let base = self.to_string();
+        format!("http://{base}")
+            .parse()
+            .expect("we validated this already")
+    }
+}
+
+impl std::fmt::Display for PeerAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SocketAddr(s) => s.fmt(f),
+            Self::HostnameAndPort { hostname, port } => write!(f, "{hostname}:{port}"),
+        }
+    }
+}
+
+impl From<SocketAddr> for PeerAddr {
+    fn from(value: SocketAddr) -> Self {
+        Self::SocketAddr(value)
+    }
+}
+
+impl FromStr for PeerAddr {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(p) = s.parse() {
+            return Ok(Self::SocketAddr(p));
+        }
+        if let Some((host, port_str)) = s.rsplit_once(':') {
+            if let Err(e) = addr::parse_domain_name(host) {
+                anyhow::bail!("invalid hostname {host}: {e:?}");
+            }
+            let port = port_str.parse::<u16>().context("parsing port")?;
+            Ok(Self::HostnameAndPort {
+                hostname: host.to_string(),
+                port,
+            })
+        } else {
+            anyhow::bail!("Unable to parse PeerAddr {s:?}");
+        }
+    }
+}
+
+impl<'d> serde::Deserialize<'d> for PeerAddr {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'d>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        raw.parse()
+            .map_err(|e| serde::de::Error::custom(format!("invalid peer address: {e:?}")))
+    }
+}
+
+impl serde::Serialize for PeerAddr {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct DatabaseConfig {
     pub path: PathBuf,
@@ -98,8 +170,15 @@ pub struct ClusterConfiguration {
     #[serde(default = "defaults::cluster_election_timeout_max_ms")]
     pub election_timeout_max_ms: u64,
 
+    /// Address that other nodes should use to communicate with this one. If not passed, we'll
+    /// attempt to discover it at boot time. This cannot currently be changed after cluster
+    /// initialization.
     #[serde(default)]
-    pub seed_nodes: Vec<SocketAddr>,
+    pub my_address: Option<PeerAddr>,
+
+    /// Other nodes that we should attempt to join a cluster with at boot time.
+    #[serde(default)]
+    pub seed_nodes: Vec<PeerAddr>,
 
     /// Automatically initialize the cluster on bootup if we can't discover any
     /// peers and we don't have any existing state. If you initialize all peers
@@ -313,6 +392,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         bootstrap_cfg_path,
         cluster:
             ClusterConfiguration {
+                my_address: cluster_my_address,
                 listen_address: cluster_listen_address,
                 name: cluster_name,
                 snapshot_path: cluster_snapshot_path,
@@ -370,6 +450,9 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
     }
     if let Some(value) = env_var("COYOTE_BOOTSTRAP_CFG_PATH")? {
         *bootstrap_cfg_path = Some(value);
+    }
+    if let Some(value) = env_var("COYOTE_MY_ADDRESS")? {
+        *cluster_my_address = Some(value);
     }
 
     // Fields that require different parsing
@@ -442,9 +525,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-    use super::load_toml;
+    use super::{PeerAddr, load_toml};
 
     #[test]
     fn test_db() {
@@ -472,5 +555,61 @@ persistent_db.path = "/2"
             config.listen_address,
             "0.0.0.0:1234".parse::<SocketAddr>().unwrap()
         );
+    }
+
+    #[test]
+    fn test_peer_addr_parsing() {
+        let Ok(PeerAddr::SocketAddr(SocketAddr::V4(sa))) = "127.0.0.2:8050".parse() else {
+            panic!("failed to parse v4 addr")
+        };
+        assert_eq!(sa.port(), 8050);
+        assert_eq!(*sa.ip(), Ipv4Addr::new(127, 0, 0, 2));
+        let Ok(PeerAddr::SocketAddr(SocketAddr::V6(sa))) = "[::1001:2%1234]:8050".parse() else {
+            panic!("failed to parse v6 addr");
+        };
+        assert_eq!(sa.scope_id(), 1234);
+        assert_eq!(sa.port(), 8050);
+        assert_eq!(*sa.ip(), Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x1001, 0x2));
+        assert_eq!(
+            "foobar:8050".parse::<PeerAddr>().expect("should parse"),
+            PeerAddr::HostnameAndPort {
+                hostname: "foobar".to_owned(),
+                port: 8050
+            }
+        );
+        "  illegal-hostname:1"
+            .parse::<PeerAddr>()
+            .expect_err("should fail to parse");
+        "no-port-provided"
+            .parse::<PeerAddr>()
+            .expect_err("should fail to parse");
+        "port-out-of-bounds:65537"
+            .parse::<PeerAddr>()
+            .expect_err("should fail to parse");
+    }
+
+    #[test]
+    fn test_peer_addr_serde() {
+        let addrs = [
+            PeerAddr::SocketAddr(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                8050,
+            )),
+            PeerAddr::SocketAddr(SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)),
+                8051,
+            )),
+            PeerAddr::HostnameAndPort {
+                hostname: "foo".to_owned(),
+                port: 8052,
+            },
+        ];
+        for addr in addrs {
+            let serialized = serde_json::to_string(&addr).expect("should serialize");
+            assert_ne!(&serialized, "");
+            let deserialized: PeerAddr =
+                serde_json::from_str(&serialized).expect("should deserialize");
+            assert_eq!(deserialized, addr);
+        }
     }
 }

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -451,7 +451,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
     if let Some(value) = env_var("COYOTE_BOOTSTRAP_CFG_PATH")? {
         *bootstrap_cfg_path = Some(value);
     }
-    if let Some(value) = env_var("COYOTE_MY_ADDRESS")? {
+    if let Some(value) = env_var("COYOTE_ADVERTISED_ADDRESS")? {
         *cluster_advertised_address = Some(value);
     }
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -174,7 +174,7 @@ pub struct ClusterConfiguration {
     /// attempt to discover it at boot time. This cannot currently be changed after cluster
     /// initialization.
     #[serde(default)]
-    pub my_address: Option<PeerAddr>,
+    pub advertised_address: Option<PeerAddr>,
 
     /// Other nodes that we should attempt to join a cluster with at boot time.
     #[serde(default)]
@@ -392,7 +392,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         bootstrap_cfg_path,
         cluster:
             ClusterConfiguration {
-                my_address: cluster_my_address,
+                advertised_address: cluster_advertised_address,
                 listen_address: cluster_listen_address,
                 name: cluster_name,
                 snapshot_path: cluster_snapshot_path,
@@ -452,7 +452,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         *bootstrap_cfg_path = Some(value);
     }
     if let Some(value) = env_var("COYOTE_MY_ADDRESS")? {
-        *cluster_my_address = Some(value);
+        *cluster_advertised_address = Some(value);
     }
 
     // Fields that require different parsing

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -9,7 +9,7 @@ use axum::{
     routing::{get, post},
 };
 use coyote_proto::MsgPack;
-use http::{StatusCode, Uri};
+use http::StatusCode;
 use openraft::{
     ChangeMembers,
     raft::{AppendEntriesRequest, InstallSnapshotRequest, VoteRequest},
@@ -165,7 +165,14 @@ async fn discover(
                 .membership_state
                 .committed()
                 .nodes()
-                .map(|(nid, n)| (*nid, n.addrs()))
+                .filter_map(|(nid, n)| {
+                    if let Ok(peer) = n.clone().try_into() {
+                        Some((*nid, peer))
+                    } else {
+                        tracing::warn!(node_id = ?nid, node = ?n, "could not construct peer address for node");
+                        None
+                    }
+                })
                 .collect(),
         })
         .await
@@ -188,18 +195,8 @@ async fn add_learner(
     Extension(state): Extension<RaftState>,
     MsgPack(request): MsgPack<AddLearnerRequest>,
 ) -> impl IntoResponse {
-    let url = format!("http://{}/repl/raft/vote", request.address);
-    let Ok(Some(authority)) = Uri::try_from(url).map(|v| v.authority().map(|a| a.to_string()))
-    else {
-        return internal_error("invalid address");
-    };
-    let Ok(addr) = authority.parse::<std::net::SocketAddr>() else {
-        return internal_error(format!(
-            "unable to get socketaddr for authority {authority}"
-        ));
-    };
-    tracing::debug!(?authority, ?addr, "looked up learner");
-    let node = Node::new(addr);
+    tracing::debug!(address=?request.address, "adding a learner");
+    let node = Node::from(request.address);
     rpc_response(state.raft.add_learner(request.node_id, node, true).await)
 }
 

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -1,6 +1,6 @@
 use super::{
+    NodeId,
     handle::{Request, Response},
-    raft::NodeId,
     state_machine::Store,
 };
 use openraft::LogId;

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -49,13 +49,13 @@ impl Discovery {
         network: NetworkFactory,
     ) -> anyhow::Result<Self> {
         let client = build_client(&cfg, cfg.cluster.discovery_request_timeout)?;
-        let my_addr = if let Some(addr) = &cfg.cluster.my_address {
+        let my_addr = if let Some(addr) = &cfg.cluster.advertised_address {
             addr.clone()
         } else if is_not_any(&cfg.cluster.listen_address) {
-            tracing::debug!(listen_address=?cfg.cluster.listen_address, "my_address not passed, but listen_address is not INADDR_ANY, so using that");
+            tracing::debug!(listen_address=?cfg.cluster.listen_address, "advertised_address not passed, but listen_address is not INADDR_ANY, so using that");
             cfg.cluster.listen_address.into()
         } else {
-            tracing::debug!("my_address not passed, attempting to detect local socketaddr");
+            tracing::debug!("advertised_address not passed, attempting to detect local socketaddr");
             PeerAddr::SocketAddr(detect_address(&cfg)?)
         };
         Ok(Self {

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -11,11 +11,7 @@ use openraft::ServerState;
 use tap::Pipe;
 use url::Url;
 
-use super::{
-    network::build_client,
-    raft::{Node, NodeId, Raft},
-    state_machine::ClusterId,
-};
+use super::{Node, NodeId, network::build_client, raft::Raft, state_machine::ClusterId};
 use crate::{
     Configuration,
     core::cluster::{

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -15,7 +15,7 @@ use crate::{
     Configuration,
     cfg::PeerAddr,
     core::cluster::{
-        network::detect_address,
+        network::{NetworkFactory, detect_address},
         proto::{
             AddLearnerRequest, DiscoverClusterResponse, DiscoverResponse, UpgradeLearnerRequest,
         },
@@ -31,6 +31,7 @@ pub(super) struct Discovery {
     raft: Raft,
     cfg: Configuration,
     my_addr: PeerAddr,
+    network: NetworkFactory,
 }
 
 fn is_not_any(s: &SocketAddr) -> bool {
@@ -41,7 +42,12 @@ fn is_not_any(s: &SocketAddr) -> bool {
 }
 
 impl Discovery {
-    pub(super) fn new(cfg: Configuration, raft: Raft, my_node_id: NodeId) -> anyhow::Result<Self> {
+    pub(super) fn new(
+        cfg: Configuration,
+        raft: Raft,
+        my_node_id: NodeId,
+        network: NetworkFactory,
+    ) -> anyhow::Result<Self> {
         let client = build_client(&cfg, cfg.cluster.discovery_request_timeout)?;
         let my_addr = if let Some(addr) = &cfg.cluster.my_address {
             addr.clone()
@@ -58,6 +64,7 @@ impl Discovery {
             cfg,
             raft,
             my_node_id,
+            network,
         })
     }
 
@@ -110,8 +117,8 @@ impl Discovery {
         peers: Vec<(PeerAddr, NodeId, DiscoverClusterResponse)>,
     ) -> anyhow::Result<()> {
         tracing::info!(?cluster_id, "joining running cluster");
-        let Some((leader_addr, _leader_node_id, leader_cluster)) = peers
-            .iter()
+        let Some((leader_addr, leader_node_id, leader_cluster)) = peers
+            .into_iter()
             .find_or_first(|p| p.2.state == ServerState::Leader)
         else {
             anyhow::bail!("failed to find any peers to join!");
@@ -120,24 +127,24 @@ impl Discovery {
             anyhow::bail!("existing cluster has no logs");
         };
         // TODO: if any of these steps fail, how do we recover?
-        let node = Node::from(leader_addr.clone());
-        let url = node.url_for("/repl/raft/admin/add-learner")?;
-        let request = AddLearnerRequest {
-            node_id: self.my_node_id,
-            address: self.my_addr.clone(),
-        };
-        self.client.post(url).msgpack(&request)?.send().await?;
+        let client = self.network.client_for(leader_node_id, &leader_addr.into());
+        client
+            .add_learner(AddLearnerRequest {
+                node_id: self.my_node_id,
+                address: self.my_addr.clone(),
+            })
+            .await?;
         tracing::debug!("waiting to catch up in replication");
         self.raft
             .wait(None)
             .log_index_at_least(Some(log_id.index), "waiting to catch up to leader")
             .await?;
         tracing::debug!("adding self as a full member");
-        let url = node.url_for("/repl/raft/admin/upgrade-learner")?;
-        let request = UpgradeLearnerRequest {
-            node_id: self.my_node_id,
-        };
-        self.client.post(url).msgpack(&request)?.send().await?;
+        client
+            .upgrade_learner(UpgradeLearnerRequest {
+                node_id: self.my_node_id,
+            })
+            .await?;
         Ok(())
     }
 

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -8,12 +8,12 @@ use coyote_proto::prelude::*;
 use futures_util::{StreamExt, stream};
 use itertools::Itertools;
 use openraft::ServerState;
-use tap::Pipe;
-use url::Url;
+use tap::{Pipe, TapFallible};
 
 use super::{Node, NodeId, network::build_client, raft::Raft, state_machine::ClusterId};
 use crate::{
     Configuration,
+    cfg::PeerAddr,
     core::cluster::{
         network::detect_address,
         proto::{
@@ -30,14 +30,30 @@ pub(super) struct Discovery {
     my_node_id: NodeId,
     raft: Raft,
     cfg: Configuration,
-    my_addr: SocketAddr,
+    my_addr: PeerAddr,
+}
+
+fn is_not_any(s: &SocketAddr) -> bool {
+    match s {
+        SocketAddr::V4(s) => s.ip().is_unspecified(),
+        SocketAddr::V6(s) => s.ip().is_unspecified(),
+    }
 }
 
 impl Discovery {
     pub(super) fn new(cfg: Configuration, raft: Raft, my_node_id: NodeId) -> anyhow::Result<Self> {
         let client = build_client(&cfg, cfg.cluster.discovery_request_timeout)?;
+        let my_addr = if let Some(addr) = &cfg.cluster.my_address {
+            addr.clone()
+        } else if is_not_any(&cfg.cluster.listen_address) {
+            tracing::debug!(listen_address=?cfg.cluster.listen_address, "my_address not passed, but listen_address is not INADDR_ANY, so using that");
+            cfg.cluster.listen_address.into()
+        } else {
+            tracing::debug!("my_address not passed, attempting to detect local socketaddr");
+            PeerAddr::SocketAddr(detect_address(&cfg)?)
+        };
         Ok(Self {
-            my_addr: detect_address(&cfg)?,
+            my_addr,
             client,
             cfg,
             raft,
@@ -45,36 +61,39 @@ impl Discovery {
         })
     }
 
-    async fn poll_seeds(&self) -> (Option<SocketAddr>, BTreeMap<SocketAddr, DiscoverResponse>) {
-        let mut responses = self.cfg.cluster.seed_nodes.iter().copied().map(|s| async move {
-                    let url_string = format!("http://{s}/repl/discover");
-                    let url = match Url::parse(&url_string) {
-                        Ok(url) => url,
-                        Err(err) => {
-                            tracing::warn!(peer=?s, ?err, "invalid seed node");
-                            return None;
-                        }
-                    };
-                    let response = match self.client.get(url).send().await {
-                        Ok(resp) => resp,
-                        Err(err) => {
-                            tracing::warn!(peer=?s, ?err, "unable to poll seed node");
-                            return None;
-                        }
-                    };
-                    let response: DiscoverResponse = match response.msgpack().await {
-                        Ok(resp) => resp,
-                        Err(err) => {
-                            tracing::warn!(peer=?s, ?err, "unable to read response body from seed node");
-                            return None
-                        }
-                    };
-                    Some((s, response))
-                }).pipe(stream::iter)
-                .buffer_unordered(CONCURRENT_FETCHES)
-                .filter_map(futures_util::future::ready)
-                .collect::<BTreeMap<_, _>>()
-                .await;
+    async fn poll_node(&self, s: &PeerAddr) -> Option<DiscoverResponse> {
+        let url = s
+            .as_base_url()
+            .join("/repl/discover")
+            .expect("discovery URL should be valid");
+        self.client
+            .get(url)
+            .send()
+            .await
+            .tap_err(|err| tracing::warn!(peer=?s, ?err, "unable to poll seed node"))
+            .ok()?
+            .error_for_status()
+            .tap_err(|err| tracing::warn!(peer=?s, ?err, "got invalid HTTP response from seed"))
+            .ok()?
+            .msgpack()
+            .await
+            .tap_err(|err| tracing::warn!(peer=?s, ?err, "unable to read response body from seed"))
+            .ok()
+    }
+
+    async fn poll_seeds(&self) -> (Option<PeerAddr>, BTreeMap<PeerAddr, DiscoverResponse>) {
+        let mut responses = self
+            .cfg
+            .cluster
+            .seed_nodes
+            .clone()
+            .into_iter()
+            .map(|s| async move { self.poll_node(&s).await.map(|resp| (s, resp)) })
+            .pipe(stream::iter)
+            .buffer_unordered(CONCURRENT_FETCHES)
+            .filter_map(futures_util::future::ready)
+            .collect::<BTreeMap<_, _>>()
+            .await;
         let my_addr = responses
             .iter()
             .find(|(_k, v)| v.node_id == self.my_node_id)
@@ -82,13 +101,13 @@ impl Discovery {
         if let Some(addr) = &my_addr {
             responses.remove(addr);
         }
-        (my_addr, responses)
+        (my_addr.clone(), responses)
     }
 
     async fn join_cluster(
         &self,
         cluster_id: ClusterId,
-        peers: Vec<(SocketAddr, NodeId, DiscoverClusterResponse)>,
+        peers: Vec<(PeerAddr, NodeId, DiscoverClusterResponse)>,
     ) -> anyhow::Result<()> {
         tracing::info!(?cluster_id, "joining running cluster");
         let Some((leader_addr, _leader_node_id, leader_cluster)) = peers
@@ -101,10 +120,11 @@ impl Discovery {
             anyhow::bail!("existing cluster has no logs");
         };
         // TODO: if any of these steps fail, how do we recover?
-        let url = format!("http://{leader_addr}/repl/raft/admin/add-learner");
+        let node = Node::from(leader_addr.clone());
+        let url = node.url_for("/repl/raft/admin/add-learner")?;
         let request = AddLearnerRequest {
             node_id: self.my_node_id,
-            address: self.my_addr.to_string(),
+            address: self.my_addr.clone(),
         };
         self.client.post(url).msgpack(&request)?.send().await?;
         tracing::debug!("waiting to catch up in replication");
@@ -113,7 +133,7 @@ impl Discovery {
             .log_index_at_least(Some(log_id.index), "waiting to catch up to leader")
             .await?;
         tracing::debug!("adding self as a full member");
-        let url = format!("http://{leader_addr}/repl/raft/admin/upgrade-learner");
+        let url = node.url_for("/repl/raft/admin/upgrade-learner")?;
         let request = UpgradeLearnerRequest {
             node_id: self.my_node_id,
         };
@@ -123,7 +143,7 @@ impl Discovery {
 
     async fn initialize_cluster(
         &self,
-        discovered_seeds: BTreeMap<SocketAddr, DiscoverResponse>,
+        discovered_seeds: BTreeMap<PeerAddr, DiscoverResponse>,
     ) -> anyhow::Result<()> {
         if !self.cfg.cluster.auto_initialize {
             tracing::warn!(
@@ -131,13 +151,13 @@ impl Discovery {
             );
             return Ok(());
         }
-        let my_node = Node::new(self.my_addr);
+        let my_node = Node::from(self.my_addr.clone());
         let mut nodes = [(self.my_node_id, my_node)]
             .into_iter()
             .collect::<BTreeMap<_, _>>();
         for (peer_address, response) in discovered_seeds {
             tracing::trace!(?peer_address, ?response, "adding node to new cluster");
-            nodes.insert(response.node_id, Node::new(peer_address));
+            nodes.insert(response.node_id, Node::from(peer_address));
         }
         tracing::debug!(?nodes, "initializing cluster with nodes");
         super::raft::initialize_cluster(&self.raft, nodes).await?;
@@ -167,13 +187,11 @@ impl Discovery {
         let mut rounds_with_no_peers = 0;
         while Instant::now() < deadline {
             let (my_addr, discovered_seeds) = self.poll_seeds().await;
-            if let Some(addr) = my_addr {
-                self.my_addr = addr;
+            if let Some(addr) = &my_addr {
+                tracing::debug!(?addr, "discovered my seed address");
+                self.my_addr = addr.clone();
             }
             tracing::debug!(?discovered_seeds, "discovered peers");
-            if let Some(addr) = my_addr {
-                tracing::debug!(?addr, "discovered my seed address")
-            };
 
             let num_nodes_in_live_clusters = discovered_seeds
                 .values()

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -1,10 +1,11 @@
 use crate::{cfg::Configuration, core::cluster::state_machine::StoreHandle};
 
 use super::{
+    NodeId,
     discovery::Discovery,
     network::NetworkFactory,
     operations::{InternalRequest, InternalResponse},
-    raft::{NodeId, Raft},
+    raft::Raft,
 };
 use anyhow::{Context, Result};
 use coyote_operations::{OperationRequest, OperationResponse};

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -303,6 +303,7 @@ impl RaftState {
     }
 
     pub async fn run_discovery_if_necessary(&self, cfg: Configuration) -> Result<()> {
+        let network = NetworkFactory::new(&cfg);
         let has_cluster = self
             .raft
             .with_raft_state(|s| {
@@ -314,7 +315,7 @@ impl RaftState {
             tracing::debug!("node already has cluster information; skipping discovery");
         } else {
             tracing::debug!("node has no cluster information; kicking off discovery");
-            let disco = Discovery::new(cfg, self.raft.clone(), self.node_id)?;
+            let disco = Discovery::new(cfg, self.raft.clone(), self.node_id, network)?;
             if let Err(err) = disco.discover_cluster().await {
                 tracing::error!(
                     ?err,

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -303,7 +303,7 @@ impl RaftState {
     }
 
     pub async fn run_discovery_if_necessary(&self, cfg: Configuration) -> Result<()> {
-        let network = NetworkFactory::new(&cfg);
+        let network = NetworkFactory::new(&cfg)?;
         let has_cluster = self
             .raft
             .with_raft_state(|s| {

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -8,6 +8,7 @@ mod errors;
 mod handle;
 mod logs;
 mod network;
+mod node;
 mod operations;
 pub mod proto;
 mod raft;

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -14,7 +14,7 @@ use openraft::{
     error::{NetworkError, RPCError, Unreachable},
     network::RPCOption,
 };
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 pub(super) fn build_client(
     cfg: &Configuration,
@@ -45,6 +45,21 @@ impl NetworkFactory {
         Ok(Self {
             client: build_client(cfg, cfg.cluster.replication_request_timeout)?,
         })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct UnreachableError {}
+
+impl std::fmt::Display for UnreachableError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "impossible")
+    }
+}
+
+impl std::error::Error for UnreachableError {
+    fn description(&self) -> &str {
+        "this is unreachable"
     }
 }
 
@@ -128,6 +143,25 @@ impl NetworkClient {
         self.send_request("/repl/raft/handle-forwarded-write", req)
             .await
     }
+
+    pub(super) async fn add_learner(
+        &self,
+        req: proto::AddLearnerRequest,
+    ) -> Result<proto::AddLearnerResponse, openraft::error::RPCError<NodeId, Node, UnreachableError>>
+    {
+        self.send_request("/repl/raft/admin/add-learner", req).await
+    }
+
+    pub(super) async fn upgrade_learner(
+        &self,
+        req: proto::UpgradeLearnerRequest,
+    ) -> Result<
+        proto::UpgradeLearnerResponse,
+        openraft::error::RPCError<NodeId, Node, UnreachableError>,
+    > {
+        self.send_request("/repl/raft/admin/upgrade-learner", req)
+            .await
+    }
 }
 
 impl RaftNetwork<TypeConfig> for NetworkClient {
@@ -177,6 +211,13 @@ impl RaftNetworkFactory<TypeConfig> for NetworkFactory {
         target: <TypeConfig as RaftTypeConfig>::NodeId,
         node: &<TypeConfig as RaftTypeConfig>::Node,
     ) -> Self::Network {
+        self.client_for(target, node)
+    }
+}
+
+impl NetworkFactory {
+    /// Create a new client pointed at the given target
+    pub(super) fn client_for(&self, target: NodeId, node: &Node) -> NetworkClient {
         NetworkClient {
             target,
             node: node.clone(),

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -67,15 +67,13 @@ impl NetworkClient {
     {
         let start = Instant::now();
         // TODO(jbrown|2026-02-20) handle multiple addresses
-        let addrs = self.node.addrs();
-        let Some(addr) = addrs.first() else {
+        let Ok(url) = self.node.url_for(path) else {
             tracing::warn!(node_id=?self.target, node=?self.node, "node has no valid addresses, cannot send rpc");
             return Err(RPCError::Unreachable(Unreachable::new(
                 &crate::Error::generic("no has no known addresses"),
             )));
         };
-        let url = format!("http://{addr}/{path}");
-        tracing::trace!(url, target=?self.target, "sending internal RPC");
+        tracing::trace!(%url, target=?self.target, "sending internal RPC");
 
         let response = self
             .client

--- a/src/core/cluster/node.rs
+++ b/src/core/cluster/node.rs
@@ -1,12 +1,47 @@
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
+use tap::Pipe;
+use url::Url;
 use uuid::Uuid;
+
+use crate::cfg::PeerAddr;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum Node {
     #[default]
     NoAddress,
     SingleHomed(SocketAddr),
+    HostnameAndPort {
+        hostname: String,
+        port: u16,
+    },
+}
+
+impl From<PeerAddr> for Node {
+    fn from(value: PeerAddr) -> Self {
+        match value {
+            PeerAddr::SocketAddr(socket_addr) => Self::SingleHomed(socket_addr),
+            PeerAddr::HostnameAndPort { hostname, port } => {
+                Self::HostnameAndPort { hostname, port }
+            }
+        }
+    }
+}
+
+impl TryFrom<Node> for PeerAddr {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Node) -> Result<Self, Self::Error> {
+        match value {
+            Node::NoAddress => anyhow::bail!("cannot construct peer address from unaddressed node"),
+            Node::SingleHomed(sa) => PeerAddr::SocketAddr(sa),
+            Node::HostnameAndPort { hostname, port } => {
+                PeerAddr::HostnameAndPort { hostname, port }
+            }
+        }
+        .pipe(Ok)
+    }
 }
 
 impl Node {
@@ -14,11 +49,23 @@ impl Node {
         Self::SingleHomed(s)
     }
 
-    pub fn addrs(&self) -> Vec<SocketAddr> {
+    pub fn names(&self) -> Vec<String> {
         match self {
             Self::NoAddress => vec![],
-            Self::SingleHomed(s) => vec![*s],
+            Self::SingleHomed(addr) => vec![addr.to_string()],
+            Self::HostnameAndPort { hostname, port } => vec![format!("{hostname}:{port}")],
         }
+    }
+
+    pub fn url_for(&self, path: &str) -> anyhow::Result<Url> {
+        let base = match self {
+            Self::NoAddress => anyhow::bail!("no address provided"),
+            Self::SingleHomed(sa) => sa.to_string(),
+            Self::HostnameAndPort { hostname, port } => format!("{hostname}:{port}"),
+        };
+        format!("http://{base}/{path}")
+            .parse()
+            .context("generating url for network RPC")
     }
 }
 

--- a/src/core/cluster/node.rs
+++ b/src/core/cluster/node.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum Node {
+    #[default]
+    NoAddress,
+    SingleHomed(SocketAddr),
+}
+
+impl Node {
+    pub fn new(s: SocketAddr) -> Self {
+        Self::SingleHomed(s)
+    }
+
+    pub fn addrs(&self) -> Vec<SocketAddr> {
+        match self {
+            Self::NoAddress => vec![],
+            Self::SingleHomed(s) => vec![*s],
+        }
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct NodeId {
+    #[serde(with = "uuid::serde::simple")]
+    inner: Uuid,
+}
+
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl NodeId {
+    pub(super) fn generate() -> Self {
+        Self {
+            inner: Uuid::new_v4(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl From<u64> for NodeId {
+    fn from(value: u64) -> Self {
+        let inner = Uuid::from_u64_pair(value, value);
+        Self { inner }
+    }
+}

--- a/src/core/cluster/operations.rs
+++ b/src/core/cluster/operations.rs
@@ -1,6 +1,6 @@
 use crate::core::cluster::state_machine::ClusterId;
 
-use super::{raft::NodeId, state_machine::Store};
+use super::{NodeId, state_machine::Store};
 use openraft::LogId;
 use serde::{Deserialize, Serialize};
 

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -1,15 +1,12 @@
 //! This module contains custom protocol extensions for the interserver protocol
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    net::SocketAddr,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 use openraft::{LogId, ServerState};
 use serde::{Deserialize, Serialize};
 
 use super::handle::{Request, Response};
-use crate::core::cluster::state_machine::ClusterId;
+use crate::{cfg::PeerAddr, core::cluster::state_machine::ClusterId};
 
 use super::NodeId;
 
@@ -17,7 +14,7 @@ use super::NodeId;
 pub(super) struct DiscoverClusterResponse {
     pub cluster_name: String,
     pub cluster_id: Option<ClusterId>,
-    pub known_peers: BTreeMap<NodeId, Vec<SocketAddr>>,
+    pub known_peers: BTreeMap<NodeId, PeerAddr>,
     pub state: ServerState,
     pub last_committed_log_id: Option<LogId<NodeId>>,
 }
@@ -31,7 +28,7 @@ pub(super) struct DiscoverResponse {
 #[derive(Debug, Deserialize, Serialize)]
 pub(super) struct AddLearnerRequest {
     pub node_id: NodeId,
-    pub address: String,
+    pub address: PeerAddr,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::handle::{Request, Response};
 use crate::core::cluster::state_machine::ClusterId;
 
-use super::raft::NodeId;
+use super::NodeId;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(super) struct DiscoverClusterResponse {

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -32,9 +32,15 @@ pub(super) struct AddLearnerRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub(super) struct AddLearnerResponse {}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub(super) struct UpgradeLearnerRequest {
     pub node_id: NodeId,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(super) struct UpgradeLearnerResponse {}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(super) struct ChangeMembershipRequest {

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -1,13 +1,12 @@
-use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Instant};
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
 
 use anyhow::Context;
 use openraft::error::{InitializeError, RaftError};
-use serde::{Deserialize, Serialize};
 use tap::TapFallible;
-use uuid::Uuid;
 
 use super::{
     handle::{RaftState, Request, Response},
+    node::{Node, NodeId},
     state_machine::StoredSnapshot,
 };
 use crate::{
@@ -18,57 +17,6 @@ use crate::{
         state_machine::{ClusterId, StoreHandle},
     },
 };
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub enum Node {
-    #[default]
-    NoAddress,
-    SingleHomed(SocketAddr),
-}
-
-impl Node {
-    pub fn new(s: SocketAddr) -> Self {
-        Self::SingleHomed(s)
-    }
-
-    pub fn addrs(&self) -> Vec<SocketAddr> {
-        match self {
-            Self::NoAddress => vec![],
-            Self::SingleHomed(s) => vec![*s],
-        }
-    }
-}
-
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash, Serialize, Deserialize,
-)]
-#[serde(transparent)]
-pub struct NodeId {
-    #[serde(with = "uuid::serde::simple")]
-    inner: Uuid,
-}
-
-impl std::fmt::Display for NodeId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.inner)
-    }
-}
-
-impl NodeId {
-    pub(super) fn generate() -> Self {
-        Self {
-            inner: Uuid::new_v4(),
-        }
-    }
-}
-
-#[cfg(test)]
-impl From<u64> for NodeId {
-    fn from(value: u64) -> Self {
-        let inner = Uuid::from_u64_pair(value, value);
-        Self { inner }
-    }
-}
 
 openraft::declare_raft_types!(
     pub TypeConfig:

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -21,15 +21,11 @@ use tokio::sync::RwLock as TokioRwLock;
 use uuid::Uuid;
 
 use super::{
-    errors::*,
-    handle::Response,
-    logs::CoyoteLogs,
-    raft::{Node, TypeConfig},
+    Node, NodeId, errors::*, handle::Response, logs::CoyoteLogs, raft::TypeConfig,
     serialized_state_machine,
 };
 use crate::AppState;
 
-type NodeId = <TypeConfig as RaftTypeConfig>::NodeId;
 type StorageError = openraft::StorageError<NodeId>;
 type StorageResult<T> = Result<T, StorageError>;
 


### PR DESCRIPTION
This adds hostname support throughout the stack (in the config, at discovery time, and at actual replication time). In a production config, I'd want to use SocketAddrs to avoid having DNS as a piece that could break, but if you need hostnames, you need hostnames.

I intentionally did not go the route of resolving the hostname at discovery time and storing the SocketAddr in the Raft membership because I think that violates the principle of least surprise, and would be bad for users when DNS mappings change (which can even happen in docker-compose around a `down` + `up`).

I'm keeping the `Node` object (which gets serialized into logs) as an explicitly-tagged enum, to minimize potential confusion, but adding a new `PeerAddr` type that's used in config and discovery which is just greedily parsed from a string. We use the popular [addr](https://crates.io/crates/addr) crate to validate that the name portion is a valid domain name.

Fixes #199 