### PR TITLE
Fix failing `concurrent_receives_same_cg_no_overlap` test

### DIFF
--- a/crates/msgs/src/operations/stream_receive.rs
+++ b/crates/msgs/src/operations/stream_receive.rs
@@ -126,6 +126,16 @@ impl StreamReceiveOperation {
                 .unwrap_or(Offset::MIN);
 
             let leases = LeaseRow::fetch_all(state, self.namespace_id, partition, &self.cg)?;
+
+            // Check for active leases inside apply_real (Raft state machine) to
+            // prevent races — the pre-Raft check in the constructor is only an
+            // optimistic fast-path.
+            let has_active_lease = leases.iter().any(|l| l.is_active(now));
+            if has_active_lease {
+                all_lease_diffs.push(LeaseRow::cull_and_compact(leases, now));
+                continue;
+            }
+
             let blocked_leases = leases.iter().filter(|l| l.acked_at.is_some() || l.is_dlq());
 
             let batch_size = remaining;

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -695,31 +695,18 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
     }
 
     let mut total_msgs = 0usize;
-    let mut ok_count = 0usize;
     for handle in handles {
         let resp = handle.await.unwrap();
-        match resp.status() {
-            StatusCode::OK => {
-                let body = resp.json();
-                let msgs = body["msgs"].as_array().unwrap();
-                total_msgs += msgs.len();
-                ok_count += 1;
-            }
-            StatusCode::BAD_REQUEST => {
-                // Partition locked — expected for losers of the race.
-            }
-            other => panic!("unexpected status: {other}"),
-        }
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.json();
+        let msgs = body["msgs"].as_array().unwrap();
+        total_msgs += msgs.len();
     }
 
-    // Exactly one consumer should have received the 3 messages.
+    // Exactly 3 messages total — the winner gets them, losers get empty responses.
     assert_eq!(
         total_msgs, 3,
         "messages must not be duplicated across consumers"
-    );
-    assert_eq!(
-        ok_count, 1,
-        "exactly one consumer should win the single partition"
     );
 
     Ok(())


### PR DESCRIPTION
This happened because I merged the test separately from another PR that actually broke the test. 😅 

The main bug was
- still need to check leases with apply_real, for concurrent consumer acccess
- we no longer return a LOCKED response, and just return an empty message set, if no messages are available. (The test was expecting a LOCKED response).