### PR TITLE
cluster: support periodic snapshotting and log retention

### DIFF
--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -241,6 +241,8 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
             startup_discovery_delay: Duration::from_millis(0),
             log_index_interval: Duration::from_millis(500),
             log_sync: coyote::cfg::FsyncMode::EverySecond,
+            snapshot_after_writes: None,
+            snapshot_after_time: None,
         },
         bootstrap_cfg_path: None,
     }

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -74,3 +74,7 @@ pub(super) fn cluster_auto_initialize() -> bool {
 pub(super) fn log_index_interval() -> Duration {
     Duration::from_mins(10)
 }
+
+pub(super) fn cluster_snapshot_after_time() -> Option<Duration> {
+    Some(Duration::from_mins(15))
+}

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -102,7 +102,7 @@ pub struct DatabaseConfig {
 }
 
 /// Wrapper around a path that we know to be an extant dir
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Dir {
     inner: PathBuf,
 }
@@ -294,6 +294,17 @@ pub struct ClusterConfiguration {
     /// corruption.
     #[serde(default)]
     pub log_sync: FsyncMode,
+
+    /// Trigger a background snapshot after this many writes
+    pub snapshot_after_writes: Option<u32>,
+
+    /// Trigger a background snapshot after this many milliseconds
+    #[serde(
+        rename = "snapshot_after_ms",
+        with = "crate::serde::duration::opt_millis",
+        default = "defaults::cluster_snapshot_after_time"
+    )]
+    pub snapshot_after_time: Option<Duration>,
 }
 
 impl ClusterConfiguration {
@@ -544,6 +555,8 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
                 startup_discovery_delay: cluster_startup_discovery_delay,
                 log_index_interval: cluster_log_index_interval,
                 log_sync: _cluster_log_sync, // TODO: impl FromStr for this
+                snapshot_after_writes: cluster_snapshot_after_writes,
+                snapshot_after_time: cluster_snapshot_after_time,
             },
     } = &mut config;
 
@@ -572,6 +585,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         cluster_snapshot_path: "COYOTE_CLUSTER_SNAPSHOT_PATH",
         cluster_log_path: "COYOTE_CLUSTER_LOG_PATH",
         cluster_secret: "COYOTE_CLUSTER_SECRET",
