### PR TITLE
Reorder fields in KvSetIn

### DIFF
--- a/clients/go/internal/models/kv_set_in.go
+++ b/clients/go/internal/models/kv_set_in.go
@@ -4,7 +4,7 @@ package coyote_models
 
 type KvSetIn struct {
 	Key      string             `json:"key"`
+	Value    []uint8            `json:"value"`
 	Ttl      *uint64            `json:"ttl,omitempty"` // Time to live in milliseconds
 	Behavior *OperationBehavior `json:"behavior,omitempty"`
-	Value    []uint8            `json:"value"`
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/KvSetIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvSetIn.java
@@ -29,9 +29,9 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class KvSetIn {
 @JsonProperty private String key;
+@JsonProperty private List<Byte> value;
 @JsonProperty private Long ttl;
 @JsonProperty private OperationBehavior behavior;
-@JsonProperty private List<Byte> value;
 public KvSetIn () {}
 
  public KvSetIn key(String key) {
@@ -51,6 +51,32 @@ public KvSetIn () {}
 
      public void setKey(String key) {
         this.key = key;
+    }
+
+     public KvSetIn value(List<Byte> value) {
+        this.value = value;
+        return this;
+    }
+
+     public KvSetIn addValueItem(Byte valueItem) {
+        if (this.value == null) {
+            this.value = new ArrayList<>();
+        }
+        this.value.add(valueItem);
+        return this;
+    }
+    /**
+    * Get value
+    *
+     * @return value
+     */
+    @javax.annotation.Nonnull
+     public List<Byte> getValue() {
+        return value;
+    }
+
+     public void setValue(List<Byte> value) {
+        this.value = value;
     }
 
      public KvSetIn ttl(Long ttl) {
@@ -89,32 +115,6 @@ public KvSetIn () {}
 
      public void setBehavior(OperationBehavior behavior) {
         this.behavior = behavior;
-    }
-
-     public KvSetIn value(List<Byte> value) {
-        this.value = value;
-        return this;
-    }
-
-     public KvSetIn addValueItem(Byte valueItem) {
-        if (this.value == null) {
-            this.value = new ArrayList<>();
-        }
-        this.value.add(valueItem);
-        return this;
-    }
-    /**
-    * Get value
-    *
-     * @return value
-     */
-    @javax.annotation.Nonnull
-     public List<Byte> getValue() {
-        return value;
-    }
-
-     public void setValue(List<Byte> value) {
-        this.value = value;
     }
 
     /**

--- a/clients/javascript/src/models/kvSetIn.ts
+++ b/clients/javascript/src/models/kvSetIn.ts
@@ -10,28 +10,28 @@ import {
 
 export interface KvSetIn {
     key: string;
+value: number[];
 /** Time to live in milliseconds */
     ttl?: number | null;
 behavior?: OperationBehavior;
-value: number[];
 }
 
 export const KvSetInSerializer = {
     _fromJsonObject(object: any): KvSetIn {
         return {
             key: object['key'],
+            value: object['value'],
             ttl: object['ttl'],
             behavior: object['behavior'] != null ? OperationBehaviorSerializer._fromJsonObject(object['behavior']): undefined,
-            value: object['value'],
             };
     },
 
     _toJsonObject(self: KvSetIn): any {
         return {
             'key': self.key,
+            'value': self.value,
             'ttl': self.ttl,
             'behavior': self.behavior != null ? OperationBehaviorSerializer._toJsonObject(self.behavior) : undefined,
-            'value': self.value,
             };
     }
 }

--- a/clients/python/coyote/models/kv_set_in.py
+++ b/clients/python/coyote/models/kv_set_in.py
@@ -9,9 +9,9 @@ from .operation_behavior import OperationBehavior
 class KvSetIn(BaseModel):
     key: str
 
+    value: bytes
+
     ttl: t.Optional[int] = None
     """Time to live in milliseconds"""
 
     behavior: t.Optional[OperationBehavior] = None
-
-    value: bytes

--- a/clients/rust/src/models/kv_set_in.rs
+++ b/clients/rust/src/models/kv_set_in.rs
@@ -7,23 +7,23 @@ use super::operation_behavior::OperationBehavior;
 pub struct KvSetIn {
     pub key: String,
 
+    pub value: Vec<u8>,
+
     /// Time to live in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ttl: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub behavior: Option<OperationBehavior>,
-
-    pub value: Vec<u8>,
 }
 
 impl KvSetIn {
     pub fn new(key: String, value: Vec<u8>) -> Self {
         Self {
             key,
+            value,
             ttl: None,
             behavior: None,
-            value,
         }
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1239,6 +1239,15 @@
             "pattern": "^[a-zA-Z0-9\\-_.:]+$",
             "example": "some_key"
           },
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0,
+              "maximum": 255
+            }
+          },
           "ttl": {
             "description": "Time to live in milliseconds",
             "type": "integer",
@@ -1249,15 +1258,6 @@
           "behavior": {
             "default": "upsert",
             "$ref": "#/components/schemas/OperationBehavior"
-          },
-          "value": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0,
-              "maximum": 255
-            }
           }
         },
         "required": [

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -38,14 +38,14 @@ pub struct KvSetIn {
     #[validate(nested)]
     pub key: Arc<EntityKey>,
 
+    pub value: Vec<u8>,
+
     /// Time to live in milliseconds
     #[validate(range(min = 1))]
     pub ttl: Option<u64>,
 
     #[serde(default)]
     pub behavior: OperationBehavior,
-
-    pub value: Vec<u8>,
 }
 
 impl KvSetIn {


### PR DESCRIPTION
Put required field value before optional fields.

Doesn't affect normal use of the SDKs right now (and might never do), but feels cleaner.