### PR TITLE
python: Fix serialization when `None`s are explicitly specified 

### DIFF
--- a/clients/python/coyote/apis/cache.py
+++ b/clients/python/coyote/apis/cache.py
@@ -27,7 +27,7 @@ class CacheAsync(ApiBase):
             key=key,
             value=cache_set_in.value,
             ttl=cache_set_in.ttl,
-        ).model_dump(exclude_unset=True, by_alias=True)
+        ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -44,7 +44,7 @@ class CacheAsync(ApiBase):
         """Cache Get"""
         body = _CacheGetIn(
             key=key,
-        ).model_dump(exclude_unset=True, by_alias=True)
+        ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -58,7 +58,7 @@ class CacheAsync(ApiBase):
         cache_get_namespace_in: CacheGetNamespaceIn,
     ) -> CacheGetNamespaceOut:
         """Get cache namespace"""
-        body = cache_get_namespace_in.model_dump(exclude_unset=True, by_alias=True)
+        body = cache_get_namespace_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -72,7 +72,7 @@ class CacheAsync(ApiBase):
         cache_delete_in: CacheDeleteIn,
     ) -> CacheDeleteOut:
         """Cache Delete"""
-        body = cache_delete_in.model_dump(exclude_unset=True, by_alias=True)
+        body = cache_delete_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -93,7 +93,7 @@ class Cache(ApiBase):
             key=key,
             value=cache_set_in.value,
             ttl=cache_set_in.ttl,
-        ).model_dump(exclude_unset=True, by_alias=True)
+        ).model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -110,7 +110,7 @@ class Cache(ApiBase):
         """Cache Get"""
         body = _CacheGetIn(
             key=key,
-        ).model_dump(exclude_unset=True, by_alias=True)
+        ).model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -124,7 +124,7 @@ class Cache(ApiBase):
         cache_get_namespace_in: CacheGetNamespaceIn,
     ) -> CacheGetNamespaceOut:
         """Get cache namespace"""
-        body = cache_get_namespace_in.model_dump(exclude_unset=True, by_alias=True)
+        body = cache_get_namespace_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -138,7 +138,7 @@ class Cache(ApiBase):
         cache_delete_in: CacheDeleteIn,
     ) -> CacheDeleteOut:
         """Cache Delete"""
-        body = cache_delete_in.model_dump(exclude_unset=True, by_alias=True)
+        body = cache_delete_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/apis/idempotency.py
+++ b/clients/python/coyote/apis/idempotency.py
@@ -15,7 +15,7 @@ class IdempotencyAsync(ApiBase):
         idempotency_abort_in: IdempotencyAbortIn,
     ) -> IdempotencyAbortOut:
         """Abandon an idempotent request (remove lock without saving response)"""
-        body = idempotency_abort_in.model_dump(exclude_unset=True, by_alias=True)
+        body = idempotency_abort_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -29,9 +29,7 @@ class IdempotencyAsync(ApiBase):
         idempotency_get_namespace_in: IdempotencyGetNamespaceIn,
     ) -> IdempotencyGetNamespaceOut:
         """Get idempotency namespace"""
-        body = idempotency_get_namespace_in.model_dump(
-            exclude_unset=True, by_alias=True
-        )
+        body = idempotency_get_namespace_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -47,7 +45,7 @@ class Idempotency(ApiBase):
         idempotency_abort_in: IdempotencyAbortIn,
     ) -> IdempotencyAbortOut:
         """Abandon an idempotent request (remove lock without saving response)"""
-        body = idempotency_abort_in.model_dump(exclude_unset=True, by_alias=True)
+        body = idempotency_abort_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -61,9 +59,7 @@ class Idempotency(ApiBase):
         idempotency_get_namespace_in: IdempotencyGetNamespaceIn,
     ) -> IdempotencyGetNamespaceOut:
         """Get idempotency namespace"""
-        body = idempotency_get_namespace_in.model_dump(
-            exclude_unset=True, by_alias=True
-        )
+        body = idempotency_get_namespace_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/apis/kv.py
+++ b/clients/python/coyote/apis/kv.py
@@ -19,7 +19,7 @@ class KvAsync(ApiBase):
         kv_set_in: KvSetIn,
     ) -> KvSetOut:
         """KV Set"""
-        body = kv_set_in.model_dump(exclude_unset=True, by_alias=True)
+        body = kv_set_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -33,7 +33,7 @@ class KvAsync(ApiBase):
         kv_get_in: KvGetIn,
     ) -> KvGetOut:
         """KV Get"""
