### PR TITLE
cluster: some replication improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3741,6 +3741,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "hickory-resolver",
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ proc-macro2 = "1.0.78"
 quote = "1.0.15"
 rand = "0.9.2"
 regex = "1.5.5"
-reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "hickory-dns", "stream"] }
+reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "hickory-dns", "stream", "http2"] }
 rmp-serde = "1.3.1"
 rmpv = "1.3.1"
 rustls = "0.23.31"

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -30,6 +30,7 @@ pub(super) fn build_client(
     }
     let client = reqwest::Client::builder()
         .connect_timeout(cfg.cluster.connection_timeout)
+        .http2_prior_knowledge()
         .default_headers(headers)
         .build()
         .context("building raft network client")?;

--- a/src/core/otel_spans.rs
+++ b/src/core/otel_spans.rs
@@ -48,7 +48,7 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             .get("x-request-id")
             .and_then(|id| id.to_str().map(ToOwned::to_owned).ok())
             // If `x-request-id` isn't set, check `svix-req-id`. If the `svix-req-id` isn't a
-            // valid `str`, or it isn't set, then fallback to a random [`KsuidMs`]
+            // valid `str`, or it isn't set, then fallback to a random [`Uuid`]
             .or_else(|| {
                 request
                     .headers()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ use tokio::{
     net::TcpListener,
     sync::{Barrier, Mutex},
 };
+use tower_http::trace::TraceLayer;
+
 use tokio_util::sync::CancellationToken;
 use tower_http::{
     ServiceExt,
@@ -50,6 +52,7 @@ use crate::{
     core::{
         cluster::RaftState,
         db::{Databases, ReadonlyDatabases},
+        otel_spans::{AxumOtelOnFailure, AxumOtelOnResponse, AxumOtelSpanCreator},
     },
 };
 use coyote_cache::CacheStore;
@@ -154,7 +157,13 @@ async fn run_interserver(
     let app = core::cluster::router(&cfg)
         .with_state(state.clone())
         .layer(Extension(raft.clone()))
-        .layer(middleware::from_fn(coyote_proto::capture_accept_hdr));
+        .layer(middleware::from_fn(coyote_proto::capture_accept_hdr))
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(AxumOtelSpanCreator)
+                .on_response(AxumOtelOnResponse)
+                .on_failure(AxumOtelOnFailure),
+        );
     let svc = tower::make::Shared::new(
         // It is important that this service wraps the router instead of being
         // applied via `Router::layer`, as it would run after routing then.


### PR DESCRIPTION
Changes:

 - enable otel logs for interserver protocol endpoints
 - use HTTTP/2 for interserver requests
 - fix a bad comment