### PR TITLE
cluster: refactor log sync worker

### DIFF
--- a/config.bench.toml
+++ b/config.bench.toml
@@ -8,4 +8,6 @@ opentelemetry_address="http://localhost:4317"
 opentelemetry_sample_ratio=1
 
 [cluster]
-log_sync = "every-second"
+log_sync_interval_commits = 0
+log_sync_interval_ms = 10000
+log_ack_immediately = true

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -240,9 +240,11 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
             replication_request_timeout: Duration::from_millis(50),
             startup_discovery_delay: Duration::from_millis(0),
             log_index_interval: Duration::from_millis(500),
-            log_sync: coyote::cfg::FsyncMode::EverySecond,
             snapshot_after_writes: None,
             snapshot_after_time: None,
+            log_sync_interval_commits: 0,
+            log_sync_interval_duration: Duration::from_secs(30),
+            log_ack_immediately: true,
         },
         bootstrap_cfg_path: None,
     }

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -5,6 +5,10 @@ use std::{
 
 use super::DatabaseConfig;
 
+pub(super) fn default_true() -> bool {
+    true
+}
+
 pub(super) fn listen_address() -> SocketAddr {
     (Ipv4Addr::UNSPECIFIED, 8050).into()
 }
@@ -77,4 +81,12 @@ pub(super) fn log_index_interval() -> Duration {
 
 pub(super) fn cluster_snapshot_after_time() -> Option<Duration> {
     Some(Duration::from_mins(15))
+}
+
+pub(super) fn cluster_log_sync_interval_commits() -> usize {
+    0
+}
+
+pub(super) fn cluster_log_sync_interval_duration() -> Duration {
+    Duration::from_secs(10)
 }

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -16,10 +16,12 @@ use fs_err as fs;
 use serde::{Deserialize, de::DeserializeOwned};
 use tap::Pipe;
 use tracing::Level;
+use validator::Validate;
 
 use crate::error::{Error, Result};
 
 mod defaults;
+mod validators;
 
 pub type Configuration = Arc<ConfigurationInner>;
 
@@ -142,14 +144,6 @@ impl From<Dir> for PathBuf {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq, Clone, Copy, Default)]
-#[serde(rename_all = "kebab-case")]
-pub enum FsyncMode {
-    EveryCommit,
-    #[default]
-    EverySecond,
-}
-
 impl DatabaseConfig {
     fn default_cache_size() -> u64 {
         let mut sys = sysinfo::System::new_all();
@@ -191,7 +185,11 @@ impl DatabaseConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Validate)]
+#[validate(schema(
+    function = "validators::validate_cluster_configuration",
+    skip_on_field_errors = true
+))]
 pub struct ClusterConfiguration {
     /// The address to listen on for replication. Defaults to the main listen address,
     /// but with the port incremented by 10000
@@ -307,12 +305,31 @@ pub struct ClusterConfiguration {
     )]
     pub log_index_interval: Duration,
 
-    /// How often to sync logs. If this is set to "every second" and you experience a catastrophic
-    /// failure of a node (e.g., an unsafe shutdown of the OS), you should remove that node from
-    /// the cluster and then restore it from another surviving node to avoid potential data
-    /// corruption.
-    #[serde(default)]
-    pub log_sync: FsyncMode,
+    /// Interval (in transactions) between fsyncing the commit log. This should be set to 1
+    /// for full ACID compliance; at any other value, data may be lost in the event of catastrophic
+    /// hardware failure. If you are using a multi-node cluster and set this to a value other than
+    /// 1, if a node experiences catastrophic failure and the OS shuts down uncleanly, that node
+    /// should be removed from the cluster and rebuilt. If set to 0, logs will only be fsynced on a
+    /// timer
+    #[validate(range(min = 0, max = 1024))]
+    #[serde(default = "defaults::cluster_log_sync_interval_commits")]
+    pub log_sync_interval_commits: usize,
+
+    /// Interval (in milliseconds) between fsyncing the commit log.
+    #[validate(custom(function = "validators::validate_log_sync_interval_duration"))]
+    #[serde(
+        default = "defaults::cluster_log_sync_interval_duration",
+        rename = "log_sync_interval_ms",
+        with = "crate::serde::duration::millis"
+    )]
+    pub log_sync_interval_duration: Duration,
+
+    /// Commit logs to the cluster immediately, before fsyncing them to persistent storage. This
+    /// should be set to `false` for full ACID compliance, but can be set to `true` to enable
+    /// higher throughput than your fsync rate. Note that we always flush to the OS buffers before
+    /// acking, so data will only be lost of the OS crashes.
+    #[serde(default = "defaults::default_true")]
+    pub log_ack_immediately: bool,
 
     /// Trigger a background snapshot after this many writes
     pub snapshot_after_writes: Option<u32>,
