### PR TITLE
Fix order of parameters in ::new calls

### DIFF
--- a/benchmarks/benches/msgs.rs
+++ b/benchmarks/benches/msgs.rs
@@ -90,7 +90,7 @@ fn bench_msgs<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGr
         group.bench_function("msgs_stream_receive_commit_batch_100", |b| {
             b.iter(|| {
                 rt.block_on(async {
-                    let mut input = MsgStreamReceiveIn::new(consumer_group.clone(), topic.clone());
+                    let mut input = MsgStreamReceiveIn::new(topic.clone(), consumer_group.clone());
                     input.batch_size = Some(100);
                     let out =
                         std::hint::black_box(client.msgs().stream().receive(input).await.unwrap());
@@ -101,8 +101,8 @@ fn bench_msgs<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGr
                             .msgs()
                             .stream()
                             .commit(MsgStreamCommitIn::new(
-                                consumer_group.clone(),
                                 last.topic.clone(),
+                                consumer_group.clone(),
                                 last.offset,
                             ))
                             .await

--- a/clients/cli/src/cmds/benchmark.rs
+++ b/clients/cli/src/cmds/benchmark.rs
@@ -710,7 +710,7 @@ impl BenchShard for BenchMsgsStreamReceive {
 
         // Start of real code
         let t = Instant::now();
-        let mut recv = MsgStreamReceiveIn::new(consumer_group.to_owned(), topic.clone());
+        let mut recv = MsgStreamReceiveIn::new(topic.clone(), consumer_group.to_owned());
         recv.batch_size = Some(self.batch_size);
         let out = client.msgs().stream().receive(recv).await?;
         let rcv_bytes = out.msgs.iter().fold(0, |acc, e| acc + e.value.len()) as u64;
@@ -729,8 +729,8 @@ impl BenchShard for BenchMsgsStreamReceive {
                 .msgs()
                 .stream()
                 .commit(MsgStreamCommitIn::new(
-                    consumer_group.to_owned(),
                     topic,
+                    consumer_group.to_owned(),
                     offset,
                 ))
                 .await?;


### PR DESCRIPTION
Broken in https://github.com/svix/coyote-private/pull/306, sorry.