### PR TITLE
pass along interserver authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef252edff26ddba56bbcdf2ee3307b8129acb86f5749b68990c168a6fcc9c76"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum-macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,7 +874,9 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "axum",
+ "axum-extra",
  "byteorder",
+ "constant_time_eq 0.4.2",
  "coyote-cache",
  "coyote-client",
  "coyote-derive",
@@ -861,6 +891,7 @@ dependencies = [
  "fjall",
  "fjall-utils",
  "futures-util",
+ "headers",
  "http",
  "idna_adapter",
  "indexmap",
@@ -1853,6 +1884,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -5427,7 +5482,7 @@ checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "aes",
  "bzip2",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "crc32fast",
  "deflate64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,9 @@ aide.workspace = true
 anyerror.workspace = true
 anyhow.workspace = true
 axum.workspace = true
+axum-extra.workspace = true
 byteorder.workspace = true
+constant_time_eq.workspace = true
 coyote-cache.workspace = true
 coyote-derive.workspace = true
 coyote-error.workspace = true
@@ -41,6 +43,7 @@ coyote-rate-limiter.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true
 futures-util.workspace = true
+headers.workspace = true
 http.workspace = true
 idna_adapter.workspace = true
 indexmap.workspace = true
@@ -118,6 +121,7 @@ anyerror = { version = "0.1.13", features = ["anyhow"] }
 anyhow = "1.0.56"
 assert_matches = "1.5.0"
 axum = { version = "0.8.8", features = ["macros"] }
+axum-extra = { version = "0.12", features = ["typed-header"] }
 byteorder = "1.5.0"
 bytes = "1.11.1"
 clap = { version = "4.1.8", features = ["derive"] }
@@ -125,6 +129,7 @@ clap_complete = "4.5.38"
 colored_json = "5.0.0"
 concolor-clap = "0.1.0"
 config = { version = "0.15.19", default-features = false, features = ["toml", "yaml"] }
+constant_time_eq = "0.4"
 coyote.path = "."
 coyote-cache.path = "crates/cache"
 coyote-client.path = "clients/rust"
@@ -145,6 +150,7 @@ fjall-utils.path = "crates/fjall-utils"
 fs-err = "3.3.0"
 futures-util = "0.3"
 hashlink = "0.11"
+headers = "0.4.1"
 hex = "0.4.3"
 hickory-resolver = "0.25.2"
 http = "1.1.0"

--- a/example-configs/three-node-cluster/first.toml
+++ b/example-configs/three-node-cluster/first.toml
@@ -6,6 +6,7 @@ persistent_db.path = "./db-first"
 ephemeral_db.path = "./db-first-ephemeral"
 
 [cluster]
+secret = "hunter2"
 listen_address = "127.0.0.1:18050"
 log_path = "./logs-first"
 snapshot_path = "./snapshots-first"

--- a/example-configs/three-node-cluster/second.toml
+++ b/example-configs/three-node-cluster/second.toml
@@ -6,6 +6,7 @@ persistent_db.path = "./db-second"
 ephemeral_db.path = "./db-second-ephemeral"
 
 [cluster]
+secret = "hunter2"
 listen_address = "127.0.0.1:18051"
 log_path = "./logs-second"
 snapshot_path = "./snapshots-second"

--- a/example-configs/three-node-cluster/third.toml
+++ b/example-configs/three-node-cluster/third.toml
@@ -6,6 +6,7 @@ persistent_db.path = "./db-third"
 ephemeral_db.path = "./db-third-ephemeral"
 
 [cluster]
+secret = "hunter2"
 listen_address = "127.0.0.1:18052"
 log_path = "./logs-third"
 snapshot_path = "./snapshots-third"

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -1,14 +1,17 @@
 #![expect(clippy::disallowed_types)] // we can't use MsgPackOrJson because these endpoints are not OpenAPI-based
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 use axum::{
     Extension, Json,
-    extract::State,
+    extract::{Request, State},
+    middleware::Next,
     response::{IntoResponse, Response},
     routing::{get, post},
 };
+use axum_extra::TypedHeader;
 use coyote_proto::MsgPack;
+use headers::{Authorization, authorization::Bearer};
 use http::StatusCode;
 use openraft::{
     ChangeMembers,
@@ -18,12 +21,36 @@ use serde::Serialize;
 use tap::{Pipe, TapFallible};
 
 use super::{Node, NodeId, handle::RaftState, network::detect_address, proto::*, raft::TypeConfig};
-use crate::AppState;
+use crate::{AppState, Configuration};
 
-pub fn router() -> axum::Router<AppState> {
-    // TODO: implement snapshot methods
-    axum::Router::new()
-        .route("/repl/discover", get(discover))
+#[derive(Clone)]
+struct RaftSecret(Arc<Vec<u8>>);
+
+impl RaftSecret {
+    fn new(secret: &str) -> Self {
+        Self(Arc::new(secret.as_bytes().to_owned()))
+    }
+}
+
+async fn authenticate(
+    bearer: Option<TypedHeader<Authorization<Bearer>>>,
+    Extension(RaftSecret(secret)): Extension<RaftSecret>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let Some(TypedHeader(Authorization(bearer))) = bearer else {
+        tracing::error!("got request without bearer token; rejecting");
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+    if !constant_time_eq::constant_time_eq(&secret, bearer.token().as_bytes()) {
+        tracing::error!("got invalid bearer token for raft operation");
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    next.run(request).await
+}
+
+pub fn router(cfg: &Configuration) -> axum::Router<AppState> {
+    let mut authenticated = axum::Router::new()
         .route("/repl/raft/append_entries", post(append_entries))
         .route("/repl/raft/vote", post(vote))
         .route("/repl/raft/stream-snapshot", post(stream_snapshot))
@@ -31,15 +58,26 @@ pub fn router() -> axum::Router<AppState> {
             "/repl/raft/handle-forwarded-write",
             post(handle_forwarded_write),
         )
-        .route("/repl/raft/admin/metrics", get(metrics))
         .route("/repl/raft/admin/add-learner", post(add_learner))
         .route("/repl/raft/admin/upgrade-learner", post(upgrade_learner))
         .route(
             "/repl/raft/admin/change-membership",
             post(change_membership),
         )
-        .route("/repl/raft/admin/initialize", post(initialize))
-        .route("/repl/health", get(health))
+        .route("/repl/raft/admin/initialize", post(initialize));
+
+    if let Some(secret) = &cfg.cluster.secret {
+        authenticated = authenticated
+            .layer(axum::middleware::from_fn(authenticate))
+            .layer(Extension(RaftSecret::new(secret)));
+    }
+
+    let unauthenticated = axum::Router::new()
+        .route("/repl/raft/admin/metrics", get(metrics))
+        .route("/repl/discover", get(discover))
+        .route("/repl/health", get(health));
+
+    authenticated.merge(unauthenticated)
 }
 
 // Helpers
@@ -204,6 +242,7 @@ async fn upgrade_learner(
     Extension(raft_state): Extension<RaftState>,
     MsgPack(request): MsgPack<UpgradeLearnerRequest>,
 ) -> impl IntoResponse {
+    tracing::debug!(node_id=?request.node_id, "upgrading learner to follower");
     let request = ChangeMembers::AddVoterIds([request.node_id].into_iter().collect());
     rpc_response(raft_state.raft.change_membership(request, true).await)
 }

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -54,6 +54,7 @@ impl BackgroundJobRunner {
     }
 
     async fn stop_all(mut self) -> anyhow::Result<()> {
+        tracing::debug!("shutting down background jobs");
         self.jobs.abort_all();
         while let Some(job) = self.jobs.join_next().await {
             match job {

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -15,6 +15,7 @@ use openraft::{
     network::RPCOption,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tap::Pipe;
 
 pub(super) fn build_client(
     cfg: &Configuration,
@@ -38,12 +39,14 @@ pub(super) fn build_client(
 #[derive(Clone)]
 pub(super) struct NetworkFactory {
     client: reqwest::Client,
+    cfg: Configuration,
 }
 
 impl NetworkFactory {
     pub(super) fn new(cfg: &Configuration) -> anyhow::Result<Self> {
         Ok(Self {
             client: build_client(cfg, cfg.cluster.replication_request_timeout)?,
+            cfg: cfg.clone(),
         })
     }
 }
@@ -67,9 +70,11 @@ pub(super) struct NetworkClient {
     target: NodeId,
     node: Node,
     client: reqwest::Client,
+    cfg: Configuration,
 }
 
 impl NetworkClient {
+    #[allow(clippy::result_large_err)]
     async fn send_request<Req, Resp, Err>(
         &self,
         path: &str,
@@ -105,6 +110,20 @@ impl NetworkClient {
                 header::ACCEPT,
                 "application/msgpack;q=0.9, application/json;q=0.5",
             )
+            .pipe(
+                |this| -> Result<reqwest::RequestBuilder, RPCError<NodeId, Node, Err>> {
+                    if let Some(secret) = &self.cfg.cluster.secret {
+                        let auth = format!("Bearer {secret}");
+                        let auth = HeaderValue::from_str(&auth).map_err(|err| {
+                            tracing::warn!("invalid interserver secret value");
+                            RPCError::Network::<NodeId, Node, Err>(NetworkError::new(&err))
+                        })?;
+                        Ok(this.header(header::AUTHORIZATION, auth))
+                    } else {
+                        Ok(this)
+                    }
+                },
+            )?
             .send()
             .await
             .map_err(|e| {
@@ -218,6 +237,7 @@ impl NetworkFactory {
             target,
             node: node.clone(),
             client: self.client.clone(),
+            cfg: self.cfg.clone(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ async fn run_interserver(
     );
     bind_barrier.wait().await;
 
-    let app = core::cluster::router()
+    let app = core::cluster::router(&cfg)
         .with_state(state.clone())
         .layer(Extension(raft.clone()))
         .layer(middleware::from_fn(coyote_proto::capture_accept_hdr));
@@ -298,11 +298,13 @@ pub async fn run_with_prefix(
 
     // Spawn background workers for each module
     let workers = tokio::spawn(async move {
+        tracing::debug!("spawned workers");
         // FIXME: gotta do actual error handling...
         let _ = tokio::join!(
             tokio::spawn(v1::modules::kv::worker(app_state.clone())),
             tokio::spawn(v1::modules::rate_limiter::worker(app_state.clone())),
         );
+        tracing::debug!("workers died");
     });
 
     bootstrap::run(cfg, raft_state)
@@ -315,8 +317,10 @@ pub async fn run_with_prefix(
         .unwrap();
 
     // Wait for workers to finish cleanup
+    tracing::debug!("done serving; waiting for background tasks to finish");
     let _ = workers.await;
     let _ = interserver.await;
+    tracing::debug!("we're outta here!");
 }
 
 pub fn setup_tracing(


### PR DESCRIPTION
This actually sets the shared secret as a bearer-token on interserver requests and rejects any that don't have it.

Branched off of and depends on #207, so keeping in draft.

Fixes #212 