### PR TITLE
Use +beta instead of +nightly for just lint (consistent with CI). Also run just lint

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,8 +3,8 @@ set quiet := true
 HERE := justfile_directory()
 
 lint:
-    cargo +nightly clippy --workspace --fix --allow-dirty --all-features --all-targets
-    cargo +nightly fmt
+    cargo +beta clippy --workspace --fix --allow-dirty --all-features --all-targets
+    cargo +beta fmt
     cargo sort --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
 
 # Test the backend

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -74,7 +74,7 @@ impl LogCacheInner {
     }
 
     fn get(&self, log_index: &u64) -> Option<&LogEntry> {
-        self.inner.get(&log_index)
+        self.inner.get(log_index)
     }
 }
 
@@ -99,7 +99,7 @@ impl LogCache {
     }
 
     fn get(&self, log_index: &u64) -> Option<LogEntry> {
-        self.0.lock().get(log_index).map(|e| e.clone())
+        self.0.lock().get(log_index).cloned()
     }
 }
 


### PR DESCRIPTION
Seems like `clippy` in CI and clippy locally should be in agreement.