### PR TITLE
Propagate tracing info across raft requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
  "coyote-error",
  "http",
  "http-serde",
+ "opentelemetry",
  "paste",
  "serde",
 ]

--- a/crates/coyote-operations/Cargo.toml
+++ b/crates/coyote-operations/Cargo.toml
@@ -10,6 +10,7 @@ axum.workspace = true
 coyote-error.workspace = true
 http.workspace = true
 http-serde.workspace = true
+opentelemetry.workspace = true
 paste.workspace = true
 serde.workspace = true
 

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -1,5 +1,6 @@
 use axum::response::IntoResponse;
-use std::fmt::Debug;
+use opentelemetry::{Context, trace::TraceContextExt};
+use std::{collections::HashMap, fmt::Debug};
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
@@ -26,6 +27,27 @@ pub trait ModuleResponse: Serialize + DeserializeOwned + Clone + Debug {}
 
 pub trait ModuleRequest: Serialize + DeserializeOwned + Clone + Debug {
     type Response: ModuleResponse;
+}
+
+#[derive(Default, Serialize, Deserialize, Clone, Debug)]
+pub struct OperationRequestMetadata {
+    pub trace_context: Option<HashMap<String, String>>,
+}
+
+impl From<Context> for OperationRequestMetadata {
+    fn from(ctx: Context) -> Self {
+        let span = ctx.span();
+        let span_ctx = span.span_context();
+        let traceparent = format!(
+            "00-{}-{}-{}",
+            span_ctx.trace_id(),
+            span_ctx.span_id(),
+            span_ctx.trace_flags().to_u8(),
+        );
+        OperationRequestMetadata {
+            trace_context: Some(HashMap::from([("traceparent".to_string(), traceparent)])),
+        }
+    }
 }
 
 /// coyote_error::Error isn't Serialize or Deserialize, and can contain arbitrary

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -1,17 +1,35 @@
+use crate::core::cluster::handle::Request;
+
 use super::{
     NodeId,
-    handle::{Request, Response},
+    handle::{RequestWithContext, Response},
     state_machine::Store,
 };
 use openraft::LogId;
+use opentelemetry::{Value, propagation::TextMapPropagator};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use tracing::info_span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-#[tracing::instrument(skip_all, fields(request = %request))]
 pub(super) async fn apply_request(
-    request: Request,
+    request: RequestWithContext,
     state_machine: &mut Store,
     log_id: LogId<NodeId>,
 ) -> anyhow::Result<Response> {
-    Ok(match request {
+    let child_span = info_span!("apply_request");
+    let trace_ctx = request
+        .context
+        .as_ref()
+        .and_then(|x| x.trace_context.as_ref());
+    if let Some(ctx) = trace_ctx {
+        let propagator = TraceContextPropagator::new();
+        // This should only fail if OTEL is not enabled:
+        let _ = child_span.set_parent(propagator.extract(ctx));
+    }
+    child_span.set_attribute("request", Value::String(request.to_string().into()));
+    let _exit = child_span.enter();
+
+    Ok(match request.inner {
         Request::Kv(req) => {
             // TODO: this shouldn't be mut but KvStore currently requires it
             let mut store = state_machine

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -7,7 +7,7 @@ use super::{
     raft::Raft,
 };
 use anyhow::Context;
-use coyote_operations::{OperationRequest, OperationResponse};
+use coyote_operations::{OperationRequest, OperationRequestMetadata, OperationResponse};
 use openraft::RaftNetworkFactory;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::Sender;
@@ -46,9 +46,16 @@ pub enum Request {
     Msgs(coyote_msgs::operations::MsgsOperation),
 }
 
-impl fmt::Display for Request {
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct RequestWithContext {
+    pub inner: Request,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<OperationRequestMetadata>,
+}
+
+impl fmt::Display for RequestWithContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
+        match self.inner {
             Request::ClusterInternal(_) => write!(f, "cluster_internal"),
             Request::Kv(_) => write!(f, "kv"),
             Request::CreateKv(_) => write!(f, "create_kv"),
@@ -58,6 +65,15 @@ impl fmt::Display for Request {
             Request::CreateCache(_) => write!(f, "create_cache"),
             Request::CreateIdempotency(_) => write!(f, "create_idempotency"),
             Request::Msgs(_) => write!(f, "msgs"),
+        }
+    }
+}
+
+impl RequestWithContext {
+    pub(crate) fn new(req: Request, ctx: Option<OperationRequestMetadata>) -> Self {
+        Self {
+            inner: req,
+            context: ctx,
         }
     }
 }
@@ -258,7 +274,9 @@ impl RaftState {
             <O as OperationRequest>::Response,
         >>::Error: fmt::Debug,
     {
-        let request = op.into().into();
+        let inner: Request = op.into().into();
+        let request =
+            RequestWithContext::new(inner, Some(opentelemetry::Context::current().into()));
         let response = match self.raft.client_write(request.clone()).await {
             Ok(resp) => {
                 tracing::trace!(log_id=?resp.log_id(), "request applied to log");

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -17,7 +17,7 @@ mod state_machine;
 
 pub use self::{
     app::router,
-    handle::{RaftState, Request},
+    handle::{RaftState, RequestWithContext},
     logs::CoyoteLogs,
     raft::{Raft, TypeConfig, initialize_raft},
     state_machine::Stores,

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use openraft::{LogId, ServerState};
 use serde::{Deserialize, Serialize};
 
-use super::handle::{Request, Response};
+use super::handle::{RequestWithContext, Response};
 use crate::{cfg::PeerAddr, core::cluster::state_machine::ClusterId};
 
 use super::NodeId;
@@ -59,7 +59,7 @@ pub struct HealthResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ForwardedWriteRequest {
     pub source_node_id: NodeId,
-    pub request: Request,
+    pub request: RequestWithContext,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -5,7 +5,7 @@ use openraft::error::{InitializeError, RaftError};
 use tap::TapFallible;
 
 use super::{
-    handle::{RaftState, Request, Response},
+    handle::{RaftState, Request, RequestWithContext, Response},
     node::{Node, NodeId},
     state_machine::StoredSnapshot,
 };
@@ -20,7 +20,7 @@ use crate::{
 
 openraft::declare_raft_types!(
     pub TypeConfig:
-        D = Request,
+        D = RequestWithContext,
         R = Response,
         Node = Node,
         NodeId = NodeId,
@@ -51,8 +51,9 @@ pub(super) async fn initialize_cluster(
         .await?;
     let new_id = ClusterId::generate();
     tracing::debug!(cluster_id=?new_id, "cluster initialized, setting cluster_id");
-    raft.client_write(Request::ClusterInternal(
-        SetClusterUuidOperation(new_id).into(),
+    raft.client_write(RequestWithContext::new(
+        Request::ClusterInternal(SetClusterUuidOperation(new_id).into()),
+        None,
     ))
     .await
     .tap_err(|err| tracing::error!(?err, "failed to set initial cluster id"))?;


### PR DESCRIPTION
This will cause the raft requests to show up as child span of the original HTTP request trace.