### PR TITLE
Revert "py: enable http/2 for the python client library"

### DIFF
--- a/clients/python/coyote/internal/api_common.py
+++ b/clients/python/coyote/internal/api_common.py
@@ -41,10 +41,10 @@ class ApiBase:
             async_proxy_mounts = None
 
         self._httpx_client = httpx.Client(
-            mounts=proxy_mounts, cookies=self._client.get_cookies(), http2=True
+            mounts=proxy_mounts, cookies=self._client.get_cookies()
         )
         self._httpx_async_client = httpx.AsyncClient(
-            mounts=async_proxy_mounts, cookies=self._client.get_cookies(), http2=True
+            mounts=async_proxy_mounts, cookies=self._client.get_cookies()
         )
 
     def _get_httpx_kwargs(


### PR DESCRIPTION
Reverts svix/coyote-private#323.
We're seeing latency issues with http/2.