+        cluster_snapshot_after_writes: "COYOTE_SNAPSHOT_AFTER_WRITES"
     );
 
     env_ms_overrides!(
@@ -589,6 +603,9 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
     // Fields that require different parsing
     if let Some(value) = env_var_comma_separated("COYOTE_CLUSTER_SEED_NODES")? {
         *cluster_seed_nodes = value;
+    }
+    if let Some(value) = env_var_ms("COYOTE_CLUSTER_SNAPSHOT_AFTER_MS")? {
+        *cluster_snapshot_after_time = Some(value);
     }
 
     Ok(Arc::from(config))

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -75,6 +75,7 @@ pub fn router(cfg: &Configuration) -> axum::Router<AppState> {
     let unauthenticated = axum::Router::new()
         .route("/repl/raft/admin/metrics", get(metrics))
         .route("/repl/discover", get(discover))
+        .route("/repl/raft/admin/force-snapshot", post(force_snapshot)) // TODO: should this be unauth?
         .route("/repl/health", get(health));
 
     authenticated.merge(unauthenticated)
@@ -273,6 +274,10 @@ async fn initialize(
     super::raft::initialize_cluster(&state.raft, nodes)
         .await
         .pipe(admin_response)
+}
+
+async fn force_snapshot(Extension(state): Extension<RaftState>) -> impl IntoResponse {
+    state.trigger_snapshot().await.pipe(admin_response)
 }
 
 async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -3,9 +3,13 @@ use std::{
     time::Duration,
 };
 
-use super::{Node, NodeId, handle::RaftState};
+use super::{
+    Node, NodeId,
+    handle::{BackgroundCommand, RaftState},
+};
 use crate::cfg::Configuration;
 use openraft::error::{ClientWriteError, RaftError};
+use tap::TapFallible;
 use tokio::task::JoinSet;
 
 trait BackgroundJob {
@@ -186,5 +190,111 @@ pub(super) async fn run_background_jobs_on_leader(
         }
         runner.stop_all().await?;
     }
+    Ok(())
+}
+
+enum PurgeBy {
+    Time(Duration),
+    Index(u64),
+    Nothing,
+}
+
+pub(super) async fn run_background_jobs_on_all_nodes(
+    cfg: Configuration,
+    handle: RaftState,
+    mut receiver: tokio::sync::mpsc::Receiver<BackgroundCommand>,
+) -> anyhow::Result<()> {
+    let mut last_snapshot_time = std::time::Instant::now();
+    let mut last_snapshot_index = handle.raft.with_raft_state(|st| st.committed).await?;
+    let mut ticker = tokio::time::interval(Duration::from_secs(60));
+    let shutdown = crate::shutting_down_token();
+
+    loop {
+        let event = tokio::select! {
+            event = receiver.recv() => {
+                if event.is_some() {
+                    event
+                } else {
+                    break;
+                }
+            },
+            _ = ticker.tick() => None,
+            _ = shutdown.cancelled() => break,
+        };
+        let (committed, state) = handle
+            .raft
+            .with_raft_state(|st| (st.committed, st.server_state))
+            .await?;
+        // even if the time interval has passed, if we haven't written anything it would be dumb to
+        // snapshot
+        if committed == last_snapshot_index {
+            continue;
+        }
+        let delta = match (committed, last_snapshot_index) {
+            (Some(a), Some(b)) => Some(a.index - b.index),
+            (Some(a), None) => Some(a.index),
+            _ => None,
+        };
+        let (should_snapshot, purge_by) = if let Some(threshold) = cfg.cluster.snapshot_after_time
+            && last_snapshot_time.elapsed() > threshold
+        {
+            (true, PurgeBy::Time(threshold))
+        } else if let Some(threshold) = cfg.cluster.snapshot_after_writes
+            && let Some(delta) = delta
+            && delta > (threshold as u64)
+        {
+            let purge_by = if let Some(idx) = last_snapshot_index {
+                PurgeBy::Index(idx.index)
+            } else {
+                PurgeBy::Nothing
+            };
+            (true, purge_by)
+        } else if event == Some(BackgroundCommand::Snapshot) {
+            (true, PurgeBy::Nothing)
+        } else {
+            (false, PurgeBy::Nothing)
+        };
+
+        if should_snapshot {
+            if state.is_learner() {
+                tracing::warn!("refusing to snapshot a learner");
+            } else {
+                last_snapshot_time = std::time::Instant::now();
+                last_snapshot_index = committed;
+                tracing::debug!("triggering background snapshot");
+                if let Err(err) = handle.raft.trigger().snapshot().await {
+                    tracing::error!(?err, "error triggering background snapshot; ignoring");
+                }
+            }
+
+            let offset_to_purge = match purge_by {
+                PurgeBy::Time(duration) => {
+                    let then = jiff::Timestamp::now() - duration;
+                    handle
+                        .state_machine
+                        .log_id_before_time(then)
+                        .await
+                        .tap_err(|err| {
+                            tracing::warn!(
+                                ?err,
+                                "unable to find index for timestamp; not purging logs"
+                            )
+                        })
+                        .ok()
+                        .flatten()
+                }
+                PurgeBy::Index(log_id) => Some(log_id),
+                PurgeBy::Nothing => None,
+            };
+
+            if let Some(offset_to_purge) = offset_to_purge {
+                tracing::debug!(offset_to_purge, "triggering purge of old logs");
+                if let Err(err) = handle.raft.trigger().purge_log(offset_to_purge).await {
+                    tracing::error!(?err, "failed to purge old logs");
+                }
+            }
+        }
+    }
+    tracing::info!("shutting down");
     Ok(())
 }

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -13,6 +13,7 @@ use anyhow::Context;
 use coyote_operations::{OperationRequest, OperationResponse};
 use openraft::RaftNetworkFactory;
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponseParseError {
@@ -251,12 +252,18 @@ impl TryFrom<Response> for InternalResponse {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackgroundCommand {
+    Snapshot,
+}
+
 #[derive(Clone)]
 pub struct RaftState {
     pub raft: Raft,
     pub node_id: NodeId,
     pub state_machine: StoreHandle,
     pub(super) network: NetworkFactory,
+    pub background_channel: Sender<BackgroundCommand>,
 }
 
 impl RaftState {
@@ -358,5 +365,12 @@ impl RaftState {
             })
             .await
             .unwrap_or(false)
+    }
+
+    pub(crate) async fn trigger_snapshot(&self) -> anyhow::Result<()> {
+        self.background_channel
+            .send(BackgroundCommand::Snapshot)
+            .await
+            .context("attempting to send background command to trigger snapshot")
     }
 }

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -75,6 +75,7 @@ pub async fn initialize_raft(
         election_timeout_min: cfg.cluster.election_timeout_min.as_millis() as u64,
         election_timeout_max: cfg.cluster.election_timeout_max.as_millis() as u64,
         cluster_name: cfg.cluster.name.clone(),
+        snapshot_policy: openraft::SnapshotPolicy::Never,
         ..Default::default()
     };
     let config = Arc::new(config.validate().context("configuring openraft")?);
@@ -95,11 +96,13 @@ pub async fn initialize_raft(
     let raft = Raft::new(id, config, network.clone(), logs, state_machine.clone())
         .await
         .context("initializing openraft")?;
+    let (bgtx, bgrx) = tokio::sync::mpsc::channel(10);
     let handle = RaftState {
         raft,
         node_id: id,
         state_machine,
         network,
+        background_channel: bgtx,
     };
     tokio::spawn({
         let handle = handle.clone();
@@ -107,6 +110,25 @@ pub async fn initialize_raft(
         async move {
             if let Err(err) =
                 super::background::run_background_jobs_on_leader(cfg.clone(), handle.clone()).await
+            {
+                tracing::error!(
+                    ?err,
+                    "raft administrative process died; shutting everything down"
+                );
+                crate::start_shut_down()
+            }
+        }
+    });
+    tokio::spawn({
+        let handle = handle.clone();
+        let cfg = cfg.clone();
+        async move {
+            if let Err(err) = super::background::run_background_jobs_on_all_nodes(
+                cfg.clone(),
+                handle.clone(),
+                bgrx,
+            )
+            .await
             {
                 tracing::error!(
                     ?err,

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -212,7 +212,7 @@ impl Store {
         self.snapshot_idx = std::cmp::max(self.snapshot_idx + 1, meta.snapshot_idx()?);
         let data = LastSnapshot {
             meta,
-            path: snapshot_path,
+            path: snapshot_path.clone(),
         };
         tracing::trace!(last_snapshot=?data, "setting last_snapshot");
         let data = tokio::task::spawn_blocking(move || -> anyhow::Result<LastSnapshot> {
@@ -223,6 +223,9 @@ impl Store {
         })
         .await??;
         *self.last_snapshot.write() = Some(data);
+        self.delete_unused_snapshots(&snapshot_path)
+            .await
+            .context("cleaning up snapshots after setting new snapshot")?;
         Ok(())
     }
 
@@ -519,7 +522,7 @@ impl StoredSnapshot {
         targets: Vec<(StorageType, Database, fjall::Snapshot, Vec<String>)>,
     ) -> anyhow::Result<Self> {
         let file_name = format!("coyote-{}", metadata.snapshot_id);
-        let path = directory.with_file_name(file_name);
+        let path = directory.join(file_name);
         let path_c = path.clone();
         let file = tokio::task::spawn_blocking(move || -> anyhow::Result<std::fs::File> {
             tracing::info!(path=%path_c.display(), "writing snapshot");
@@ -592,5 +595,12 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
 impl StoreHandle {
     pub async fn cluster_id(&self) -> Option<ClusterId> {
         self.0.read().await.cluster_id().copied()
+    }
+
+    pub async fn log_id_before_time(
+        &self,
+        timestamp: jiff::Timestamp,
+    ) -> anyhow::Result<Option<u64>> {
+        self.0.read().await.logs.log_index_before(timestamp).await
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -22,4 +22,26 @@ pub(crate) mod duration {
             Ok(Duration::from_millis(millis))
         }
     }
+
+    /// Deserialize an Optional<Duration> as a number of milliseconds
+    pub(crate) mod opt_millis {
+        use serde::{Deserialize, Deserializer, Serialize, Serializer};
+        use std::time::Duration;
+
+        pub(crate) fn serialize<S>(x: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let raw = x.map(|x| x.as_millis());
+            raw.serialize(serializer)
+        }
+
+        pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let millis: Option<u64> = Deserialize::deserialize(deserializer)?;
+            Ok(millis.map(Duration::from_millis))
+        }
+    }
 }


### PR DESCRIPTION
This allows the user to configure the database to take snapshots periodically (either after a certain number of writes or a certain time period), and to truncate logs that are included by a more recent snapshot.

Fixes #36