### PR TITLE
codegen: Remove support for special patch fields

### DIFF
--- a/codegen/templates/go/types/struct.go.jinja
+++ b/codegen/templates/go/types/struct.go.jinja
@@ -10,20 +10,3 @@ import (
 type {{ type.name | to_upper_camel_case }} struct {
 	{% include "types/struct_fields.go.jinja" -%}
 }
-{% if type.name is endingwith "Patch" -%}
-func (o {{ type.name | to_upper_camel_case }}) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	{% for field in type.fields -%}
-		{% if field.nullable -%}
-	if o.{{ field.name | to_upper_camel_case }}.IsSet() {
-		toSerialize["{{ field.name }}"] = o.{{ field.name | to_upper_camel_case }}
-	}
-		{% else -%}
-	if o.{{ field.name | to_upper_camel_case }} != nil {
-		toSerialize["{{ field.name }}"] = o.{{ field.name | to_upper_camel_case }}
-	}
-		{% endif -%}
-	{% endfor -%}
-	return json.Marshal(toSerialize)
-}
-{% endif -%}

--- a/codegen/templates/go/types/struct_fields.go.jinja
+++ b/codegen/templates/go/types/struct_fields.go.jinja
@@ -1,12 +1,8 @@
 {% for field in type.fields -%}
     {% set f_name = field.name | to_upper_camel_case -%}
     {% set f_type = field.type.to_go() -%}
-    {% set use_nullable = type.name is endingwith "Patch" and field.nullable -%}
     {% set json_annotation = "" -%}
-    {% if use_nullable -%}
-        {% set f_type %}coyote_proto.Nullable[{{ f_type }}]{% endset -%}
-    {% endif -%}
-    {% if (not field.required or field.nullable) and not use_nullable -%}
+    {% if (not field.required or field.nullable) -%}
         {% set json_annotation = ",omitempty" -%}
         {% if not field.type.is_set() and not field.type.is_list() -%}
             {% set f_type %}*{{ f_type }}{% endset -%}

--- a/codegen/templates/rust/types/struct_enum.rs.jinja
+++ b/codegen/templates/rust/types/struct_enum.rs.jinja
@@ -1,7 +1,4 @@
 use serde::{Deserialize, Serialize};
-{% if type.name is endingwith "Patch" -%}
-    use js_option::JsOption;
-{% endif %}
 
 use super::{
     {% for c in referenced_components -%}

--- a/codegen/templates/rust/types/struct_fields.rs.jinja
+++ b/codegen/templates/rust/types/struct_fields.rs.jinja
@@ -22,15 +22,8 @@
     {% set field_ty = field.type.to_rust() -%}
 
     {% if not field.required or field.nullable -%}
-        {# only for patch requests, if the field is both non-required
-            and nullable, use JsOption -#}
-        {% if type.name is endingwith "Patch" and field.nullable -%}
-            {% set field_ty %}JsOption<{{ field_ty }}>{% endset -%}
-            #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
-        {% else -%}
-            {% set field_ty %}Option<{{ field_ty }}>{% endset -%}
-            #[serde(skip_serializing_if = "Option::is_none")]
-        {% endif -%}
+        {% set field_ty %}Option<{{ field_ty }}>{% endset -%}
+        #[serde(skip_serializing_if = "Option::is_none")]
     {% endif -%}
 
     pub {{ field_name(field.name | to_snake_case) }}: {{ field_ty }},


### PR DESCRIPTION
… for Go and Rust. Already removed for other languages.

Small simplification I found while working on https://github.com/svix/coyote-private/issues/177.