### PR TITLE
expose HTTP/2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ aide = { version = "=0.16.0-alpha.2", features = ["axum", "axum-json", "axum-que
 anyerror = { version = "0.1.13", features = ["anyhow"] }
 anyhow = "1.0.56"
 assert_matches = "1.5.0"
-axum = { version = "0.8.8", features = ["macros"] }
+axum = { version = "0.8.8", features = ["macros", "http2"] }
 axum-extra = { version = "0.12", features = ["typed-header"] }
 byteorder = "1.5.0"
 bytes = "1.11.1"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -12,6 +12,14 @@ ignored = [
     "idna_adapter",
 ]
 
+[features]
+default = ["http1", "http2", "rustls-tls"]
+
+http1 = ["coyote-client/http1"]
+http2 = ["coyote-client/http2"]
+native-tls = ["coyote-client/native-tls"]
+rustls-tls = ["coyote-client/rustls-tls"]
+
 [[bin]]
 name = "coyote"
 path = "src/main.rs"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -12,6 +12,11 @@ ignored = [
     "idna_adapter",
 ]
 
+[[bin]]
+name = "coyote"
+path = "src/main.rs"
+doctest = false
+
 [features]
 default = ["http1", "http2", "rustls-tls"]
 
@@ -19,11 +24,6 @@ http1 = ["coyote-client/http1"]
 http2 = ["coyote-client/http2"]
 native-tls = ["coyote-client/native-tls"]
 rustls-tls = ["coyote-client/rustls-tls"]
-
-[[bin]]
-name = "coyote"
-path = "src/main.rs"
-doctest = false
 
 [dependencies]
 anyhow.workspace = true

--- a/clients/cli/src/cmds/benchmark.rs
+++ b/clients/cli/src/cmds/benchmark.rs
@@ -751,13 +751,13 @@ impl BenchShard for BenchMsgsStreamReceive {
             .unzip();
         BenchResult::finalize_result_stats(
             Arc::clone(&cfg),
-            rcv_results.into_iter(),
+            rcv_results,
             format!("{} - receive", self.test_name()),
             all_stats,
         )?;
         BenchResult::finalize_result_stats(
             Arc::clone(&cfg),
-            commit_results.into_iter(),
+            commit_results,
             format!("{} - commit", self.test_name()),
             all_stats,
         )?;

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -10,9 +10,9 @@ pub struct Config {
     pub auth_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     server_url: Option<String>,
-    #[cfg(feature = "http2")]
+    #[cfg(feature = "http1")]
     #[serde(default)]
-    pub force_http2: bool,
+    pub http1: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     debug_url: Option<String>,
 }

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -10,6 +10,9 @@ pub struct Config {
     pub auth_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     server_url: Option<String>,
+    #[cfg(feature = "http2")]
+    #[serde(default)]
+    pub force_http2: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     debug_url: Option<String>,
 }

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -10,7 +10,7 @@ pub struct Config {
     pub auth_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     server_url: Option<String>,
-    #[cfg(feature = "http1")]
+    #[cfg(all(feature = "http1", feature = "http2"))]
     #[serde(default)]
     pub http1: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -160,6 +160,8 @@ fn get_client_options(cfg: &Config) -> Result<CoyoteOptions> {
         debug: false,
         server_url: cfg.server_url().map(Into::into),
         timeout: None,
+        #[cfg(feature = "http2")]
+        http2_only: cfg.force_http2,
         ..CoyoteOptions::default()
     })
 }

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -160,8 +160,8 @@ fn get_client_options(cfg: &Config) -> Result<CoyoteOptions> {
         debug: false,
         server_url: cfg.server_url().map(Into::into),
         timeout: None,
-        #[cfg(feature = "http2")]
-        http2_only: cfg.force_http2,
+        #[cfg(all(feature = "http1", feature = "http2"))]
+        http1: cfg.http1,
         ..CoyoteOptions::default()
     })
 }

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -41,6 +41,10 @@ pub struct CoyoteOptions {
     /// between the last two is that DNS resolution also goes through the proxy
     /// for `socks5h`, but not for `socks5`.
     pub proxy_address: Option<String>,
+
+    /// Force the use of HTTP/2, even on plaintext connections
+    #[cfg(feature = "http2")]
+    pub http2_only: bool,
 }
 
 impl Default for CoyoteOptions {
@@ -52,6 +56,7 @@ impl Default for CoyoteOptions {
             num_retries: None,
             retry_schedule: None,
             proxy_address: None,
+            http2_only: false,
         }
     }
 }
