### PR TITLE
kv: cache the KvStore instead of recreating twice on every request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +935,7 @@ dependencies = [
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "jiff",
+ "lru",
  "openraft",
  "opentelemetry",
  "opentelemetry-http",
@@ -1963,6 +1970,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2584,6 +2593,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ idna_adapter.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 jiff.workspace = true
+lru.workspace = true
 openraft.workspace = true
 opentelemetry.workspace = true
 opentelemetry-http.workspace = true
@@ -171,6 +172,7 @@ idna_adapter = "=1.1.0"
 indexmap = "2.6.0"
 itertools = "0.14"
 jiff = { version = "0.2.18", features = ["serde"] }
+lru = "0.16.3"
 mimalloc = "0.1.48"
 mime = "0.3"
 num_enum = "0.7.2"

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -14,7 +14,10 @@ pub(super) async fn apply_request(
     Ok(match request {
         Request::Kv(req) => {
             // TODO: this shouldn't be mut but KvStore currently requires it
-            let mut store = state_machine.state.get_kv_store_by_key(req.key_name())?;
+            let mut store = state_machine
+                .state
+                .get_kv_store_by_key(req.key_name())
+                .await?;
             Response::Kv(req.apply(&mut store))
         }
         Request::CreateKv(req) => {
@@ -27,14 +30,18 @@ pub(super) async fn apply_request(
         Request::Idempotency(req) => {
             let mut store = state_machine
                 .state
-                .get_idempotency_store_by_key(req.key_name())?;
+                .get_idempotency_store_by_key(req.key_name())
+                .await?;
             Response::Idempotency(req.apply(&mut store))
         }
         Request::CreateIdempotency(req) => {
             Response::CreateIdempotency(req.apply(&state_machine.state.namespace_state))
         }
         Request::Cache(req) => {
-            let mut store = state_machine.state.get_cache_store_by_key(req.key_name())?;
+            let mut store = state_machine
+                .state
+                .get_cache_store_by_key(req.key_name())
+                .await?;
             Response::Cache(req.apply(&mut store))
         }
         Request::CreateCache(req) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
+    num::NonZero,
     sync::{Arc, LazyLock},
     time::Duration,
 };
@@ -20,6 +21,7 @@ use coyote_namespace::{
     entities::{CacheConfig, IdempotencyConfig, KeyValueConfig, ModuleConfig},
     namespace_parse_key,
 };
+use lru::LruCache;
 use opentelemetry::{InstrumentationScope, trace::TracerProvider as _};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
@@ -30,7 +32,10 @@ use opentelemetry_sdk::{
         span_processor_with_async_runtime::BatchSpanProcessor,
     },
 };
-use tokio::{net::TcpListener, sync::Barrier};
+use tokio::{
+    net::TcpListener,
+    sync::{Barrier, Mutex},
+};
 use tokio_util::sync::CancellationToken;
 use tower_http::{
     ServiceExt,
@@ -122,6 +127,8 @@ pub struct AppState {
     // OTHERFIXME: yes, I think so.
     #[allow(unused)]
     pub(crate) ro_dbs: ReadonlyDatabases,
+
+    kv_stores: Arc<Mutex<LruCache<Option<String>, KvStore>>>,
 }
 
 async fn run_interserver(
@@ -175,6 +182,8 @@ impl AppState {
         })
         .expect("initializing namespace state");
 
+        const KV_CACHE: NonZero<usize> = NonZero::new(100).unwrap();
+
         AppState {
             cfg,
             rate_limiter: v1::modules::rate_limiter::RateLimiter::new(
@@ -183,39 +192,47 @@ impl AppState {
             ),
             namespace_state,
             ro_dbs,
+            kv_stores: Arc::new(Mutex::new(LruCache::new(KV_CACHE))),
         }
     }
 
-    fn get_store_by_key<C: ModuleConfig>(&self, key_name: &str) -> Result<KvStore> {
+    async fn get_store_by_key<C: ModuleConfig>(&self, key_name: &str) -> Result<KvStore> {
         let (ns_name, _) = namespace_parse_key(key_name);
 
-        let namespace = self
-            .namespace_state
-            .fetch_namespace::<C>(ns_name)?
-            .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
+        let mut cache = self.kv_stores.lock().await;
 
-        let policy = namespace.config.eviction_policy();
-        let kv_store = KvStore::new(
-            KeyValueConfig::NAMESPACE,
-            self.namespace_state.give_me_the_right_db(&namespace),
-            policy,
-            None,
-        );
+        // TODO: make sure to invalidate the LruCache when we change any namespace
+        // properties; right now, there aren't any endpoints to create or
+        // edit Kv/etc namespaces.
+        cache
+            .try_get_or_insert(ns_name.map(|s| s.to_string()), || -> Result<KvStore> {
+                let namespace = self
+                    .namespace_state
+                    .fetch_namespace::<C>(ns_name)?
+                    .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
-        Ok(kv_store)
+                let policy = namespace.config.eviction_policy();
+                Ok(KvStore::new(
+                    KeyValueConfig::NAMESPACE,
+                    self.namespace_state.give_me_the_right_db(&namespace),
+                    policy,
+                    None,
+                ))
+            })
+            .cloned()
     }
 
-    pub fn get_kv_store_by_key(&self, key_name: &str) -> Result<KvStore> {
-        self.get_store_by_key::<KeyValueConfig>(key_name)
+    pub async fn get_kv_store_by_key(&self, key_name: &str) -> Result<KvStore> {
+        self.get_store_by_key::<KeyValueConfig>(key_name).await
     }
 
-    pub fn get_cache_store_by_key(&self, key_name: &str) -> Result<CacheStore> {
-        let kv_store = self.get_store_by_key::<CacheConfig>(key_name)?;
+    pub async fn get_cache_store_by_key(&self, key_name: &str) -> Result<CacheStore> {
+        let kv_store = self.get_store_by_key::<CacheConfig>(key_name).await?;
         Ok(CacheStore::new(kv_store))
     }
 
-    pub fn get_idempotency_store_by_key(&self, key_name: &str) -> Result<IdempotencyStore> {
-        let kv_store = self.get_store_by_key::<IdempotencyConfig>(key_name)?;
+    pub async fn get_idempotency_store_by_key(&self, key_name: &str) -> Result<IdempotencyStore> {
+        let kv_store = self.get_store_by_key::<IdempotencyConfig>(key_name).await?;
         Ok(IdempotencyStore::new(kv_store))
     }
 }

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -103,7 +103,7 @@ async fn cache_set(
     // break if an operation with a non-existent namespace is attempted,
     // so do this here for now as a quick check that the namespace
     // exists:
-    let _cache_store = state.get_cache_store_by_key(&key_str)?;
+    let _cache_store = state.get_cache_store_by_key(&key_str).await?;
 
     let operation = SetOperation::new(key_str, data.into_model());
     repl.client_write(operation).await.map_err_generic()?.0?;
@@ -116,7 +116,7 @@ async fn cache_get(
     State(state): State<AppState>,
     MsgPackOrJson(data): MsgPackOrJson<CacheGetIn>,
 ) -> Result<MsgPackOrJson<CacheGetOut>> {
-    let mut cache_store = state.get_cache_store_by_key(&data.key.0)?;
+    let mut cache_store = state.get_cache_store_by_key(&data.key.0).await?;
     let model = cache_store
         .get(&data.key)?
         .ok_or_else(|| HttpError::not_found(None, None))?;

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -113,7 +113,7 @@ async fn kv_set(
     // break if an operation with a non-existent namespace is attempted,
     // so do this here for now as a quick check that the namespace
     // exists:
-    let _kv_store = state.get_kv_store_by_key(&key)?;
+    let _kv_store = state.get_kv_store_by_key(&key).await?;
 
     let behavior = data.behavior.clone();
     let model = data.into_model();
@@ -131,7 +131,7 @@ async fn kv_get(
     State(state): State<AppState>,
     MsgPackOrJson(data): MsgPackOrJson<KvGetIn>,
 ) -> Result<MsgPackOrJson<KvGetOut>> {
-    let mut kv_store = state.get_kv_store_by_key(&data.key.0)?;
+    let mut kv_store = state.get_kv_store_by_key(&data.key.0).await?;
 
     let model = kv_store.get(&data.key.0).map_err(|e| Error::generic(e))?;
     let ret = match model {


### PR DESCRIPTION
This shaves a few microseconds off the kv.set benchmark, and about 50µs off the kv.get benchmark.