### PR TITLE
dev: do not run clippy on coyote-cli or coyote-client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
           # only save the cache on the main branch
           # cf https://github.com/Swatinem/rust-cache/issues/95
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo clippy --workspace --all-features --all-targets
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-workspaces
+      - run: |
+          # shellcheck disable=SC2046
+          cargo clippy --all-features --all-targets $(cargo workspaces list | grep -v '^\(coyote-cli\|coyote-client\)$' | sed -e 's/^/--package=/' | tr '\n' ' ')
   prek:
     name: Validate prek
     runs-on: ubuntu-24.04

--- a/justfile
+++ b/justfile
@@ -1,7 +1,16 @@
-lint:
-    cargo +nightly clippy --workspace --fix --allow-dirty --all-features --all-targets
+clippy:
+    #!/bin/bash
+    # TODO: set this
+    PACKAGES="$(cargo workspaces list | grep -v '^\(coyote-cli\|coyote-client\)$' | sed -e 's/^/--package=/' | tr '\n' ' ')"
+    set -x
+    cargo +nightly clippy --fix --allow-dirty --all-features --all-targets $PACKAGES
+
+# Format rust code
+fmt:
     cargo +nightly fmt
     cargo sort --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
+
+lint: clippy fmt
 
 # Test the backend
 test *args='':
@@ -11,8 +20,15 @@ test *args='':
 test-sdks:
     cargo nextest run --package=coyote-client --package=coyote-cli
 
+# Run code generation for all SDKs + CLI
 codegen:
     cargo codegen
+
+# Install dependencies for using this justfile
+setup:
+    rustup toolchain install nightly
+    rustup toolchain install stable
+    cargo install --locked cargo-sort cargo-workspaces cargo-nextest
 
 # Run all the test commands
 test-all: test test-sdks


### PR DESCRIPTION
This is ugly, but it changes both CI and the `justfile` to only run clippy on the non-codegen'd packages, so that a future codegen issue won't result in inconsistent behavior for everyone.

This depends on [cargo-workspaces](https://github.com/pksunkara/cargo-workspaces), because there doesn't appear to be a first-party way to get a list of all crates in a workspace, which is kind of weird.