### PR TITLE
Change `namespace` to be referenced in the topic name for stream/msgs

### DIFF
--- a/benchmarks/benches/msgs.rs
+++ b/benchmarks/benches/msgs.rs
@@ -42,7 +42,7 @@ fn bench_msgs<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGr
 
     {
         let ns_name = "bench-publish";
-        let topic = "bench-topic";
+        let topic = format!("{ns_name}:bench-topic");
         make_test_namespace(ns_name);
 
         group.bench_function("msgs_publish_batch_100", |b| {
@@ -50,11 +50,9 @@ fn bench_msgs<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGr
                 || make_msg_batch(100),
                 |msgs| {
                     rt.block_on(async {
-                        std::hint::black_box(client.msgs().publish(PublishIn::new(
-                            msgs,
-                            ns_name.to_owned(),
-                            topic.to_owned(),
-                        )))
+                        std::hint::black_box(
+                            client.msgs().publish(PublishIn::new(msgs, topic.clone())),
+                        )
                         .await
                         .unwrap();
                     })
@@ -69,7 +67,7 @@ fn bench_msgs<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGr
     // any issues with long msgs streams to show up.
     {
         let ns_name = "bench-publish";
-        let topic = "bench-topic";
+        let topic = format!("{ns_name}:bench-topic");
         make_test_namespace(ns_name);
 
         // Start with 100_000 messages
@@ -77,11 +75,7 @@ fn bench_msgs<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGr
             for _ in 0..100 {
                 client
                     .msgs()
-                    .publish(PublishIn::new(
-                        make_msg_batch(1000),
-                        ns_name.to_owned(),
-                        topic.to_owned(),
-                    ))
+                    .publish(PublishIn::new(make_msg_batch(1000), topic.clone()))
                     .await
                     .unwrap();
             }
@@ -92,22 +86,18 @@ fn bench_msgs<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGr
         group.bench_function("msgs_stream_receive_commit_batch_100", |b| {
             b.iter(|| {
                 rt.block_on(async {
-                    let mut input = StreamReceiveIn::new(
-                        consumer_group.clone(),
-                        ns_name.to_owned(),
-                        topic.to_owned(),
-                    );
+                    let mut input = StreamReceiveIn::new(consumer_group.clone(), topic.clone());
                     input.batch_size = Some(100);
                     let out =
                         std::hint::black_box(client.msgs().stream().receive(input).await.unwrap());
                     let last = out.msgs.last().unwrap();
+                    // Response topic already includes namespace, pass directly to commit
                     std::hint::black_box(
                         client
                             .msgs()
                             .stream()
                             .commit(StreamCommitIn::new(
                                 consumer_group.clone(),
-                                ns_name.to_owned(),
                                 last.offset,
                                 last.topic.clone(),
                             ))

--- a/clients/cli/src/cmds/api/msgs_stream.rs
+++ b/clients/cli/src/cmds/api/msgs_stream.rs
@@ -20,7 +20,7 @@ pub enum MsgsStreamCommands {
     },
     /// Commits an offset for a consumer group on a specific partition.
     ///
-    /// The topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last
+    /// The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
     /// successfully processed offset; future receives will start after it.
     Commit {
         stream_commit_in: crate::json::JsonOf<coyote_client::models::StreamCommitIn>,

--- a/clients/cli/src/cmds/benchmark.rs
+++ b/clients/cli/src/cmds/benchmark.rs
@@ -429,8 +429,7 @@ impl BenchShard for BenchMsgsPublish {
         shard_id: u64,
         _iteration: u64,
     ) -> Result<Duration> {
-        let ns_name = "bench";
-        let topic = format!("bench/topic/{shard_id}");
+        let topic = format!("bench:bench/topic/{shard_id}");
         let msgs: Vec<_> = (0..self.batch_size)
             .map(|_| {
                 let mut payload = vec![0u8; 256];
@@ -443,7 +442,7 @@ impl BenchShard for BenchMsgsPublish {
         let t = Instant::now();
         client
             .msgs()
-            .publish(PublishIn::new(msgs, ns_name.to_string(), topic.to_owned()))
+            .publish(PublishIn::new(msgs, topic.clone()))
             .await?;
         Ok(t.elapsed())
     }
@@ -467,18 +466,13 @@ impl BenchShard for BenchMsgsStreamReceive {
         _iteration: u64,
     ) -> Result<Duration> {
         let consumer_group = "consumer";
-        let ns_name = "bench";
-        let topic = format!("bench/topic/{shard_id}");
+        let topic = format!("bench:bench/topic/{shard_id}");
         let mut value = vec![0u8; 256];
         rng.fill(&mut value[..]);
 
         // Start of real code
         let t = Instant::now();
-        let mut recv = StreamReceiveIn::new(
-            consumer_group.to_owned(),
-            ns_name.to_owned(),
-            topic.to_owned(),
-        );
+        let mut recv = StreamReceiveIn::new(consumer_group.to_owned(), topic.clone());
         recv.batch_size = Some(self.batch_size);
         let out = client.msgs().stream().receive(recv).await?;
         for msg in out.msgs {
@@ -487,7 +481,6 @@ impl BenchShard for BenchMsgsStreamReceive {
                 .stream()
                 .commit(StreamCommitIn::new(
                     consumer_group.to_owned(),
-                    ns_name.to_owned(),
                     msg.offset,
                     msg.topic.clone(),
                 ))

--- a/clients/go/internal/apis/msgs_stream.go
+++ b/clients/go/internal/apis/msgs_stream.go
@@ -38,7 +38,7 @@ func (msgsStream MsgsStream) Receive(
 
 // Commits an offset for a consumer group on a specific partition.
 //
-// The topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last
+// The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
 // successfully processed offset; future receives will start after it.
 func (msgsStream MsgsStream) Commit(
 	ctx context.Context,

--- a/clients/go/internal/models/publish_in.go
+++ b/clients/go/internal/models/publish_in.go
@@ -4,6 +4,5 @@ package coyote_models
 
 type PublishIn struct {
 	Msgs  []MsgIn `json:"msgs"`
-	Name  string  `json:"name"`
 	Topic string  `json:"topic"`
 }

--- a/clients/go/internal/models/stream_commit_in.go
+++ b/clients/go/internal/models/stream_commit_in.go
@@ -4,7 +4,6 @@ package coyote_models
 
 type StreamCommitIn struct {
 	ConsumerGroup string `json:"consumer_group"`
-	Name          string `json:"name"`
 	Offset        uint64 `json:"offset"`
 	Topic         string `json:"topic"`
 }

--- a/clients/go/internal/models/stream_receive_in.go
+++ b/clients/go/internal/models/stream_receive_in.go
@@ -6,6 +6,5 @@ type StreamReceiveIn struct {
 	BatchSize           *uint16 `json:"batch_size,omitempty"`
 	ConsumerGroup       string  `json:"consumer_group"`
 	LeaseDurationMillis *uint64 `json:"lease_duration_millis,omitempty"`
-	Name                string  `json:"name"`
 	Topic               string  `json:"topic"`
 }

--- a/clients/go/internal/models/topic_configure_in.go
+++ b/clients/go/internal/models/topic_configure_in.go
@@ -3,7 +3,6 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type TopicConfigureIn struct {
-	Name       string `json:"name"`
 	Partitions uint16 `json:"partitions"`
 	Topic      string `json:"topic"`
 }

--- a/clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
@@ -47,7 +47,7 @@ public class MsgsStream {
     /**
 * Commits an offset for a consumer group on a specific partition.
 * 
-* The topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last
+* The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
 * successfully processed offset; future receives will start after it.
 */
     public StreamCommitOut commit(

--- a/clients/java/src/main/java/com/svix/coyote/models/PublishIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/PublishIn.java
@@ -29,7 +29,6 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class PublishIn {
 @JsonProperty private List<MsgIn> msgs;
-@JsonProperty private String name;
 @JsonProperty private String topic;
 public PublishIn () {}
 
@@ -57,25 +56,6 @@ public PublishIn () {}
 
      public void setMsgs(List<MsgIn> msgs) {
         this.msgs = msgs;
-    }
-
-     public PublishIn name(String name) {
-        this.name = name;
-        return this;
-    }
-
-    /**
-    * Get name
-    *
-     * @return name
-     */
-    @javax.annotation.Nonnull
-     public String getName() {
-        return name;
-    }
-
-     public void setName(String name) {
-        this.name = name;
     }
 
      public PublishIn topic(String topic) {

--- a/clients/java/src/main/java/com/svix/coyote/models/StreamCommitIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/StreamCommitIn.java
@@ -29,7 +29,6 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class StreamCommitIn {
 @JsonProperty("consumer_group") private String consumerGroup;
-@JsonProperty private String name;
 @JsonProperty private Long offset;
 @JsonProperty private String topic;
 public StreamCommitIn () {}
@@ -51,25 +50,6 @@ public StreamCommitIn () {}
 
      public void setConsumerGroup(String consumerGroup) {
         this.consumerGroup = consumerGroup;
-    }
-
-     public StreamCommitIn name(String name) {
-        this.name = name;
-        return this;
-    }
-
-    /**
-    * Get name
-    *
-     * @return name
-     */
-    @javax.annotation.Nonnull
-     public String getName() {
-        return name;
-    }
-
-     public void setName(String name) {
-        this.name = name;
     }
 
      public StreamCommitIn offset(Long offset) {

--- a/clients/java/src/main/java/com/svix/coyote/models/StreamReceiveIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/StreamReceiveIn.java
@@ -31,7 +31,6 @@ public class StreamReceiveIn {
 @JsonProperty("batch_size") private Short batchSize;
 @JsonProperty("consumer_group") private String consumerGroup;
 @JsonProperty("lease_duration_millis") private Long leaseDurationMillis;
-@JsonProperty private String name;
 @JsonProperty private String topic;
 public StreamReceiveIn () {}
 
@@ -90,25 +89,6 @@ public StreamReceiveIn () {}
 
      public void setLeaseDurationMillis(Long leaseDurationMillis) {
         this.leaseDurationMillis = leaseDurationMillis;
-    }
-
-     public StreamReceiveIn name(String name) {
-        this.name = name;
-        return this;
-    }
-
-    /**
-    * Get name
-    *
-     * @return name
-     */
-    @javax.annotation.Nonnull
-     public String getName() {
-        return name;
-    }
-
-     public void setName(String name) {
-        this.name = name;
     }
 
      public StreamReceiveIn topic(String topic) {

--- a/clients/java/src/main/java/com/svix/coyote/models/TopicConfigureIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/TopicConfigureIn.java
@@ -28,31 +28,11 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class TopicConfigureIn {
-@JsonProperty private String name;
 @JsonProperty private Short partitions;
 @JsonProperty private String topic;
 public TopicConfigureIn () {}
 
- public TopicConfigureIn name(String name) {
-        this.name = name;
-        return this;
-    }
-
-    /**
-    * Get name
-    *
-     * @return name
-     */
-    @javax.annotation.Nonnull
-     public String getName() {
-        return name;
-    }
-
-     public void setName(String name) {
-        this.name = name;
-    }
-
-     public TopicConfigureIn partitions(Short partitions) {
+ public TopicConfigureIn partitions(Short partitions) {
         this.partitions = partitions;
         return this;
     }

--- a/clients/javascript/src/apis/msgsStream.ts
+++ b/clients/javascript/src/apis/msgsStream.ts
@@ -49,7 +49,7 @@ export class MsgsStream {
     /**
 * Commits an offset for a consumer group on a specific partition.
 * 
-* The topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last
+* The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
 * successfully processed offset; future receives will start after it.
 */
         public commit(

--- a/clients/javascript/src/models/publishIn.ts
+++ b/clients/javascript/src/models/publishIn.ts
@@ -10,7 +10,6 @@ import {
 
 export interface PublishIn {
     msgs: MsgIn[];
-name: string;
 topic: string;
 }
 
@@ -18,7 +17,6 @@ export const PublishInSerializer = {
     _fromJsonObject(object: any): PublishIn {
         return {
             msgs: object['msgs'].map((item: MsgIn) => MsgInSerializer._fromJsonObject(item)),
-            name: object['name'],
             topic: object['topic'],
             };
     },
@@ -26,7 +24,6 @@ export const PublishInSerializer = {
     _toJsonObject(self: PublishIn): any {
         return {
             'msgs': self.msgs.map((item) => MsgInSerializer._toJsonObject(item)),
-            'name': self.name,
             'topic': self.topic,
             };
     }

--- a/clients/javascript/src/models/streamCommitIn.ts
+++ b/clients/javascript/src/models/streamCommitIn.ts
@@ -6,7 +6,6 @@
 
 export interface StreamCommitIn {
     consumerGroup: string;
-name: string;
 offset: number;
 topic: string;
 }
@@ -15,7 +14,6 @@ export const StreamCommitInSerializer = {
     _fromJsonObject(object: any): StreamCommitIn {
         return {
             consumerGroup: object['consumer_group'],
-            name: object['name'],
             offset: object['offset'],
             topic: object['topic'],
             };
@@ -24,7 +22,6 @@ export const StreamCommitInSerializer = {
     _toJsonObject(self: StreamCommitIn): any {
         return {
             'consumer_group': self.consumerGroup,
-            'name': self.name,
             'offset': self.offset,
             'topic': self.topic,
             };

--- a/clients/javascript/src/models/streamReceiveIn.ts
+++ b/clients/javascript/src/models/streamReceiveIn.ts
@@ -8,7 +8,6 @@ export interface StreamReceiveIn {
     batchSize?: number;
 consumerGroup: string;
 leaseDurationMillis?: number;
-name: string;
 topic: string;
 }
 
@@ -18,7 +17,6 @@ export const StreamReceiveInSerializer = {
             batchSize: object['batch_size'],
             consumerGroup: object['consumer_group'],
             leaseDurationMillis: object['lease_duration_millis'],
-            name: object['name'],
             topic: object['topic'],
             };
     },
@@ -28,7 +26,6 @@ export const StreamReceiveInSerializer = {
             'batch_size': self.batchSize,
             'consumer_group': self.consumerGroup,
             'lease_duration_millis': self.leaseDurationMillis,
-            'name': self.name,
             'topic': self.topic,
             };
     }

--- a/clients/javascript/src/models/topicConfigureIn.ts
+++ b/clients/javascript/src/models/topicConfigureIn.ts
@@ -5,15 +5,13 @@
 
 
 export interface TopicConfigureIn {
-    name: string;
-partitions: number;
+    partitions: number;
 topic: string;
 }
 
 export const TopicConfigureInSerializer = {
     _fromJsonObject(object: any): TopicConfigureIn {
         return {
-            name: object['name'],
             partitions: object['partitions'],
             topic: object['topic'],
             };
@@ -21,7 +19,6 @@ export const TopicConfigureInSerializer = {
 
     _toJsonObject(self: TopicConfigureIn): any {
         return {
-            'name': self.name,
             'partitions': self.partitions,
             'topic': self.topic,
             };

--- a/clients/python/coyote/apis/msgs_stream.py
+++ b/clients/python/coyote/apis/msgs_stream.py
@@ -31,7 +31,7 @@ class MsgsStreamAsync(ApiBase):
     ) -> StreamCommitOut:
         """Commits an offset for a consumer group on a specific partition.
 
-        The topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last
+        The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
         successfully processed offset; future receives will start after it."""
         return await self._request_asyncio(
             method="post",
@@ -63,7 +63,7 @@ class MsgsStream(ApiBase):
     ) -> StreamCommitOut:
         """Commits an offset for a consumer group on a specific partition.
 
-        The topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last
+        The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
         successfully processed offset; future receives will start after it."""
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/models/publish_in.py
+++ b/clients/python/coyote/models/publish_in.py
@@ -9,6 +9,4 @@ from .msg_in import MsgIn
 class PublishIn(BaseModel):
     msgs: t.List[MsgIn]
 
-    name: str
-
     topic: str

--- a/clients/python/coyote/models/stream_commit_in.py
+++ b/clients/python/coyote/models/stream_commit_in.py
@@ -7,8 +7,6 @@ from ..internal.base_model import BaseModel
 class StreamCommitIn(BaseModel):
     consumer_group: str = Field(alias="consumer_group")
 
-    name: str
-
     offset: int
 
     topic: str

--- a/clients/python/coyote/models/stream_receive_in.py
+++ b/clients/python/coyote/models/stream_receive_in.py
@@ -14,6 +14,4 @@ class StreamReceiveIn(BaseModel):
         default=None, alias="lease_duration_millis"
     )
 
-    name: str
-
     topic: str

--- a/clients/python/coyote/models/topic_configure_in.py
+++ b/clients/python/coyote/models/topic_configure_in.py
@@ -4,8 +4,6 @@ from ..internal.base_model import BaseModel
 
 
 class TopicConfigureIn(BaseModel):
-    name: str
-
     partitions: int
 
     topic: str

--- a/clients/rust/src/api/msgs_stream.rs
+++ b/clients/rust/src/api/msgs_stream.rs
@@ -23,7 +23,7 @@ impl<'a> MsgsStream<'a> {
 
     /// Commits an offset for a consumer group on a specific partition.
     ///
-    /// The topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last
+    /// The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
     /// successfully processed offset; future receives will start after it.
     pub async fn commit(&self, stream_commit_in: StreamCommitIn) -> Result<StreamCommitOut> {
         crate::request::Request::new(http::Method::POST, "/api/v1/msgs/stream/commit")

--- a/clients/rust/src/models/publish_in.rs
+++ b/clients/rust/src/models/publish_in.rs
@@ -7,13 +7,11 @@ use super::msg_in::MsgIn;
 pub struct PublishIn {
     pub msgs: Vec<MsgIn>,
 
-    pub name: String,
-
     pub topic: String,
 }
 
 impl PublishIn {
-    pub fn new(msgs: Vec<MsgIn>, name: String, topic: String) -> Self {
-        Self { msgs, name, topic }
+    pub fn new(msgs: Vec<MsgIn>, topic: String) -> Self {
+        Self { msgs, topic }
     }
 }

--- a/clients/rust/src/models/stream_commit_in.rs
+++ b/clients/rust/src/models/stream_commit_in.rs
@@ -5,18 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct StreamCommitIn {
     pub consumer_group: String,
 
-    pub name: String,
-
     pub offset: u64,
 
     pub topic: String,
 }
 
 impl StreamCommitIn {
-    pub fn new(consumer_group: String, name: String, offset: u64, topic: String) -> Self {
+    pub fn new(consumer_group: String, offset: u64, topic: String) -> Self {
         Self {
             consumer_group,
-            name,
             offset,
             topic,
         }

--- a/clients/rust/src/models/stream_receive_in.rs
+++ b/clients/rust/src/models/stream_receive_in.rs
@@ -11,18 +11,15 @@ pub struct StreamReceiveIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lease_duration_millis: Option<u64>,
 
-    pub name: String,
-
     pub topic: String,
 }
 
 impl StreamReceiveIn {
-    pub fn new(consumer_group: String, name: String, topic: String) -> Self {
+    pub fn new(consumer_group: String, topic: String) -> Self {
         Self {
             batch_size: None,
             consumer_group,
             lease_duration_millis: None,
-            name,
             topic,
         }
     }

--- a/clients/rust/src/models/topic_configure_in.rs
+++ b/clients/rust/src/models/topic_configure_in.rs
@@ -3,19 +3,13 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TopicConfigureIn {
-    pub name: String,
-
     pub partitions: u16,
 
     pub topic: String,
 }
 
 impl TopicConfigureIn {
-    pub fn new(name: String, partitions: u16, topic: String) -> Self {
-        Self {
-            name,
-            partitions,
-            topic,
-        }
+    pub fn new(partitions: u16, topic: String) -> Self {
+        Self { partitions, topic }
     }
 }

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -15,6 +15,8 @@ pub const MAX_PARTITION_COUNT: u16 = 64;
 
 pub const TOPIC_PARTITION_DELIMITER: &str = "~";
 
+pub const NAMESPACE_DELIMITER: char = ':';
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Partition(u16);
@@ -36,35 +38,64 @@ impl Partition {
 }
 
 /// A topic identifier without the partition.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct RawTopic(String);
+///
+/// Carries the `namespace` that owns this topic. Serializes as `"namespace:topic"`.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RawTopic {
+    namespace: String,
+    topic: String,
+}
 
 impl RawTopic {
-    pub fn new(s: String) -> Result<Self, Error> {
-        if s.contains(TOPIC_PARTITION_DELIMITER) {
+    pub fn new(namespace: String, topic: String) -> Result<Self, Error> {
+        if topic.contains(TOPIC_PARTITION_DELIMITER) {
             Err(Error::generic("invalid topic"))
-        } else if s.len() > 64 {
-            // arbitrary limit for now. If you want to change this, just do it.
-            // No need to tag me or make a ticket or something.
+        } else if topic.len() > 64 {
             Err(Error::generic("topic cannot exceed 64 bytes"))
         } else {
-            Ok(Self(s))
+            Ok(Self { namespace, topic })
         }
+    }
+
+    pub fn namespace(&self) -> &str {
+        &self.namespace
     }
 }
 
+/// Derefs to the topic name (without namespace or partition).
 impl Deref for RawTopic {
     type Target = str;
 
     fn deref(&self) -> &str {
-        &self.0
+        &self.topic
     }
 }
 
 impl fmt::Display for RawTopic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        write!(f, "{}{}{}", self.namespace, NAMESPACE_DELIMITER, self.topic)
+    }
+}
+
+impl Serialize for RawTopic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for RawTopic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let (ns, topic) = s
+            .split_once(NAMESPACE_DELIMITER)
+            .ok_or_else(|| serde::de::Error::custom("missing ':' namespace delimiter"))?;
+        Self::new(ns.to_owned(), topic.to_owned()).map_err(serde::de::Error::custom)
     }
 }
 
@@ -92,20 +123,27 @@ impl Topic {
     pub fn new(raw: RawTopic, partition: Partition) -> Self {
         Self { raw, partition }
     }
+
+    pub fn namespace(&self) -> &str {
+        self.raw.namespace()
+    }
 }
 
 impl TryFrom<String> for Topic {
     type Error = Error;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let (topic, idx_str) = value
+        let (ns, rest) = value
+            .split_once(NAMESPACE_DELIMITER)
+            .ok_or_else(|| Error::generic("missing ':' namespace delimiter in topic"))?;
+        let (topic, idx_str) = rest
             .rsplit_once(TOPIC_PARTITION_DELIMITER)
             .ok_or_else(|| Error::generic("missing '~' separator in topic"))?;
         let idx: u16 = idx_str
             .parse()
             .map_err(|_| Error::generic("invalid partition index in topic"))?;
         let partition = Partition::new(idx)?;
-        let raw = RawTopic::new(topic.to_owned())?;
+        let raw = RawTopic::new(ns.to_owned(), topic.to_owned())?;
         Ok(Self { raw, partition })
     }
 }
@@ -115,7 +153,7 @@ impl fmt::Display for Topic {
         write!(
             f,
             "{}{}{}",
-            self.raw.0, TOPIC_PARTITION_DELIMITER, self.partition.0
+            self.raw, TOPIC_PARTITION_DELIMITER, self.partition.0
         )
     }
 }
@@ -170,6 +208,10 @@ impl TopicIn {
             TopicIn::WithPartition(topic) => &topic.raw,
         }
     }
+
+    pub fn namespace(&self) -> &str {
+        self.raw_topic().namespace()
+    }
 }
 
 impl<'de> Deserialize<'de> for TopicIn {
@@ -178,12 +220,16 @@ impl<'de> Deserialize<'de> for TopicIn {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        if s.contains(TOPIC_PARTITION_DELIMITER) {
+        let (ns, rest) = s
+            .split_once(NAMESPACE_DELIMITER)
+            .ok_or_else(|| serde::de::Error::custom("missing ':' namespace delimiter"))?;
+        if rest.contains(TOPIC_PARTITION_DELIMITER) {
+            // Re-parse the full string via Topic::try_from (it also splits on ':')
             Topic::try_from(s)
                 .map(TopicIn::WithPartition)
                 .map_err(serde::de::Error::custom)
         } else {
-            RawTopic::new(s)
+            RawTopic::new(ns.to_owned(), rest.to_owned())
                 .map(TopicIn::Raw)
                 .map_err(serde::de::Error::custom)
         }

--- a/openapi.json
+++ b/openapi.json
@@ -709,7 +709,7 @@
           "Msgs"
         ],
         "summary": "Stream Commit",
-        "description": "Commits an offset for a consumer group on a specific partition.\n\nThe topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last\nsuccessfully processed offset; future receives will start after it.",
+        "description": "Commits an offset for a consumer group on a specific partition.\n\nThe topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last\nsuccessfully processed offset; future receives will start after it.",
         "operationId": "v1.msgs.stream.commit",
         "requestBody": {
           "content": {
@@ -793,7 +793,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           }
         },
@@ -818,7 +818,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           }
         },
@@ -881,7 +881,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           },
           "expiry": {
@@ -911,7 +911,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           },
           "ttl": {
@@ -1047,7 +1047,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           }
         },
@@ -1064,7 +1064,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           },
           "response": {
@@ -1137,7 +1137,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           },
           "ttl": {
@@ -1217,7 +1217,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           }
         },
@@ -1242,7 +1242,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           }
         },
@@ -1298,7 +1298,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           },
           "expiry": {
@@ -1328,7 +1328,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           },
           "ttl": {
@@ -1411,9 +1411,6 @@
       "PublishIn": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string"
-          },
           "topic": {
             "type": "string"
           },
@@ -1425,7 +1422,6 @@
           }
         },
         "required": [
-          "name",
           "topic",
           "msgs"
         ]
@@ -1474,7 +1470,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           },
           "tokens": {
@@ -1580,7 +1576,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+            "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           }
         },
@@ -1702,9 +1698,6 @@
       "StreamCommitIn": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string"
-          },
           "topic": {
             "type": "string"
           },
@@ -1718,7 +1711,6 @@
           }
         },
         "required": [
-          "name",
           "topic",
           "consumer_group",
           "offset"
@@ -1769,9 +1761,6 @@
       "StreamReceiveIn": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string"
-          },
           "topic": {
             "type": "string"
           },
@@ -1793,7 +1782,6 @@
           }
         },
         "required": [
-          "name",
           "topic",
           "consumer_group"
         ]
@@ -1815,9 +1803,6 @@
       "TopicConfigureIn": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string"
-          },
           "topic": {
             "type": "string"
           },
@@ -1829,7 +1814,6 @@
           }
         },
         "required": [
-          "name",
           "topic",
           "partitions"
         ]

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -105,7 +105,6 @@ async fn get_namespace(
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
 struct PublishIn {
-    pub name: String,
     pub topic: TopicIn,
     pub msgs: Vec<coyote_msgs::entities::MsgIn>,
 }
@@ -130,7 +129,7 @@ async fn publish(
 ) -> Result<MsgPackOrJson<PublishOut>> {
     let namespace = state
         .namespace_state
-        .fetch_stream_namespace(&data.name)?
+        .fetch_stream_namespace(data.topic.namespace())?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
     let ro_db = state.ro_dbs.db_for(namespace.storage_type);
@@ -163,7 +162,6 @@ fn default_lease_duration_millis() -> u64 {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
 struct StreamReceiveIn {
-    pub name: String,
     pub topic: TopicIn,
     pub consumer_group: coyote_msgs::entities::ConsumerGroup,
     #[serde(default = "default_batch_size")]
@@ -189,7 +187,7 @@ async fn stream_receive(
 ) -> Result<MsgPackOrJson<StreamReceiveOut>> {
     let namespace = state
         .namespace_state
-        .fetch_stream_namespace(&data.name)?
+        .fetch_stream_namespace(data.topic.namespace())?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
     let ro_db = state.ro_dbs.db_for(namespace.storage_type);
@@ -224,7 +222,6 @@ async fn stream_receive(
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
 struct StreamCommitIn {
-    pub name: String,
     pub topic: Topic,
     pub consumer_group: coyote_msgs::entities::ConsumerGroup,
     pub offset: u64,
@@ -235,7 +232,7 @@ struct StreamCommitOut {}
 
 /// Commits an offset for a consumer group on a specific partition.
 ///
-/// The topic must be a partition-level topic (e.g. `my-topic~3`). The offset is the last
+/// The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
 /// successfully processed offset; future receives will start after it.
 #[aide_annotate(op_id = "v1.msgs.stream.commit")]
 async fn stream_commit(
@@ -245,7 +242,7 @@ async fn stream_commit(
 ) -> Result<MsgPackOrJson<StreamCommitOut>> {
     let namespace = state
         .namespace_state
-        .fetch_stream_namespace(&data.name)?
+        .fetch_stream_namespace(data.topic.namespace())?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
     let operation = coyote_msgs::operations::StreamCommitOperation::new(
@@ -265,7 +262,6 @@ async fn stream_commit(
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
 struct TopicConfigureIn {
-    pub name: String,
     pub topic: RawTopic,
     pub partitions: u16,
 }
@@ -295,7 +291,7 @@ async fn topic_configure(
 
     let namespace = state
         .namespace_state
-        .fetch_stream_namespace(&data.name)?
+        .fetch_stream_namespace(data.topic.namespace())?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
     let operation = coyote_msgs::operations::TopicConfigureOperation::new(

--- a/tests/it/msgs/publish.rs
+++ b/tests/it/msgs/publish.rs
@@ -21,8 +21,7 @@ async fn publish_to_topic() -> TestResult {
     let response = client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns1",
-            "topic": "my-topic",
+            "topic": "ns1:my-topic",
             "msgs": [
                 { "value": "hello".as_bytes() },
                 { "value": "world".as_bytes() },
@@ -35,9 +34,9 @@ async fn publish_to_topic() -> TestResult {
     let msgs = response["msgs"].as_array().unwrap();
     assert_eq!(msgs.len(), 2);
 
-    // Each message should have a topic (with partition) and offset
+    // Each message should have a namespaced topic (with partition) and offset
     for m in msgs {
-        assert!(m["topic"].as_str().unwrap().starts_with("my-topic~"));
+        assert!(m["topic"].as_str().unwrap().starts_with("ns1:my-topic~"));
         assert!(m["offset"].is_u64());
     }
 
@@ -61,8 +60,7 @@ async fn publish_with_partition_key() -> TestResult {
     let response = client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-key",
-            "topic": "keyed-topic",
+            "topic": "ns-key:keyed-topic",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "user-123" },
                 { "value": "b".as_bytes(), "key": "user-123" },
@@ -78,7 +76,7 @@ async fn publish_with_partition_key() -> TestResult {
 
     // All messages with the same key must land in the same partition topic
     let topic = msgs[0]["topic"].as_str().unwrap();
-    assert!(topic.starts_with("keyed-topic~"));
+    assert!(topic.starts_with("ns-key:keyed-topic~"));
     for m in msgs {
         assert_eq!(m["topic"].as_str().unwrap(), topic);
     }
@@ -108,15 +106,14 @@ async fn publish_directly_to_partition() -> TestResult {
     // Configure the topic to have 4 partitions.
     client
         .post("msgs/topic/configure")
-        .json(json!({ "name": "ns-direct", "topic": "my-topic", "partitions": 4 }))
+        .json(json!({ "topic": "ns-direct:my-topic", "partitions": 4 }))
         .await?
         .expect(StatusCode::OK);
 
     let response = client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-direct",
-            "topic": "my-topic~2",
+            "topic": "ns-direct:my-topic~2",
             "msgs": [
                 { "value": "a".as_bytes() },
                 { "value": "b".as_bytes() },
@@ -130,7 +127,7 @@ async fn publish_directly_to_partition() -> TestResult {
     assert_eq!(msgs.len(), 2);
 
     for m in msgs {
-        assert_eq!(m["topic"].as_str().unwrap(), "my-topic~2");
+        assert_eq!(m["topic"].as_str().unwrap(), "ns-direct:my-topic~2");
     }
 
     let offsets: Vec<u64> = msgs.iter().map(|m| m["offset"].as_u64().unwrap()).collect();
@@ -158,8 +155,7 @@ async fn publish_rejects_out_of_range_partition() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-range",
-            "topic": "my-topic~1",
+            "topic": "ns-range:my-topic~1",
             "msgs": [{ "value": "a".as_bytes() }],
         }))
         .await?
@@ -185,8 +181,7 @@ async fn publish_rejects_malformed_partition_topic() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-bad",
-            "topic": "my-topic~abc",
+            "topic": "ns-bad:my-topic~abc",
             "msgs": [{ "value": "a".as_bytes() }],
         }))
         .await?
@@ -206,8 +201,7 @@ async fn publish_to_nonexistent_namespace() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "does-not-exist",
-            "topic": "topic",
+            "topic": "does-not-exist:topic",
             "msgs": [{ "value": "x".as_bytes() }],
         }))
         .await?
@@ -233,8 +227,7 @@ async fn publish_keyless_same_partition() -> TestResult {
     let response = client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-kl",
-            "topic": "keyless-topic",
+            "topic": "ns-kl:keyless-topic",
             "msgs": [
                 { "value": "a".as_bytes() },
                 { "value": "b".as_bytes() },
@@ -250,7 +243,7 @@ async fn publish_keyless_same_partition() -> TestResult {
 
     // All keyless messages in a single publish call land on the same partition topic
     let topic = msgs[0]["topic"].as_str().unwrap();
-    assert!(topic.starts_with("keyless-topic~"));
+    assert!(topic.starts_with("ns-kl:keyless-topic~"));
     for m in msgs {
         assert_eq!(m["topic"].as_str().unwrap(), topic);
     }

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -23,8 +23,7 @@ async fn stream_receive_returns_published_messages() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-recv",
-            "topic": "my-topic",
+            "topic": "ns-recv:my-topic",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "user-1" },
                 { "value": "b".as_bytes(), "key": "user-1" },
@@ -37,8 +36,7 @@ async fn stream_receive_returns_published_messages() -> TestResult {
     let response = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-recv",
-            "topic": "my-topic",
+            "topic": "ns-recv:my-topic",
             "consumer_group": "cg1",
         }))
         .await?
@@ -52,7 +50,7 @@ async fn stream_receive_returns_published_messages() -> TestResult {
         assert!(m["offset"].is_u64());
         let topic = m["topic"].as_str().unwrap();
         assert!(
-            topic.starts_with("my-topic~"),
+            topic.starts_with("ns-recv:my-topic~"),
             "topic should be partition-level: {topic}"
         );
         assert!(!m["value"].is_null());
@@ -84,8 +82,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-nodup",
-            "topic": "t1",
+            "topic": "ns-nodup:t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -98,8 +95,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     let r1 = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-nodup",
-            "topic": "t1",
+            "topic": "ns-nodup:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -111,8 +107,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     let r2 = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-nodup",
-            "topic": "t1",
+            "topic": "ns-nodup:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -120,15 +115,15 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
         .json();
     assert_eq!(r2["msgs"].as_array().unwrap().len(), 0);
 
-    // Commit the first batch to unlock the partition
+    // Commit the first batch to unlock the partition.
+    // The response topic already includes the namespace, so we can pass it directly.
     let msgs = r1["msgs"].as_array().unwrap();
-    let partition_topic = msgs[0]["topic"].as_str().unwrap().to_owned();
+    let partition_topic = msgs[0]["topic"].as_str().unwrap();
     let last_offset = msgs[1]["offset"].as_u64().unwrap();
 
     client
         .post("msgs/stream/commit")
         .json(json!({
-            "name": "ns-nodup",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -140,8 +135,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-nodup",
-            "topic": "t1",
+            "topic": "ns-nodup:t1",
             "msgs": [
                 { "value": "c".as_bytes(), "key": "k1" },
             ],
@@ -153,8 +147,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     let r3 = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-nodup",
-            "topic": "t1",
+            "topic": "ns-nodup:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -182,8 +175,7 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-cg",
-            "topic": "t1",
+            "topic": "ns-cg:t1",
             "msgs": [
                 { "value": "x".as_bytes(), "key": "k1" },
                 { "value": "y".as_bytes(), "key": "k1" },
@@ -195,8 +187,7 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     let r_a = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-cg",
-            "topic": "t1",
+            "topic": "ns-cg:t1",
             "consumer_group": "group-a",
         }))
         .await?
@@ -206,8 +197,7 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     let r_b = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-cg",
-            "topic": "t1",
+            "topic": "ns-cg:t1",
             "consumer_group": "group-b",
         }))
         .await?
@@ -245,8 +235,7 @@ async fn stream_receive_nonexistent_namespace() -> TestResult {
     client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "does-not-exist",
-            "topic": "t1",
+            "topic": "does-not-exist:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -272,8 +261,7 @@ async fn stream_receive_with_defaults() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-def",
-            "topic": "t1",
+            "topic": "ns-def:t1",
             "msgs": [{ "value": "hello".as_bytes(), "key": "k1" }],
         }))
         .await?
@@ -283,8 +271,7 @@ async fn stream_receive_with_defaults() -> TestResult {
     let response = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-def",
-            "topic": "t1",
+            "topic": "ns-def:t1",
             "consumer_group": "cg-default",
         }))
         .await?
@@ -314,8 +301,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-lock",
-            "topic": "t1",
+            "topic": "ns-lock:t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -331,8 +317,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     let r_a = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-lock",
-            "topic": "t1",
+            "topic": "ns-lock:t1",
             "consumer_group": "cg1",
             "batch_size": 2,
         }))
@@ -345,8 +330,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     let r_b_locked = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-lock",
-            "topic": "t1",
+            "topic": "ns-lock:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -354,15 +338,15 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
         .json();
     assert_eq!(r_b_locked["msgs"].as_array().unwrap().len(), 0);
 
-    // Consumer A commits — unlocks the partition
+    // Consumer A commits — unlocks the partition.
+    // The response topic already includes the namespace.
     let msgs_a = r_a["msgs"].as_array().unwrap();
-    let partition_topic = msgs_a[0]["topic"].as_str().unwrap().to_owned();
+    let partition_topic = msgs_a[0]["topic"].as_str().unwrap();
     let last_offset = msgs_a[1]["offset"].as_u64().unwrap();
 
     client
         .post("msgs/stream/commit")
         .json(json!({
-            "name": "ns-lock",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -374,8 +358,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     let r_b = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-lock",
-            "topic": "t1",
+            "topic": "ns-lock:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -408,8 +391,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     client
         .post("msgs/topic/configure")
         .json(json!({
-            "name": "ns-concurrent",
-            "topic": "t1",
+            "topic": "ns-concurrent:t1",
             "partitions": 16,
         }))
         .await?
@@ -419,8 +401,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-concurrent",
-            "topic": "t1",
+            "topic": "ns-concurrent:t1",
             "msgs": [
                 { "value": "a1".as_bytes(), "key": "k1" },
                 { "value": "a2".as_bytes(), "key": "k1" },
@@ -441,8 +422,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     let r_a = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-concurrent",
-            "topic": "t1",
+            "topic": "ns-concurrent:t1",
             "consumer_group": "cg1",
             "batch_size": 5,
         }))
@@ -457,8 +437,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     let r_b = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-concurrent",
-            "topic": "t1",
+            "topic": "ns-concurrent:t1",
             "consumer_group": "cg1",
             "batch_size": 10,
         }))
@@ -514,8 +493,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-commit",
-            "topic": "t1",
+            "topic": "ns-commit:t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -529,8 +507,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     let r1 = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-commit",
-            "topic": "t1",
+            "topic": "ns-commit:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -540,15 +517,15 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     let msgs = r1["msgs"].as_array().unwrap();
     assert_eq!(msgs.len(), 3);
 
-    // Extract partition-level topic and last offset in the batch
-    let partition_topic = msgs[0]["topic"].as_str().unwrap().to_owned();
+    // Extract partition-level topic and last offset in the batch.
+    // The response topic already includes the namespace.
+    let partition_topic = msgs[0]["topic"].as_str().unwrap();
     let last_offset = msgs[2]["offset"].as_u64().unwrap();
 
     // Commit the last offset we processed
     client
         .post("msgs/stream/commit")
         .json(json!({
-            "name": "ns-commit",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -560,8 +537,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     let r2 = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-commit",
-            "topic": "t1",
+            "topic": "ns-commit:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -573,8 +549,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-commit",
-            "topic": "t1",
+            "topic": "ns-commit:t1",
             "msgs": [
                 { "value": "d".as_bytes(), "key": "k1" },
             ],
@@ -586,8 +561,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     let r3 = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-commit",
-            "topic": "t1",
+            "topic": "ns-commit:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -616,8 +590,7 @@ async fn commit_requires_partition_topic() -> TestResult {
     client
         .post("msgs/stream/commit")
         .json(json!({
-            "name": "ns-commit-pt",
-            "topic": "t1",
+            "topic": "ns-commit-pt:t1",
             "consumer_group": "cg1",
             "offset": 0,
         }))
@@ -638,8 +611,7 @@ async fn commit_nonexistent_namespace() -> TestResult {
     client
         .post("msgs/stream/commit")
         .json(json!({
-            "name": "does-not-exist",
-            "topic": "t1~0",
+            "topic": "does-not-exist:t1~0",
             "consumer_group": "cg1",
             "offset": 0,
         }))
@@ -667,8 +639,7 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-race",
-            "topic": "t1",
+            "topic": "ns-race:t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -685,8 +656,7 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
         handles.push(tokio::spawn(async move {
             c.post("msgs/stream/receive")
                 .json(json!({
-                    "name": "ns-race",
-                    "topic": "t1",
+                    "topic": "ns-race:t1",
                     "consumer_group": "cg1",
                 }))
                 .await

--- a/tests/it/msgs/topic_configure.rs
+++ b/tests/it/msgs/topic_configure.rs
@@ -24,8 +24,7 @@ async fn default_is_one_partition() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-def-part",
-            "topic": "t1",
+            "topic": "ns-def-part:t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "alpha" },
                 { "value": "b".as_bytes(), "key": "beta" },
@@ -38,8 +37,7 @@ async fn default_is_one_partition() -> TestResult {
     let response = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-def-part",
-            "topic": "t1",
+            "topic": "ns-def-part:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -52,7 +50,10 @@ async fn default_is_one_partition() -> TestResult {
     // All messages should be on the same single partition
     let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].as_str().unwrap()).collect();
     assert_eq!(topics.len(), 1, "all messages should be on one partition");
-    assert!(topics.contains("t1~0"), "single partition should be t1~0");
+    assert!(
+        topics.contains("ns-def-part:t1~0"),
+        "single partition should be ns-def-part:t1~0"
+    );
 
     Ok(())
 }
@@ -74,8 +75,7 @@ async fn configure_topic_partitions() -> TestResult {
     let response = client
         .post("msgs/topic/configure")
         .json(json!({
-            "name": "ns-conf",
-            "topic": "t1",
+            "topic": "ns-conf:t1",
             "partitions": 4,
         }))
         .await?
@@ -88,8 +88,7 @@ async fn configure_topic_partitions() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-conf",
-            "topic": "t1",
+            "topic": "ns-conf:t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "alpha" },
                 { "value": "b".as_bytes(), "key": "beta" },
@@ -102,8 +101,7 @@ async fn configure_topic_partitions() -> TestResult {
     let response = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-conf",
-            "topic": "t1",
+            "topic": "ns-conf:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -113,14 +111,14 @@ async fn configure_topic_partitions() -> TestResult {
     let msgs = response["msgs"].as_array().unwrap();
     assert_eq!(msgs.len(), 3);
 
-    // All partition-level topics should be within t1~0..t1~3
+    // All partition-level topics should be within ns-conf:t1~0..ns-conf:t1~3
     for m in msgs {
         let topic = m["topic"].as_str().unwrap();
         assert!(
-            topic.starts_with("t1~"),
+            topic.starts_with("ns-conf:t1~"),
             "expected partition-level topic: {topic}"
         );
-        let partition: u16 = topic.strip_prefix("t1~").unwrap().parse().unwrap();
+        let partition: u16 = topic.strip_prefix("ns-conf:t1~").unwrap().parse().unwrap();
         assert!(partition < 4, "partition {partition} should be < 4");
     }
 
@@ -144,8 +142,7 @@ async fn cannot_decrease_partitions() -> TestResult {
     client
         .post("msgs/topic/configure")
         .json(json!({
-            "name": "ns-dec",
-            "topic": "t1",
+            "topic": "ns-dec:t1",
             "partitions": 4,
         }))
         .await?
@@ -155,8 +152,7 @@ async fn cannot_decrease_partitions() -> TestResult {
     client
         .post("msgs/topic/configure")
         .json(json!({
-            "name": "ns-dec",
-            "topic": "t1",
+            "topic": "ns-dec:t1",
             "partitions": 2,
         }))
         .await?
@@ -182,8 +178,7 @@ async fn configure_rejects_zero() -> TestResult {
     client
         .post("msgs/topic/configure")
         .json(json!({
-            "name": "ns-zero",
-            "topic": "t1",
+            "topic": "ns-zero:t1",
             "partitions": 0,
         }))
         .await?
@@ -209,8 +204,7 @@ async fn configure_rejects_over_max() -> TestResult {
     client
         .post("msgs/topic/configure")
         .json(json!({
-            "name": "ns-max",
-            "topic": "t1",
+            "topic": "ns-max:t1",
             "partitions": 65,
         }))
         .await?
@@ -230,8 +224,7 @@ async fn configure_nonexistent_namespace() -> TestResult {
     client
         .post("msgs/topic/configure")
         .json(json!({
-            "name": "does-not-exist",
-            "topic": "t1",
+            "topic": "does-not-exist:t1",
             "partitions": 4,
         }))
         .await?
@@ -257,8 +250,7 @@ async fn receive_respects_configured_partitions() -> TestResult {
     client
         .post("msgs/topic/configure")
         .json(json!({
-            "name": "ns-recv-conf",
-            "topic": "t1",
+            "topic": "ns-recv-conf:t1",
             "partitions": 16,
         }))
         .await?
@@ -268,8 +260,7 @@ async fn receive_respects_configured_partitions() -> TestResult {
     client
         .post("msgs/publish")
         .json(json!({
-            "name": "ns-recv-conf",
-            "topic": "t1",
+            "topic": "ns-recv-conf:t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k2" },
@@ -281,8 +272,7 @@ async fn receive_respects_configured_partitions() -> TestResult {
     let response = client
         .post("msgs/stream/receive")
         .json(json!({
-            "name": "ns-recv-conf",
-            "topic": "t1",
+            "topic": "ns-recv-conf:t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -302,10 +292,14 @@ async fn receive_respects_configured_partitions() -> TestResult {
 
     for topic in &topics {
         assert!(
-            topic.starts_with("t1~"),
+            topic.starts_with("ns-recv-conf:t1~"),
             "expected partition-level topic: {topic}"
         );
-        let partition: u16 = topic.strip_prefix("t1~").unwrap().parse().unwrap();
+        let partition: u16 = topic
+            .strip_prefix("ns-recv-conf:t1~")
+            .unwrap()
+            .parse()
+            .unwrap();
         assert!(partition < 16, "partition {partition} should be < 16");
     }
 


### PR DESCRIPTION
From this conversation

<img width="979" height="672" alt="Screenshot 2026-02-28 at 13 44 38" src="https://github.com/user-attachments/assets/11efe1f9-825a-462a-847c-da2c72dee35b" />

This PR basically fixes the core issue. BUT there's no default namespace handling yet. That's gonna be in a followup PR (this one would've been way too unwieldily) 