### PR TITLE
rust: disable nagle on the rust client

### DIFF
--- a/clients/rust/src/connector.rs
+++ b/clients/rust/src/connector.rs
@@ -67,6 +67,8 @@ pub(crate) fn make_connector(proxy_addr: Option<String>) -> Connector {
         http.enforce_http(false);
     }
 
+    http.set_nodelay(true);
+
     let Some(proxy_addr) = proxy_addr else {
         return Connector::Regular(wrap_connector(http));
     };


### PR DESCRIPTION
`HttpConnector` enables nagle by default for its sockets.

This is somewhat bad with HTTP/1.1 (but not catastrophically so because for small requests the headers and data are always in the same packet, linux doesn't use nagle for the first or last packet in a TCP stream and also is generally better about setting PSH on single-packet writes), but it's very bad with HTTP/2 because the `h2` library always puts headers and data in different packets (because it makes different `writev` calls for them), and the second packet won't get a PSH so it'll sit there until an ack is received for the first packet (which will not happen for 40-60ms, depending on kernel settings). This could theoretically be mitigated with TCP_QUICKACK on the server, but that would get broken by middleboxes anyway so we shouldn't rely on it.

It's always nagle.

We probably don't see this very much for lightweight requests in our main app because they're usually GETs without bodies (which all fit in one packet, so aren't affected), but we should do this there, too. Although most SSL libraries turn off nagle internally so it's likely that over SSL we're not seeing this anyway.