### PR TITLE
gha: set timeout on test and benchmark jobs so that runners don't block forever

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,36 @@
+name: Coyote CI
+on:
+  workflow_dispatch:
+  workflow_call:
+jobs:
+  benchmark:
+    name: Benchmark
+    timeout-minutes: 15
+    runs-on: ubuntu-latest-8-cores
+    defaults:
+      run:
+        working-directory: ./benchmarks
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-criterion
+        run: cargo install cargo-criterion
+      - name: Run benchmarks
+        # For some weird reason, it seems to log test output
+        # to stderr:
+        run: cargo criterion --output-format bencher 2>&1 | tee output.txt
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'cargo'
+          output-file-path: ./benchmarks/output.txt
+          external-data-json-path: ./cache/benchmark-data.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          summary-always: true
+          fail-on-alert: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     env:
       RUST_LOG: debug
       "COYOTE_LOG_LEVEL": debug

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -7,32 +7,5 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
   benchmark:
-    name: Benchmark
-    runs-on: ubuntu-latest-8-cores
-    defaults:
-      run:
-        working-directory: ./benchmarks
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-criterion
-        run: cargo install cargo-criterion
-      - name: Run benchmarks
-        # For some weird reason, it seems to log test output
-        # to stderr:
-        run: cargo criterion --output-format bencher 2>&1 | tee output.txt
-      - name: Download previous benchmark data
-        uses: actions/cache@v4
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'cargo'
-          output-file-path: ./benchmarks/output.txt
-          external-data-json-path: ./cache/benchmark-data.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          summary-always: true
-          fail-on-alert: true
+    uses: ./.github/workflows/benchmark.yml
+    secrets: inherit


### PR DESCRIPTION
Also moves benchmark into its own file because I'm trying to keep the dispatch files minimal.