### PR TITLE
OTEL tweaks

### DIFF
--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -5,6 +5,7 @@ use super::{
 };
 use openraft::LogId;
 
+#[tracing::instrument(skip_all, fields(request = %request))]
 pub(super) async fn apply_request(
     request: Request,
     state_machine: &mut Store,

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -45,6 +45,22 @@ pub enum Request {
     Stream(stream_deprecated::operations::StreamOperation),
 }
 
+impl std::fmt::Display for Request {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Request::ClusterInternal(_) => write!(f, "cluster_internal"),
+            Request::Kv(_) => write!(f, "kv"),
+            Request::CreateKv(_) => write!(f, "create_kv"),
+            Request::RateLimiter(_) => write!(f, "ratelimiter"),
+            Request::Idempotency(_) => write!(f, "idempotency"),
+            Request::Cache(_) => write!(f, "cache"),
+            Request::CreateCache(_) => write!(f, "create_cache"),
+            Request::CreateIdempotency(_) => write!(f, "create_idempotency"),
+            Request::Stream(_) => write!(f, "stream"),
+        }
+    }
+}
+
 impl From<coyote_kv::operations::KvOperation> for Request {
     fn from(value: coyote_kv::operations::KvOperation) -> Self {
         Request::Kv(value)
@@ -222,6 +238,7 @@ pub struct RaftState {
 
 impl RaftState {
     /// Write a single operation into the Raft log and return its response.
+    #[tracing::instrument(skip_all)]
     pub async fn client_write<O>(&self, op: O) -> anyhow::Result<O::Response>
     where
         O: OperationRequest + Into<O::RequestParent>,

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -120,6 +120,7 @@ impl NetworkClient {
             .map_err(|e| RPCError::Network(NetworkError::new(&e)))
     }
 
+    #[tracing::instrument(skip_all)]
     pub(crate) async fn forward_request<Err>(
         &self,
         req: proto::ForwardedWriteRequest,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,7 @@ pub fn setup_tracing(
         let var = [
             format!("{CRATE_NAME}={level}"),
             format!("tower_http={level}"),
+            "opentelemetry_sdk=ERROR".to_string(),
         ];
 
         var.join(",")


### PR DESCRIPTION
Add a bit more context. Also ensure that `opentelemetry_sdk`
errors are captured. It's a bit maddening trying to diagnose
failed exports if the relevant events aren't captured.

