### PR TITLE
python: Remove dead template code

### DIFF
--- a/codegen/templates/python/api_resource.py.jinja
+++ b/codegen/templates/python/api_resource.py.jinja
@@ -1,7 +1,4 @@
 # This file is @generated
-{% set api_mod_name %}{{ resource.name | to_snake_case }}_api{% endset -%}
-{% set resource_class_name = resource.name | to_upper_camel_case -%}
-{% set resource_type_name = resource.name | to_upper_camel_case -%}
 import typing as t
 from datetime import datetime
 from dataclasses import dataclass


### PR DESCRIPTION
The variables being `set` there were copy-pasted from Svix, but aren't used in the template anymore.