### PR TITLE
go: disable HTTP/2 in the golang client library too

### DIFF
--- a/clients/go/internal/proto/http_client.go
+++ b/clients/go/internal/proto/http_client.go
@@ -26,8 +26,9 @@ type HttpClient struct {
 }
 
 func DefaultHttpClient(defaultBaseUrl string) HttpClient {
+	// Disable HTTP/2.0
 	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.ForceAttemptHTTP2 = true
+	tr.ForceAttemptHTTP2 = false
 	tr.TLSClientConfig = new(tls.Config)
 	tr.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
 


### PR DESCRIPTION
as discussed in slack
