### PR TITLE
Fix default partition count, allowing configuring partitions

### DIFF
--- a/clients/cli/src/cmds/api/mod.rs
+++ b/clients/cli/src/cmds/api/mod.rs
@@ -6,9 +6,11 @@ mod kv;
 mod msgs;
 mod msgs_namespace;
 mod msgs_stream;
+mod msgs_topic;
 mod rate_limiter;
 
 pub(crate) use self::{
     cache::CacheArgs, health::HealthArgs, idempotency::IdempotencyArgs, kv::KvArgs, msgs::MsgsArgs,
-    msgs_namespace::MsgsNamespaceArgs, msgs_stream::MsgsStreamArgs, rate_limiter::RateLimiterArgs,
+    msgs_namespace::MsgsNamespaceArgs, msgs_stream::MsgsStreamArgs, msgs_topic::MsgsTopicArgs,
+    rate_limiter::RateLimiterArgs,
 };

--- a/clients/cli/src/cmds/api/msgs.rs
+++ b/clients/cli/src/cmds/api/msgs.rs
@@ -2,7 +2,7 @@
 use clap::{Args, Subcommand};
 use coyote_client::CoyoteClient;
 
-use super::{MsgsNamespaceArgs, MsgsStreamArgs};
+use super::{MsgsNamespaceArgs, MsgsStreamArgs, MsgsTopicArgs};
 
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
@@ -15,6 +15,7 @@ pub struct MsgsArgs {
 pub enum MsgsCommands {
     Namespace(MsgsNamespaceArgs),
     Stream(MsgsStreamArgs),
+    Topic(MsgsTopicArgs),
     /// Publishes messages to a topic within a namespace.
     Publish {
         publish_in: crate::json::JsonOf<coyote_client::models::PublishIn>,
@@ -32,6 +33,9 @@ impl MsgsCommands {
                 args.command.exec(client, color_mode).await?;
             }
             Self::Stream(args) => {
+                args.command.exec(client, color_mode).await?;
+            }
+            Self::Topic(args) => {
                 args.command.exec(client, color_mode).await?;
             }
             Self::Publish { publish_in } => {

--- a/clients/cli/src/cmds/api/msgs_topic.rs
+++ b/clients/cli/src/cmds/api/msgs_topic.rs
@@ -1,0 +1,41 @@
+// this file is @generated
+use clap::{Args, Subcommand};
+use coyote_client::CoyoteClient;
+
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true, flatten_help = true)]
+pub struct MsgsTopicArgs {
+    #[command(subcommand)]
+    pub command: MsgsTopicCommands,
+}
+
+#[derive(Subcommand)]
+pub enum MsgsTopicCommands {
+    /// Configures the number of partitions for a topic.
+    ///
+    /// Partition count can only be increased, never decreased. The default for a new topic is 1.
+    Configure {
+        topic_configure_in: crate::json::JsonOf<coyote_client::models::TopicConfigureIn>,
+    },
+}
+
+impl MsgsTopicCommands {
+    pub async fn exec(
+        self,
+        client: &CoyoteClient,
+        color_mode: colored_json::ColorMode,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::Configure { topic_configure_in } => {
+                let resp = client
+                    .msgs()
+                    .topic()
+                    .configure(topic_configure_in.into_inner())
+                    .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/clients/go/internal/apis/msgs.go
+++ b/clients/go/internal/apis/msgs.go
@@ -13,6 +13,7 @@ type Msgs struct {
 	client    *coyote_proto.HttpClient
 	Namespace *MsgsNamespace
 	Stream    *MsgsStream
+	Topic     *MsgsTopic
 }
 
 func NewMsgs(client *coyote_proto.HttpClient) Msgs {

--- a/clients/go/internal/apis/msgs_topic.go
+++ b/clients/go/internal/apis/msgs_topic.go
@@ -1,0 +1,36 @@
+package coyote_apis
+
+// This file is @generated DO NOT EDIT
+
+import (
+	"context"
+
+	coyote_models "github.com/svix/coyote/clients/go/internal/models"
+	coyote_proto "github.com/svix/coyote/clients/go/internal/proto"
+)
+
+type MsgsTopic struct {
+	client *coyote_proto.HttpClient
+}
+
+func NewMsgsTopic(client *coyote_proto.HttpClient) MsgsTopic {
+	return MsgsTopic{client}
+}
+
+// Configures the number of partitions for a topic.
+//
+// Partition count can only be increased, never decreased. The default for a new topic is 1.
+func (msgsTopic MsgsTopic) Configure(
+	ctx context.Context,
+	topicConfigureIn coyote_models.TopicConfigureIn,
+) (*coyote_models.TopicConfigureOut, error) {
+	return coyote_proto.ExecuteRequest[coyote_models.TopicConfigureIn, coyote_models.TopicConfigureOut](
+		ctx,
+		msgsTopic.client,
+		"POST",
+		"/api/v1/msgs/topic/configure",
+		nil,
+		nil,
+		&topicConfigureIn,
+	)
+}

--- a/clients/go/internal/models/topic_configure_in.go
+++ b/clients/go/internal/models/topic_configure_in.go
@@ -1,0 +1,9 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type TopicConfigureIn struct {
+	Name       string `json:"name"`
+	Partitions uint16 `json:"partitions"`
+	Topic      string `json:"topic"`
+}

--- a/clients/go/internal/models/topic_configure_out.go
+++ b/clients/go/internal/models/topic_configure_out.go
@@ -1,0 +1,7 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type TopicConfigureOut struct {
+	Partitions uint16 `json:"partitions"`
+}

--- a/clients/go/models.go
+++ b/clients/go/models.go
@@ -50,4 +50,6 @@ type (
 	StreamMsgOut                 = coyote_models.StreamMsgOut
 	StreamReceiveIn              = coyote_models.StreamReceiveIn
 	StreamReceiveOut             = coyote_models.StreamReceiveOut
+	TopicConfigureIn             = coyote_models.TopicConfigureIn
+	TopicConfigureOut            = coyote_models.TopicConfigureOut
 )

--- a/clients/java/src/main/java/com/svix/coyote/apis/Msgs.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/Msgs.java
@@ -24,6 +24,8 @@ import com.svix.coyote.models.StreamCommitIn;
 import com.svix.coyote.models.StreamCommitOut;
 import com.svix.coyote.models.StreamReceiveIn;
 import com.svix.coyote.models.StreamReceiveOut;
+import com.svix.coyote.models.TopicConfigureIn;
+import com.svix.coyote.models.TopicConfigureOut;
 
 public class Msgs {
     private final HttpClient client;

--- a/clients/java/src/main/java/com/svix/coyote/apis/MsgsTopic.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/MsgsTopic.java
@@ -1,0 +1,43 @@
+// this file is @generated
+package com.svix.coyote.apis;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.svix.coyote.ApiException;
+import com.svix.coyote.HttpClient;
+import com.svix.coyote.Utils;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import com.svix.coyote.models.TopicConfigureIn;
+import com.svix.coyote.models.TopicConfigureOut;
+
+public class MsgsTopic {
+    private final HttpClient client;
+
+    public MsgsTopic(HttpClient client) {
+        this.client = client;
+    }
+
+    /**
+* Configures the number of partitions for a topic.
+* 
+* Partition count can only be increased, never decreased. The default for a new topic is 1.
+*/
+    public TopicConfigureOut configure(
+        final TopicConfigureIn topicConfigureIn
+    ) throws IOException, ApiException {
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/topic/configure");
+        return this.client.executeRequest(
+            "POST",
+            url.build(),
+            null,
+            topicConfigureIn,
+            TopicConfigureOut.class
+            );
+    }
+}

--- a/clients/java/src/main/java/com/svix/coyote/models/TopicConfigureIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/TopicConfigureIn.java
@@ -1,0 +1,112 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
+public class TopicConfigureIn {
+@JsonProperty private String name;
+@JsonProperty private Short partitions;
+@JsonProperty private String topic;
+public TopicConfigureIn () {}
+
+ public TopicConfigureIn name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+    * Get name
+    *
+     * @return name
+     */
+    @javax.annotation.Nonnull
+     public String getName() {
+        return name;
+    }
+
+     public void setName(String name) {
+        this.name = name;
+    }
+
+     public TopicConfigureIn partitions(Short partitions) {
+        this.partitions = partitions;
+        return this;
+    }
+
+    /**
+    * Get partitions
+    *
+     * @return partitions
+     */
+    @javax.annotation.Nonnull
+     public Short getPartitions() {
+        return partitions;
+    }
+
+     public void setPartitions(Short partitions) {
+        this.partitions = partitions;
+    }
+
+     public TopicConfigureIn topic(String topic) {
+        this.topic = topic;
+        return this;
+    }
+
+    /**
+    * Get topic
+    *
+     * @return topic
+     */
+    @javax.annotation.Nonnull
+     public String getTopic() {
+        return topic;
+    }
+
+     public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    /**
+     * Create an instance of TopicConfigureIn given an JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of TopicConfigureIn
+     * @throws JsonProcessingException if the JSON string is invalid with respect to TopicConfigureIn
+     */
+    public static TopicConfigureIn fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, TopicConfigureIn.class);
+    }
+
+    /**
+     * Convert an instance of TopicConfigureIn to an JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/clients/java/src/main/java/com/svix/coyote/models/TopicConfigureOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/TopicConfigureOut.java
@@ -1,0 +1,72 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
+public class TopicConfigureOut {
+@JsonProperty private Short partitions;
+public TopicConfigureOut () {}
+
+ public TopicConfigureOut partitions(Short partitions) {
+        this.partitions = partitions;
+        return this;
+    }
+
+    /**
+    * Get partitions
+    *
+     * @return partitions
+     */
+    @javax.annotation.Nonnull
+     public Short getPartitions() {
+        return partitions;
+    }
+
+     public void setPartitions(Short partitions) {
+        this.partitions = partitions;
+    }
+
+    /**
+     * Create an instance of TopicConfigureOut given an JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of TopicConfigureOut
+     * @throws JsonProcessingException if the JSON string is invalid with respect to TopicConfigureOut
+     */
+    public static TopicConfigureOut fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, TopicConfigureOut.class);
+    }
+
+    /**
+     * Convert an instance of TopicConfigureOut to an JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/clients/javascript/src/apis/msgs.ts
+++ b/clients/javascript/src/apis/msgs.ts
@@ -40,8 +40,17 @@ import {
     type StreamReceiveOut,
     StreamReceiveOutSerializer,
 } from '../models/streamReceiveOut';
+import {
+    type TopicConfigureIn,
+    TopicConfigureInSerializer,
+} from '../models/topicConfigureIn';
+import {
+    type TopicConfigureOut,
+    TopicConfigureOutSerializer,
+} from '../models/topicConfigureOut';
 import { MsgsNamespace } from './msgsNamespace';
 import { MsgsStream } from './msgsStream';
+import { MsgsTopic } from './msgsTopic';
 import { HttpMethod, CoyoteRequest, CoyoteRequestContext } from "../request";
 
 export class Msgs {
@@ -53,6 +62,10 @@ export class Msgs {
 
     public get stream() {
         return new MsgsStream(this.requestCtx);
+    }
+
+    public get topic() {
+        return new MsgsTopic(this.requestCtx);
     }
 
     /** Publishes messages to a topic within a namespace. */

--- a/clients/javascript/src/apis/msgsTopic.ts
+++ b/clients/javascript/src/apis/msgsTopic.ts
@@ -1,0 +1,41 @@
+// this file is @generated
+
+import {
+    type TopicConfigureIn,
+    TopicConfigureInSerializer,
+} from '../models/topicConfigureIn';
+import {
+    type TopicConfigureOut,
+    TopicConfigureOutSerializer,
+} from '../models/topicConfigureOut';
+import { HttpMethod, CoyoteRequest, CoyoteRequestContext } from "../request";
+
+export class MsgsTopic {
+    public constructor(private readonly requestCtx: CoyoteRequestContext) {}
+
+    /**
+* Configures the number of partitions for a topic.
+* 
+* Partition count can only be increased, never decreased. The default for a new topic is 1.
+*/
+        public configure(
+            topicConfigureIn: TopicConfigureIn,
+            ): Promise<TopicConfigureOut> {
+            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/topic/configure");
+
+            request.setBody(
+                    TopicConfigureInSerializer._toJsonObject(
+                        topicConfigureIn,
+                    )
+                );
+            
+                return request.send(
+                    this.requestCtx,
+                    TopicConfigureOutSerializer._fromJsonObject,
+                );
+            }
+
+        
+
+    }
+

--- a/clients/javascript/src/models/topicConfigureIn.ts
+++ b/clients/javascript/src/models/topicConfigureIn.ts
@@ -1,0 +1,29 @@
+// this file is @generated
+
+
+
+
+
+export interface TopicConfigureIn {
+    name: string;
+partitions: number;
+topic: string;
+}
+
+export const TopicConfigureInSerializer = {
+    _fromJsonObject(object: any): TopicConfigureIn {
+        return {
+            name: object['name'],
+            partitions: object['partitions'],
+            topic: object['topic'],
+            };
+    },
+
+    _toJsonObject(self: TopicConfigureIn): any {
+        return {
+            'name': self.name,
+            'partitions': self.partitions,
+            'topic': self.topic,
+            };
+    }
+}

--- a/clients/javascript/src/models/topicConfigureOut.ts
+++ b/clients/javascript/src/models/topicConfigureOut.ts
@@ -1,0 +1,23 @@
+// this file is @generated
+
+
+
+
+
+export interface TopicConfigureOut {
+    partitions: number;
+}
+
+export const TopicConfigureOutSerializer = {
+    _fromJsonObject(object: any): TopicConfigureOut {
+        return {
+            partitions: object['partitions'],
+            };
+    },
+
+    _toJsonObject(self: TopicConfigureOut): any {
+        return {
+            'partitions': self.partitions,
+            };
+    }
+}

--- a/clients/python/coyote/apis/__init__.py
+++ b/clients/python/coyote/apis/__init__.py
@@ -6,6 +6,7 @@ from .kv import Kv, KvAsync
 from .msgs import Msgs, MsgsAsync
 from .msgs_namespace import MsgsNamespace, MsgsNamespaceAsync
 from .msgs_stream import MsgsStream, MsgsStreamAsync
+from .msgs_topic import MsgsTopic, MsgsTopicAsync
 from .rate_limiter import RateLimiter, RateLimiterAsync
 
 
@@ -24,6 +25,8 @@ __all__ = [
     "MsgsNamespaceAsync",
     "MsgsStream",
     "MsgsStreamAsync",
+    "MsgsTopic",
+    "MsgsTopicAsync",
     "RateLimiter",
     "RateLimiterAsync",
 ]

--- a/clients/python/coyote/apis/msgs.py
+++ b/clients/python/coyote/apis/msgs.py
@@ -13,6 +13,10 @@ from .msgs_stream import (
     MsgsStream,
     MsgsStreamAsync,
 )
+from .msgs_topic import (
+    MsgsTopic,
+    MsgsTopicAsync,
+)
 
 
 class MsgsAsync(ApiBase):
@@ -23,6 +27,10 @@ class MsgsAsync(ApiBase):
     @property
     def stream(self) -> MsgsStreamAsync:
         return MsgsStreamAsync(self._client)
+
+    @property
+    def topic(self) -> MsgsTopicAsync:
+        return MsgsTopicAsync(self._client)
 
     async def publish(
         self,
@@ -45,6 +53,10 @@ class Msgs(ApiBase):
     @property
     def stream(self) -> MsgsStream:
         return MsgsStream(self._client)
+
+    @property
+    def topic(self) -> MsgsTopic:
+        return MsgsTopic(self._client)
 
     def publish(
         self,

--- a/clients/python/coyote/apis/msgs_topic.py
+++ b/clients/python/coyote/apis/msgs_topic.py
@@ -1,0 +1,39 @@
+# This file is @generated
+
+from ..internal.api_common import ApiBase
+from ..models import (
+    TopicConfigureIn,
+    TopicConfigureOut,
+)
+
+
+class MsgsTopicAsync(ApiBase):
+    async def configure(
+        self,
+        topic_configure_in: TopicConfigureIn,
+    ) -> TopicConfigureOut:
+        """Configures the number of partitions for a topic.
+
+        Partition count can only be increased, never decreased. The default for a new topic is 1."""
+        return await self._request_asyncio(
+            method="post",
+            path="/api/v1/msgs/topic/configure",
+            body=topic_configure_in.model_dump(exclude_unset=True, by_alias=True),
+            response_type=TopicConfigureOut,
+        )
+
+
+class MsgsTopic(ApiBase):
+    def configure(
+        self,
+        topic_configure_in: TopicConfigureIn,
+    ) -> TopicConfigureOut:
+        """Configures the number of partitions for a topic.
+
+        Partition count can only be increased, never decreased. The default for a new topic is 1."""
+        return self._request_sync(
+            method="post",
+            path="/api/v1/msgs/topic/configure",
+            body=topic_configure_in.model_dump(exclude_unset=True, by_alias=True),
+            response_type=TopicConfigureOut,
+        )

--- a/clients/python/coyote/models/__init__.py
+++ b/clients/python/coyote/models/__init__.py
@@ -44,6 +44,8 @@ from .stream_commit_out import StreamCommitOut
 from .stream_msg_out import StreamMsgOut
 from .stream_receive_in import StreamReceiveIn
 from .stream_receive_out import StreamReceiveOut
+from .topic_configure_in import TopicConfigureIn
+from .topic_configure_out import TopicConfigureOut
 
 
 __all__ = [
@@ -92,4 +94,6 @@ __all__ = [
     "StreamMsgOut",
     "StreamReceiveIn",
     "StreamReceiveOut",
+    "TopicConfigureIn",
+    "TopicConfigureOut",
 ]

--- a/clients/python/coyote/models/topic_configure_in.py
+++ b/clients/python/coyote/models/topic_configure_in.py
@@ -1,0 +1,11 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class TopicConfigureIn(BaseModel):
+    name: str
+
+    partitions: int
+
+    topic: str

--- a/clients/python/coyote/models/topic_configure_out.py
+++ b/clients/python/coyote/models/topic_configure_out.py
@@ -1,0 +1,7 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class TopicConfigureOut(BaseModel):
+    partitions: int

--- a/clients/rust/src/api/mod.rs
+++ b/clients/rust/src/api/mod.rs
@@ -8,11 +8,13 @@ mod kv;
 mod msgs;
 mod msgs_namespace;
 mod msgs_stream;
+mod msgs_topic;
 mod rate_limiter;
 
 pub use self::{
     cache::Cache, health::Health, idempotency::Idempotency, kv::Kv, msgs::Msgs,
-    msgs_namespace::MsgsNamespace, msgs_stream::MsgsStream, rate_limiter::RateLimiter,
+    msgs_namespace::MsgsNamespace, msgs_stream::MsgsStream, msgs_topic::MsgsTopic,
+    rate_limiter::RateLimiter,
 };
 
 impl CoyoteClient {

--- a/clients/rust/src/api/msgs.rs
+++ b/clients/rust/src/api/msgs.rs
@@ -1,5 +1,5 @@
 // this file is @generated
-use super::{MsgsNamespace, MsgsStream};
+use super::{MsgsNamespace, MsgsStream, MsgsTopic};
 use crate::{Configuration, error::Result, models::*};
 
 pub struct Msgs<'a> {
@@ -17,6 +17,10 @@ impl<'a> Msgs<'a> {
 
     pub fn stream(&self) -> MsgsStream<'a> {
         MsgsStream::new(self.cfg)
+    }
+
+    pub fn topic(&self) -> MsgsTopic<'a> {
+        MsgsTopic::new(self.cfg)
     }
 
     /// Publishes messages to a topic within a namespace.

--- a/clients/rust/src/api/msgs_topic.rs
+++ b/clients/rust/src/api/msgs_topic.rs
@@ -1,0 +1,25 @@
+// this file is @generated
+use crate::{Configuration, error::Result, models::*};
+
+pub struct MsgsTopic<'a> {
+    cfg: &'a Configuration,
+}
+
+impl<'a> MsgsTopic<'a> {
+    pub(super) fn new(cfg: &'a Configuration) -> Self {
+        Self { cfg }
+    }
+
+    /// Configures the number of partitions for a topic.
+    ///
+    /// Partition count can only be increased, never decreased. The default for a new topic is 1.
+    pub async fn configure(
+        &self,
+        topic_configure_in: TopicConfigureIn,
+    ) -> Result<TopicConfigureOut> {
+        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/topic/configure")
+            .with_body(topic_configure_in)
+            .execute(self.cfg)
+            .await
+    }
+}

--- a/clients/rust/src/models/mod.rs
+++ b/clients/rust/src/models/mod.rs
@@ -46,6 +46,8 @@ mod stream_commit_out;
 mod stream_msg_out;
 mod stream_receive_in;
 mod stream_receive_out;
+mod topic_configure_in;
+mod topic_configure_out;
 
 pub use self::{
     cache_delete_in::CacheDeleteIn,
@@ -93,4 +95,6 @@ pub use self::{
     stream_msg_out::StreamMsgOut,
     stream_receive_in::StreamReceiveIn,
     stream_receive_out::StreamReceiveOut,
+    topic_configure_in::TopicConfigureIn,
+    topic_configure_out::TopicConfigureOut,
 };

--- a/clients/rust/src/models/topic_configure_in.rs
+++ b/clients/rust/src/models/topic_configure_in.rs
@@ -1,0 +1,22 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TopicConfigureIn {
+    pub name: String,
+
+    pub partitions: u16,
+
+    pub topic: String,
+}
+
+impl TopicConfigureIn {
+    pub fn new(name: String, partitions: u16, topic: String) -> Self {
+        Self {
+            name,
+            partitions,
+            topic,
+        }
+    }
+}

--- a/clients/rust/src/models/topic_configure_out.rs
+++ b/clients/rust/src/models/topic_configure_out.rs
@@ -1,0 +1,14 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TopicConfigureOut {
+    pub partitions: u16,
+}
+
+impl TopicConfigureOut {
+    pub fn new(partitions: u16) -> Self {
+        Self { partitions }
+    }
+}

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -7,8 +7,10 @@ use validator::Validate;
 
 pub type Offset = u64;
 
-// FIXME(@svix-gabriel): Make partition count configurable per-namespace.
-pub const DEFAULT_PARTITION_COUNT: u16 = 16;
+pub const DEFAULT_PARTITION_COUNT: u16 = 1;
+
+/// Hard ceiling on partition count per topic. Arbitrary for now — may be raised later.
+pub const MAX_PARTITION_COUNT: u16 = 64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -16,7 +18,7 @@ pub struct PartitionIndex(u16);
 
 impl PartitionIndex {
     pub fn new(index: u16) -> Option<Self> {
-        if index < DEFAULT_PARTITION_COUNT {
+        if index < MAX_PARTITION_COUNT {
             Some(Self(index))
         } else {
             None
@@ -46,14 +48,14 @@ pub fn parse_partition_topic(s: &str) -> Result<(&str, PartitionIndex), &'static
         .ok_or("partition index out of range")
 }
 
-pub fn random_partition() -> PartitionIndex {
-    PartitionIndex(rand::random_range(..DEFAULT_PARTITION_COUNT))
+pub fn random_partition(partition_count: u16) -> PartitionIndex {
+    PartitionIndex(rand::random_range(..partition_count))
 }
 
 /// Deterministically maps a key to a partition via hash.
-pub fn partition_for_key(key: &[u8]) -> PartitionIndex {
+pub fn partition_for_key(key: &[u8], partition_count: u16) -> PartitionIndex {
     let hash = djb2_hash(key);
-    PartitionIndex((hash % u32::from(DEFAULT_PARTITION_COUNT)) as u16)
+    PartitionIndex((hash % u32::from(partition_count)) as u16)
 }
 
 fn djb2_hash(data: &[u8]) -> u32 {

--- a/crates/msgs/src/operations/mod.rs
+++ b/crates/msgs/src/operations/mod.rs
@@ -2,8 +2,11 @@ mod create_namespace;
 mod publish;
 mod stream_commit;
 mod stream_receive;
+mod topic_configure;
 
-pub use self::{create_namespace::*, publish::*, stream_commit::*, stream_receive::*};
+pub use self::{
+    create_namespace::*, publish::*, stream_commit::*, stream_receive::*, topic_configure::*,
+};
 
 use crate::State;
 use serde::{Deserialize, Serialize};
@@ -22,6 +25,7 @@ raft_module_operations!(
         Publish(PublishOperation) -> PublishResponseData,
         StreamCommit(StreamCommitOperation) -> StreamCommitResponseData,
         StreamReceive(StreamReceiveOperation) -> StreamReceiveResponseData,
+        TopicConfigure(TopicConfigureOperation) -> TopicConfigureResponseData,
     },
     state = MsgsRaftState<'_>,
 );

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -41,13 +41,20 @@ impl PublishOperation {
     }
 
     fn apply_real(self, state: &State) -> coyote_operations::Result<PublishResponseData> {
+        let partition_count =
+            crate::tables::topic_partition_count(state, self.namespace_id, &self.topic)?;
+
+        // Clamp the pre-chosen keyless partition to the topic's actual count.
+        let keyless_partition = PartitionIndex::new(self.keyless_partition.get() % partition_count)
+            .expect("clamped value is always in range");
+
         let mut by_partition: BTreeMap<PartitionIndex, Vec<(usize, MsgIn)>> = BTreeMap::new();
 
         for (idx, msg) in self.msgs.into_iter().enumerate() {
             let partition = if let Some(key) = &msg.key {
-                partition_for_key(key.as_bytes())
+                partition_for_key(key.as_bytes(), partition_count)
             } else {
-                self.keyless_partition
+                keyless_partition
             };
 
             by_partition.entry(partition).or_default().push((idx, msg));

--- a/crates/msgs/src/operations/stream_receive.rs
+++ b/crates/msgs/src/operations/stream_receive.rs
@@ -6,9 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     State,
-    entities::{
-        ConsumerGroup, DEFAULT_PARTITION_COUNT, Offset, PartitionIndex, partition_topic_name,
-    },
+    entities::{ConsumerGroup, Offset, PartitionIndex, partition_topic_name},
     tables::{LeaseDiff, LeaseRow, MsgRow, OffsetRow},
 };
 
@@ -98,12 +96,15 @@ impl StreamReceiveOperation {
         let mut remaining = usize::from(self.batch_size.get());
         let mut any_partition_locked = false;
 
-        for p in 0..DEFAULT_PARTITION_COUNT {
+        let partition_count =
+            crate::tables::topic_partition_count(state, self.namespace_id, &self.topic)?;
+
+        for p in 0..partition_count {
             if remaining == 0 {
                 break;
             }
-            let partition = PartitionIndex::new(p)
-                .expect("already validated the partition number is in the valid range.");
+            let partition =
+                PartitionIndex::new(p).expect("partition index is within MAX_PARTITION_COUNT");
 
             let start_offset = OffsetRow::fetch(state, self.namespace_id, partition, &self.cg)?
                 .unwrap_or(Offset::MIN);

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -1,0 +1,79 @@
+use coyote_namespace::entities::NamespaceId;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    State,
+    entities::MAX_PARTITION_COUNT,
+    tables::{TopicConfig, TopicConfigRow, topic_partition_count},
+};
+
+use super::{MsgsRaftState, MsgsRequest, TopicConfigureResponse};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopicConfigureOperation {
+    namespace_id: NamespaceId,
+    topic: String,
+    partitions: u16,
+}
+
+impl TopicConfigureOperation {
+    pub fn new(namespace_id: NamespaceId, topic: String, partitions: u16) -> Self {
+        Self {
+            namespace_id,
+            topic,
+            partitions,
+        }
+    }
+
+    fn apply_real(self, state: &State) -> coyote_operations::Result<TopicConfigureResponseData> {
+        if self.partitions == 0 || self.partitions > MAX_PARTITION_COUNT {
+            return Err(
+                coyote_error::Error::http(coyote_error::HttpError::bad_request(
+                    Some("invalid_partition_count".to_owned()),
+                    Some(format!(
+                        "Partition count must be between 1 and {MAX_PARTITION_COUNT}."
+                    )),
+                ))
+                .into(),
+            );
+        }
+
+        let current = topic_partition_count(state, self.namespace_id, &self.topic)?;
+
+        if self.partitions < current {
+            return Err(coyote_error::Error::http(
+                coyote_error::HttpError::bad_request(
+                    Some("cannot_decrease_partitions".to_owned()),
+                    Some(format!(
+                        "Cannot decrease partition count from {current} to {}. Only increases are allowed.",
+                        self.partitions
+                    )),
+                ),
+            )
+            .into());
+        }
+
+        let config = TopicConfig {
+            partition_count: self.partitions,
+        };
+
+        let mut batch = state.db.batch();
+        TopicConfigRow::store(&mut batch, state, self.namespace_id, &self.topic, &config)?;
+        batch.commit().map_err(coyote_error::Error::from)?;
+
+        Ok(TopicConfigureResponseData {
+            partitions: self.partitions,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopicConfigureResponseData {
+    pub partitions: u16,
+}
+
+impl MsgsRequest for TopicConfigureOperation {
+    fn apply(self, state: MsgsRaftState<'_>) -> TopicConfigureResponse {
+        TopicConfigureResponse(self.apply_real(state.msgs))
+    }
+}

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -527,8 +527,70 @@ impl OffsetRow {
     }
 }
 
+// ---------------------------------------------------------------------------
+// TopicConfigRow — per (namespace, topic) configuration (e.g. partition count)
+// ---------------------------------------------------------------------------
+
+const TOPIC_CONFIG_PREFIX: &[u8] = b"_MSGTOPICCONF_\0";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct TopicConfig {
+    pub partition_count: u16,
+}
+
+fn topic_config_key(ns_id: NamespaceId, topic: &str) -> Vec<u8> {
+    let mut key = Vec::with_capacity(TOPIC_CONFIG_PREFIX.len() + 16 + 1 + topic.len());
+    key.extend_from_slice(TOPIC_CONFIG_PREFIX);
+    key.extend_from_slice(&ns_id.as_u128().to_be_bytes());
+    key.extend_from_slice(b"\0");
+    key.extend_from_slice(topic.as_bytes());
+    key
+}
+
+pub(crate) struct TopicConfigRow;
+
+impl TopicConfigRow {
+    pub(crate) fn fetch(
+        state: &State,
+        ns_id: NamespaceId,
+        topic: &str,
+    ) -> Result<Option<TopicConfig>> {
+        let key = topic_config_key(ns_id, topic);
+        match state.metadata_tables.get(&key)? {
+            Some(val) => {
+                let config: TopicConfig = rmp_serde::from_slice(&val).map_err(Error::generic)?;
+                Ok(Some(config))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) fn store(
+        batch: &mut OwnedWriteBatch,
+        state: &State,
+        ns_id: NamespaceId,
+        topic: &str,
+        config: &TopicConfig,
+    ) -> Result<()> {
+        let key = topic_config_key(ns_id, topic);
+        let val: Vec<u8> = rmp_serde::to_vec_named(config).map_err(Error::generic)?;
+        let val: fjall::UserValue = val.into();
+        batch.insert(&state.metadata_tables, key, val);
+        Ok(())
+    }
+}
+
+/// Returns the configured partition count for a topic, or `DEFAULT_PARTITION_COUNT` if not set.
+pub(crate) fn topic_partition_count(state: &State, ns_id: NamespaceId, topic: &str) -> Result<u16> {
+    match TopicConfigRow::fetch(state, ns_id, topic)? {
+        Some(config) => Ok(config.partition_count),
+        None => Ok(crate::entities::DEFAULT_PARTITION_COUNT),
+    }
+}
+
 // Compile-time check that table prefixes used in the metadata keyspace are unique.
 static_assertions::const_assert!(fjall_utils::are_all_unique(&[
     LeaseRow::TABLE_PREFIX,
     "_MSGOFFSET_",
+    "_MSGTOPICCONF_",
 ]));

--- a/openapi.json
+++ b/openapi.json
@@ -739,6 +739,43 @@
           }
         ]
       }
+    },
+    "/api/v1/msgs/topic/configure": {
+      "post": {
+        "tags": [
+          "Msgs"
+        ],
+        "summary": "Topic Configure",
+        "description": "Configures the number of partitions for a topic.\n\nPartition count can only be increased, never decreased. The default for a new topic is 1.",
+        "operationId": "v1.msgs.topic.configure",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TopicConfigureIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopicConfigureOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -1776,6 +1813,42 @@
         },
         "required": [
           "msgs"
+        ]
+      },
+      "TopicConfigureIn": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "partitions": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0,
+            "maximum": 65535
+          }
+        },
+        "required": [
+          "name",
+          "topic",
+          "partitions"
+        ]
+      },
+      "TopicConfigureOut": {
+        "type": "object",
+        "properties": {
+          "partitions": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0,
+            "maximum": 65535
+          }
+        },
+        "required": [
+          "partitions"
         ]
       }
     }

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -1,9 +1,11 @@
 use std::num::NonZeroU16;
 
+use crate::{AppState, core::cluster::RaftState, v1::utils::openapi_tag};
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_derive::aide_annotate;
 use coyote_error::{Error, HttpError, Result, ResultExt};
+use coyote_msgs::entities::MAX_PARTITION_COUNT;
 use coyote_namespace::entities::StorageType;
 use coyote_proto::MsgPackOrJson;
 use jiff::Timestamp;
@@ -11,8 +13,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use stream_internals::entities::{Retention, default_retention_bytes, default_retention_millis};
 use validator::Validate;
-
-use crate::{AppState, core::cluster::RaftState, v1::utils::openapi_tag};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct CreateNamespaceIn {
@@ -133,7 +133,7 @@ async fn publish(
         .fetch_stream_namespace(&data.name)?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
-    let keyless_partition = coyote_msgs::entities::random_partition();
+    let keyless_partition = coyote_msgs::entities::random_partition(MAX_PARTITION_COUNT);
     let operation = coyote_msgs::operations::PublishOperation::new(
         namespace.id,
         data.topic,
@@ -270,6 +270,64 @@ async fn stream_commit(
     Ok(MsgPackOrJson(StreamCommitOut {}))
 }
 
+// ---------------------------------------------------------------------------
+// topic/configure
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+struct TopicConfigureIn {
+    pub name: String,
+    pub topic: String,
+    pub partitions: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+struct TopicConfigureOut {
+    pub partitions: u16,
+}
+
+/// Configures the number of partitions for a topic.
+///
+/// Partition count can only be increased, never decreased. The default for a new topic is 1.
+#[aide_annotate(op_id = "v1.msgs.topic.configure")]
+async fn topic_configure(
+    State(state): State<AppState>,
+    Extension(repl): Extension<RaftState>,
+    MsgPackOrJson(data): MsgPackOrJson<TopicConfigureIn>,
+) -> Result<MsgPackOrJson<TopicConfigureOut>> {
+    if data.topic.contains('~') {
+        return Err(Error::http(HttpError::bad_request(
+            Some("invalid_topic".to_owned()),
+            Some("Topic name must not contain '~'.".to_owned()),
+        )));
+    }
+
+    if data.partitions == 0 || data.partitions > MAX_PARTITION_COUNT {
+        return Err(Error::http(HttpError::bad_request(
+            Some("invalid_partition_count".to_owned()),
+            Some(format!(
+                "Partition count must be between 1 and {MAX_PARTITION_COUNT}."
+            )),
+        )));
+    }
+
+    let namespace = state
+        .namespace_state
+        .fetch_stream_namespace(&data.name)?
+        .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
+
+    let operation = coyote_msgs::operations::TopicConfigureOperation::new(
+        namespace.id,
+        data.topic,
+        data.partitions,
+    );
+    let response = repl.client_write(operation).await.map_err_generic()?.0?;
+
+    Ok(MsgPackOrJson(TopicConfigureOut {
+        partitions: response.partitions,
+    }))
+}
+
 pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Msgs");
 
@@ -293,6 +351,11 @@ pub fn router() -> ApiRouter<AppState> {
         .api_route_with(
             "/msgs/stream/commit",
             post_with(stream_commit, stream_commit_operation),
+            &tag,
+        )
+        .api_route_with(
+            "/msgs/topic/configure",
+            post_with(topic_configure, topic_configure_operation),
             &tag,
         )
 }

--- a/tests/it/msgs/mod.rs
+++ b/tests/it/msgs/mod.rs
@@ -1,3 +1,4 @@
 mod namespace;
 mod publish;
 mod stream_receive;
+mod topic_configure;

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -400,7 +400,18 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
         .await?
         .expect(StatusCode::OK);
 
-    // "k1" and "k2" hash to different partitions (1 and 2 respectively via djb2)
+    // Default is 1 partition; configure more so "k1" and "k2" hash to different ones.
+    client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "name": "ns-concurrent",
+            "topic": "t1",
+            "partitions": 16,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // "k1" and "k2" hash to different partitions via djb2
     client
         .post("msgs/publish")
         .json(json!({

--- a/tests/it/msgs/topic_configure.rs
+++ b/tests/it/msgs/topic_configure.rs
@@ -1,0 +1,313 @@
+use std::collections::HashSet;
+
+use serde_json::json;
+use test_utils::{
+    StatusCode, TestResult,
+    server::{TestContext, start_server},
+};
+
+#[tokio::test]
+async fn default_is_one_partition() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-def-part" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish messages with different keys — with 1 partition they all land on the same one.
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "name": "ns-def-part",
+            "topic": "t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "alpha" },
+                { "value": "b".as_bytes(), "key": "beta" },
+                { "value": "c".as_bytes(), "key": "gamma" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "name": "ns-def-part",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].as_array().unwrap();
+    assert_eq!(msgs.len(), 3);
+
+    // All messages should be on the same single partition
+    let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].as_str().unwrap()).collect();
+    assert_eq!(topics.len(), 1, "all messages should be on one partition");
+    assert!(topics.contains("t1~0"), "single partition should be t1~0");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_topic_partitions() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-conf" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "name": "ns-conf",
+            "topic": "t1",
+            "partitions": 4,
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(response["partitions"].as_u64().unwrap(), 4);
+
+    // Publish messages with different keys to spread across partitions
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "name": "ns-conf",
+            "topic": "t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "alpha" },
+                { "value": "b".as_bytes(), "key": "beta" },
+                { "value": "c".as_bytes(), "key": "gamma" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "name": "ns-conf",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].as_array().unwrap();
+    assert_eq!(msgs.len(), 3);
+
+    // All partition-level topics should be within t1~0..t1~3
+    for m in msgs {
+        let topic = m["topic"].as_str().unwrap();
+        assert!(
+            topic.starts_with("t1~"),
+            "expected partition-level topic: {topic}"
+        );
+        let partition: u16 = topic.strip_prefix("t1~").unwrap().parse().unwrap();
+        assert!(partition < 4, "partition {partition} should be < 4");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn cannot_decrease_partitions() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-dec" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "name": "ns-dec",
+            "topic": "t1",
+            "partitions": 4,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Attempt to decrease — should be rejected
+    client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "name": "ns-dec",
+            "topic": "t1",
+            "partitions": 2,
+        }))
+        .await?
+        .expect(StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_rejects_zero() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-zero" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "name": "ns-zero",
+            "topic": "t1",
+            "partitions": 0,
+        }))
+        .await?
+        .expect(StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_rejects_over_max() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-max" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "name": "ns-max",
+            "topic": "t1",
+            "partitions": 65,
+        }))
+        .await?
+        .expect(StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_nonexistent_namespace() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "name": "does-not-exist",
+            "topic": "t1",
+            "partitions": 4,
+        }))
+        .await?
+        .expect(StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn receive_respects_configured_partitions() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-recv-conf" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "name": "ns-recv-conf",
+            "topic": "t1",
+            "partitions": 16,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // "k1" and "k2" hash to different partitions with 16 partitions
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "name": "ns-recv-conf",
+            "topic": "t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k2" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "name": "ns-recv-conf",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].as_array().unwrap();
+    assert_eq!(msgs.len(), 2);
+
+    // Messages should come from different partition-level topics
+    let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].as_str().unwrap()).collect();
+    assert_eq!(
+        topics.len(),
+        2,
+        "k1 and k2 should route to different partitions"
+    );
+
+    for topic in &topics {
+        assert!(
+            topic.starts_with("t1~"),
+            "expected partition-level topic: {topic}"
+        );
+        let partition: u16 = topic.strip_prefix("t1~").unwrap().parse().unwrap();
+        assert!(partition < 16, "partition {partition} should be < 16");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Mistakenly earlier had topics start with a default of 16 partitions, rather than 1.

So we start with 1, but need to support configurable number of partitions for together.ai.

I've capped it at 64 for now, but this is arbitrary.