### PR TITLE
Grabbag of prefactors / code simplifications

### DIFF
--- a/crates/coyote-namespace/src/lib.rs
+++ b/crates/coyote-namespace/src/lib.rs
@@ -79,23 +79,9 @@ impl State {
 
     pub fn fetch_namespace<C: ModuleConfig>(
         &self,
-        namespace_name: Option<&str>,
+        namespace_name: &str,
     ) -> Result<Option<Namespace<C>>> {
-        if let Some(ns) = namespace_name
-            && ns == DEFAULT_NAMESPACE_NAME
-        {
-            return Err(coyote_error::Error::http(
-                coyote_error::HttpError::bad_request(
-                    Some("no_explicit_default_namespace".to_owned()),
-                    Some("Explicitly setting the \"default\" namespace is not allowed.".to_owned()),
-                ),
-            ));
-        }
-
-        Namespace::fetch(
-            &self.keyspace,
-            namespace_name.unwrap_or(DEFAULT_NAMESPACE_NAME),
-        )
+        Namespace::fetch(&self.keyspace, namespace_name)
     }
 
     /// Like `fetch_namespace` but allows passing `default` explicitly for admin purposes.

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt, ops::Deref, str::FromStr};
 
 use coyote_error::Error;
-use coyote_namespace::{entities::NamespaceName, parse_namespace};
+use coyote_namespace::{DEFAULT_NAMESPACE_NAME, entities::NamespaceName, parse_namespace};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{
@@ -59,12 +59,12 @@ impl FromStr for Partition {
 /// `"topic"` when the namespace is the default.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TopicName {
-    namespace: Option<NamespaceName>,
+    namespace: NamespaceName,
     topic: String,
 }
 
 impl TopicName {
-    pub fn new(namespace: Option<NamespaceName>, topic: String) -> Result<Self, Error> {
+    pub fn new(namespace: NamespaceName, topic: String) -> Result<Self, Error> {
         if topic.contains(TOPIC_PARTITION_DELIMITER) {
             Err(Error::generic("invalid topic"))
         } else if topic.len() > 64 {
@@ -74,8 +74,8 @@ impl TopicName {
         }
     }
 
-    pub fn namespace(&self) -> Option<&str> {
-        self.namespace.as_ref().map(|x| &x[..])
+    pub fn namespace(&self) -> &str {
+        &self.namespace
     }
 }
 
@@ -90,8 +90,8 @@ impl Deref for TopicName {
 
 impl fmt::Display for TopicName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(namespace) = &self.namespace {
-            write!(f, "{}{}{}", namespace, NAMESPACE_DELIMITER, self.topic)
+        if self.namespace != DEFAULT_NAMESPACE_NAME {
+            write!(f, "{}{}{}", self.namespace, NAMESPACE_DELIMITER, self.topic)
         } else {
             write!(f, "{}", self.topic)
         }
@@ -114,7 +114,11 @@ impl<'de> Deserialize<'de> for TopicName {
     {
         let s = String::deserialize(deserializer)?;
         let (ns, topic) = parse_namespace(&s);
-        Self::new(ns.map(|x| x.to_owned()), topic.to_owned()).map_err(de::Error::custom)
+        Self::new(
+            ns.unwrap_or(DEFAULT_NAMESPACE_NAME).to_owned(),
+            topic.to_owned(),
+        )
+        .map_err(de::Error::custom)
     }
 }
 
@@ -143,7 +147,7 @@ impl TopicPartition {
         Self { raw, partition }
     }
 
-    pub fn namespace(&self) -> Option<&str> {
+    pub fn namespace(&self) -> &str {
         self.raw.namespace()
     }
 }
@@ -160,7 +164,10 @@ impl TryFrom<String> for TopicPartition {
             .parse()
             .map_err(|_| Error::generic("invalid partition index in topic"))?;
         let partition = Partition::new(idx)?;
-        let raw = TopicName::new(ns.map(|x| x.to_owned()), topic.to_owned())?;
+        let raw = TopicName::new(
+            ns.unwrap_or(DEFAULT_NAMESPACE_NAME).to_owned(),
+            topic.to_owned(),
+        )?;
         Ok(Self { raw, partition })
     }
 }
@@ -226,7 +233,7 @@ impl TopicIn {
         }
     }
 
-    pub fn namespace(&self) -> Option<&str> {
+    pub fn namespace(&self) -> &str {
         self.topic_name().namespace()
     }
 }
@@ -244,9 +251,12 @@ impl<'de> Deserialize<'de> for TopicIn {
                 .map(TopicIn::TopicPartition)
                 .map_err(de::Error::custom)
         } else {
-            TopicName::new(ns.map(|x| x.to_owned()), rest.to_owned())
-                .map(TopicIn::TopicName)
-                .map_err(de::Error::custom)
+            TopicName::new(
+                ns.unwrap_or(DEFAULT_NAMESPACE_NAME).to_owned(),
+                rest.to_owned(),
+            )
+            .map(TopicIn::TopicName)
+            .map_err(de::Error::custom)
         }
     }
 }

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -216,9 +216,7 @@ impl JsonSchema for TopicPartition {
 }
 
 /// Topic input from the user, which may or may not contain the partition.
-// TODO: remove Serialize — only needed temporarily for Raft operation serialization.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TopicIn {
     TopicName(TopicName),
     TopicPartition(TopicPartition),

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -1,21 +1,26 @@
-use std::{collections::BTreeMap, time::Instant};
-
-use coyote_namespace::entities::NamespaceId;
-use jiff::Timestamp;
-use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 use crate::{
     State,
-    entities::{MsgIn, Offset, Partition, TopicIn, TopicPartition, partition_for_key},
+    entities::{
+        MsgIn, Offset, Partition, TopicId, TopicIn, TopicName, TopicPartition, partition_for_key,
+    },
     tables::{MsgRow, TableRow, TopicRow},
 };
+use coyote_error::Error;
+use coyote_namespace::entities::NamespaceId;
+use fjall::OwnedWriteBatch;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use tracing::Span;
 
 use super::{MsgsRaftState, MsgsRequest, PublishResponse};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublishOperation {
     namespace_id: NamespaceId,
-    topic: TopicIn,
+    topic: TopicName,
+    partition: Option<Partition>,
     msgs: Vec<MsgIn>,
     now: Timestamp,
 }
@@ -26,9 +31,22 @@ impl PublishOperation {
         topic: TopicIn,
         msgs: Vec<MsgIn>,
     ) -> coyote_error::Result<Self> {
+        let (topic, partition) = match topic {
+            TopicIn::TopicPartition(tp) => {
+                if msgs.iter().any(|m| m.key.is_some()) {
+                    return Err(Error::invalid_user_input(
+                        "msg key cannot be specified alongside a specific partition",
+                    ));
+                }
+                (tp.raw, Some(tp.partition))
+            }
+            TopicIn::TopicName(tn) => (tn, None),
+        };
+
         Ok(Self {
             namespace_id,
             topic,
+            partition,
             msgs,
             now: Timestamp::now(),
         })
@@ -36,109 +54,44 @@ impl PublishOperation {
 
     #[tracing::instrument(skip_all, level = "debug", fields(msg_count = self.msgs.len()))]
     fn apply_real(self, state: &State) -> coyote_operations::Result<PublishResponseData> {
-        let topic_row = TopicRow::fetch(
-            &state.metadata_tables,
-            self.namespace_id,
-            self.topic.topic_name(),
-        )?;
+        let topic_row = TopicRow::fetch(&state.metadata_tables, self.namespace_id, &self.topic)?;
         let mut batch = state.db.batch();
 
-        let topic_row = match (topic_row, &self.topic) {
-            (Some(topic_row), TopicIn::TopicPartition(topic)) => {
-                if !(0..topic_row.partitions).contains(&topic.partition.get()) {
-                    return Err(
-                        coyote_error::Error::http(coyote_error::HttpError::bad_request(
-                            Some("partition_out_of_range".to_owned()),
-                            None,
-                        ))
-                        .into(),
-                    );
-                }
-
-                topic_row
+        let topic_row = match (topic_row, self.partition) {
+            (Some(row), Some(partition)) if (0..row.partitions).contains(&partition.get()) => row,
+            (Some(_), Some(_)) => {
+                return Err(Error::invalid_user_input("partition out of range").into());
             }
-            (Some(topic_row), TopicIn::TopicName(_)) => {
-                // If there isn't a partition, need to use the key or round-robin choose the right one.
-                topic_row
+            (Some(row), None) => row,
+            (None, Some(_)) => {
+                return Err(Error::invalid_user_input("topic does not exist").into());
             }
-            (None, TopicIn::TopicPartition(_)) => {
-                // Topic has to exist if passing a specific partition
-                return Err(
-                    coyote_error::Error::http(coyote_error::HttpError::bad_request(
-                        Some("partition_must_exist".to_owned()),
-                        None,
-                    ))
-                    .into(),
-                );
-            }
-            (None, TopicIn::TopicName(topic)) => {
-                // Need to create the topic with default settings
-                let topic_row = TopicRow::new(topic.clone(), self.now)?;
+            (None, None) => {
+                let row = TopicRow::new(self.topic.clone(), self.now);
                 batch.insert(
                     &state.metadata_tables,
-                    TopicRow::construct_key(self.namespace_id, topic),
-                    topic_row.to_fjall_value()?,
+                    TopicRow::construct_key(self.namespace_id, &self.topic),
+                    row.to_fjall_value()?,
                 );
-                topic_row
+                row
             }
         };
 
-        tracing::Span::current().record("partition_count", topic_row.partitions);
+        Span::current().record("partition_count", topic_row.partitions);
 
-        // Group the messages by partitions
-        let mut by_partition: BTreeMap<Partition, Vec<MsgIn>> = BTreeMap::new();
-        for msg in self.msgs.into_iter() {
-            let partition =
-                if let TopicIn::TopicPartition(TopicPartition { partition, .. }) = self.topic {
-                    if msg.key.is_some() {
-                        // We currently don't allow setting a key + sending to a specific partition
-                        // We should probably allow it, just need to think about the right way of doing it.
-                        return Err(coyote_error::Error::http(
-                            coyote_error::HttpError::bad_request(
-                                Some("both_key_and_partition_are_set".to_owned()),
-                                None,
-                            ),
-                        )
-                        .into());
-                    }
-                    partition
-                } else {
-                    partition_for_key(msg.key.as_deref(), topic_row.partitions)
-                };
-            by_partition.entry(partition).or_default().push(msg);
-        }
+        let msgs_by_partition =
+            group_msgs_by_partition(self.msgs, self.partition, topic_row.partitions);
 
-        // Write the messages to the db
-        let t = Instant::now();
-        let mut results: Vec<PublishedTopic> = Vec::with_capacity(by_partition.keys().len());
-        for (partition, msgs) in by_partition {
-            let topic = TopicPartition::new(self.topic.topic_name().clone(), partition);
-            let mut offset = MsgRow::next_offset(&state.msg_table, topic_row.id, partition)?;
-            let start_offset = offset;
+        let results = write_msg_batch(
+            &mut batch,
+            &state.msg_table,
+            &self.topic,
+            topic_row.id,
+            msgs_by_partition,
+            self.now,
+        )?;
 
-            for msg in msgs.into_iter() {
-                let msg = MsgRow {
-                    value: msg.value,
-                    headers: msg.headers,
-                    timestamp: self.now + t.elapsed(),
-                };
-                batch.insert(
-                    &state.msg_table,
-                    MsgRow::construct_key(topic_row.id, partition, offset),
-                    msg.to_fjall_value()?,
-                );
-
-                offset += 1;
-            }
-
-            results.push(PublishedTopic {
-                start_offset,
-                topic,
-                offset,
-            });
-        }
-
-        batch.commit().map_err(coyote_error::Error::from)?;
+        batch.commit().map_err(Error::from)?;
 
         Ok(PublishResponseData { topics: results })
     }
@@ -162,4 +115,59 @@ impl MsgsRequest for PublishOperation {
     fn apply(self, state: MsgsRaftState<'_>) -> PublishResponse {
         PublishResponse(self.apply_real(state.msgs))
     }
+}
+
+fn group_msgs_by_partition(
+    msgs: Vec<MsgIn>,
+    partition: Option<Partition>,
+    num_partitions: u16,
+) -> BTreeMap<Partition, Vec<MsgIn>> {
+    let mut msgs_by_partition: BTreeMap<Partition, Vec<MsgIn>> = BTreeMap::new();
+    for msg in msgs {
+        let p = match partition {
+            Some(p) => p,
+            None => partition_for_key(msg.key.as_deref(), num_partitions),
+        };
+        msgs_by_partition.entry(p).or_default().push(msg);
+    }
+    msgs_by_partition
+}
+
+fn write_msg_batch(
+    batch: &mut OwnedWriteBatch,
+    msg_table: &fjall::Keyspace,
+    topic_name: &TopicName,
+    topic_id: TopicId,
+    msgs_by_partition: BTreeMap<Partition, Vec<MsgIn>>,
+    now: Timestamp,
+) -> coyote_operations::Result<Vec<PublishedTopic>> {
+    let mut results: Vec<PublishedTopic> = Vec::with_capacity(msgs_by_partition.len());
+
+    for (partition, msgs) in msgs_by_partition {
+        let topic = TopicPartition::new(topic_name.clone(), partition);
+        let mut offset = MsgRow::next_offset(msg_table, topic_id, partition)?;
+        let start_offset = offset;
+
+        for msg in msgs {
+            let msg = MsgRow {
+                value: msg.value,
+                headers: msg.headers,
+                timestamp: now,
+            };
+            batch.insert(
+                msg_table,
+                MsgRow::construct_key(topic_id, partition, offset),
+                msg.to_fjall_value()?,
+            );
+            offset += 1;
+        }
+
+        results.push(PublishedTopic {
+            start_offset,
+            topic,
+            offset,
+        });
+    }
+
+    Ok(results)
 }

--- a/crates/msgs/src/operations/stream_commit.rs
+++ b/crates/msgs/src/operations/stream_commit.rs
@@ -2,6 +2,8 @@ use coyote_namespace::entities::NamespaceId;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
+use coyote_error::Error;
+
 use crate::{
     State,
     entities::{ConsumerGroup, Offset, TopicPartition},
@@ -41,12 +43,7 @@ impl StreamCommitOperation {
         let topic = self.topic;
 
         let topic_row = TopicRow::fetch(&state.metadata_tables, self.namespace_id, &topic.raw)?
-            .ok_or_else(|| {
-                coyote_error::Error::http(coyote_error::HttpError::bad_request(
-                    Some("partition_must_exist".to_owned()),
-                    None,
-                ))
-            })?;
+            .ok_or_else(|| Error::invalid_user_input("partition must exist"))?;
 
         let mut lease = StreamLeaseRow::fetch(
             &state.metadata_tables,
@@ -54,12 +51,7 @@ impl StreamCommitOperation {
             topic.partition,
             &self.consumer_group,
         )?
-        .ok_or_else(|| {
-            coyote_error::Error::http(coyote_error::HttpError::bad_request(
-                Some("lease_not_found".to_owned()),
-                None,
-            ))
-        })?;
+        .ok_or_else(|| Error::invalid_user_input("lease not found"))?;
 
         lease.offset = self.offset + 1;
         lease.expiry = Timestamp::MIN;
@@ -70,7 +62,7 @@ impl StreamCommitOperation {
             lease.to_fjall_value()?,
         );
 
-        batch.commit().map_err(coyote_error::Error::from)?;
+        batch.commit().map_err(Error::from)?;
 
         Ok(StreamCommitResponseData {})
     }

--- a/crates/msgs/src/operations/stream_receive.rs
+++ b/crates/msgs/src/operations/stream_receive.rs
@@ -1,13 +1,15 @@
-use std::num::NonZeroU16;
+use std::{num::NonZeroU16, time::Duration};
 
+use coyote_error::Error;
 use coyote_namespace::entities::NamespaceId;
 use jiff::Timestamp;
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
+use tracing::Span;
 
 use crate::{
     State,
-    entities::{ConsumerGroup, Offset, Partition, TopicIn, TopicPartition},
+    entities::{ConsumerGroup, Offset, Partition, TopicIn, TopicName, TopicPartition},
     tables::{MsgRow, StreamLeaseRow, TableRow, TopicRow},
 };
 
@@ -16,7 +18,8 @@ use super::{MsgsRaftState, MsgsRequest, StreamReceiveResponse};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamReceiveOperation {
     namespace_id: NamespaceId,
-    topic: TopicIn,
+    topic: TopicName,
+    partition: Option<Partition>,
     consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
     lease_duration_millis: u64,
@@ -31,62 +34,60 @@ impl StreamReceiveOperation {
         batch_size: NonZeroU16,
         lease_duration_millis: u64,
     ) -> coyote_error::Result<Self> {
-        let now = Timestamp::now();
-
+        let (topic, partition) = match topic {
+            TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
+            TopicIn::TopicName(tn) => (tn, None),
+        };
         Ok(Self {
             namespace_id,
             topic,
+            partition,
             consumer_group,
             batch_size,
             lease_duration_millis,
-            now,
+            now: Timestamp::now(),
         })
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size = self.batch_size))]
     fn apply_real(self, state: &State) -> coyote_operations::Result<StreamReceiveResponseData> {
-        let lease_duration = std::time::Duration::from_millis(self.lease_duration_millis);
+        let lease_duration = Duration::from_millis(self.lease_duration_millis);
         let mut remaining = self.batch_size.get();
         let mut all_msgs: Vec<StreamReceiveMsg> = Vec::with_capacity(remaining as usize);
         let expiry = self.now + lease_duration;
 
         let mut batch = state.db.batch();
 
-        let topic_row = match TopicRow::fetch(
-            &state.metadata_tables,
-            self.namespace_id,
-            self.topic.topic_name(),
-        )? {
-            Some(topic_row) => topic_row,
-            None => {
-                let topic_row = TopicRow::new(self.topic.topic_name().clone(), self.now)?;
-                batch.insert(
-                    &state.metadata_tables,
-                    TopicRow::construct_key(self.namespace_id, self.topic.topic_name()),
-                    topic_row.to_fjall_value()?,
-                );
-                topic_row
-            }
-        };
+        let topic_row =
+            match TopicRow::fetch(&state.metadata_tables, self.namespace_id, &self.topic)? {
+                Some(topic_row) => topic_row,
+                None => {
+                    let topic_row = TopicRow::new(self.topic.clone(), self.now);
+                    batch.insert(
+                        &state.metadata_tables,
+                        TopicRow::construct_key(self.namespace_id, &self.topic),
+                        topic_row.to_fjall_value()?,
+                    );
+                    topic_row
+                }
+            };
 
-        tracing::Span::current().record("partition_count", topic_row.partitions);
+        Span::current().record("partition_count", topic_row.partitions);
 
         // Create a list of partitions to fetch from
-        let partitions =
-            if let TopicIn::TopicPartition(TopicPartition { partition, .. }) = self.topic {
-                vec![partition.get()]
-            } else {
-                // Create a shuffled list of all the partitions, so we distribute fetches
-                let mut partition_list: Vec<u16> = (0..topic_row.partitions).collect();
-                partition_list.shuffle(&mut rand::rng());
-                partition_list
-            };
+        let partitions = if let Some(partition) = self.partition {
+            vec![partition.get()]
+        } else {
+            // Create a shuffled list of all the partitions, so we distribute fetches
+            let mut partition_list: Vec<u16> = (0..topic_row.partitions).collect();
+            partition_list.shuffle(&mut rand::rng());
+            partition_list
+        };
 
         let mut no_lease_available = true;
 
         for partition in partitions {
-            let topic =
-                TopicPartition::new(self.topic.topic_name().clone(), Partition::new(partition)?);
+            let topic = TopicPartition::new(self.topic.clone(), Partition::new(partition)?);
             let mut lease = match StreamLeaseRow::fetch(
                 &state.metadata_tables,
                 topic_row.id,
@@ -97,7 +98,6 @@ impl StreamReceiveOperation {
                 None => StreamLeaseRow::new()?,
             };
 
-            // No lease available, error.
             if lease.expiry > self.now {
                 continue;
             }
@@ -112,6 +112,7 @@ impl StreamReceiveOperation {
                 lease.offset,
                 remaining,
             )?;
+
             // We don't need to take a lease if there are no items.
             if msgs.is_empty() {
                 continue;
@@ -143,18 +144,12 @@ impl StreamReceiveOperation {
         }
 
         if no_lease_available {
-            return Err(
-                coyote_error::Error::http(coyote_error::HttpError::bad_request(
-                    Some("no_lease_available".to_owned()),
-                    None,
-                ))
-                .into(),
-            );
+            return Err(Error::invalid_user_input("no available leases").into());
         }
 
-        batch.commit().map_err(coyote_error::Error::from)?;
+        batch.commit().map_err(Error::from)?;
 
-        tracing::Span::current().record("msgs_returned", all_msgs.len());
+        Span::current().record("msgs_returned", all_msgs.len());
 
         Ok(StreamReceiveResponseData { msgs: all_msgs })
     }

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -2,6 +2,8 @@ use coyote_namespace::entities::NamespaceId;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
+use coyote_error::Error;
+
 use crate::{
     State,
     entities::{MAX_PARTITION_COUNT, TopicName},
@@ -19,41 +21,36 @@ pub struct TopicConfigureOperation {
 }
 
 impl TopicConfigureOperation {
-    pub fn new(namespace_id: NamespaceId, topic: TopicName, partitions: u16) -> Self {
-        Self {
+    pub fn new(
+        namespace_id: NamespaceId,
+        topic: TopicName,
+        partitions: u16,
+    ) -> Result<Self, Error> {
+        if partitions == 0 || partitions > MAX_PARTITION_COUNT {
+            return Err(Error::invalid_user_input(format!(
+                "Partition count must be between 1 and {MAX_PARTITION_COUNT}."
+            )));
+        }
+        Ok(Self {
             namespace_id,
             topic,
             partitions,
             now: Timestamp::now(),
-        }
+        })
     }
 
     fn apply_real(self, state: &State) -> coyote_operations::Result<TopicConfigureResponseData> {
-        if self.partitions == 0 || self.partitions > MAX_PARTITION_COUNT {
-            return Err(
-                coyote_error::Error::http(coyote_error::HttpError::bad_request(
-                    Some("invalid_partition_count".to_owned()),
-                    Some(format!(
-                        "Partition count must be between 1 and {MAX_PARTITION_COUNT}."
-                    )),
-                ))
-                .into(),
-            );
-        }
         let mut topic_row =
             match TopicRow::fetch(&state.metadata_tables, self.namespace_id, &self.topic)? {
                 Some(topic_row) => topic_row,
-                None => TopicRow::new(self.topic.clone(), self.now)?,
+                None => TopicRow::new(self.topic.clone(), self.now),
             };
 
         if self.partitions < topic_row.partitions {
-            return Err(
-                coyote_error::Error::http(coyote_error::HttpError::bad_request(
-                    Some("cannot_decrease_partitions".to_owned()),
-                    Some("Cannot decrease partition count. Only increases are allowed.".to_owned()),
-                ))
-                .into(),
-            );
+            return Err(Error::invalid_user_input(
+                "Cannot decrease partition count. Only increases are allowed.",
+            )
+            .into());
         }
 
         topic_row.partitions = self.partitions;
@@ -64,7 +61,7 @@ impl TopicConfigureOperation {
             TopicRow::construct_key(self.namespace_id, &self.topic),
             topic_row.to_fjall_value()?,
         );
-        batch.commit().map_err(coyote_error::Error::from)?;
+        batch.commit().map_err(Error::from)?;
 
         Ok(TopicConfigureResponseData {
             partitions: self.partitions,

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -49,8 +49,8 @@ impl TopicRow {
         construct_key(&parts)
     }
 
-    pub(crate) fn new(name: TopicName, now: Timestamp) -> Result<Self> {
-        Ok(Self {
+    pub(crate) fn new(name: TopicName, now: Timestamp) -> Self {
+        Self {
             id: uuid::Uuid::new_v7(uuid::Timestamp::from_unix(
                 uuid::NoContext,
                 now.as_second() as u64,
@@ -58,7 +58,7 @@ impl TopicRow {
             )),
             name,
             partitions: 1,
-        })
+        }
     }
 
     pub(crate) fn fetch(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use cfg::ConfigurationInner;
 use coyote_error::{Error, HttpError, Result};
 use coyote_kv::KvStore;
 use coyote_namespace::{
-    BothDatabases,
+    BothDatabases, DEFAULT_NAMESPACE_NAME,
     entities::{CacheConfig, IdempotencyConfig, KeyValueConfig, ModuleConfig},
     parse_namespace,
 };
@@ -217,7 +217,7 @@ impl AppState {
             .try_get_or_insert(ns_name.map(|s| s.to_string()), || -> Result<KvStore> {
                 let namespace = self
                     .namespace_state
-                    .fetch_namespace::<C>(ns_name)?
+                    .fetch_namespace::<C>(ns_name.unwrap_or(DEFAULT_NAMESPACE_NAME))?
                     .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
                 let policy = namespace.config.eviction_policy();

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -282,7 +282,7 @@ async fn topic_configure(
         .fetch_namespace(data.topic.namespace())?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
-    let operation = TopicConfigureOperation::new(namespace.id, data.topic, data.partitions);
+    let operation = TopicConfigureOperation::new(namespace.id, data.topic, data.partitions)?;
     let response = repl.client_write(operation).await.map_err_generic()?.0?;
 
     Ok(MsgPackOrJson(MsgTopicConfigureOut {


### PR DESCRIPTION
Pre-factor to a larger changeset w/stream.

This cleans up a lot
- remove redundant comments
- avoid excessively verbose fully qualified module syntax (just import bro)
- move complex logic into helper functions
- move validation that was inappropriately happening in `Operation::apply_real` into `Operation::new`
- ...other stuff

Collectively a NOOP, though there's some minor performance improvements. More changes/fixes to come.