-        body = kv_get_in.model_dump(exclude_unset=True, by_alias=True)
+        body = kv_get_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -47,7 +47,7 @@ class KvAsync(ApiBase):
         kv_get_namespace_in: KvGetNamespaceIn,
     ) -> KvGetNamespaceOut:
         """Get KV namespace"""
-        body = kv_get_namespace_in.model_dump(exclude_unset=True, by_alias=True)
+        body = kv_get_namespace_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -61,7 +61,7 @@ class KvAsync(ApiBase):
         kv_delete_in: KvDeleteIn,
     ) -> KvDeleteOut:
         """KV Delete"""
-        body = kv_delete_in.model_dump(exclude_unset=True, by_alias=True)
+        body = kv_delete_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -77,7 +77,7 @@ class Kv(ApiBase):
         kv_set_in: KvSetIn,
     ) -> KvSetOut:
         """KV Set"""
-        body = kv_set_in.model_dump(exclude_unset=True, by_alias=True)
+        body = kv_set_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -91,7 +91,7 @@ class Kv(ApiBase):
         kv_get_in: KvGetIn,
     ) -> KvGetOut:
         """KV Get"""
-        body = kv_get_in.model_dump(exclude_unset=True, by_alias=True)
+        body = kv_get_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -105,7 +105,7 @@ class Kv(ApiBase):
         kv_get_namespace_in: KvGetNamespaceIn,
     ) -> KvGetNamespaceOut:
         """Get KV namespace"""
-        body = kv_get_namespace_in.model_dump(exclude_unset=True, by_alias=True)
+        body = kv_get_namespace_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -119,7 +119,7 @@ class Kv(ApiBase):
         kv_delete_in: KvDeleteIn,
     ) -> KvDeleteOut:
         """KV Delete"""
-        body = kv_delete_in.model_dump(exclude_unset=True, by_alias=True)
+        body = kv_delete_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/apis/msgs.py
+++ b/clients/python/coyote/apis/msgs.py
@@ -37,7 +37,7 @@ class MsgsAsync(ApiBase):
         msg_publish_in: MsgPublishIn,
     ) -> MsgPublishOut:
         """Publishes messages to a topic within a namespace."""
-        body = msg_publish_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_publish_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -65,7 +65,7 @@ class Msgs(ApiBase):
         msg_publish_in: MsgPublishIn,
     ) -> MsgPublishOut:
         """Publishes messages to a topic within a namespace."""
-        body = msg_publish_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_publish_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/apis/msgs_namespace.py
+++ b/clients/python/coyote/apis/msgs_namespace.py
@@ -15,7 +15,7 @@ class MsgsNamespaceAsync(ApiBase):
         msg_namespace_create_in: MsgNamespaceCreateIn,
     ) -> MsgNamespaceCreateOut:
         """Creates or updates a msgs namespace with the given name."""
-        body = msg_namespace_create_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_namespace_create_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -29,7 +29,7 @@ class MsgsNamespaceAsync(ApiBase):
         msg_namespace_get_in: MsgNamespaceGetIn,
     ) -> MsgNamespaceGetOut:
         """Gets a msgs namespace by name."""
-        body = msg_namespace_get_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_namespace_get_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -45,7 +45,7 @@ class MsgsNamespace(ApiBase):
         msg_namespace_create_in: MsgNamespaceCreateIn,
     ) -> MsgNamespaceCreateOut:
         """Creates or updates a msgs namespace with the given name."""
-        body = msg_namespace_create_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_namespace_create_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -59,7 +59,7 @@ class MsgsNamespace(ApiBase):
         msg_namespace_get_in: MsgNamespaceGetIn,
     ) -> MsgNamespaceGetOut:
         """Gets a msgs namespace by name."""
-        body = msg_namespace_get_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_namespace_get_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/apis/msgs_stream.py
+++ b/clients/python/coyote/apis/msgs_stream.py
@@ -18,7 +18,7 @@ class MsgsStreamAsync(ApiBase):
 
         Each consumer in the group reads from all partitions. Messages are locked by leases for the
         specified duration to prevent duplicate delivery within the same consumer group."""
-        body = msg_stream_receive_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_stream_receive_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -35,7 +35,7 @@ class MsgsStreamAsync(ApiBase):
 
         The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
         successfully processed offset; future receives will start after it."""