@@ -67,10 +72,14 @@ impl CoyoteClient {
     pub fn new(token: String, options: Option<CoyoteOptions>) -> Self {
         let options = options.unwrap_or_default();
 
+        let mut builder = HyperClient::builder(TokioExecutor::new());
+
+        #[cfg(feature = "http2")]
+        builder.http2_only(options.http2_only);
+
         let cfg = Arc::new(Configuration {
             user_agent: Some(format!("coyote-client/{CRATE_VERSION}/rust")),
-            client: HyperClient::builder(TokioExecutor::new())
-                .build(make_connector(options.proxy_address)),
+            client: builder.build(make_connector(options.proxy_address)),
             timeout: options.timeout,
             // These fields will be set by `with_token` below
             base_path: String::new(),

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -56,6 +56,7 @@ impl Default for CoyoteOptions {
             num_retries: None,
             retry_schedule: None,
             proxy_address: None,
+            #[cfg(feature = "http2")]
             http2_only: false,
         }
     }
@@ -73,6 +74,7 @@ impl CoyoteClient {
         let options = options.unwrap_or_default();
 
         let mut builder = HyperClient::builder(TokioExecutor::new());
+        builder.pool_idle_timeout(Duration::from_secs(10));
 
         #[cfg(feature = "http2")]
         builder.http2_only(options.http2_only);

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -42,9 +42,10 @@ pub struct CoyoteOptions {
     /// for `socks5h`, but not for `socks5`.
     pub proxy_address: Option<String>,
 
-    /// Force the use of HTTP/2, even on plaintext connections
-    #[cfg(feature = "http2")]
-    pub http2_only: bool,
+    /// Use HTTP/1.1 on plaintext connections (otherwise forces HTTP/2 on plaintext,
+    /// and uses standard ALPN on secure connections)
+    #[cfg(all(feature = "http1", feature = "http2"))]
+    pub http1: bool,
 }
 
 impl Default for CoyoteOptions {
@@ -56,8 +57,8 @@ impl Default for CoyoteOptions {
             num_retries: None,
             retry_schedule: None,
             proxy_address: None,
-            #[cfg(feature = "http2")]
-            http2_only: false,
+            #[cfg(all(feature = "http1", feature = "http2"))]
+            http1: false,
         }
     }
 }
@@ -76,8 +77,10 @@ impl CoyoteClient {
         let mut builder = HyperClient::builder(TokioExecutor::new());
         builder.pool_idle_timeout(Duration::from_secs(10));
 
-        #[cfg(feature = "http2")]
-        builder.http2_only(options.http2_only);
+        #[cfg(all(feature = "http2", not(feature = "http1")))]
+        builder.http2_only(true);
+        #[cfg(all(feature = "http1", feature = "http2"))]
+        builder.http2_only(!options.http1);
 
         let cfg = Arc::new(Configuration {
             user_agent: Some(format!("coyote-client/{CRATE_VERSION}/rust")),


### PR DESCRIPTION
This makes a few changes:

- enables the `http2` feature in axum so it supports both
- exposes `http2` as a feature in coyote-cli and enables it by default
- adds a `http1` option to both the rust client and the cli which enables HTTP1; by default, we force HTTP/2 even over plaintext (RFC be damned).

Tested that this makes HTTP/2 requests by default but falls back to HTTP/1.1 if you pass `COYOTE_HTTP1=true`