### PR TITLE
rust: Reduce dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,7 @@ dependencies = [
 name = "coyote-client"
 version = "0.0.1"
 dependencies = [
+ "form_urlencoded",
  "http",
  "http-body-util",
  "hyper",
@@ -1007,7 +1008,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ dirs = "6.0.0"
 dotenvy = "0.15.7"
 fjall = { version = "3.0.1", features = ["lz4", "metrics"] }
 fjall-utils.path = "crates/fjall-utils"
+form_urlencoded = "1.2.2"
 fs-err = "3.3.0"
 futures-util = "0.3"
 hashlink = "0.11"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -17,6 +17,7 @@ native-tls = ["dep:hyper-tls"]
 rustls-tls = ["dep:hyper-rustls", "dep:rustls", "hyper-rustls?/rustls-native-certs"]
 
 [dependencies]
+form_urlencoded.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
@@ -33,7 +34,6 @@ serde_json.workspace = true
 tokio.workspace = true
 tower-service.workspace = true
 tracing.workspace = true
-url.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }

--- a/clients/rust/src/request.rs
+++ b/clients/rust/src/request.rs
@@ -156,7 +156,7 @@ impl Request {
 
         let mut uri = format!("{}{}", conf.base_path, path);
 
-        let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
+        let mut query_string = form_urlencoded::Serializer::new("".to_owned());
         for (key, val) in self.query_params {
             query_string.append_pair(key, &val);
         }


### PR DESCRIPTION
We weren't really using the `url` dependency, only `form_urlencoded` which `url` re-exports.