### PR TITLE
justfile: change clippy lint to not override channel.

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,8 +3,7 @@ set quiet := true
 HERE := justfile_directory()
 
 lint:
-    # keep this beta to keep it in sync with CI
-    cargo +beta clippy --workspace --fix --allow-dirty --all-features --all-targets
+    cargo clippy --workspace --fix --allow-dirty --all-features --all-targets
     # this has to be nightly to get import sorting working correctly
     cargo +nightly fmt
     cargo sort --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace


### PR DESCRIPTION
I have an alternative PR where I let us override the channel, but tbh,
I don't see the point if just forcing it for clippy.
We can just all use beta/nightly (we already do?) so let's just set this to that.
In CI we force beta anyway, so no need for this either.