@@ -363,7 +380,7 @@ fn default_from_serde<T: DeserializeOwned>() -> Result<T, serde::de::value::Erro
     T::deserialize(serde::de::value::MapDeserializer::new(empty.into_iter()))
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Validate)]
 pub struct ConfigurationInner {
     /// The address to listen on
     #[serde(default = "defaults::listen_address")]
@@ -408,6 +425,7 @@ pub struct ConfigurationInner {
     #[serde(default)]
     pub environment: Environment,
 
+    #[validate(nested)]
     #[serde(default)]
     pub cluster: ClusterConfiguration,
 
@@ -573,7 +591,9 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
                 discovery_timeout: cluster_discovery_timeout,
                 startup_discovery_delay: cluster_startup_discovery_delay,
                 log_index_interval: cluster_log_index_interval,
-                log_sync: _cluster_log_sync, // TODO: impl FromStr for this
+                log_sync_interval_commits: cluster_log_sync_interval_commits,
+                log_sync_interval_duration: cluster_log_sync_interval_duration,
+                log_ack_immediately: cluster_log_ack_immediately,
                 snapshot_after_writes: cluster_snapshot_after_writes,
                 snapshot_after_time: cluster_snapshot_after_time,
             },
@@ -591,6 +611,8 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         environment: "COYOTE_ENVIRONMENT",
         cluster_name: "COYOTE_CLUSTER_NAME",
         cluster_auto_initialize: "COYOTE_CLUSTER_AUTO_INITIALIZE",
+        cluster_log_sync_interval_commits: "COYOTE_CLUSTER_LOG_SYNC_INTERVAL_COMMITS",
+        cluster_log_ack_immediately: "COYOTE_CLUSTER_LOG_ACK_IMMEDIATELY"
     );
 
     opt_env_overrides!(
@@ -617,6 +639,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         cluster_discovery_timeout: "COYOTE_CLUSTER_DISCOVERY_TIMEOUT_MS",
         cluster_startup_discovery_delay: "COYOTE_CLUSTER_STARTUP_DISCOVERY_DELAY_MS",
         cluster_log_index_interval: "COYOTE_LOG_INDEX_INTERVAL_MS",
+        cluster_log_sync_interval_duration: "COYOTE_CLUSTER_LOG_SYNC_INTERVAL_MS"
     );
 
     // Fields that require different parsing
@@ -626,6 +649,8 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
     if let Some(value) = env_var_ms("COYOTE_CLUSTER_SNAPSHOT_AFTER_MS")? {
         *cluster_snapshot_after_time = Some(value);
     }
+
+    config.validate()?;
 
     Ok(Arc::from(config))
 }

