### PR TITLE
codegen: use nightly to format cli/rust lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "futures-lite",
  "openapi-codegen",
  "serde_json",
+ "tracing",
  "tracing-subscriber",
  "which",
 ]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -20,6 +20,7 @@ coyote.workspace = true
 futures-lite = { version = "2.6.1", default-features = false }
 openapi-codegen.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
 tracing-subscriber.workspace = true
 which.workspace = true
 

--- a/codegen/src/formatting.rs
+++ b/codegen/src/formatting.rs
@@ -28,7 +28,12 @@ async fn format_rust_clients() -> io::Result<()> {
     exec(
         "cargo",
         &std::env::current_dir().unwrap(),
-        ["fmt", "--package=coyote-client", "--package=coyote-cli"],
+        [
+            "+nightly",
+            "fmt",
+            "--package=coyote-client",
+            "--package=coyote-cli",
+        ],
     )
     .await
 }
@@ -109,17 +114,12 @@ impl ContainerizedFormatter<'_> {
         if base == "docker" {
             args.push(".");
         }
-        println!("Running {base} with args \"{}\"", args.join(" "));
         exec(base, &path, args).await?;
         let args = ["run"]
             .into_iter()
             .chain(mounts.iter().map(|m| m.as_str()))
             .chain([tag.as_str()])
             .chain(cmd.iter().copied());
-        println!(
-            "Running {base} with args \"{}\"",
-            args.clone().collect::<Vec<_>>().join(" ")
-        );
         exec(base, &path, args).await?;
 
         Ok(())
@@ -127,6 +127,8 @@ impl ContainerizedFormatter<'_> {
 }
 
 async fn exec(cmd: &str, dir: &Path, args: impl IntoIterator<Item = &str>) -> io::Result<()> {
+    let args = args.into_iter().collect::<Vec<_>>();
+    tracing::debug!(workdir=?dir, cmd, ?args, "running formatter command");
     let output = Command::new(cmd)
         .args(args)
         .current_dir(dir)

--- a/justfile
+++ b/justfile
@@ -11,9 +11,12 @@ test *args='':
 test-sdks:
     cargo nextest run --package=coyote-client --package=coyote-cli
 
+codegen:
+    cargo codegen
+
 # Run all the test commands
 test-all: test test-sdks
 
-[working-directory: 'benchmarks']
+[working-directory('benchmarks')]
 bench:
     cargo bench


### PR DESCRIPTION
I think this will fix the inconsistencies between `cargo codegen` and `just fmt`.

Also moves the logging to `tracing` instead of `println`