### PR TITLE
Allow publishing/receiving from specific partitions in a topic, other stuff

### DIFF
--- a/clients/go/internal/models/publish_out_msg.go
+++ b/clients/go/internal/models/publish_out_msg.go
@@ -3,6 +3,6 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type PublishOutMsg struct {
-	Offset    uint64 `json:"offset"`
-	Partition uint16 `json:"partition"`
+	Offset uint64 `json:"offset"`
+	Topic  string `json:"topic"`
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/PublishOutMsg.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/PublishOutMsg.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class PublishOutMsg {
 @JsonProperty private Long offset;
-@JsonProperty private Short partition;
+@JsonProperty private String topic;
 public PublishOutMsg () {}
 
  public PublishOutMsg offset(Long offset) {
@@ -51,23 +51,23 @@ public PublishOutMsg () {}
         this.offset = offset;
     }
 
-     public PublishOutMsg partition(Short partition) {
-        this.partition = partition;
+     public PublishOutMsg topic(String topic) {
+        this.topic = topic;
         return this;
     }
 
     /**
-    * Get partition
+    * Get topic
     *
-     * @return partition
+     * @return topic
      */
     @javax.annotation.Nonnull
-     public Short getPartition() {
-        return partition;
+     public String getTopic() {
+        return topic;
     }
 
-     public void setPartition(Short partition) {
-        this.partition = partition;
+     public void setTopic(String topic) {
+        this.topic = topic;
     }
 
     /**

--- a/clients/javascript/src/models/publishOutMsg.ts
+++ b/clients/javascript/src/models/publishOutMsg.ts
@@ -6,21 +6,21 @@
 
 export interface PublishOutMsg {
     offset: number;
-partition: number;
+topic: string;
 }
 
 export const PublishOutMsgSerializer = {
     _fromJsonObject(object: any): PublishOutMsg {
         return {
             offset: object['offset'],
-            partition: object['partition'],
+            topic: object['topic'],
             };
     },
 
     _toJsonObject(self: PublishOutMsg): any {
         return {
             'offset': self.offset,
-            'partition': self.partition,
+            'topic': self.topic,
             };
     }
 }

--- a/clients/python/coyote/models/publish_out_msg.py
+++ b/clients/python/coyote/models/publish_out_msg.py
@@ -6,4 +6,4 @@ from ..internal.base_model import BaseModel
 class PublishOutMsg(BaseModel):
     offset: int
 
-    partition: int
+    topic: str

--- a/clients/rust/src/models/publish_out_msg.rs
+++ b/clients/rust/src/models/publish_out_msg.rs
@@ -6,11 +6,11 @@ use serde::{Deserialize, Serialize};
 pub struct PublishOutMsg {
     pub offset: u64,
 
-    pub partition: u16,
+    pub topic: String,
 }
 
 impl PublishOutMsg {
-    pub fn new(offset: u64, partition: u16) -> Self {
-        Self { offset, partition }
+    pub fn new(offset: u64, topic: String) -> Self {
+        Self { offset, topic }
     }
 }

--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -49,6 +49,19 @@ impl Error {
     }
 
     #[track_caller]
+    pub fn invalid_user_input(s: impl fmt::Display) -> Self {
+        // We'll probably change _how_ invalid user input is displayed later on,
+        // but having a universal error function to capture user errors is ideal
+        Self::new(ErrorType::Http(HttpError {
+            status: StatusCode::BAD_REQUEST,
+            body: HttpErrorBody::Standard(StandardHttpError {
+                code: "invalid_input".to_owned(),
+                detail: s.to_string(),
+            }),
+        }))
+    }
+
+    #[track_caller]
     pub fn validation(s: impl fmt::Display) -> Self {
         Self::new(ErrorType::Validation(s.to_string()))
     }

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt, ops::Deref};
 
+use coyote_error::Error;
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -9,19 +10,23 @@ pub type Offset = u64;
 
 pub const DEFAULT_PARTITION_COUNT: u16 = 1;
 
-/// Hard ceiling on partition count per topic. Arbitrary for now — may be raised later.
+/// Arbitrary for now — may be raised later.
 pub const MAX_PARTITION_COUNT: u16 = 64;
+
+pub const TOPIC_PARTITION_DELIMITER: &str = "~";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct PartitionIndex(u16);
+pub struct Partition(u16);
 
-impl PartitionIndex {
-    pub fn new(index: u16) -> Option<Self> {
+impl Partition {
+    pub fn new(index: u16) -> Result<Self, Error> {
         if index < MAX_PARTITION_COUNT {
-            Some(Self(index))
+            Ok(Self(index))
         } else {
-            None
+            Err(Error::invalid_user_input(format!(
+                "partition cannot be higher than {MAX_PARTITION_COUNT}"
+            )))
         }
     }
 
@@ -30,32 +35,183 @@ impl PartitionIndex {
     }
 }
 
-/// Builds the partition-level topic name: `"{topic}~{partition}"`.
-pub fn partition_topic_name(topic: &str, partition: PartitionIndex) -> String {
-    format!("{topic}~{}", partition.0)
+/// A topic identifier without the partition.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RawTopic(String);
+
+impl RawTopic {
+    pub fn new(s: String) -> Result<Self, Error> {
+        if s.contains(TOPIC_PARTITION_DELIMITER) {
+            Err(Error::generic("invalid topic"))
+        } else if s.len() > 64 {
+            // arbitrary limit for now. If you want to change this, just do it.
+            // No need to tag me or make a ticket or something.
+            Err(Error::generic("topic cannot exceed 64 bytes"))
+        } else {
+            Ok(Self(s))
+        }
+    }
 }
 
-/// Splits a partition-level topic name back into `(topic, partition)`.
-pub fn parse_partition_topic(s: &str) -> Result<(&str, PartitionIndex), &'static str> {
-    let (topic, idx_str) = s
-        .rsplit_once('~')
-        .ok_or("missing '~' separator in partition topic name")?;
-    let idx: u16 = idx_str
-        .parse()
-        .map_err(|_| "invalid partition index in topic name")?;
-    PartitionIndex::new(idx)
-        .map(|p| (topic, p))
-        .ok_or("partition index out of range")
+impl Deref for RawTopic {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
 }
 
-pub fn random_partition(partition_count: u16) -> PartitionIndex {
-    PartitionIndex(rand::random_range(..partition_count))
+impl fmt::Display for RawTopic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl JsonSchema for RawTopic {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        String::schema_name()
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Topic {
+    pub raw: RawTopic,
+    pub partition: Partition,
+}
+
+impl Topic {
+    pub fn new(raw: RawTopic, partition: Partition) -> Self {
+        Self { raw, partition }
+    }
+}
+
+impl TryFrom<String> for Topic {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let (topic, idx_str) = value
+            .rsplit_once(TOPIC_PARTITION_DELIMITER)
+            .ok_or_else(|| Error::generic("missing '~' separator in topic"))?;
+        let idx: u16 = idx_str
+            .parse()
+            .map_err(|_| Error::generic("invalid partition index in topic"))?;
+        let partition = Partition::new(idx)?;
+        let raw = RawTopic::new(topic.to_owned())?;
+        Ok(Self { raw, partition })
+    }
+}
+
+impl fmt::Display for Topic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{}{}",
+            self.raw.0, TOPIC_PARTITION_DELIMITER, self.partition.0
+        )
+    }
+}
+
+impl Serialize for Topic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for Topic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Topic::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl JsonSchema for Topic {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        String::schema_name()
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
+    }
+}
+
+/// Topic input from the user, which may or may not contain the partition.
+// TODO: remove Serialize — only needed temporarily for Raft operation serialization.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum TopicIn {
+    Raw(RawTopic),
+    WithPartition(Topic),
+}
+
+impl TopicIn {
+    /// Returns the raw topic name (without partition suffix).
+    pub fn raw_topic(&self) -> &RawTopic {
+        match self {
+            TopicIn::Raw(raw) => raw,
+            TopicIn::WithPartition(topic) => &topic.raw,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TopicIn {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s.contains(TOPIC_PARTITION_DELIMITER) {
+            Topic::try_from(s)
+                .map(TopicIn::WithPartition)
+                .map_err(serde::de::Error::custom)
+        } else {
+            RawTopic::new(s)
+                .map(TopicIn::Raw)
+                .map_err(serde::de::Error::custom)
+        }
+    }
+}
+
+impl JsonSchema for TopicIn {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        String::schema_name()
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
+    }
+}
+
+pub fn random_partition(partition_count: u16) -> Partition {
+    Partition(rand::random_range(..partition_count))
 }
 
 /// Deterministically maps a key to a partition via hash.
-pub fn partition_for_key(key: &[u8], partition_count: u16) -> PartitionIndex {
+pub fn partition_for_key(key: &[u8], partition_count: u16) -> Partition {
     let hash = djb2_hash(key);
-    PartitionIndex((hash % u32::from(partition_count)) as u16)
+    Partition((hash % u32::from(partition_count)) as u16)
 }
 
 fn djb2_hash(data: &[u8]) -> u32 {
@@ -67,26 +223,60 @@ fn djb2_hash(data: &[u8]) -> u32 {
 }
 
 /// An opaque message ID that internally encodes `(partition, offset)`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
-#[serde(transparent)]
-pub struct MsgId(String);
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MsgId {
+    pub partition: Partition,
+    pub offset: Offset,
+}
 
 impl MsgId {
-    pub fn new(partition: PartitionIndex, offset: Offset) -> Self {
-        Self(format!("{}:{offset}", partition.get()))
-    }
-
-    pub fn decode(&self) -> Option<(PartitionIndex, Offset)> {
-        let (part_str, offset_str) = self.0.split_once(':')?;
-        let part: u16 = part_str.parse().ok()?;
-        let offset: Offset = offset_str.parse().ok()?;
-        Some((PartitionIndex::new(part)?, offset))
+    pub fn new(partition: Partition, offset: Offset) -> Self {
+        Self { partition, offset }
     }
 }
 
 impl fmt::Display for MsgId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        write!(f, "{}:{}", self.partition.0, self.offset)
+    }
+}
+
+impl Serialize for MsgId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for MsgId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let (part_str, off_str) = s
+            .split_once(':')
+            .ok_or_else(|| serde::de::Error::custom("Invalid MsgId"))?;
+        let partition: u16 = part_str.parse().map_err(serde::de::Error::custom)?;
+        let offset: Offset = off_str.parse().map_err(serde::de::Error::custom)?;
+        let partition = Partition::new(partition).map_err(serde::de::Error::custom)?;
+        Ok(MsgId { partition, offset })
+    }
+}
+
+impl JsonSchema for MsgId {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        String::schema_name()
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
     }
 }
 
@@ -102,7 +292,7 @@ pub struct MsgIn {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct StreamMsgOut {
     pub offset: Offset,
-    pub topic: String,
+    pub topic: Topic,
     pub value: Vec<u8>,
     #[serde(default)]
     pub headers: HashMap<String, String>,

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -1,9 +1,13 @@
 use coyote_error::Error;
+use coyote_namespace::entities::NamespaceId;
 use fjall::KeyspaceCreateOptions;
+use fjall_utils::{ReadableDatabase, ReadableKeyspace};
 
 pub mod entities;
 pub mod operations;
 pub(crate) mod tables;
+
+const METADATA_KEYSPACE: &str = "_coyote_msgs_metadata";
 
 #[derive(Clone)]
 pub struct State {
@@ -14,7 +18,6 @@ pub struct State {
 
 impl State {
     pub fn init(db: fjall::Database) -> Result<Self, Error> {
-        const METADATA_KEYSPACE: &str = "_coyote_msgs_metadata";
         const MSG_TABLE_KEYSPACE: &str = "_coyote_msgs";
 
         let metadata_tables = {
@@ -33,4 +36,35 @@ impl State {
             msg_table,
         })
     }
+}
+
+/// Reads the configured partition count for a topic from a database handle.
+pub fn topic_partition_count(
+    db: &impl ReadableDatabase,
+    ns_id: NamespaceId,
+    topic: &str,
+) -> coyote_error::Result<u16> {
+    let metadata = db.keyspace(METADATA_KEYSPACE)?;
+    let key = tables::topic_config_key(ns_id, topic);
+    match metadata.get(&key)? {
+        Some(val) => {
+            let config: tables::TopicConfig =
+                rmp_serde::from_slice(&val).map_err(Error::generic)?;
+            Ok(config.partition_count)
+        }
+        None => Ok(entities::DEFAULT_PARTITION_COUNT),
+    }
+}
+
+/// Checks whether a partition has any active (unexpired, unacked, non-DLQ) lease
+/// for the given consumer group.
+pub fn partition_has_active_lease(
+    db: &impl ReadableDatabase,
+    ns_id: NamespaceId,
+    partition: entities::Partition,
+    cg: &entities::ConsumerGroup,
+    now: jiff::Timestamp,
+) -> coyote_error::Result<bool> {
+    let metadata = db.keyspace(METADATA_KEYSPACE)?;
+    tables::LeaseRow::has_active_lease_in(&metadata, ns_id, partition, cg, now)
 }

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -4,9 +4,13 @@ use coyote_namespace::entities::NamespaceId;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
+use fjall_utils::ReadableDatabase;
+
 use crate::{
     State,
-    entities::{MsgIn, Offset, PartitionIndex, partition_for_key},
+    entities::{
+        MsgIn, Offset, Partition, RawTopic, Topic, TopicIn, partition_for_key, random_partition,
+    },
     tables::{MsgRow, msg_row_key},
 };
 
@@ -15,48 +19,60 @@ use super::{MsgsRaftState, MsgsRequest, PublishResponse};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublishOperation {
     namespace_id: NamespaceId,
-    topic: String,
+    topic: RawTopic,
+    partition_count: u16,
+    /// The partition used for messages without a key.
+    fallback_partition: Partition,
     msgs: Vec<MsgIn>,
-    /// Partition assigned to messages without a key.
-    ///
-    /// Chosen randomly by the caller so the Raft state machine stays deterministic.
-    keyless_partition: PartitionIndex,
     created_at: Timestamp,
 }
 
 impl PublishOperation {
     pub fn new(
+        db: &impl ReadableDatabase,
         namespace_id: NamespaceId,
-        topic: String,
+        topic: TopicIn,
         msgs: Vec<MsgIn>,
-        keyless_partition: PartitionIndex,
-    ) -> Self {
-        Self {
+    ) -> coyote_error::Result<Self> {
+        let partition_count = crate::topic_partition_count(db, namespace_id, topic.raw_topic())?;
+
+        let (topic, fallback_partition) = match topic {
+            TopicIn::WithPartition(t) => (t.raw, t.partition),
+            TopicIn::Raw(raw) => (raw, random_partition(partition_count)),
+        };
+
+        if fallback_partition.get() >= partition_count {
+            return Err(coyote_error::Error::http(
+                coyote_error::HttpError::bad_request(
+                    Some("partition_out_of_range".to_owned()),
+                    Some(format!(
+                        "Partition {} is out of range. Topic has {} partition(s). \
+                         Use topic/configure to increase the partition count.",
+                        fallback_partition.get(),
+                        partition_count,
+                    )),
+                ),
+            ));
+        }
+
+        Ok(Self {
             namespace_id,
             topic,
+            partition_count,
+            fallback_partition,
             msgs,
-            keyless_partition,
             created_at: Timestamp::now(),
-        }
+        })
     }
 
     fn apply_real(self, state: &State) -> coyote_operations::Result<PublishResponseData> {
-        let partition_count =
-            crate::tables::topic_partition_count(state, self.namespace_id, &self.topic)?;
-
-        // Clamp the pre-chosen keyless partition to the topic's actual count.
-        let keyless_partition = PartitionIndex::new(self.keyless_partition.get() % partition_count)
-            .expect("clamped value is always in range");
-
-        let mut by_partition: BTreeMap<PartitionIndex, Vec<(usize, MsgIn)>> = BTreeMap::new();
-
+        let mut by_partition: BTreeMap<Partition, Vec<(usize, MsgIn)>> = BTreeMap::new();
         for (idx, msg) in self.msgs.into_iter().enumerate() {
             let partition = if let Some(key) = &msg.key {
-                partition_for_key(key.as_bytes(), partition_count)
+                partition_for_key(key.as_bytes(), self.partition_count)
             } else {
-                keyless_partition
+                self.fallback_partition
             };
-
             by_partition.entry(partition).or_default().push((idx, msg));
         }
 
@@ -77,7 +93,13 @@ impl PublishOperation {
                 };
                 let key = msg_row_key(self.namespace_id, partition, offset);
                 batch.insert(&state.msg_table, key, row.to_fjall_value()?);
-                results.push((original_idx, PublishedMsg { partition, offset }));
+                results.push((
+                    original_idx,
+                    PublishedMsg {
+                        topic: Topic::new(self.topic.clone(), partition),
+                        offset,
+                    },
+                ));
             }
         }
 
@@ -93,7 +115,7 @@ impl PublishOperation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublishedMsg {
-    pub partition: PartitionIndex,
+    pub topic: Topic,
     pub offset: Offset,
 }
 

--- a/crates/msgs/src/operations/stream_commit.rs
+++ b/crates/msgs/src/operations/stream_commit.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     State,
-    entities::{ConsumerGroup, Offset, PartitionIndex},
+    entities::{ConsumerGroup, Offset, Partition},
     tables::{LeaseDiff, LeaseRow, OffsetRow},
 };
 
@@ -13,7 +13,7 @@ use super::{MsgsRaftState, MsgsRequest, StreamCommitResponse};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamCommitOperation {
     namespace_id: NamespaceId,
-    partition: PartitionIndex,
+    partition: Partition,
     cg: ConsumerGroup,
     offset: Offset,
     now: Timestamp,
@@ -22,7 +22,7 @@ pub struct StreamCommitOperation {
 impl StreamCommitOperation {
     pub fn new(
         namespace_id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
         cg: ConsumerGroup,
         offset: Offset,
     ) -> Self {

--- a/crates/msgs/src/operations/stream_receive.rs
+++ b/crates/msgs/src/operations/stream_receive.rs
@@ -1,12 +1,13 @@
 use std::num::NonZeroU16;
 
 use coyote_namespace::entities::NamespaceId;
+use fjall_utils::ReadableDatabase;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     State,
-    entities::{ConsumerGroup, Offset, PartitionIndex, partition_topic_name},
+    entities::{ConsumerGroup, Offset, Partition, RawTopic, Topic, TopicIn},
     tables::{LeaseDiff, LeaseRow, MsgRow, OffsetRow},
 };
 
@@ -38,7 +39,7 @@ fn group_into_contiguous_ranges(offsets: &[Offset]) -> Vec<(Offset, Offset)> {
 fn create_leases_for_msgs(
     offsets: &[Offset],
     namespace_id: NamespaceId,
-    partition: PartitionIndex,
+    partition: Partition,
     cg: &ConsumerGroup,
     now: Timestamp,
     lease_duration: std::time::Duration,
@@ -63,7 +64,8 @@ fn create_leases_for_msgs(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamReceiveOperation {
     namespace_id: NamespaceId,
-    topic: String,
+    topic: RawTopic,
+    partitions: Vec<Partition>,
     cg: ConsumerGroup,
     batch_size: NonZeroU16,
     lease_duration_millis: u64,
@@ -72,20 +74,40 @@ pub struct StreamReceiveOperation {
 
 impl StreamReceiveOperation {
     pub fn new(
+        db: &impl ReadableDatabase,
         namespace_id: NamespaceId,
-        topic: String,
+        topic: TopicIn,
         cg: ConsumerGroup,
         batch_size: NonZeroU16,
         lease_duration_millis: u64,
-    ) -> Self {
-        Self {
+    ) -> coyote_error::Result<Self> {
+        let now = Timestamp::now();
+        let raw_topic = topic.raw_topic().clone();
+        let partition_count = crate::topic_partition_count(db, namespace_id, &raw_topic)?;
+
+        let all_partitions: Vec<Partition> = match topic {
+            TopicIn::WithPartition(t) => vec![t.partition],
+            TopicIn::Raw(_) => (0..partition_count)
+                .map(|p| Partition::new(p).expect("partition index is within MAX_PARTITION_COUNT"))
+                .collect(),
+        };
+
+        let mut partitions = Vec::with_capacity(all_partitions.len());
+        for p in all_partitions {
+            if !crate::partition_has_active_lease(db, namespace_id, p, &cg, now)? {
+                partitions.push(p);
+            }
+        }
+
+        Ok(Self {
             namespace_id,
-            topic,
+            topic: raw_topic,
+            partitions,
             cg,
             batch_size,
             lease_duration_millis,
-            now: Timestamp::now(),
-        }
+            now,
+        })
     }
 
     fn apply_real(self, state: &State) -> coyote_operations::Result<StreamReceiveResponseData> {
@@ -94,31 +116,16 @@ impl StreamReceiveOperation {
         let mut all_msgs = Vec::new();
         let mut all_lease_diffs = Vec::new();
         let mut remaining = usize::from(self.batch_size.get());
-        let mut any_partition_locked = false;
 
-        let partition_count =
-            crate::tables::topic_partition_count(state, self.namespace_id, &self.topic)?;
-
-        for p in 0..partition_count {
+        for partition in self.partitions {
             if remaining == 0 {
                 break;
             }
-            let partition =
-                PartitionIndex::new(p).expect("partition index is within MAX_PARTITION_COUNT");
 
             let start_offset = OffsetRow::fetch(state, self.namespace_id, partition, &self.cg)?
                 .unwrap_or(Offset::MIN);
 
             let leases = LeaseRow::fetch_all(state, self.namespace_id, partition, &self.cg)?;
-
-            // If any active lease exists on this partition, skip it entirely
-            let has_active_lease = leases.iter().any(|l| l.is_active(now));
-            if has_active_lease {
-                any_partition_locked = true;
-                all_lease_diffs.push(LeaseRow::cull_and_compact(leases, now));
-                continue;
-            }
-
             let blocked_leases = leases.iter().filter(|l| l.acked_at.is_some() || l.is_dlq());
 
             let batch_size = remaining;
@@ -149,7 +156,7 @@ impl StreamReceiveOperation {
             for (offset, msg) in msgs {
                 all_msgs.push(StreamReceiveMsg {
                     offset,
-                    topic: partition_topic_name(&self.topic, partition),
+                    topic: Topic::new(self.topic.clone(), partition),
                     value: msg.value,
                     headers: msg.headers,
                     timestamp: msg.created_at,
@@ -165,15 +172,6 @@ impl StreamReceiveOperation {
         }
         batch.commit().map_err(coyote_error::Error::from)?;
 
-        // If we got no messages and at least one partition was locked, return an error
-        // so the caller knows to retry after committing or waiting for lease expiry.
-        if all_msgs.is_empty() && any_partition_locked {
-            return Err(coyote_error::Error::http(coyote_error::HttpError::bad_request(
-                Some("partition_locked".to_owned()),
-                Some("All partitions with pending messages are locked by active leases. Commit offsets or wait for lease expiry.".to_owned()),
-            )).into());
-        }
-
         Ok(StreamReceiveResponseData { msgs: all_msgs })
     }
 }
@@ -181,7 +179,7 @@ impl StreamReceiveOperation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamReceiveMsg {
     pub offset: Offset,
-    pub topic: String,
+    pub topic: Topic,
     pub value: Vec<u8>,
     pub headers: std::collections::HashMap<String, String>,
     pub timestamp: Timestamp,

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     State,
-    entities::MAX_PARTITION_COUNT,
+    entities::{MAX_PARTITION_COUNT, RawTopic},
     tables::{TopicConfig, TopicConfigRow, topic_partition_count},
 };
 
@@ -12,12 +12,12 @@ use super::{MsgsRaftState, MsgsRequest, TopicConfigureResponse};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TopicConfigureOperation {
     namespace_id: NamespaceId,
-    topic: String,
+    topic: RawTopic,
     partitions: u16,
 }
 
 impl TopicConfigureOperation {
-    pub fn new(namespace_id: NamespaceId, topic: String, partitions: u16) -> Self {
+    pub fn new(namespace_id: NamespaceId, topic: RawTopic, partitions: u16) -> Self {
         Self {
             namespace_id,
             topic,

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -3,13 +3,13 @@ use std::{borrow::Cow, collections::HashMap, ops::RangeInclusive};
 use coyote_error::{Error, Result};
 use coyote_namespace::entities::NamespaceId;
 use fjall::OwnedWriteBatch;
-use fjall_utils::{TableKey, TableRow};
+use fjall_utils::{ReadableKeyspace, TableKey, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     State,
-    entities::{ConsumerGroup, Offset, PartitionIndex},
+    entities::{ConsumerGroup, Offset, Partition},
 };
 
 #[derive(Serialize, Deserialize)]
@@ -23,11 +23,7 @@ const MSG_KEY_LEN: usize = size_of::<NamespaceId>() + size_of::<u16>() + size_of
 
 type MsgRowKey = [u8; MSG_KEY_LEN];
 
-pub(crate) fn msg_row_key(
-    ns_id: NamespaceId,
-    partition: PartitionIndex,
-    offset: Offset,
-) -> MsgRowKey {
+pub(crate) fn msg_row_key(ns_id: NamespaceId, partition: Partition, offset: Offset) -> MsgRowKey {
     let mut key = [0u8; MSG_KEY_LEN];
     let ns_bytes = ns_id.as_u128().to_be_bytes();
     key[..16].copy_from_slice(&ns_bytes);
@@ -43,7 +39,7 @@ fn parse_msg_offset(key: MsgRowKey) -> Result<Offset> {
 
 pub(crate) fn msg_row_key_range(
     ns_id: NamespaceId,
-    partition: PartitionIndex,
+    partition: Partition,
     offsets: RangeInclusive<Offset>,
 ) -> RangeInclusive<MsgRowKey> {
     msg_row_key(ns_id, partition, *offsets.start())..=msg_row_key(ns_id, partition, *offsets.end())
@@ -53,7 +49,7 @@ impl MsgRow {
     pub(crate) fn max_offset(
         state: &State,
         ns_id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
     ) -> Result<Option<Offset>> {
         let range = msg_row_key_range(ns_id, partition, Offset::MIN..=Offset::MAX);
 
@@ -74,7 +70,7 @@ impl MsgRow {
     pub(crate) fn next_offset(
         state: &State,
         ns_id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
     ) -> Result<Offset> {
         match Self::max_offset(state, ns_id, partition)? {
             None => Ok(Offset::MIN),
@@ -91,7 +87,7 @@ impl MsgRow {
     fn fetch_in_range(
         state: &State,
         ns_id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
         offsets: RangeInclusive<Offset>,
         buf: &mut Vec<(Offset, MsgRow)>,
         batch_size: usize,
@@ -116,7 +112,7 @@ impl MsgRow {
     pub(crate) fn fetch_available<'a>(
         state: &State,
         ns_id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
         start_offset: Offset,
         blocked_leases: impl IntoIterator<Item = &'a LeaseRow>,
         batch_size: usize,
@@ -172,7 +168,7 @@ impl MsgRow {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct LeaseRow {
     pub namespace_id: NamespaceId,
-    pub partition: PartitionIndex,
+    pub partition: Partition,
     pub cg: ConsumerGroup,
     pub block_start: Offset,
     pub block_end: Offset,
@@ -191,7 +187,7 @@ pub(crate) struct LeaseKey(Vec<u8>);
 impl LeaseKey {
     pub(crate) fn new(
         id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
         cg: &ConsumerGroup,
         block_end: Offset,
     ) -> Self {
@@ -212,7 +208,7 @@ impl LeaseKey {
         Self(key)
     }
 
-    fn prefix(id: NamespaceId, partition: PartitionIndex, cg: &ConsumerGroup) -> Vec<u8> {
+    fn prefix(id: NamespaceId, partition: Partition, cg: &ConsumerGroup) -> Vec<u8> {
         let id_bytes = id.as_u128().to_be_bytes();
         let part_bytes = partition.get().to_be_bytes();
 
@@ -287,7 +283,7 @@ impl LeaseRow {
     pub(crate) fn fetch_all(
         state: &State,
         id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
         cg: &ConsumerGroup,
     ) -> Result<Vec<Self>> {
         let prefix = LeaseKey::prefix(id, partition, cg);
@@ -300,6 +296,24 @@ impl LeaseRow {
                 Self::from_fjall_value(value)
             })
             .collect()
+    }
+
+    pub(crate) fn has_active_lease_in(
+        keyspace: &impl ReadableKeyspace,
+        id: NamespaceId,
+        partition: Partition,
+        cg: &ConsumerGroup,
+        now: Timestamp,
+    ) -> Result<bool> {
+        let prefix = LeaseKey::prefix(id, partition, cg);
+        for entry in keyspace.prefix(prefix) {
+            let value = entry.value()?;
+            let lease = Self::from_fjall_value(value)?;
+            if lease.is_active(now) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     /// Cull expired leases and compact adjacent acked/DLQ'd leases.
@@ -482,7 +496,7 @@ fn merge_lease_ranges<'a>(leases: impl Iterator<Item = &'a LeaseRow>) -> Vec<Blo
 
 const OFFSET_PREFIX: &[u8] = b"_MSGOFFSET_\0";
 
-fn offset_key(ns_id: NamespaceId, partition: PartitionIndex, cg: &ConsumerGroup) -> Vec<u8> {
+fn offset_key(ns_id: NamespaceId, partition: Partition, cg: &ConsumerGroup) -> Vec<u8> {
     let mut key = Vec::with_capacity(OFFSET_PREFIX.len() + 16 + 2 + 1 + cg.len());
     key.extend_from_slice(OFFSET_PREFIX);
     key.extend_from_slice(&ns_id.as_u128().to_be_bytes());
@@ -498,7 +512,7 @@ impl OffsetRow {
     pub(crate) fn fetch(
         state: &State,
         ns_id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
         cg: &ConsumerGroup,
     ) -> Result<Option<Offset>> {
         let key = offset_key(ns_id, partition, cg);
@@ -515,7 +529,7 @@ impl OffsetRow {
         batch: &mut OwnedWriteBatch,
         state: &State,
         ns_id: NamespaceId,
-        partition: PartitionIndex,
+        partition: Partition,
         cg: &ConsumerGroup,
         offset: Offset,
     ) -> Result<()> {
@@ -538,7 +552,7 @@ pub(crate) struct TopicConfig {
     pub partition_count: u16,
 }
 
-fn topic_config_key(ns_id: NamespaceId, topic: &str) -> Vec<u8> {
+pub(crate) fn topic_config_key(ns_id: NamespaceId, topic: &str) -> Vec<u8> {
     let mut key = Vec::with_capacity(TOPIC_CONFIG_PREFIX.len() + 16 + 1 + topic.len());
     key.extend_from_slice(TOPIC_CONFIG_PREFIX);
     key.extend_from_slice(&ns_id.as_u128().to_be_bytes());

--- a/openapi.json
+++ b/openapi.json
@@ -1447,11 +1447,8 @@
       "PublishOutMsg": {
         "type": "object",
         "properties": {
-          "partition": {
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0,
-            "maximum": 65535
+          "topic": {
+            "type": "string"
           },
           "offset": {
             "type": "integer",
@@ -1460,7 +1457,7 @@
           }
         },
         "required": [
-          "partition",
+          "topic",
           "offset"
         ]
       },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,7 @@ pub struct AppState {
 
     namespace_state: coyote_namespace::State,
 
-    #[allow(dead_code)]
-    ro_dbs: ReadonlyDatabases,
+    pub(crate) ro_dbs: ReadonlyDatabases,
 }
 
 async fn run_interserver(

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -1,11 +1,18 @@
 use std::num::NonZeroU16;
 
-use crate::{AppState, core::cluster::RaftState, v1::utils::openapi_tag};
+use crate::{
+    AppState,
+    core::{cluster::RaftState, db::ReadonlyConnection},
+    v1::utils::openapi_tag,
+};
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_derive::aide_annotate;
 use coyote_error::{Error, HttpError, Result, ResultExt};
-use coyote_msgs::entities::MAX_PARTITION_COUNT;
+use coyote_msgs::{
+    entities::{MAX_PARTITION_COUNT, RawTopic, Topic, TopicIn},
+    operations::{PublishOperation, StreamReceiveOperation},
+};
 use coyote_namespace::entities::StorageType;
 use coyote_proto::MsgPackOrJson;
 use jiff::Timestamp;
@@ -96,16 +103,16 @@ async fn get_namespace(
     }))
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
 struct PublishIn {
     pub name: String,
-    pub topic: String,
+    pub topic: TopicIn,
     pub msgs: Vec<coyote_msgs::entities::MsgIn>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct PublishOutMsg {
-    pub partition: u16,
+    pub topic: Topic,
     pub offset: u64,
 }
 
@@ -121,25 +128,13 @@ async fn publish(
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<PublishIn>,
 ) -> Result<MsgPackOrJson<PublishOut>> {
-    if data.topic.contains('~') {
-        return Err(Error::http(HttpError::bad_request(
-            Some("invalid_topic".to_owned()),
-            Some("Topic name must not contain '~'. Use the partition key to route messages to a specific partition.".to_owned()),
-        )));
-    }
-
     let namespace = state
         .namespace_state
         .fetch_stream_namespace(&data.name)?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
-    let keyless_partition = coyote_msgs::entities::random_partition(MAX_PARTITION_COUNT);
-    let operation = coyote_msgs::operations::PublishOperation::new(
-        namespace.id,
-        data.topic,
-        data.msgs,
-        keyless_partition,
-    );
+    let ro_db = state.ro_dbs.db_for(namespace.storage_type);
+    let operation = PublishOperation::new(&ro_db, namespace.id, data.topic, data.msgs)?;
     let response = repl.client_write(operation).await.map_err_generic()?.0?;
 
     Ok(MsgPackOrJson(PublishOut {
@@ -147,7 +142,7 @@ async fn publish(
             .msgs
             .into_iter()
             .map(|m| PublishOutMsg {
-                partition: m.partition.get(),
+                topic: m.topic,
                 offset: m.offset,
             })
             .collect(),
@@ -166,10 +161,10 @@ fn default_lease_duration_millis() -> u64 {
     300_000 // 5 minutes
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
 struct StreamReceiveIn {
     pub name: String,
-    pub topic: String,
+    pub topic: TopicIn,
     pub consumer_group: coyote_msgs::entities::ConsumerGroup,
     #[serde(default = "default_batch_size")]
     pub batch_size: NonZeroU16,
@@ -197,13 +192,15 @@ async fn stream_receive(
         .fetch_stream_namespace(&data.name)?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
-    let operation = coyote_msgs::operations::StreamReceiveOperation::new(
+    let ro_db = state.ro_dbs.db_for(namespace.storage_type);
+    let operation = StreamReceiveOperation::new(
+        &ro_db,
         namespace.id,
         data.topic,
         data.consumer_group,
         data.batch_size,
         data.lease_duration_millis,
-    );
+    )?;
     let response = repl.client_write(operation).await.map_err_generic()?.0?;
 
     Ok(MsgPackOrJson(StreamReceiveOut {
@@ -225,10 +222,10 @@ async fn stream_receive(
 // stream/commit
 // ---------------------------------------------------------------------------
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
 struct StreamCommitIn {
     pub name: String,
-    pub topic: String,
+    pub topic: Topic,
     pub consumer_group: coyote_msgs::entities::ConsumerGroup,
     pub offset: u64,
 }
@@ -246,14 +243,6 @@ async fn stream_commit(
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<StreamCommitIn>,
 ) -> Result<MsgPackOrJson<StreamCommitOut>> {
-    let (_topic, partition) =
-        coyote_msgs::entities::parse_partition_topic(&data.topic).map_err(|msg| {
-            Error::http(HttpError::bad_request(
-                Some("invalid_topic".to_owned()),
-                Some(msg.to_owned()),
-            ))
-        })?;
-
     let namespace = state
         .namespace_state
         .fetch_stream_namespace(&data.name)?
@@ -261,7 +250,7 @@ async fn stream_commit(
 
     let operation = coyote_msgs::operations::StreamCommitOperation::new(
         namespace.id,
-        partition,
+        data.topic.partition,
         data.consumer_group,
         data.offset,
     );
@@ -274,10 +263,10 @@ async fn stream_commit(
 // topic/configure
 // ---------------------------------------------------------------------------
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
 struct TopicConfigureIn {
     pub name: String,
-    pub topic: String,
+    pub topic: RawTopic,
     pub partitions: u16,
 }
 
@@ -295,13 +284,6 @@ async fn topic_configure(
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<TopicConfigureIn>,
 ) -> Result<MsgPackOrJson<TopicConfigureOut>> {
-    if data.topic.contains('~') {
-        return Err(Error::http(HttpError::bad_request(
-            Some("invalid_topic".to_owned()),
-            Some("Topic name must not contain '~'.".to_owned()),
-        )));
-    }
-
     if data.partitions == 0 || data.partitions > MAX_PARTITION_COUNT {
         return Err(Error::http(HttpError::bad_request(
             Some("invalid_partition_count".to_owned()),

--- a/tests/it/msgs/publish.rs
+++ b/tests/it/msgs/publish.rs
@@ -35,9 +35,9 @@ async fn publish_to_topic() -> TestResult {
     let msgs = response["msgs"].as_array().unwrap();
     assert_eq!(msgs.len(), 2);
 
-    // Each message should have a partition and offset
+    // Each message should have a topic (with partition) and offset
     for m in msgs {
-        assert!(m["partition"].is_u64());
+        assert!(m["topic"].as_str().unwrap().starts_with("my-topic~"));
         assert!(m["offset"].is_u64());
     }
 
@@ -76,10 +76,11 @@ async fn publish_with_partition_key() -> TestResult {
     let msgs = response["msgs"].as_array().unwrap();
     assert_eq!(msgs.len(), 3);
 
-    // All messages with the same key must land in the same partition
-    let partition = msgs[0]["partition"].as_u64().unwrap();
+    // All messages with the same key must land in the same partition topic
+    let topic = msgs[0]["topic"].as_str().unwrap();
+    assert!(topic.starts_with("keyed-topic~"));
     for m in msgs {
-        assert_eq!(m["partition"].as_u64().unwrap(), partition);
+        assert_eq!(m["topic"].as_str().unwrap(), topic);
     }
 
     // Offsets should be sequential within the partition
@@ -91,7 +92,7 @@ async fn publish_with_partition_key() -> TestResult {
 }
 
 #[tokio::test]
-async fn publish_rejects_partition_topic() -> TestResult {
+async fn publish_directly_to_partition() -> TestResult {
     let TestContext {
         client,
         handle: _handle,
@@ -100,19 +101,96 @@ async fn publish_rejects_partition_topic() -> TestResult {
 
     client
         .post("msgs/namespace/create")
-        .json(json!({ "name": "ns-part" }))
+        .json(json!({ "name": "ns-direct" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Configure the topic to have 4 partitions.
+    client
+        .post("msgs/topic/configure")
+        .json(json!({ "name": "ns-direct", "topic": "my-topic", "partitions": 4 }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("msgs/publish")
+        .json(json!({
+            "name": "ns-direct",
+            "topic": "my-topic~2",
+            "msgs": [
+                { "value": "a".as_bytes() },
+                { "value": "b".as_bytes() },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].as_array().unwrap();
+    assert_eq!(msgs.len(), 2);
+
+    for m in msgs {
+        assert_eq!(m["topic"].as_str().unwrap(), "my-topic~2");
+    }
+
+    let offsets: Vec<u64> = msgs.iter().map(|m| m["offset"].as_u64().unwrap()).collect();
+    assert_eq!(offsets[1], offsets[0] + 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn publish_rejects_out_of_range_partition() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-range" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Default topic has 1 partition (index 0 only).
+    // Publishing to partition 1 should fail.
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "name": "ns-range",
+            "topic": "my-topic~1",
+            "msgs": [{ "value": "a".as_bytes() }],
+        }))
+        .await?
+        .expect(StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn publish_rejects_malformed_partition_topic() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-bad" }))
         .await?
         .expect(StatusCode::OK);
 
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-part",
-            "topic": "mytopic~3",
+            "name": "ns-bad",
+            "topic": "my-topic~abc",
             "msgs": [{ "value": "a".as_bytes() }],
         }))
         .await?
-        .expect(StatusCode::BAD_REQUEST);
+        .expect(StatusCode::UNPROCESSABLE_ENTITY);
 
     Ok(())
 }
@@ -170,10 +248,11 @@ async fn publish_keyless_same_partition() -> TestResult {
     let msgs = response["msgs"].as_array().unwrap();
     assert_eq!(msgs.len(), 3);
 
-    // All keyless messages in a single publish call land on the same partition
-    let partition = msgs[0]["partition"].as_u64().unwrap();
+    // All keyless messages in a single publish call land on the same partition topic
+    let topic = msgs[0]["topic"].as_str().unwrap();
+    assert!(topic.starts_with("keyless-topic~"));
     for m in msgs {
-        assert_eq!(m["partition"].as_u64().unwrap(), partition);
+        assert_eq!(m["topic"].as_str().unwrap(), topic);
     }
 
     // Offsets should be sequential

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -107,8 +107,8 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
         .json();
     assert_eq!(r1["msgs"].as_array().unwrap().len(), 2);
 
-    // Second receive with the same CG — partition is locked
-    client
+    // Second receive with the same CG — partition is locked, returns empty
+    let r2 = client
         .post("msgs/stream/receive")
         .json(json!({
             "name": "ns-nodup",
@@ -116,7 +116,9 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
             "consumer_group": "cg1",
         }))
         .await?
-        .expect(StatusCode::BAD_REQUEST);
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(r2["msgs"].as_array().unwrap().len(), 0);
 
     // Commit the first batch to unlock the partition
     let msgs = r1["msgs"].as_array().unwrap();
@@ -339,8 +341,8 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
         .json();
     assert_eq!(r_a["msgs"].as_array().unwrap().len(), 2);
 
-    // Consumer B (same CG) — partition is locked, should be rejected
-    client
+    // Consumer B (same CG) — partition is locked, returns empty
+    let r_b_locked = client
         .post("msgs/stream/receive")
         .json(json!({
             "name": "ns-lock",
@@ -348,7 +350,9 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
             "consumer_group": "cg1",
         }))
         .await?
-        .expect(StatusCode::BAD_REQUEST);
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(r_b_locked["msgs"].as_array().unwrap().len(), 0);
 
     // Consumer A commits — unlocks the partition
     let msgs_a = r_a["msgs"].as_array().unwrap();
@@ -608,7 +612,7 @@ async fn commit_requires_partition_topic() -> TestResult {
         .await?
         .expect(StatusCode::OK);
 
-    // Base topic (no ~partition suffix) should be rejected
+    // Base topic (no ~partition suffix) should be rejected at deserialization
     client
         .post("msgs/stream/commit")
         .json(json!({
@@ -618,7 +622,7 @@ async fn commit_requires_partition_topic() -> TestResult {
             "offset": 0,
         }))
         .await?
-        .expect(StatusCode::BAD_REQUEST);
+        .expect(StatusCode::UNPROCESSABLE_ENTITY);
 
     Ok(())
 }


### PR DESCRIPTION
A couple changes requested by Tom

- We allow publishing / receiving from specific partitions, e.g. `TopicName~1` instead of just `TopicName`.
- If a consumer in the group can't receive messages because other partitions are locked, we simply return empty list of messages.

I also did some selfish refactoring because I didn't like how Topics/Partitions were currently delineated in code. Specifically, we need to be able to distinguish between

`topic="T"` vs `topic="T~1"`

as user input.

Gonna address the `namespace:` stuff in a followup PR.