--- a/src/cfg/validators.rs
+++ b/src/cfg/validators.rs
@@ -1,0 +1,35 @@
+use std::time::Duration;
+
+use validator::ValidationError;
+
+use crate::cfg::ClusterConfiguration;
+
+pub(super) fn validate_log_sync_interval_duration(d: &Duration) -> Result<(), ValidationError> {
+    if d.is_zero() {
+        return Err(ValidationError::new(
+            "sync interval duration must be non-zero",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_cluster_configuration(
+    c: &ClusterConfiguration,
+) -> Result<(), ValidationError> {
+    if !(c.log_ack_immediately || c.log_sync_interval_commits == 1) {
+        return Err(ValidationError::new(
+            "If log_sync_interval_commits != 1, log_ack_immediately must be true (until openraft 0.10)",
+        ));
+    }
+    if c.election_timeout_min >= c.election_timeout_max {
+        return Err(ValidationError::new(
+            "election_timeout_min must be < election_timeout_max",
+        ));
+    }
+    if c.heartbeat_interval < c.replication_request_timeout {
+        return Err(ValidationError::new(
+            "heartbeat_interval must be >= replication_request_teimout",
+        ));
+    }
+    Ok(())
+}

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -4,6 +4,7 @@ use std::{
     fmt::Debug,
     ops::{Bound, RangeBounds},
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::Context;
@@ -17,10 +18,10 @@ use openraft::{
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use tap::{Pipe, Tap, TapFallible, TapOptional};
-use tracing::Span;
+use tracing::{Instrument, Span};
 
 use super::{NodeId, errors::*, raft::TypeConfig};
-use crate::cfg::{Dir, FsyncMode};
+use crate::cfg::Dir;
 
 // This is an implementation of an openraft Logs store backed by fjall
 
@@ -238,63 +239,67 @@ impl std::error::Error for BackgroundFsyncFailedError {
     }
 }
 
-async fn flush_every_commit(
+// Specialization for `flush_worker` when commits_before_fsync is 1 (which implies
+// that ack_immediately is false) which just fsyncs as fast as it can.
+async fn flush_every_worker(
     db: Database,
     mut channel: tokio::sync::mpsc::Receiver<LogFlushed<TypeConfig>>,
 ) {
-    // coalesce requests to flush the database; this doesn't actually do anything in openraft 0.9,
-    // but in v0.10, we will be able to coalesce
-    let mut buf = Vec::with_capacity(10);
-    while channel.recv_many(&mut buf, 10).await > 0 {
-        let mut new_buf = Vec::with_capacity(10);
+    // TODO: on openraft 0.10, we can actually do `.recv_many` to amortize this cost
+    while let Some(callback) = channel.recv().await {
         let db = db.clone();
-        std::mem::swap(&mut buf, &mut new_buf);
-        tokio::task::spawn_blocking(move || {
-            let _guard = tracing::info_span!("logs:flush_every_commit").entered();
-
-            let result = db
-                .persist(PersistMode::SyncAll)
+        let result = tokio::task::spawn_blocking(move || {
+            tracing::trace!("fsyncing logs to disk");
+            db.persist(PersistMode::SyncAll)
                 // fjall::Error isn't Clone
                 .map_err(|err| {
                     tracing::error!(?err, "error flushing fjall in background");
                     BackgroundFsyncFailedError(err.to_string())
-                });
-            for callback in new_buf.drain(..) {
-                callback.log_io_completed(result.clone().map_err(std::io::Error::other));
-            }
+                })
         })
+        .instrument(tracing::info_span!("logs:flush_worker:every"))
         .await
         .expect("failed joining blocking task");
+        callback.log_io_completed(result.map_err(std::io::Error::other));
     }
 }
 
-async fn flush_every_second(
+/// General background worker for flushing the fjall database
+async fn flush_worker(
     db: Database,
     mut channel: tokio::sync::mpsc::Receiver<LogFlushed<TypeConfig>>,
+    commits_before_fsync: usize,
+    duration_before_fsync: Duration,
+    ack_immediately: bool,
 ) {
-    let mut has_changes = false;
+    let mut pending = Vec::new();
     let mut done = false;
     let shutting_down = crate::shutting_down_token();
-    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(1));
+    let mut ticker = tokio::time::interval(duration_before_fsync);
     while !done {
+        let mut sync_now = false;
+
         tokio::select! {
             message = channel.recv() => {
-                has_changes = true;
                 if let Some(callback) = message {
                     let db = db.clone();
-                    tokio::task::spawn_blocking(move || {
-                        let _guard =
-                            tracing::info_span!("logs:flush_every_second:buffer").entered();
-                        let result = db.persist(PersistMode::Buffer)
+                    let result = tokio::task::spawn_blocking(move || {
+                        db.persist(PersistMode::Buffer)
                             // fjall::Error isn't Clone
                             .map_err(|err| {
                                 tracing::error!(?err, "error flushing fjall in background");
                                 BackgroundFsyncFailedError(err.to_string())
-                            });
-                        callback.log_io_completed(result.map_err(std::io::Error::other));
+                            })
                     })
+                    .instrument(tracing::info_span!("logs:flush_worker:buffer"))
                     .await
                     .expect("failed joining blocking task");
+                    if ack_immediately {
+                        callback.log_io_completed(result.map_err(std::io::Error::other));
+                        pending.push(None);
+                    } else {
+                        pending.push(Some(callback))
+                    }
                 } else {
                     done = true;
                 }
@@ -303,21 +308,26 @@ async fn flush_every_second(
                 done = true
             },
             _ = ticker.tick() => {
-                if has_changes {
-                    let db = db.clone();
-                    tokio::task::spawn_blocking(move || {
-                        let _guard =
-                            tracing::info_span!("logs:flush_every_second:flush").entered();
-                        tracing::debug!("running periodic sync of logs");
-                        if let Err(err) = db.persist(PersistMode::SyncAll) {
-                            tracing::error!(?err, "error flushing fjall");
-                        }
+                sync_now = pending.len() > 0
+            }
+        }
+
+        if sync_now || (commits_before_fsync > 0 && pending.len() >= commits_before_fsync) {
+            let db = db.clone();
+            let result =
+                tokio::task::spawn_blocking(move || -> Result<(), BackgroundFsyncFailedError> {
+                    tracing::trace!("flushing logs to disk");
+                    db.persist(PersistMode::SyncAll).map_err(|err| {
+                        tracing::error!(?err, "error flushing fjall");
+                        BackgroundFsyncFailedError(err.to_string())
                     })
-                    .await
-                    .expect("failed joining blocking task");
-                    has_changes = false
-                } else {
-                    tracing::trace!("no changes in the last interval, doing nothing");
+                })
+                .instrument(tracing::info_span!("logs:flush_worker:flush"))
+                .await
+                .expect("failed joining blocking task");
+            for item in pending.drain(..) {
+                if let Some(callback) = item {
+                    callback.log_io_completed(result.clone().map_err(std::io::Error::other))
                 }
             }
         }
@@ -328,7 +338,12 @@ async fn flush_every_second(
 }
 
 impl CoyoteLogs {
-    pub fn new(path: Dir, fsync_mode: FsyncMode) -> anyhow::Result<Self> {
+    pub fn new(
+        path: Dir,
+        commits_before_fsync: usize,
+        duration_before_fsync: Duration,
+        ack_immediately: bool,
+    ) -> anyhow::Result<Self> {
         let pb: std::path::PathBuf = path.into();
         let db = Database::builder(&pb).worker_threads(1).open()?;
         let log_keyspace = db.keyspace("cluster:logs", || {
@@ -338,10 +353,16 @@ impl CoyoteLogs {
         })?;
         let meta_keyspace = db.keyspace("cluster:meta", KeyspaceCreateOptions::default)?;
         let (flush_tx, flush_rx) = tokio::sync::mpsc::channel(1000);
-        if fsync_mode == FsyncMode::EveryCommit {
-            tokio::spawn(flush_every_commit(db.clone(), flush_rx));
+        if commits_before_fsync == 1 {
+            tokio::spawn(flush_every_worker(db.clone(), flush_rx));
         } else {
-            tokio::spawn(flush_every_second(db.clone(), flush_rx));
+            tokio::spawn(flush_worker(
+                db.clone(),
+                flush_rx,
+                commits_before_fsync,
+                duration_before_fsync,
+                ack_immediately,
+            ));
         }
         Ok(Self {
             db,
@@ -401,11 +422,11 @@ impl CoyoteLogs {
         Span::current().record("num_entries", entries.len());
 
         let keyspace = self.log_keyspace.clone();
-        let mut batch = fjall::OwnedWriteBatch::with_capacity(self.db.clone(), entries.len())
-            .durability(Some(PersistMode::Buffer));
         let persisted_entries = entries.clone();
+        // set durability to None because we're going to sync it in the flush worker
+        let mut batch =
+            fjall::OwnedWriteBatch::with_capacity(self.db.clone(), entries.len()).durability(None);
         spawn_blocking_in_current_span(move || -> anyhow::Result<()> {
-            let _guard = tracing::info_span!("append:write_entries").entered();
             for entry in persisted_entries {
                 let (k, v) = Log(entry).to_fjall_entry()?;
                 batch.insert(&keyspace, k, v);
@@ -413,6 +434,7 @@ impl CoyoteLogs {
             batch.commit()?;
             Ok(())
         })
+        .instrument(tracing::info_span!("append:write_entries"))
         .await??;
 
         self.flush_tx
@@ -608,6 +630,8 @@ fn spawn_blocking_in_current_span<T: Send + 'static>(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::CoyoteLogs;
     use crate::cfg::Dir;
     use jiff::{Span, Timestamp};
@@ -623,7 +647,7 @@ mod tests {
         fn new() -> Self {
             let workdir = tempfile::tempdir().unwrap();
             let logdir = Dir::new(&workdir).unwrap();
-            let logs = CoyoteLogs::new(logdir, crate::cfg::FsyncMode::default()).unwrap();
+            let logs = CoyoteLogs::new(logdir, 0, Duration::from_hours(1), true).unwrap();
             Self {
                 _workdir: workdir,
                 logs,

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -249,6 +249,7 @@ async fn flush_every_worker(
     while let Some(callback) = channel.recv().await {
         let db = db.clone();
         let result = tokio::task::spawn_blocking(move || {
+            let _guard = tracing::info_span!("logs:flush_worker:every").entered();
             tracing::trace!("fsyncing logs to disk");
             db.persist(PersistMode::SyncAll)
                 // fjall::Error isn't Clone
@@ -257,7 +258,6 @@ async fn flush_every_worker(
                     BackgroundFsyncFailedError(err.to_string())
                 })
         })
-        .instrument(tracing::info_span!("logs:flush_worker:every"))
         .await
         .expect("failed joining blocking task");
         callback.log_io_completed(result.map_err(std::io::Error::other));
@@ -277,60 +277,69 @@ async fn flush_worker(
     let shutting_down = crate::shutting_down_token();
     let mut ticker = tokio::time::interval(duration_before_fsync);
     while !done {
-        let mut sync_now = false;
+        async {
+            let mut sync_now = false;
 
-        tokio::select! {
-            message = channel.recv() => {
-                if let Some(callback) = message {
-                    let db = db.clone();
-                    let result = tokio::task::spawn_blocking(move || {
-                        db.persist(PersistMode::Buffer)
-                            // fjall::Error isn't Clone
-                            .map_err(|err| {
-                                tracing::error!(?err, "error flushing fjall in background");
-                                BackgroundFsyncFailedError(err.to_string())
-                            })
-                    })
-                    .instrument(tracing::info_span!("logs:flush_worker:buffer"))
-                    .await
-                    .expect("failed joining blocking task");
-                    if ack_immediately {
-                        callback.log_io_completed(result.map_err(std::io::Error::other));
-                        pending.push(None);
+            tokio::select! {
+                message = channel.recv() => {
+                    if let Some(callback) = message {
+                        let db = db.clone();
+                        let result = spawn_blocking_in_current_span(move || {
+                            let _guard = tracing::info_span!("logs:flush_worker:buffer").entered();
+                            db.persist(PersistMode::Buffer)
+                                // fjall::Error isn't Clone
+                                .map_err(|err| {
+                                    tracing::error!(?err, "error flushing fjall in background");
+                                    BackgroundFsyncFailedError(err.to_string())
+                                })
+                        })
+                        .await
+                        .expect("failed joining blocking task");
+                        if ack_immediately {
+                            callback.log_io_completed(result.map_err(std::io::Error::other));
+                            pending.push(None);
+                        } else {
+                            pending.push(Some(callback))
+                        }
                     } else {
-                        pending.push(Some(callback))
+                        done = true;
                     }
-                } else {
-                    done = true;
+                },
+                _ = shutting_down.cancelled() => {
+                    done = true
+                },
+                _ = ticker.tick() => {
+                    sync_now = pending.len() > 0
                 }
-            },
-            _ = shutting_down.cancelled() => {
-                done = true
-            },
-            _ = ticker.tick() => {
-                sync_now = pending.len() > 0
             }
-        }
 
-        if sync_now || (commits_before_fsync > 0 && pending.len() >= commits_before_fsync) {
-            let db = db.clone();
-            let result =
-                tokio::task::spawn_blocking(move || -> Result<(), BackgroundFsyncFailedError> {
-                    tracing::trace!("flushing logs to disk");
-                    db.persist(PersistMode::SyncAll).map_err(|err| {
-                        tracing::error!(?err, "error flushing fjall");
-                        BackgroundFsyncFailedError(err.to_string())
-                    })
-                })
-                .instrument(tracing::info_span!("logs:flush_worker:flush"))
+            if sync_now || (commits_before_fsync > 0 && pending.len() >= commits_before_fsync) {
+                let db = db.clone();
+                let num_commits = pending.len();
+                let result = spawn_blocking_in_current_span(
+                    move || -> Result<(), BackgroundFsyncFailedError> {
+                        let _guard =
+                            tracing::info_span!("logs:flush_worker:flush", num_commits).entered();
+                        tracing::trace!("flushing logs to disk");
+                        db.persist(PersistMode::SyncAll).map_err(|err| {
+                            tracing::error!(?err, "error flushing fjall");
+                            BackgroundFsyncFailedError(err.to_string())
+                        })
+                    },
+                )
                 .await
                 .expect("failed joining blocking task");
-            for item in pending.drain(..) {
-                if let Some(callback) = item {
-                    callback.log_io_completed(result.clone().map_err(std::io::Error::other))
-                }
+                tracing::info_span!("logs:flush_worker:drain").in_scope(|| {
+                    for item in pending.drain(..) {
+                        if let Some(callback) = item {
+                            callback.log_io_completed(result.clone().map_err(std::io::Error::other))
+                        }
+                    }
+                });
             }
         }
+        .instrument(tracing::info_span!("logs:flush_worker"))
+        .await
     }
     if let Err(err) = db.persist(PersistMode::SyncAll) {
         tracing::error!(?err, "error flushing fjall at shutdown");
@@ -427,6 +436,7 @@ impl CoyoteLogs {
         let mut batch =
             fjall::OwnedWriteBatch::with_capacity(self.db.clone(), entries.len()).durability(None);
         spawn_blocking_in_current_span(move || -> anyhow::Result<()> {
+            let _guard = tracing::info_span!("append:write_entries").entered();
             for entry in persisted_entries {
                 let (k, v) = Log(entry).to_fjall_entry()?;
                 batch.insert(&keyspace, k, v);
@@ -434,7 +444,6 @@ impl CoyoteLogs {
             batch.commit()?;
             Ok(())
         })
-        .instrument(tracing::info_span!("append:write_entries"))
         .await??;
 
         self.flush_tx

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -64,8 +64,13 @@ pub async fn initialize_raft(
     cfg: &Configuration,
     app_state: AppState,
 ) -> anyhow::Result<RaftState> {
-    let mut logs = super::CoyoteLogs::new(cfg.cluster.log_path(cfg)?, cfg.cluster.log_sync)
-        .context("setting up log store")?;
+    let mut logs = super::CoyoteLogs::new(
+        cfg.cluster.log_path(cfg)?,
+        cfg.cluster.log_sync_interval_commits,
+        cfg.cluster.log_sync_interval_duration,
+        cfg.cluster.log_ack_immediately,
+    )
+    .context("setting up log store")?;
     let id = logs
         .get_node_id()
         .await
@@ -143,6 +148,8 @@ pub async fn initialize_raft(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use fjall::Database;
     use openraft::{StorageIOError, testing::StoreBuilder};
     use tempfile::TempDir;
@@ -165,7 +172,7 @@ mod tests {
             let workdir = tempfile::tempdir()?;
             let log_path = workdir.path().to_path_buf().join("logs");
             let log_path = Dir::new(log_path)?;
-            let logs = CoyoteLogs::new(log_path, crate::cfg::FsyncMode::default())?;
+            let logs = CoyoteLogs::new(log_path, 1, Duration::from_secs(10), false)?;
 
             let data_path = workdir.path().join("data");
             let e_data_path = workdir.path().join("edata");


### PR DESCRIPTION
This removes the hardcoded "every commit" and "every second" options in favor of more flexible configuration. It also adds configuration validation since there are more complicated invariants here now.