### PR TITLE
fix shutdown issues

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -121,9 +121,16 @@ impl BootstrapConfig {
 pub async fn run(app_config: AppConfig, raft_state: RaftState) -> anyhow::Result<()> {
     // FIXME: Do something smarter here:
     let mut retries = 100;
+    let shutdown = crate::shutting_down_token();
     while !raft_state.is_up().await && retries > 0 {
-        retries -= 0;
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        retries -= 1;
+        if shutdown
+            .run_until_cancelled(tokio::time::sleep(std::time::Duration::from_millis(100)))
+            .await
+            .is_none()
+        {
+            anyhow::bail!("shut down before bootstrap finished");
+        }
     }
 
     let bootstrap = BootstrapConfig::load(app_config.bootstrap_cfg_path.as_deref())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ async fn run_interserver(
     );
 
     axum::serve(listener, svc)
-        .with_graceful_shutdown(graceful_shutdown_handler())
+        .with_graceful_shutdown(crate::shutting_down_token().cancelled_owned())
         .await
         .unwrap();
 
@@ -243,6 +243,8 @@ pub async fn run_with_prefix(
 
     let interserver_started_barrier = Arc::new(Barrier::new(2));
 
+    tokio::spawn(graceful_shutdown_handler());
+
     let interserver = tokio::spawn(run_interserver(
         cfg.clone(),
         app_state.clone(),
@@ -308,7 +310,7 @@ pub async fn run_with_prefix(
         .expect("bootstrapping failed");
 
     axum::serve(listener, make_svc)
-        .with_graceful_shutdown(graceful_shutdown_handler())
+        .with_graceful_shutdown(crate::shutting_down_token().cancelled_owned())
         .await
         .unwrap();
 


### PR DESCRIPTION
There were two things causing shutdown hangs, one dumb and one less dumb.

The dumb one is that the `bootstrap` code waited forever for the cluster to come up; if it never came up, this function never returned and we never actually started the server.

The less dumb one is that we were installing //two// SIGINT handlers because we were installing the `graceful_shutdown_handler` twice. It already calls the cancellation token when sigint is signaled, so let's just use the cancellation token to shut down raft.