### PR TITLE
Grab bag of performance optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /target
 .claude
 .vscode
-.TODO.md
+.NOTES
 logs
 .data/
 __pycache__/

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use coyote_error::Error;
 use coyote_namespace::entities::NamespaceId;
-use fjall::KeyspaceCreateOptions;
+use fjall::{KeyspaceCreateOptions, compaction::Fifo};
 use fjall_utils::{ReadableDatabase, ReadableKeyspace};
 
 pub mod entities;
@@ -26,7 +28,12 @@ impl State {
         };
 
         let msg_table = {
-            let opts = KeyspaceCreateOptions::default().expect_point_read_hits(true);
+            let opts = KeyspaceCreateOptions::default()
+                .expect_point_read_hits(true)
+                .compaction_strategy(Arc::new(Fifo {
+                    limit: u64::MAX,
+                    ttl_seconds: None,
+                }));
             db.keyspace(MSG_TABLE_KEYSPACE, || opts)?
         };
 

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -21,12 +21,12 @@ impl State {
         const MSG_TABLE_KEYSPACE: &str = "_coyote_msgs";
 
         let metadata_tables = {
-            let opts = KeyspaceCreateOptions::default();
+            let opts = KeyspaceCreateOptions::default().expect_point_read_hits(true);
             db.keyspace(METADATA_KEYSPACE, || opts)?
         };
 
         let msg_table = {
-            let opts = KeyspaceCreateOptions::default();
+            let opts = KeyspaceCreateOptions::default().expect_point_read_hits(true);
             db.keyspace(MSG_TABLE_KEYSPACE, || opts)?
         };
 

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -11,7 +11,7 @@ use crate::{
     entities::{
         MsgIn, Offset, Partition, RawTopic, Topic, TopicIn, partition_for_key, random_partition,
     },
-    tables::{MsgRow, msg_row_key},
+    tables::{MsgRow, NextWriteOffsetRow, msg_row_key},
 };
 
 use super::{MsgsRaftState, MsgsRequest, PublishResponse};
@@ -83,6 +83,7 @@ impl PublishOperation {
 
         for (partition, msgs) in by_partition {
             let start_offset = MsgRow::next_offset(state, self.namespace_id, partition)?;
+            let msg_count = msgs.len();
 
             for (i, (original_idx, msg)) in msgs.into_iter().enumerate() {
                 let offset = start_offset + i as Offset;
@@ -101,6 +102,15 @@ impl PublishOperation {
                     },
                 ));
             }
+
+            let next_offset = start_offset + msg_count as Offset;
+            NextWriteOffsetRow::store(
+                &mut batch,
+                state,
+                self.namespace_id,
+                partition,
+                next_offset,
+            )?;
         }
 
         batch.commit().map_err(coyote_error::Error::from)?;

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -72,6 +72,15 @@ impl MsgRow {
         ns_id: NamespaceId,
         partition: Partition,
     ) -> Result<Offset> {
+        NextWriteOffsetRow::fetch_or_scan(state, ns_id, partition)
+    }
+
+    /// Fallback: compute next offset via reverse range scan of msg_table.
+    fn next_offset_from_scan(
+        state: &State,
+        ns_id: NamespaceId,
+        partition: Partition,
+    ) -> Result<Offset> {
         match Self::max_offset(state, ns_id, partition)? {
             None => Ok(Offset::MIN),
             Some(id) => Ok(id + 1),
@@ -606,9 +615,59 @@ pub(crate) fn topic_partition_count(state: &State, ns_id: NamespaceId, topic: &s
     }
 }
 
+// ---------------------------------------------------------------------------
+// NextWriteOffsetRow — tracks the next write offset per (namespace, partition)
+// Eliminates the reverse range scan in max_offset() on every publish.
+// ---------------------------------------------------------------------------
+
+const NEXT_WRITE_OFFSET_PREFIX: &[u8] = b"_MSGNEXTOFF_\0";
+
+fn next_write_offset_key(ns_id: NamespaceId, partition: Partition) -> Vec<u8> {
+    let mut key = Vec::with_capacity(NEXT_WRITE_OFFSET_PREFIX.len() + 16 + 2);
+    key.extend_from_slice(NEXT_WRITE_OFFSET_PREFIX);
+    key.extend_from_slice(&ns_id.as_u128().to_be_bytes());
+    key.extend_from_slice(&partition.get().to_be_bytes());
+    key
+}
+
+pub(crate) struct NextWriteOffsetRow;
+
+impl NextWriteOffsetRow {
+    /// Fetch the cached next-write offset, or fall back to a reverse range scan.
+    pub(crate) fn fetch_or_scan(
+        state: &State,
+        ns_id: NamespaceId,
+        partition: Partition,
+    ) -> Result<Offset> {
+        let key = next_write_offset_key(ns_id, partition);
+        match state.metadata_tables.get(&key)? {
+            Some(val) => {
+                let offset: Offset = rmp_serde::from_slice(&val).map_err(Error::generic)?;
+                Ok(offset)
+            }
+            None => MsgRow::next_offset_from_scan(state, ns_id, partition),
+        }
+    }
+
+    pub(crate) fn store(
+        batch: &mut OwnedWriteBatch,
+        state: &State,
+        ns_id: NamespaceId,
+        partition: Partition,
+        offset: Offset,
+    ) -> Result<()> {
+        let key = next_write_offset_key(ns_id, partition);
+        let val: Vec<u8> = rmp_serde::to_vec(&offset).map_err(Error::generic)?;
+        let val: fjall::UserValue = val.into();
+        batch.insert(&state.metadata_tables, key, val);
+        Ok(())
+    }
+}
+
 // Compile-time check that table prefixes used in the metadata keyspace are unique.
 static_assertions::const_assert!(fjall_utils::are_all_unique(&[
     LeaseRow::TABLE_PREFIX,
     "_MSGOFFSET_",
     "_MSGTOPICCONF_",
+    "_MSGNEXTOFF_",
 ]));

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -334,6 +334,10 @@ impl LeaseRow {
             }
         }
 
+        if to_delete.is_empty() && acked_leases.is_empty() && dlq_leases.is_empty() {
+            return LeaseDiff::default();
+        }
+
         Self::compact_adjacent(acked_leases, &mut to_delete, &mut to_insert);
         Self::compact_adjacent(dlq_leases, &mut to_delete, &mut to_insert);
 


### PR DESCRIPTION
This is a grab bag of performance optimizations, all of them suggested by Claude.

Each optimization run was tested separately. I'd:
- Spin up the coyote server (using `--release`)
- run the benchmarks with a hardcoded batch_size of 1000
- implement the change
- nuke the `db` folder, rerun the server
- rerun the benchmarks
- Compare.

Some of these optimizations may be, erm, controversial, so we can just throw each one out individually if need be.

Also all of them were pretty underwhelming.

One change Claude suggested, which did seem reasonable but also much more non-trivial to implement, is optimizing the Raft path so we aren't serializing entire message payloads in the raft layer. I'm not sure if that's even possible, I need to think about it more.

I'm gonna think more on suggestions from https://svixhq.slack.com/archives/C0A72988962/p1772216430053149?thread_ts=1772215766.329019&cid=C0A72988962, but not all of these necessarily apply since it was testing against the old implementation would have more concurrent leases active at any given time.