### PR TITLE
clients: re-enable HTTP/2 on python, rust, and golang

### DIFF
--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -17,6 +17,14 @@ name = "coyote"
 path = "src/main.rs"
 doctest = false
 
+[features]
+default = ["http1", "http2", "rustls-tls"]
+
+http1 = ["coyote-client/http1"]
+http2 = ["coyote-client/http2"]
+native-tls = ["coyote-client/native-tls"]
+rustls-tls = ["coyote-client/rustls-tls"]
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -10,6 +10,9 @@ pub struct Config {
     pub auth_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     server_url: Option<String>,
+    #[cfg(all(feature = "http1", feature = "http2"))]
+    #[serde(default)]
+    pub http1: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     debug_url: Option<String>,
 }

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -164,6 +164,8 @@ fn get_client_options(cfg: &Config) -> Result<CoyoteOptions> {
         debug: false,
         server_url: cfg.server_url().map(Into::into),
         timeout: None,
+        #[cfg(all(feature = "http1", feature = "http2"))]
+        http1: cfg.http1,
         ..CoyoteOptions::default()
     })
 }

--- a/clients/go/internal/proto/http_client.go
+++ b/clients/go/internal/proto/http_client.go
@@ -26,9 +26,8 @@ type HttpClient struct {
 }
 
 func DefaultHttpClient(defaultBaseUrl string) HttpClient {
-	// Disable HTTP/2.0
 	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.ForceAttemptHTTP2 = false
+	tr.ForceAttemptHTTP2 = true
 	tr.TLSClientConfig = new(tls.Config)
 	tr.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
 

--- a/clients/python/coyote/internal/api_common.py
+++ b/clients/python/coyote/internal/api_common.py
@@ -41,10 +41,10 @@ class ApiBase:
             async_proxy_mounts = None
 
         self._httpx_client = httpx.Client(
-            mounts=proxy_mounts, cookies=self._client.get_cookies()
+            mounts=proxy_mounts, cookies=self._client.get_cookies(), http2=True
         )
         self._httpx_async_client = httpx.AsyncClient(
-            mounts=async_proxy_mounts, cookies=self._client.get_cookies()
+            mounts=async_proxy_mounts, cookies=self._client.get_cookies(), http2=True
         )
 
     def _get_httpx_kwargs(

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -41,6 +41,11 @@ pub struct CoyoteOptions {
     /// between the last two is that DNS resolution also goes through the proxy
     /// for `socks5h`, but not for `socks5`.
     pub proxy_address: Option<String>,
+
+    /// Use HTTP/1.1 on plaintext connections (otherwise forces HTTP/2 on plaintext,
+    /// and uses standard ALPN on secure connections)
+    #[cfg(all(feature = "http1", feature = "http2"))]
+    pub http1: bool,
 }
 
 impl Default for CoyoteOptions {
@@ -52,6 +57,8 @@ impl Default for CoyoteOptions {
             num_retries: None,
             retry_schedule: None,
             proxy_address: None,
+            #[cfg(all(feature = "http1", feature = "http2"))]
+            http1: false,
         }
     }
 }
@@ -67,10 +74,17 @@ impl CoyoteClient {
     pub fn new(token: String, options: Option<CoyoteOptions>) -> Self {
         let options = options.unwrap_or_default();
 
+        let mut builder = HyperClient::builder(TokioExecutor::new());
+        builder.pool_idle_timeout(Duration::from_secs(10));
+
+        #[cfg(all(feature = "http2", not(feature = "http1")))]
+        builder.http2_only(true);
+        #[cfg(all(feature = "http1", feature = "http2"))]
+        builder.http2_only(!options.http1);
+
         let cfg = Arc::new(Configuration {
             user_agent: Some(format!("coyote-client/{CRATE_VERSION}/rust")),
-            client: HyperClient::builder(TokioExecutor::new())
-                .build(make_connector(options.proxy_address)),
+            client: builder.build(make_connector(options.proxy_address)),
             timeout: options.timeout,
             // These fields will be set by `with_token` below
             base_path: String::new(),


### PR DESCRIPTION
Reverts #357, #358, and #359 now that #350 and #360 resolved the problem