### PR TITLE
dev: check in the same yamlfmt.yaml that we use elsewhere

### DIFF
--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,0 +1,6 @@
+formatter:
+  type: basic
+  retain_line_breaks_single: true
+  scan_folded_as_literal: true
+  eof_newline: true
+  drop_merge_tag: false


### PR DESCRIPTION
As requested in slack; this preserves single blank lines and folded literals, and also ensures newlines at EOF.

Unlike elsewhere, I'm configuring it to leave the `!!merge` tag in place (even though it's not supported in GHA yaml, which is why we ban it in monorepo-private). Hopefully `actionlint` will catch places where we're using `!!merge` and it isn't allowed.