### PR TITLE
fix lints on main

### DIFF
--- a/benchmarks/benches/cache.rs
+++ b/benchmarks/benches/cache.rs
@@ -67,7 +67,7 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                         .unwrap();
                 })
             },
-            criterion::BatchSize::SmallInput,
+            BatchSize::SmallInput,
         )
     });
 
@@ -86,7 +86,7 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                         .unwrap();
                 })
             },
-            criterion::BatchSize::SmallInput,
+            BatchSize::SmallInput,
         )
     });
 
@@ -105,7 +105,7 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                         .unwrap();
                 })
             },
-            criterion::BatchSize::SmallInput,
+            BatchSize::SmallInput,
         )
     });
 

--- a/clients/cli/src/cmds/api/mod.rs
+++ b/clients/cli/src/cmds/api/mod.rs
@@ -10,5 +10,5 @@ mod stream;
 
 pub(crate) use self::{
     cache::CacheArgs, health::HealthArgs, idempotency::IdempotencyArgs, kv::KvArgs, msgs::MsgsArgs,
-    msgs_topic::MsgsTopicArgs, rate_limiter::RateLimiterArgs, stream::StreamArgs,
+    rate_limiter::RateLimiterArgs, stream::StreamArgs,
 };


### PR DESCRIPTION
This is the output of running `just codegen lint` on main, with the latest nightly. I don't know why it doesn't match what other folks have committed.