### PR TITLE
Some fixes for namespace resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,6 @@ dependencies = [
  "schemars 1.2.0",
  "serde",
  "stream-internals",
- "tracing",
  "uuid",
 ]
 

--- a/crates/coyote-namespace/Cargo.toml
+++ b/crates/coyote-namespace/Cargo.toml
@@ -13,7 +13,6 @@ jiff.workspace = true
 schemars.workspace = true
 serde.workspace = true
 stream-internals.workspace = true
-tracing.workspace = true
 uuid.workspace = true
 
 [lints]

--- a/crates/coyote-namespace/src/lib.rs
+++ b/crates/coyote-namespace/src/lib.rs
@@ -12,12 +12,12 @@ pub use self::tables::Namespace;
 pub const DEFAULT_NAMESPACE_NAME: &str = "default";
 
 pub fn namespace_name(key: &str) -> &str {
-    if !key.contains('/') {
+    if !key.contains(':') {
         return DEFAULT_NAMESPACE_NAME;
     }
-    match key.split("/").next() {
-        Some(k) => k,
-        None => DEFAULT_NAMESPACE_NAME,
+    match key.split(":").next() {
+        Some(k) if !k.is_empty() => k,
+        _ => DEFAULT_NAMESPACE_NAME,
     }
 }
 
@@ -108,22 +108,6 @@ impl State {
         Namespace::fetch(&self.keyspace, namespace_name)
     }
 
-    pub fn fetch_namespace_with_default<C: ModuleConfig>(
-        &self,
-        namespace_name: String,
-    ) -> Result<Option<Namespace<C>>> {
-        let fetch = self.fetch_namespace(&namespace_name)?;
-        if fetch.is_some() {
-            return Ok(fetch);
-        }
-        tracing::trace!(
-            namespace_name,
-            "cannot find namespace, falling back to default namespace"
-        );
-
-        Namespace::fetch(&self.keyspace, DEFAULT_NAMESPACE_NAME)
-    }
-
     pub fn fetch_all_namespaces<C: ModuleConfig>(
         &self,
     ) -> Result<impl Iterator<Item = Result<Namespace<C>>>> {
@@ -147,8 +131,13 @@ mod tests {
 
     #[test]
     fn test_namespace_name() {
-        assert_eq!(namespace_name("tom/bar"), "tom");
-        assert_eq!(namespace_name("tom/bar/baz"), "tom");
+        assert_eq!(namespace_name("tom:bar"), "tom");
+        assert_eq!(namespace_name("tom:bar/baz"), "tom");
         assert_eq!(namespace_name("bill"), DEFAULT_NAMESPACE_NAME);
+        assert_eq!(namespace_name(":bar"), DEFAULT_NAMESPACE_NAME);
+        assert_eq!(
+            namespace_name(&format!("{DEFAULT_NAMESPACE_NAME}:bar")),
+            DEFAULT_NAMESPACE_NAME
+        );
     }
 }

--- a/src/core/types/mod.rs
+++ b/src/core/types/mod.rs
@@ -41,7 +41,7 @@ macro_rules! enum_wrapper {
 
 fn validate_limited_str(s: &str) -> Result<(), ValidationErrors> {
     const MAX_LENGTH: usize = 256;
-    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9\-_.]+$").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9\-_.:]+$").unwrap());
     let mut errors = ValidationErrors::new();
     if s.is_empty() {
         errors.add(
@@ -61,7 +61,7 @@ fn validate_limited_str(s: &str) -> Result<(), ValidationErrors> {
             ALL_ERROR,
             validation_error(
                 Some("illegal_string_pattern"),
-                Some("String must match the following pattern: [a-zA-Z0-9\\-_.]."),
+                Some("String must match the following pattern: [a-zA-Z0-9\\-_.:]."),
             ),
         );
     }
@@ -279,7 +279,7 @@ string_wrapper!(
     StringSchema {
         string_validation: Some(json_schema!({
             "maxLength": 256,
-            "pattern": r"^[a-zA-Z0-9\-_.]+$",
+            "pattern": r"^[a-zA-Z0-9\-_.:]+$",
         })),
         example: Some("some_key".to_string()),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 use aide::axum::ApiRouter;
 use axum::{Extension, middleware};
 use cfg::ConfigurationInner;
-use coyote_error::{Error, Result};
+use coyote_error::{Error, HttpError, Result};
 use coyote_kv::KvStore;
 use coyote_namespace::{
     BothDatabases,
@@ -188,8 +188,8 @@ impl AppState {
 
         let namespace = self
             .namespace_state
-            .fetch_namespace_with_default::<C>(ns_name.to_string())?
-            .ok_or_else(|| Error::generic(format!("namespace {ns_name} not found")))?;
+            .fetch_namespace::<C>(ns_name)?
+            .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
         let policy = namespace.config.eviction_policy();
         let kv_store = KvStore::new(

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -93,10 +93,18 @@ pub struct CacheDeleteOut {
 /// Cache Set
 #[aide_annotate(op_id = "v1.cache.set")]
 async fn cache_set(
+    State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<CacheSetIn>,
 ) -> Result<MsgPackOrJson<CacheSetOut>> {
     let key_str = data.key.to_string();
+    // TODO: Presumably this should only need to happen in
+    // the consensus layer, but currently raft seems to
+    // break if an operation with a non-existent namespace is attempted,
+    // so do this here for now as a quick check that the namespace
+    // exists:
+    let _cache_store = state.get_cache_store_by_key(&key_str)?;
+
     let operation = SetOperation::new(key_str, data.into_model());
     repl.client_write(operation).await.map_err_generic()?.0?;
     Ok(MsgPackOrJson(CacheSetOut {}))

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -102,10 +102,19 @@ pub struct KvDeleteOut {
 /// KV Set
 #[aide_annotate(op_id = "v1.kv.set")]
 async fn kv_set(
+    State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<KvSetIn>,
 ) -> Result<MsgPackOrJson<KvSetOut>> {
     let key = data.key.0.clone();
+
+    // TODO: Presumably this should only need to happen in
+    // the consensus layer, but currently raft seems to
+    // break if an operation with a non-existent namespace is attempted,
+    // so do this here for now as a quick check that the namespace
+    // exists:
+    let _kv_store = state.get_kv_store_by_key(&key)?;
+
     let behavior = data.behavior.clone();
     let model = data.into_model();
 

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -46,6 +46,18 @@ async fn test_cache_set_and_get() -> TestResult {
     assert_eq!(response["value"], json!("test-value-123".as_bytes()));
     assert!(response["expiry"].is_string());
 
+    // set should fail if namespace doesn't exist:
+    client
+        .post("cache/set")
+        .json(json!({
+            "key": "nonexistentnamespace:key1",
+            "ttl": 1,
+            "value": "123".as_bytes(),
+            "behavior": "upsert",
+        }))
+        .await?
+        .ensure(StatusCode::NOT_FOUND)?;
+
     Ok(())
 }
 

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -89,6 +89,18 @@ async fn test_kv_set_and_get() -> TestResult {
             < 50 // tolerance
     );
 
+    // set should fail if namespace doesn't exist:
+    client
+        .post("kv/set")
+        .json(json!({
+            "key": "nonexistentnamespace:key1",
+            "ttl": Some(expires_in),
+            "value": "123".as_bytes(),
+            "behavior": "upsert",
+        }))
+        .await?
+        .ensure(StatusCode::NOT_FOUND)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
1. Change delimiter to be ':' not '/' for namespace names in keys.
2. Don't fall back to default if expected namespace name doesn't exist, just fail.
3. Add tests asserting this works in kv/cache

Note that trying to apply an operation if the namespace doesn't exist appears to put raft in an unhappy state. So for now, the APIs first check that the namespace exists before attempting to apply an operation.