### PR TITLE
more codegen lint stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          components: rustfmt
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/benchmarks/benches/cache.rs
+++ b/benchmarks/benches/cache.rs
@@ -67,7 +67,7 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                         .unwrap();
                 })
             },
-            criterion::BatchSize::SmallInput,
+            BatchSize::SmallInput,
         )
     });
 
@@ -86,7 +86,7 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                         .unwrap();
                 })
             },
-            criterion::BatchSize::SmallInput,
+            BatchSize::SmallInput,
         )
     });
 
@@ -105,7 +105,7 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                         .unwrap();
                 })
             },
-            criterion::BatchSize::SmallInput,
+            BatchSize::SmallInput,
         )
     });
 

--- a/clients/cli/src/cmds/api/mod.rs
+++ b/clients/cli/src/cmds/api/mod.rs
@@ -9,6 +9,5 @@ mod rate_limiter;
 mod stream;
 
 pub(crate) use self::{
-    cache::CacheArgs, health::HealthArgs, idempotency::IdempotencyArgs, kv::KvArgs, msgs::MsgsArgs,
-    rate_limiter::RateLimiterArgs, stream::StreamArgs,
+    cache::CacheArgs, health::HealthArgs, idempotency::IdempotencyArgs, kv::KvArgs, msgs::MsgsArgs, rate_limiter::RateLimiterArgs, stream::StreamArgs,
 };

--- a/clients/cli/src/cmds/api/mod.rs
+++ b/clients/cli/src/cmds/api/mod.rs
@@ -9,5 +9,6 @@ mod rate_limiter;
 mod stream;
 
 pub(crate) use self::{
-    cache::CacheArgs, health::HealthArgs, idempotency::IdempotencyArgs, kv::KvArgs, msgs::MsgsArgs, rate_limiter::RateLimiterArgs, stream::StreamArgs,
+    cache::CacheArgs, health::HealthArgs, idempotency::IdempotencyArgs, kv::KvArgs, msgs::MsgsArgs,
+    rate_limiter::RateLimiterArgs, stream::StreamArgs,
 };

--- a/clients/cli/src/cmds/api/mod.rs
+++ b/clients/cli/src/cmds/api/mod.rs
@@ -10,5 +10,5 @@ mod stream;
 
 pub(crate) use self::{
     cache::CacheArgs, health::HealthArgs, idempotency::IdempotencyArgs, kv::KvArgs, msgs::MsgsArgs,
-    msgs_topic::MsgsTopicArgs, rate_limiter::RateLimiterArgs, stream::StreamArgs,
+    rate_limiter::RateLimiterArgs, stream::StreamArgs,
 };

--- a/codegen/src/formatting.rs
+++ b/codegen/src/formatting.rs
@@ -30,7 +30,23 @@ async fn format_rust_clients() -> io::Result<()> {
             "--package=coyote-cli",
         ],
     )
-    .await
+    .await?;
+    for manifest in ["clients/cli/Cargo.toml", "clients/rust/Cargo.toml"] {
+        exec(
+            "cargo",
+            [
+                "+nightly",
+                "clippy",
+                "--fix",
+                "--allow-dirty",
+                "--no-deps",
+                "--manifest-path",
+                manifest,
+            ],
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 async fn format_go_client() -> io::Result<()> {

--- a/codegen/src/formatting.rs
+++ b/codegen/src/formatting.rs
@@ -21,16 +21,6 @@ pub(crate) fn run() -> ExitCode {
 }
 
 async fn format_rust_clients() -> io::Result<()> {
-    exec(
-        "cargo",
-        [
-            "+nightly",
-            "fmt",
-            "--package=coyote-client",
-            "--package=coyote-cli",
-        ],
-    )
-    .await?;
     for manifest in ["clients/cli/Cargo.toml", "clients/rust/Cargo.toml"] {
         exec(
             "cargo",
@@ -46,6 +36,16 @@ async fn format_rust_clients() -> io::Result<()> {
         )
         .await?;
     }
+    exec(
+        "cargo",
+        [
+            "+nightly",
+            "fmt",
+            "--package=coyote-client",
+            "--package=coyote-cli",
+        ],
+    )
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
This runs `just codegen lint` on main, fixes all the issues, and changes `cargo codegen` to also run clippy with the same args as `just lint` so they won't fight any more. This is very dumb.