-        body = msg_stream_commit_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_stream_commit_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -54,7 +54,7 @@ class MsgsStream(ApiBase):
 
         Each consumer in the group reads from all partitions. Messages are locked by leases for the
         specified duration to prevent duplicate delivery within the same consumer group."""
-        body = msg_stream_receive_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_stream_receive_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -71,7 +71,7 @@ class MsgsStream(ApiBase):
 
         The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
         successfully processed offset; future receives will start after it."""
-        body = msg_stream_commit_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_stream_commit_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/apis/msgs_topic.py
+++ b/clients/python/coyote/apis/msgs_topic.py
@@ -15,7 +15,7 @@ class MsgsTopicAsync(ApiBase):
         """Configures the number of partitions for a topic.
 
         Partition count can only be increased, never decreased. The default for a new topic is 1."""
-        body = msg_topic_configure_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_topic_configure_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -33,7 +33,7 @@ class MsgsTopic(ApiBase):
         """Configures the number of partitions for a topic.
 
         Partition count can only be increased, never decreased. The default for a new topic is 1."""
-        body = msg_topic_configure_in.model_dump(exclude_unset=True, by_alias=True)
+        body = msg_topic_configure_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/apis/rate_limiter.py
+++ b/clients/python/coyote/apis/rate_limiter.py
@@ -15,7 +15,7 @@ class RateLimiterAsync(ApiBase):
         rate_limiter_check_in: RateLimiterCheckIn,
     ) -> RateLimiterCheckOut:
         """Rate Limiter Check and Consume"""
-        body = rate_limiter_check_in.model_dump(exclude_unset=True, by_alias=True)
+        body = rate_limiter_check_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -29,9 +29,7 @@ class RateLimiterAsync(ApiBase):
         rate_limiter_get_remaining_in: RateLimiterGetRemainingIn,
     ) -> RateLimiterGetRemainingOut:
         """Rate Limiter Get Remaining"""
-        body = rate_limiter_get_remaining_in.model_dump(
-            exclude_unset=True, by_alias=True
-        )
+        body = rate_limiter_get_remaining_in.model_dump(exclude_none=True)
 
         return await self._request_asyncio(
             method="post",
@@ -47,7 +45,7 @@ class RateLimiter(ApiBase):
         rate_limiter_check_in: RateLimiterCheckIn,
     ) -> RateLimiterCheckOut:
         """Rate Limiter Check and Consume"""
-        body = rate_limiter_check_in.model_dump(exclude_unset=True, by_alias=True)
+        body = rate_limiter_check_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",
@@ -61,9 +59,7 @@ class RateLimiter(ApiBase):
         rate_limiter_get_remaining_in: RateLimiterGetRemainingIn,
     ) -> RateLimiterGetRemainingOut:
         """Rate Limiter Get Remaining"""
-        body = rate_limiter_get_remaining_in.model_dump(
-            exclude_unset=True, by_alias=True
-        )
+        body = rate_limiter_get_remaining_in.model_dump(exclude_none=True)
 
         return self._request_sync(
             method="post",

--- a/clients/python/coyote/internal/base_model.py
+++ b/clients/python/coyote/internal/base_model.py
@@ -5,6 +5,5 @@ from pydantic.alias_generators import to_camel
 class BaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(
         alias_generator=to_camel,
-        populate_by_name=True,
-        json_encoders={set: lambda v: list(v)},
+        serialize_by_alias=True,
     )

--- a/codegen/templates/python/api_resource.py.jinja
+++ b/codegen/templates/python/api_resource.py.jinja
@@ -102,7 +102,7 @@ class {{ resource.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}
         {%- else -%}
         {{ req_body_schema_snake }}
         {%- endif -%}
-        .model_dump(exclude_unset=True, by_alias=True)
+        .model_dump(exclude_none=True)
         {%- endif %}
 
         {% if op.response_body_schema_name is defined -%}return {% endif -%}


### PR DESCRIPTION
Not sure if there's a server bug here, because it seems like it should accept the msgpack equivalent of `null` for `Option`s IMO. But still, it's more efficient if we skip them and sending a different payload for `KvSetIn(value=b'x')` and `KvSetIn(value=b'x', ttl=None)` is very much not expected.

Also remove the unused `json_encoders` property on the `BaseModel` (we don't serialize to JSON anymore) and replace the deprecated `populate_by_name` by the new `serialize_by_alias`.