### PR TITLE
Fjall utils: refactor how we do TableRow/TableKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,11 +1099,9 @@ dependencies = [
  "fjall",
  "fjall-utils",
  "hashlink 0.11.0",
- "hex",
  "jiff",
  "schemars 1.2.1",
  "serde",
- "static_assertions",
  "tempfile",
  "tokio",
  "tracing",
@@ -1113,11 +1111,11 @@ dependencies = [
 name = "coyote-msgs"
 version = "0.0.1"
 dependencies = [
- "byteorder",
  "coyote-error",
  "coyote-namespace",
  "coyote-operations",
  "fjall",
+ "fjall-utils",
  "jiff",
  "rand 0.9.2",
  "rmp-serde",
@@ -1189,7 +1187,6 @@ dependencies = [
  "jiff",
  "schemars 1.2.1",
  "serde",
- "static_assertions",
  "tempfile",
  "tokio",
 ]
@@ -1669,6 +1666,7 @@ dependencies = [
  "byteorder",
  "coyote-error",
  "fjall",
+ "itertools 0.14.0",
  "rmp-serde",
  "serde",
  "tracing",
@@ -4342,12 +4340,6 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stream-internals"

--- a/crates/coyote-namespace/src/lib.rs
+++ b/crates/coyote-namespace/src/lib.rs
@@ -94,7 +94,7 @@ impl State {
 
     pub fn fetch_all_namespaces<C: ModuleConfig>(
         &self,
-    ) -> Result<impl Iterator<Item = Result<Namespace<C>>>> {
+    ) -> Result<impl Iterator<Item = Namespace<C>>> {
         Namespace::fetch_all(&self.keyspace)
     }
 

--- a/crates/coyote-namespace/src/operations/create_namespace.rs
+++ b/crates/coyote-namespace/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use coyote_error::Result;
 use std::num::NonZeroU64;
 
-use fjall_utils::TableRow;
+use fjall_utils::WriteBatchExt;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -76,9 +76,9 @@ impl<C: ModuleConfig> CreateNamespace<C> {
         };
 
         {
-            let (k1, v1) = namespace.to_fjall_entry()?;
+            let k1 = Namespace::<C>::key_for(&namespace.name);
             let mut batch = db.batch().durability(Some(fjall::PersistMode::SyncAll));
-            batch.insert(keyspace, k1, v1);
+            batch.insert_row(keyspace, k1, &namespace)?;
             batch.commit()?;
         }
 

--- a/crates/coyote-namespace/src/tables.rs
+++ b/crates/coyote-namespace/src/tables.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::entities::{ModuleConfig, NamespaceId, NamespaceName, StorageType};
 
+/// These values can never change. Only additions are allowed.
 #[repr(u8)]
 enum RowType {
     Namespace = 0,

--- a/crates/coyote-namespace/src/tables.rs
+++ b/crates/coyote-namespace/src/tables.rs
@@ -1,12 +1,17 @@
-use std::{borrow::Cow, num::NonZeroU64};
+use std::num::NonZeroU64;
 
 use coyote_error::Result;
 use fjall::Keyspace;
-use fjall_utils::TableRow;
+use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::entities::{ModuleConfig, NamespaceId, NamespaceName, StorageType};
+
+#[repr(u8)]
+enum RowType {
+    Namespace = 0,
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(bound = "C: ModuleConfig")]
@@ -25,35 +30,22 @@ pub struct Namespace<C: ModuleConfig> {
 }
 
 impl<C: ModuleConfig> TableRow for Namespace<C> {
-    const TABLE_PREFIX: &'static str = "";
-    type Key = Vec<u8>;
-
-    fn get_key(&self) -> Cow<'_, Self::Key> {
-        Cow::Owned(Self::key(&self.name))
-    }
+    const ROW_TYPE: u8 = RowType::Namespace as u8;
 }
 
 impl<C: ModuleConfig> Namespace<C> {
-    pub(crate) fn key(namespace_name: &str) -> Vec<u8> {
-        let module = (C::module() as u8).to_be_bytes();
+    pub(crate) fn key_for(namespace_name: &str) -> TableKey<Self> {
+        let module = (C::module() as u32).to_be_bytes();
 
-        let mut key = Vec::with_capacity(module.len() + b"\0".len() + namespace_name.len());
-        key.extend_from_slice(&module);
-        key.extend_from_slice(b"\0");
-        key.extend_from_slice(namespace_name.as_bytes());
-        key
+        TableKey::init_key(Self::ROW_TYPE, &[&module], &[namespace_name])
     }
 
     pub(crate) fn fetch(keyspace: &Keyspace, namespace_name: &str) -> Result<Option<Self>> {
-        let key = Self::key(namespace_name);
-        <Self as TableRow>::fetch(keyspace, &key)
+        let key = Self::key_for(namespace_name);
+        <Self as TableRow>::fetch(keyspace, key)
     }
 
-    pub(crate) fn fetch_all(keyspace: &Keyspace) -> Result<impl Iterator<Item = Result<Self>>> {
-        let prefix = format!("{}", C::module());
-        Ok(keyspace.prefix(&prefix).map(|g| {
-            let v = g.value()?;
-            Self::from_fjall_value(v)
-        }))
+    pub(crate) fn fetch_all(keyspace: &Keyspace) -> Result<impl Iterator<Item = Self>> {
+        Self::values(keyspace)
     }
 }

--- a/crates/fjall-utils/Cargo.toml
+++ b/crates/fjall-utils/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2024"
 byteorder.workspace = true
 coyote-error.workspace = true
 fjall.workspace = true
+itertools.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 tracing.workspace = true

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -2,13 +2,12 @@ pub mod duration_millis;
 mod fixed_key;
 mod readonly_db;
 mod table_row;
+pub mod table_row2;
 
 pub use self::{
     fixed_key::FjallFixedKey,
     readonly_db::{ReadableDatabase, ReadableKeyspace, ReadonlyDatabase, ReadonlyKeyspace},
-    table_row::{
-        KeyspaceExt, MonotonicTableKey, MonotonicTableRowExt, TableKey, TableRow, WriteBatchExt,
-    },
+    table_row::{TableKey, TableKeyFromFjall, TableKeyType, TableRow, WriteBatchExt},
 };
 
 /// Useful for verifying all table prefixes for a given keyspace are unique,

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -142,5 +142,5 @@ impl<'a, Tag: TableRow> TableKey<Tag> {
 pub trait TableKeyFromFjall {
     type Key;
 
-    fn key_from_key(key: fjall::UserKey) -> Result<Self::Key>;
+    fn key_from_fjall_key(key: fjall::UserKey) -> Result<Self::Key>;
 }

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -91,7 +91,7 @@ pub type TableKeyType = u8;
 
 pub struct TableKey<Tag: TableRow> {
     key: fjall::UserKey,
-    _unit: PhantomData<Tag>,
+    _table: PhantomData<Tag>,
 }
 
 impl<'a, Tag: TableRow> TableKey<Tag> {
@@ -123,14 +123,14 @@ impl<'a, Tag: TableRow> TableKey<Tag> {
 
         Self {
             key: ret.into(),
-            _unit: PhantomData,
+            _table: PhantomData,
         }
     }
 
     pub fn init_from_bytes(key: &'a [u8]) -> Self {
         Self {
             key: key.into(),
-            _unit: PhantomData,
+            _table: PhantomData,
         }
     }
 

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -1,296 +1,146 @@
-use byteorder::{BigEndian, ByteOrder};
-use fjall::Guard;
-use std::{
-    borrow::Cow,
-    ops::{Bound, RangeBounds},
-};
-use uuid::Uuid;
+use std::marker::PhantomData;
 
 use super::readonly_db::ReadableKeyspace;
-use coyote_error::{Error, Result, ResultExt};
+use coyote_error::{Error, Result};
 use serde::{Serialize, de::DeserializeOwned};
-
-/// A trait for primary keys in fjall.
-pub trait TableKey: Clone {
-    fn as_bytes(&self) -> Cow<'_, [u8]>;
-
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self>;
-}
-
-impl TableKey for String {
-    fn as_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self.as_bytes())
-    }
-
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
-        let owned: Vec<u8> = bytes.to_owned();
-        Self::from_utf8(owned).map_err_generic()
-    }
-}
-
-impl TableKey for Vec<u8> {
-    fn as_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self)
-    }
-
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
-        Ok(bytes.to_owned())
-    }
-}
-
-impl TableKey for Uuid {
-    fn as_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self.as_bytes())
-    }
-
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
-        Self::from_slice(bytes).map_err_generic()
-    }
-}
-
-impl TableKey for u64 {
-    fn as_bytes(&self) -> Cow<'_, [u8]> {
-        let mut buf = vec![0u8; 8];
-        BigEndian::write_u64(&mut buf, *self);
-        Cow::Owned(buf)
-    }
-
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() != 8 {
-            return Err(Error::generic("invalid byte length in key"));
-        }
-        Ok(BigEndian::read_u64(bytes))
-    }
-}
-
-impl MonotonicTableKey for u64 {}
-
-/// Marker trait indicating that a table key is **monotonic** with its
-/// underlying byte representation; that is to say, if K1 > K2, then byte(K1) > byte(K2)
-pub trait MonotonicTableKey {}
 
 /// A trait for types that can be stored as rows in a fjall keyspace.
 ///
 /// This is useful for having logical "tables" within the same keyspace.
 pub trait TableRow: Sized + Serialize + DeserializeOwned {
-    const TABLE_PREFIX: &'static str;
+    // FIXME: can probably get rid of this, and encode it in the type system.
+    const ROW_TYPE: u8;
 
-    type Key: TableKey;
-
-    /// Return the field used for indexing into the table.
-    fn get_key(&self) -> Cow<'_, Self::Key>;
-
-    fn make_fjall_key(key: &Self::Key) -> fjall::UserKey {
-        let raw_key_bytes = key.as_bytes();
-        let mut key_bytes = if Self::TABLE_PREFIX.is_empty() {
-            Vec::<u8>::with_capacity(raw_key_bytes.len())
-        } else {
-            let mut key_bytes = Vec::<u8>::with_capacity(
-                Self::TABLE_PREFIX.len() + b"\0".len() + raw_key_bytes.len(),
-            );
-            key_bytes.extend_from_slice(Self::TABLE_PREFIX.as_bytes());
-            key_bytes.extend_from_slice(b"\0");
-            key_bytes
-        };
-        key_bytes.extend_from_slice(&raw_key_bytes);
-        key_bytes.into()
-    }
-
-    fn to_fjall_entry(&self) -> Result<(fjall::UserKey, fjall::UserValue)> {
-        let key = Self::make_fjall_key(self.get_key().as_ref());
-        // FIXME(@svix-gabriel) - it's not clear if we're committed to using msgpack
-        // for internal serialization. Using messagepack for now, but this
-        // should be easy to change later.
-        let value = rmp_serde::to_vec_named(&self).map_err(Error::generic)?;
-
-        Ok((key, value.into()))
+    fn to_fjall_value(&self) -> Result<fjall::UserValue> {
+        rmp_serde::to_vec_named(&self)
+            .map(|bytes| bytes.into())
+            .map_err(Error::generic)
     }
 
     fn from_fjall_value(value: fjall::UserValue) -> Result<Self> {
         rmp_serde::from_slice(&value).map_err(Error::generic)
     }
 
-    fn fetch<K: ReadableKeyspace>(keyspace: &K, key: &Self::Key) -> Result<Option<Self>> {
-        let key = Self::make_fjall_key(key);
-        keyspace.get(&key)?.map(Self::from_fjall_value).transpose()
+    fn fetch<K: ReadableKeyspace>(keyspace: &K, key: TableKey<Self>) -> Result<Option<Self>> {
+        keyspace
+            .get(key.into_fjall_key())?
+            .map(Self::from_fjall_value)
+            .transpose()
     }
 
-    fn insert(keyspace: &fjall::Keyspace, row: &Self) -> Result<()> {
-        let (key, value) = row.to_fjall_entry()?;
-        keyspace.insert(key, value)?;
+    fn insert(keyspace: &fjall::Keyspace, key: TableKey<Self>, row: &Self) -> Result<()> {
+        let fjall_key = key.key;
+        let value = row.to_fjall_value()?;
+        keyspace.insert(fjall_key, value)?;
         Ok(())
     }
 
-    fn remove(keyspace: &fjall::Keyspace, key: &Self::Key) -> Result<()> {
-        let key = Self::make_fjall_key(key);
-        keyspace.remove(key)?;
+    fn remove(keyspace: &fjall::Keyspace, key: TableKey<Self>) -> Result<()> {
+        keyspace.remove(key.into_fjall_key())?;
         Ok(())
-    }
-
-    fn key_from_key(key: fjall::UserKey) -> Result<Self::Key> {
-        let without_bytes = if Self::TABLE_PREFIX.is_empty() {
-            &key
-        } else {
-            &key[Self::TABLE_PREFIX.len() + 1..]
-        };
-        Self::Key::try_from_bytes(without_bytes)
-    }
-
-    /// Iterate over all of the key/value pairs in this table, in sorted order
-    fn iter<K: ReadableKeyspace>(keyspace: &K) -> impl Iterator<Item = Result<(Self::Key, Self)>> {
-        let prefix = Self::prefix_with(&[]);
-        keyspace.prefix(prefix).map(|g| {
-            let (k, v) = g.into_inner()?;
-            let value = Self::from_fjall_value(v)?;
-            let key = Self::key_from_key(k)?;
-            Ok((key, value))
-        })
     }
 
     fn values<K: ReadableKeyspace>(keyspace: &K) -> Result<impl Iterator<Item = Self>> {
-        Ok(keyspace.prefix(Self::TABLE_PREFIX).map(|g| {
+        let prefix = &[Self::ROW_TYPE];
+        Ok(keyspace.prefix(prefix).map(|g| {
             let v = g.value().expect("iter error?");
             Self::from_fjall_value(v).expect("deserialize error?")
         }))
-    }
-
-    fn prefix_with(bytes: &[u8]) -> Vec<u8> {
-        if Self::TABLE_PREFIX.is_empty() {
-            bytes.to_owned()
-        } else {
-            let mut prefix_bytes = Vec::with_capacity(Self::TABLE_PREFIX.len() + 1 + bytes.len());
-            prefix_bytes.extend(Self::TABLE_PREFIX.as_bytes());
-            prefix_bytes.push(0x00);
-            prefix_bytes.extend(bytes);
-            prefix_bytes
-        }
-    }
-
-    fn end_prefix() -> Option<Vec<u8>> {
-        if Self::TABLE_PREFIX.is_empty() {
-            None
-        } else {
-            let mut prefix_bytes = Vec::with_capacity(Self::TABLE_PREFIX.len() + 1);
-            prefix_bytes.extend(Self::TABLE_PREFIX.as_bytes());
-            prefix_bytes.push(0x01);
-            Some(prefix_bytes)
-        }
-    }
-}
-
-fn increment(v: &mut Vec<u8>) {
-    for byte in v.iter_mut().rev() {
-        if *byte < 0xff {
-            *byte += 1;
-            break;
-        }
-    }
-    v.insert(0, 0x01)
-}
-
-fn range_helper<T, B>(
-    keyspace: &fjall::Keyspace,
-    bounds: B,
-) -> impl DoubleEndedIterator<Item = Guard>
-where
-    T: TableRow,
-    T::Key: MonotonicTableKey,
-    B: RangeBounds<T::Key>,
-{
-    let start = match bounds.start_bound() {
-        Bound::Unbounded => T::prefix_with(&[]),
-        Bound::Included(x) => T::prefix_with(x.as_bytes().as_ref()),
-        Bound::Excluded(x) => {
-            let mut bytes = T::prefix_with(x.as_bytes().as_ref());
-            increment(&mut bytes);
-            bytes
-        }
-    };
-    match bounds.end_bound() {
-        Bound::Unbounded => {
-            if let Some(end) = T::end_prefix() {
-                keyspace.range(start..end)
-            } else {
-                keyspace.range(start..)
-            }
-        }
-        Bound::Included(x) => keyspace.range(start..=T::prefix_with(x.as_bytes().as_ref())),
-        Bound::Excluded(x) => keyspace.range(start..T::prefix_with(x.as_bytes().as_ref())),
-    }
-}
-
-pub trait MonotonicTableRowExt: TableRow {
-    fn range<B: RangeBounds<Self::Key>>(
-        keyspace: &fjall::Keyspace,
-        bounds: B,
-    ) -> impl DoubleEndedIterator<Item = Result<(Self::Key, Self)>>;
-
-    fn keys_in_range<B: RangeBounds<Self::Key>>(
-        keyspace: &fjall::Keyspace,
-        bounds: B,
-    ) -> Result<Vec<fjall::UserKey>>;
-}
-
-impl<T: TableRow> MonotonicTableRowExt for T
-where
-    T::Key: MonotonicTableKey,
-{
-    fn range<B: RangeBounds<Self::Key>>(
-        keyspace: &fjall::Keyspace,
-        bounds: B,
-    ) -> impl DoubleEndedIterator<Item = Result<(Self::Key, Self)>> {
-        range_helper::<Self, B>(keyspace, bounds).map(|g| {
-            let (k, v) = g.into_inner()?;
-            let value = Self::from_fjall_value(v)?;
-            let key = Self::key_from_key(k)?;
-            Ok((key, value))
-        })
-    }
-
-    fn keys_in_range<B: RangeBounds<Self::Key>>(
-        keyspace: &fjall::Keyspace,
-        bounds: B,
-    ) -> Result<Vec<fjall::UserKey>> {
-        range_helper::<Self, B>(keyspace, bounds)
-            .map(|g| g.key().map_err(Into::into))
-            .collect()
-    }
-}
-
-/// Adds convenient methods to fjall's Keyspace to work with TableRow
-pub trait KeyspaceExt {
-    fn ingest_rows<T: TableRow, I: Iterator<Item = T>>(&self, rows: I) -> Result<()>;
-}
-
-impl KeyspaceExt for fjall::Keyspace {
-    fn ingest_rows<T: TableRow, I: Iterator<Item = T>>(&self, rows: I) -> Result<()> {
-        let mut i = self.start_ingestion()?;
-        for row in rows {
-            let (k, v) = row.to_fjall_entry()?;
-            i.write(k, v)?;
-        }
-        i.finish()?;
-        Ok(())
     }
 }
 
 /// Adds convenience methods to fjall's WriteBatch that work with TableRow
 pub trait WriteBatchExt {
-    fn insert_row<T: TableRow>(&mut self, keyspace: &fjall::Keyspace, row: &T) -> Result<()>;
+    fn insert_row<T: TableRow>(
+        &mut self,
+        keyspace: &fjall::Keyspace,
+        key: TableKey<T>,
+        row: &T,
+    ) -> Result<()>;
 
-    fn remove_row<T: TableRow>(&mut self, keyspace: &fjall::Keyspace, key: &T::Key) -> Result<()>;
+    fn remove_row<T: TableRow>(
+        &mut self,
+        keyspace: &fjall::Keyspace,
+        key: TableKey<T>,
+    ) -> Result<()>;
 }
 
 impl WriteBatchExt for fjall::OwnedWriteBatch {
-    fn insert_row<T: TableRow>(&mut self, keyspace: &fjall::Keyspace, row: &T) -> Result<()> {
-        let (key, value) = row.to_fjall_entry()?;
-        self.insert(keyspace, key, value);
+    fn insert_row<T: TableRow>(
+        &mut self,
+        keyspace: &fjall::Keyspace,
+        key: TableKey<T>,
+        row: &T,
+    ) -> Result<()> {
+        self.insert(keyspace, key.into_fjall_key(), row.to_fjall_value()?);
         Ok(())
     }
 
-    fn remove_row<T: TableRow>(&mut self, keyspace: &fjall::Keyspace, key: &T::Key) -> Result<()> {
-        let key = T::make_fjall_key(key);
-        self.remove(keyspace, key);
+    fn remove_row<T: TableRow>(
+        &mut self,
+        keyspace: &fjall::Keyspace,
+        key: TableKey<T>,
+    ) -> Result<()> {
+        self.remove(keyspace, key.into_fjall_key());
         Ok(())
     }
+}
+
+/// Can't change the size, will break everything.
+pub type TableKeyType = u8;
+
+pub struct TableKey<Tag: TableRow> {
+    key: fjall::UserKey,
+    _unit: PhantomData<Tag>,
+}
+
+impl<'a, Tag: TableRow> TableKey<Tag> {
+    /// Construct the key to be used for fjall
+    ///
+    /// In the future: should probably just have a big enough key on the stack and use that.
+    pub fn init_key(
+        row_type: TableKeyType,
+        fixed_parts: &[&[u8]],
+        nul_delimited_parts: &[&str],
+    ) -> Self {
+        let len = size_of::<u8>() /* the row tag */
+            + fixed_parts.iter().fold(0, |acc, e| acc + e.len()) /* all the fixed parts */
+            + nul_delimited_parts.iter().fold(0, |acc, e| acc + e.len()) /* The parts that are nul delimited */
+            + nul_delimited_parts.len().saturating_sub(0); /* the nul delimiters for the parts */
+        let mut ret = Vec::with_capacity(len);
+        ret.push(row_type);
+        for part in fixed_parts {
+            ret.extend_from_slice(part);
+        }
+
+        let nul_delimited_parts = itertools::Itertools::intersperse(
+            nul_delimited_parts.iter().map(|x| x.as_bytes()),
+            b"\0",
+        );
+        for part in nul_delimited_parts {
+            ret.extend_from_slice(part);
+        }
+
+        Self {
+            key: ret.into(),
+            _unit: PhantomData,
+        }
+    }
+
+    pub fn init_from_bytes(key: &'a [u8]) -> Self {
+        Self {
+            key: key.into(),
+            _unit: PhantomData,
+        }
+    }
+
+    pub fn into_fjall_key(self) -> fjall::UserKey {
+        self.key
+    }
+}
+
+pub trait TableKeyFromFjall {
+    type Key;
+
+    fn key_from_key(key: fjall::UserKey) -> Result<Self::Key>;
 }

--- a/crates/fjall-utils/src/table_row2.rs
+++ b/crates/fjall-utils/src/table_row2.rs
@@ -1,0 +1,296 @@
+use byteorder::{BigEndian, ByteOrder};
+use fjall::Guard;
+use std::{
+    borrow::Cow,
+    ops::{Bound, RangeBounds},
+};
+use uuid::Uuid;
+
+use super::readonly_db::ReadableKeyspace;
+use coyote_error::{Error, Result, ResultExt};
+use serde::{Serialize, de::DeserializeOwned};
+
+/// A trait for primary keys in fjall.
+pub trait TableKey: Clone {
+    fn as_bytes(&self) -> Cow<'_, [u8]>;
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self>;
+}
+
+impl TableKey for String {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.as_bytes())
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        let owned: Vec<u8> = bytes.to_owned();
+        Self::from_utf8(owned).map_err_generic()
+    }
+}
+
+impl TableKey for Vec<u8> {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self)
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(bytes.to_owned())
+    }
+}
+
+impl TableKey for Uuid {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.as_bytes())
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        Self::from_slice(bytes).map_err_generic()
+    }
+}
+
+impl TableKey for u64 {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        let mut buf = vec![0u8; 8];
+        BigEndian::write_u64(&mut buf, *self);
+        Cow::Owned(buf)
+    }
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != 8 {
+            return Err(Error::generic("invalid byte length in key"));
+        }
+        Ok(BigEndian::read_u64(bytes))
+    }
+}
+
+impl MonotonicTableKey for u64 {}
+
+/// Marker trait indicating that a table key is **monotonic** with its
+/// underlying byte representation; that is to say, if K1 > K2, then byte(K1) > byte(K2)
+pub trait MonotonicTableKey {}
+
+/// A trait for types that can be stored as rows in a fjall keyspace.
+///
+/// This is useful for having logical "tables" within the same keyspace.
+pub trait TableRow: Sized + Serialize + DeserializeOwned {
+    const TABLE_PREFIX: &'static str;
+
+    type Key: TableKey;
+
+    /// Return the field used for indexing into the table.
+    fn get_key(&self) -> Cow<'_, Self::Key>;
+
+    fn make_fjall_key(key: &Self::Key) -> fjall::UserKey {
+        let raw_key_bytes = key.as_bytes();
+        let mut key_bytes = if Self::TABLE_PREFIX.is_empty() {
+            Vec::<u8>::with_capacity(raw_key_bytes.len())
+        } else {
+            let mut key_bytes = Vec::<u8>::with_capacity(
+                Self::TABLE_PREFIX.len() + b"\0".len() + raw_key_bytes.len(),
+            );
+            key_bytes.extend_from_slice(Self::TABLE_PREFIX.as_bytes());
+            key_bytes.extend_from_slice(b"\0");
+            key_bytes
+        };
+        key_bytes.extend_from_slice(&raw_key_bytes);
+        key_bytes.into()
+    }
+
+    fn to_fjall_entry(&self) -> Result<(fjall::UserKey, fjall::UserValue)> {
+        let key = Self::make_fjall_key(self.get_key().as_ref());
+        // FIXME(@svix-gabriel) - it's not clear if we're committed to using msgpack
+        // for internal serialization. Using messagepack for now, but this
+        // should be easy to change later.
+        let value = rmp_serde::to_vec_named(&self).map_err(Error::generic)?;
+
+        Ok((key, value.into()))
+    }
+
+    fn from_fjall_value(value: fjall::UserValue) -> Result<Self> {
+        rmp_serde::from_slice(&value).map_err(Error::generic)
+    }
+
+    fn fetch<K: ReadableKeyspace>(keyspace: &K, key: &Self::Key) -> Result<Option<Self>> {
+        let key = Self::make_fjall_key(key);
+        keyspace.get(&key)?.map(Self::from_fjall_value).transpose()
+    }
+
+    fn insert(keyspace: &fjall::Keyspace, row: &Self) -> Result<()> {
+        let (key, value) = row.to_fjall_entry()?;
+        keyspace.insert(key, value)?;
+        Ok(())
+    }
+
+    fn remove(keyspace: &fjall::Keyspace, key: &Self::Key) -> Result<()> {
+        let key = Self::make_fjall_key(key);
+        keyspace.remove(key)?;
+        Ok(())
+    }
+
+    fn key_from_key(key: fjall::UserKey) -> Result<Self::Key> {
+        let without_bytes = if Self::TABLE_PREFIX.is_empty() {
+            &key
+        } else {
+            &key[Self::TABLE_PREFIX.len() + 1..]
+        };
+        Self::Key::try_from_bytes(without_bytes)
+    }
+
+    /// Iterate over all of the key/value pairs in this table, in sorted order
+    fn iter<K: ReadableKeyspace>(keyspace: &K) -> impl Iterator<Item = Result<(Self::Key, Self)>> {
+        let prefix = Self::prefix_with(&[]);
+        keyspace.prefix(prefix).map(|g| {
+            let (k, v) = g.into_inner()?;
+            let value = Self::from_fjall_value(v)?;
+            let key = Self::key_from_key(k)?;
+            Ok((key, value))
+        })
+    }
+
+    fn values<K: ReadableKeyspace>(keyspace: &K) -> Result<impl Iterator<Item = Self>> {
+        Ok(keyspace.prefix(Self::TABLE_PREFIX).map(|g| {
+            let v = g.value().expect("iter error?");
+            Self::from_fjall_value(v).expect("deserialize error?")
+        }))
+    }
+
+    fn prefix_with(bytes: &[u8]) -> Vec<u8> {
+        if Self::TABLE_PREFIX.is_empty() {
+            bytes.to_owned()
+        } else {
+            let mut prefix_bytes = Vec::with_capacity(Self::TABLE_PREFIX.len() + 1 + bytes.len());
+            prefix_bytes.extend(Self::TABLE_PREFIX.as_bytes());
+            prefix_bytes.push(0x00);
+            prefix_bytes.extend(bytes);
+            prefix_bytes
+        }
+    }
+
+    fn end_prefix() -> Option<Vec<u8>> {
+        if Self::TABLE_PREFIX.is_empty() {
+            None
+        } else {
+            let mut prefix_bytes = Vec::with_capacity(Self::TABLE_PREFIX.len() + 1);
+            prefix_bytes.extend(Self::TABLE_PREFIX.as_bytes());
+            prefix_bytes.push(0x01);
+            Some(prefix_bytes)
+        }
+    }
+}
+
+fn increment(v: &mut Vec<u8>) {
+    for byte in v.iter_mut().rev() {
+        if *byte < 0xff {
+            *byte += 1;
+            break;
+        }
+    }
+    v.insert(0, 0x01)
+}
+
+fn range_helper<T, B>(
+    keyspace: &fjall::Keyspace,
+    bounds: B,
+) -> impl DoubleEndedIterator<Item = Guard>
+where
+    T: TableRow,
+    T::Key: MonotonicTableKey,
+    B: RangeBounds<T::Key>,
+{
+    let start = match bounds.start_bound() {
+        Bound::Unbounded => T::prefix_with(&[]),
+        Bound::Included(x) => T::prefix_with(x.as_bytes().as_ref()),
+        Bound::Excluded(x) => {
+            let mut bytes = T::prefix_with(x.as_bytes().as_ref());
+            increment(&mut bytes);
+            bytes
+        }
+    };
+    match bounds.end_bound() {
+        Bound::Unbounded => {
+            if let Some(end) = T::end_prefix() {
+                keyspace.range(start..end)
+            } else {
+                keyspace.range(start..)
+            }
+        }
+        Bound::Included(x) => keyspace.range(start..=T::prefix_with(x.as_bytes().as_ref())),
+        Bound::Excluded(x) => keyspace.range(start..T::prefix_with(x.as_bytes().as_ref())),
+    }
+}
+
+pub trait MonotonicTableRowExt: TableRow {
+    fn range<B: RangeBounds<Self::Key>>(
+        keyspace: &fjall::Keyspace,
+        bounds: B,
+    ) -> impl DoubleEndedIterator<Item = Result<(Self::Key, Self)>>;
+
+    fn keys_in_range<B: RangeBounds<Self::Key>>(
+        keyspace: &fjall::Keyspace,
+        bounds: B,
+    ) -> Result<Vec<fjall::UserKey>>;
+}
+
+impl<T: TableRow> MonotonicTableRowExt for T
+where
+    T::Key: MonotonicTableKey,
+{
+    fn range<B: RangeBounds<Self::Key>>(
+        keyspace: &fjall::Keyspace,
+        bounds: B,
+    ) -> impl DoubleEndedIterator<Item = Result<(Self::Key, Self)>> {
+        range_helper::<Self, B>(keyspace, bounds).map(|g| {
+            let (k, v) = g.into_inner()?;
+            let value = Self::from_fjall_value(v)?;
+            let key = Self::key_from_key(k)?;
+            Ok((key, value))
+        })
+    }
+
+    fn keys_in_range<B: RangeBounds<Self::Key>>(
+        keyspace: &fjall::Keyspace,
+        bounds: B,
+    ) -> Result<Vec<fjall::UserKey>> {
+        range_helper::<Self, B>(keyspace, bounds)
+            .map(|g| g.key().map_err(Into::into))
+            .collect()
+    }
+}
+
+/// Adds convenient methods to fjall's Keyspace to work with TableRow
+pub trait KeyspaceExt {
+    fn ingest_rows<T: TableRow, I: Iterator<Item = T>>(&self, rows: I) -> Result<()>;
+}
+
+impl KeyspaceExt for fjall::Keyspace {
+    fn ingest_rows<T: TableRow, I: Iterator<Item = T>>(&self, rows: I) -> Result<()> {
+        let mut i = self.start_ingestion()?;
+        for row in rows {
+            let (k, v) = row.to_fjall_entry()?;
+            i.write(k, v)?;
+        }
+        i.finish()?;
+        Ok(())
+    }
+}
+
+/// Adds convenience methods to fjall's WriteBatch that work with TableRow
+pub trait WriteBatchExt {
+    fn insert_row<T: TableRow>(&mut self, keyspace: &fjall::Keyspace, row: &T) -> Result<()>;
+
+    fn remove_row<T: TableRow>(&mut self, keyspace: &fjall::Keyspace, key: &T::Key) -> Result<()>;
+}
+
+impl WriteBatchExt for fjall::OwnedWriteBatch {
+    fn insert_row<T: TableRow>(&mut self, keyspace: &fjall::Keyspace, row: &T) -> Result<()> {
+        let (key, value) = row.to_fjall_entry()?;
+        self.insert(keyspace, key, value);
+        Ok(())
+    }
+
+    fn remove_row<T: TableRow>(&mut self, keyspace: &fjall::Keyspace, key: &T::Key) -> Result<()> {
+        let key = T::make_fjall_key(key);
+        self.remove(keyspace, key);
+        Ok(())
+    }
+}

--- a/crates/kv/Cargo.toml
+++ b/crates/kv/Cargo.toml
@@ -12,11 +12,9 @@ coyote-operations.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true
 hashlink.workspace = true
-hex.workspace = true
 jiff.workspace = true
 schemars.workspace = true
 serde.workspace = true
-static_assertions.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -3,9 +3,8 @@ pub mod tables;
 use std::num::NonZeroU64;
 
 use coyote_error::Result;
-use coyote_namespace::{
-    Namespace,
-    entities::{CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig, ModuleConfig},
+use coyote_namespace::entities::{
+    CacheConfig, EvictionPolicy, IdempotencyConfig, KeyValueConfig, ModuleConfig,
 };
 use fjall::KeyspaceCreateOptions;
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -97,7 +96,7 @@ impl KvStore {
 
     // FIXME(@svix-lucho): needs to be passed now() from the caller!
     fn fetch_non_expired(&mut self, key: &str) -> Result<Option<KvModel>> {
-        let Some(data) = KvPairRow::fetch(&self.tables, &key.to_string())? else {
+        let Some(data) = KvPairRow::fetch(&self.tables, KvPairRow::key_for(key))? else {
             return Ok(None);
         };
 
@@ -120,11 +119,15 @@ impl KvStore {
             expiry: model.expiry,
         };
 
-        batch.insert_row(&self.tables, &row)?;
+        batch.insert_row(&self.tables, KvPairRow::key_for(key), &row)?;
 
         if let Some(expiry) = model.expiry {
             let expiration_row = ExpirationRow::new(expiry, key.to_string());
-            batch.insert_row(&self.tables, &expiration_row)?;
+            batch.insert_row(
+                &self.tables,
+                ExpirationRow::key_for(expiry, key),
+                &expiration_row,
+            )?;
         }
 
         batch.commit()?;
@@ -178,13 +181,12 @@ impl KvStore {
     pub fn delete(&mut self, key: &str) -> Result<()> {
         let mut batch = self.db.batch();
 
-        if let Some(data) = KvPairRow::fetch(&self.tables, &key.to_string())? {
+        if let Some(data) = KvPairRow::fetch(&self.tables, KvPairRow::key_for(key))? {
             // Delete from the expiration keyspace
             if let Some(expiry) = data.expiry {
-                let r = ExpirationRow::new(expiry, key.to_string());
-                batch.remove_row::<ExpirationRow>(&self.tables, r.get_key().as_ref())?;
+                batch.remove_row(&self.tables, ExpirationRow::key_for(expiry, key))?;
             }
-            batch.remove_row::<KvPairRow>(&self.tables, &key.to_string())?;
+            batch.remove_row(&self.tables, KvPairRow::key_for(key))?;
         }
 
         batch.commit()?;
@@ -274,7 +276,7 @@ where
 
         timer.tick().await;
 
-        let kv_namespaces = match namespace_state.fetch_all_namespaces() {
+        let kv_namespaces = match namespace_state.fetch_all_namespaces::<KeyValueConfig>() {
             Ok(namespaces) => namespaces,
             Err(e) => {
                 tracing::error!(error = ?e, "Failed to get KV namespaces.");
@@ -283,13 +285,6 @@ where
         };
 
         for namespace in kv_namespaces {
-            let namespace: Namespace<KeyValueConfig> = match namespace {
-                Ok(g) => g,
-                Err(e) => {
-                    tracing::error!(error = ?e, "Failed to parse KV namespace.");
-                    continue;
-                }
-            };
             let db = namespace_state.give_me_the_right_db(&namespace);
             let policy = namespace.config.eviction_policy();
             let store = KvStore::new(
@@ -302,7 +297,7 @@ where
             clean_up(store);
         }
 
-        let cache_namespaces = match namespace_state.fetch_all_namespaces() {
+        let cache_namespaces = match namespace_state.fetch_all_namespaces::<CacheConfig>() {
             Ok(namespaces) => namespaces,
             Err(e) => {
                 tracing::error!(error = ?e, "Failed to get Cache namespaces.");
@@ -311,13 +306,6 @@ where
         };
 
         for namespace in cache_namespaces {
-            let namespace: Namespace<CacheConfig> = match namespace {
-                Ok(g) => g,
-                Err(e) => {
-                    tracing::error!(error = ?e, "Failed to process Cache namespace.");
-                    continue;
-                }
-            };
             let db = namespace_state.give_me_the_right_db(&namespace);
             let policy = namespace.config.eviction_policy();
             let store = KvStore::new(
@@ -330,22 +318,16 @@ where
             clean_up(store);
         }
 
-        let idempotency_namespaces = match namespace_state.fetch_all_namespaces() {
-            Ok(namespaces) => namespaces,
-            Err(e) => {
-                tracing::error!(error = ?e, "Failed to get Idempotency namespaces.");
-                continue;
-            }
-        };
-
-        for namespace in idempotency_namespaces {
-            let namespace: Namespace<IdempotencyConfig> = match namespace {
-                Ok(g) => g,
+        let idempotency_namespaces =
+            match namespace_state.fetch_all_namespaces::<IdempotencyConfig>() {
+                Ok(namespaces) => namespaces,
                 Err(e) => {
-                    tracing::error!(error = ?e, "Failed to process Idempotency namespace.");
+                    tracing::error!(error = ?e, "Failed to get Idempotency namespaces.");
                     continue;
                 }
             };
+
+        for namespace in idempotency_namespaces {
             let db = namespace_state.give_me_the_right_db(&namespace);
             let policy = namespace.config.eviction_policy();
             let store = KvStore::new(

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -3,6 +3,7 @@ use fjall_utils::{TableKey, TableKeyFromFjall, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
+/// These values can never change. Only additions are allowed.
 #[repr(u8)]
 enum RowType {
     Pair = 0,

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -1,15 +1,13 @@
-use std::borrow::Cow;
-
-use coyote_error::ResultExt;
-use fjall_utils::{TableKey, TableRow};
+use coyote_error::{Result, ResultExt};
+use fjall_utils::{TableKey, TableKeyFromFjall, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-// IMPORTANT. Since these are all shared in the same fjall::Keyspace, the table prefixes must be unique.
-static_assertions::const_assert!(fjall_utils::are_all_unique(&[
-    KvPairRow::TABLE_PREFIX,
-    ExpirationRow::TABLE_PREFIX,
-]));
+#[repr(u8)]
+enum RowType {
+    Pair = 0,
+    Expiration = 1,
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct KvPairRow {
@@ -19,11 +17,12 @@ pub struct KvPairRow {
 }
 
 impl TableRow for KvPairRow {
-    const TABLE_PREFIX: &'static str = "_KV_PAIR_";
-    type Key = String;
+    const ROW_TYPE: u8 = RowType::Pair as u8;
+}
 
-    fn get_key(&self) -> Cow<'_, Self::Key> {
-        Cow::Borrowed(&self.key)
+impl KvPairRow {
+    pub(crate) fn key_for(key: &str) -> TableKey<Self> {
+        TableKey::init_key(Self::ROW_TYPE, &[], &[key])
     }
 }
 
@@ -31,53 +30,29 @@ impl TableRow for KvPairRow {
 pub(crate) struct ExpirationRow {
     pub expiry: Timestamp,
     pub key: String,
-
-    #[serde(skip)]
-    computed_key: ExpirationKey,
 }
 
 impl ExpirationRow {
     pub(crate) fn new(expiry: Timestamp, key: String) -> Self {
-        Self {
-            computed_key: ExpirationKey::from(expiry, key.clone()),
-            expiry,
-            key,
-        }
+        Self { expiry, key }
     }
-}
 
-#[derive(Clone, Serialize, Deserialize, Default)]
-pub struct ExpirationKey(String);
-
-impl ExpirationKey {
-    pub(crate) fn from(expiration_time: Timestamp, key: String) -> Self {
+    pub(crate) fn key_for(expiration_time: Timestamp, key: &str) -> TableKey<Self> {
         let ts_ms = expiration_time.as_millisecond();
         let ts_bytes = ts_ms.to_be_bytes();
-        let ts_hex = hex::encode(ts_bytes);
-        let computed_key = format!("{ts_hex}\0{key}");
 
-        Self(computed_key)
+        TableKey::init_key(Self::ROW_TYPE, &[&ts_bytes], &[key])
     }
 }
 
-impl TableKey for ExpirationKey {
-    fn as_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self.0.as_bytes())
-    }
+impl TableKeyFromFjall for ExpirationRow {
+    type Key = String;
 
-    fn try_from_bytes(bytes: &[u8]) -> coyote_error::Result<Self> {
-        String::from_utf8(bytes.to_owned())
-            .map(Self)
-            .map_err_generic()
+    fn key_from_key(key: fjall::UserKey) -> Result<Self::Key> {
+        String::from_utf8(key.to_vec()).map_err_generic()
     }
 }
 
 impl TableRow for ExpirationRow {
-    const TABLE_PREFIX: &'static str = "_KV_EXP_";
-
-    type Key = ExpirationKey;
-
-    fn get_key(&self) -> Cow<'_, Self::Key> {
-        Cow::Borrowed(&self.computed_key)
-    }
+    const ROW_TYPE: u8 = RowType::Expiration as u8;
 }

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -49,7 +49,7 @@ impl ExpirationRow {
 impl TableKeyFromFjall for ExpirationRow {
     type Key = String;
 
-    fn key_from_key(key: fjall::UserKey) -> Result<Self::Key> {
+    fn key_from_fjall_key(key: fjall::UserKey) -> Result<Self::Key> {
         String::from_utf8(key.to_vec()).map_err_generic()
     }
 }

--- a/crates/msgs/Cargo.toml
+++ b/crates/msgs/Cargo.toml
@@ -6,11 +6,11 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-byteorder.workspace = true
 coyote-error.workspace = true
 coyote-namespace.workspace = true
 coyote-operations.workspace = true
 fjall.workspace = true
+fjall-utils.workspace = true
 jiff.workspace = true
 rand.workspace = true
 rmp-serde.workspace = true

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -5,11 +5,12 @@ use crate::{
     entities::{
         MsgIn, Offset, Partition, TopicId, TopicIn, TopicName, TopicPartition, partition_for_key,
     },
-    tables::{MsgRow, TableRow, TopicRow},
+    tables::{MsgRow, TopicRow},
 };
 use coyote_error::Error;
 use coyote_namespace::entities::NamespaceId;
 use fjall::OwnedWriteBatch;
+use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use tracing::Span;
@@ -54,7 +55,10 @@ impl PublishOperation {
 
     #[tracing::instrument(skip_all, level = "debug", fields(msg_count = self.msgs.len()))]
     fn apply_real(self, state: &State) -> coyote_operations::Result<PublishResponseData> {
-        let topic_row = TopicRow::fetch(&state.metadata_tables, self.namespace_id, &self.topic)?;
+        let topic_row = TopicRow::fetch(
+            &state.metadata_tables,
+            TopicRow::key_for(self.namespace_id, &self.topic),
+        )?;
         let mut batch = state.db.batch();
 
         let topic_row = match (topic_row, self.partition) {
@@ -68,11 +72,11 @@ impl PublishOperation {
             }
             (None, None) => {
                 let row = TopicRow::new(self.topic.clone(), self.now);
-                batch.insert(
+                batch.insert_row(
                     &state.metadata_tables,
-                    TopicRow::construct_key(self.namespace_id, &self.topic),
-                    row.to_fjall_value()?,
-                );
+                    TopicRow::key_for(self.namespace_id, &self.topic),
+                    &row,
+                )?;
                 row
             }
         };
@@ -154,11 +158,11 @@ fn write_msg_batch(
                 headers: msg.headers,
                 timestamp: now,
             };
-            batch.insert(
+            batch.insert_row(
                 msg_table,
-                MsgRow::construct_key(topic_id, partition, offset),
-                msg.to_fjall_value()?,
-            );
+                MsgRow::key_for(topic_id, partition, offset),
+                &msg,
+            )?;
             offset += 1;
         }
 

--- a/crates/msgs/src/operations/stream_commit.rs
+++ b/crates/msgs/src/operations/stream_commit.rs
@@ -1,4 +1,5 @@
 use coyote_namespace::entities::NamespaceId;
+use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +8,7 @@ use coyote_error::Error;
 use crate::{
     State,
     entities::{ConsumerGroup, Offset, TopicPartition},
-    tables::{StreamLeaseRow, TableRow, TopicRow},
+    tables::{StreamLeaseRow, TopicRow},
 };
 
 use super::{MsgsRaftState, MsgsRequest, StreamCommitResponse};
@@ -42,14 +43,15 @@ impl StreamCommitOperation {
         let mut batch = state.db.batch();
         let topic = self.topic;
 
-        let topic_row = TopicRow::fetch(&state.metadata_tables, self.namespace_id, &topic.raw)?
-            .ok_or_else(|| Error::invalid_user_input("partition must exist"))?;
+        let topic_row = TopicRow::fetch(
+            &state.metadata_tables,
+            TopicRow::key_for(self.namespace_id, &topic.raw),
+        )?
+        .ok_or_else(|| Error::invalid_user_input("partition must exist"))?;
 
         let mut lease = StreamLeaseRow::fetch(
             &state.metadata_tables,
-            topic_row.id,
-            topic.partition,
-            &self.consumer_group,
+            StreamLeaseRow::key_for(topic_row.id, topic.partition, &self.consumer_group),
         )?
         .ok_or_else(|| Error::invalid_user_input("lease not found"))?;
 
@@ -58,11 +60,11 @@ impl StreamCommitOperation {
             lease.expiry = Timestamp::MIN;
         }
 
-        batch.insert(
+        batch.insert_row(
             &state.metadata_tables,
-            StreamLeaseRow::construct_key(topic_row.id, topic.partition, &self.consumer_group),
-            lease.to_fjall_value()?,
-        );
+            StreamLeaseRow::key_for(topic_row.id, topic.partition, &self.consumer_group),
+            &lease,
+        )?;
 
         batch.commit().map_err(Error::from)?;
 

--- a/crates/msgs/src/operations/stream_receive.rs
+++ b/crates/msgs/src/operations/stream_receive.rs
@@ -2,6 +2,7 @@ use std::{num::NonZeroU16, time::Duration};
 
 use coyote_error::Error;
 use coyote_namespace::entities::NamespaceId;
+use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
@@ -10,7 +11,7 @@ use tracing::Span;
 use crate::{
     State,
     entities::{ConsumerGroup, Offset, Partition, TopicIn, TopicName, TopicPartition},
-    tables::{MsgRow, StreamLeaseRow, TableRow, TopicRow},
+    tables::{MsgRow, StreamLeaseRow, TopicRow},
 };
 
 use super::{MsgsRaftState, MsgsRequest, StreamReceiveResponse};
@@ -58,19 +59,21 @@ impl StreamReceiveOperation {
 
         let mut batch = state.db.batch();
 
-        let topic_row =
-            match TopicRow::fetch(&state.metadata_tables, self.namespace_id, &self.topic)? {
-                Some(topic_row) => topic_row,
-                None => {
-                    let topic_row = TopicRow::new(self.topic.clone(), self.now);
-                    batch.insert(
-                        &state.metadata_tables,
-                        TopicRow::construct_key(self.namespace_id, &self.topic),
-                        topic_row.to_fjall_value()?,
-                    );
-                    topic_row
-                }
-            };
+        let topic_row = match TopicRow::fetch(
+            &state.metadata_tables,
+            TopicRow::key_for(self.namespace_id, &self.topic),
+        )? {
+            Some(topic_row) => topic_row,
+            None => {
+                let topic_row = TopicRow::new(self.topic.clone(), self.now);
+                batch.insert_row(
+                    &state.metadata_tables,
+                    TopicRow::key_for(self.namespace_id, &self.topic),
+                    &topic_row,
+                )?;
+                topic_row
+            }
+        };
 
         Span::current().record("partition_count", topic_row.partitions);
 
@@ -90,9 +93,7 @@ impl StreamReceiveOperation {
             let topic = TopicPartition::new(self.topic.clone(), Partition::new(partition)?);
             let (mut lease, is_new) = match StreamLeaseRow::fetch(
                 &state.metadata_tables,
-                topic_row.id,
-                topic.partition,
-                &self.consumer_group,
+                StreamLeaseRow::key_for(topic_row.id, topic.partition, &self.consumer_group),
             )? {
                 Some(lease) => (lease, false),
                 None => {
@@ -118,15 +119,15 @@ impl StreamReceiveOperation {
 
             if msgs.is_empty() {
                 if is_new {
-                    batch.insert(
+                    batch.insert_row(
                         &state.metadata_tables,
-                        StreamLeaseRow::construct_key(
+                        StreamLeaseRow::key_for(
                             topic_row.id,
                             topic.partition,
                             &self.consumer_group,
                         ),
-                        lease.to_fjall_value()?,
-                    );
+                        &lease,
+                    )?;
                 }
                 continue;
             }
@@ -150,11 +151,11 @@ impl StreamReceiveOperation {
                     }),
             );
 
-            batch.insert(
+            batch.insert_row(
                 &state.metadata_tables,
-                StreamLeaseRow::construct_key(topic_row.id, topic.partition, &self.consumer_group),
-                lease.to_fjall_value()?,
-            );
+                StreamLeaseRow::key_for(topic_row.id, topic.partition, &self.consumer_group),
+                &lease,
+            )?;
 
             if remaining == 0 {
                 break;

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -1,4 +1,5 @@
 use coyote_namespace::entities::NamespaceId;
+use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +8,7 @@ use coyote_error::Error;
 use crate::{
     State,
     entities::{MAX_PARTITION_COUNT, TopicName},
-    tables::{TableRow, TopicRow},
+    tables::TopicRow,
 };
 
 use super::{MsgsRaftState, MsgsRequest, TopicConfigureResponse};
@@ -40,11 +41,13 @@ impl TopicConfigureOperation {
     }
 
     fn apply_real(self, state: &State) -> coyote_operations::Result<TopicConfigureResponseData> {
-        let mut topic_row =
-            match TopicRow::fetch(&state.metadata_tables, self.namespace_id, &self.topic)? {
-                Some(topic_row) => topic_row,
-                None => TopicRow::new(self.topic.clone(), self.now),
-            };
+        let mut topic_row = match TopicRow::fetch(
+            &state.metadata_tables,
+            TopicRow::key_for(self.namespace_id, &self.topic),
+        )? {
+            Some(topic_row) => topic_row,
+            None => TopicRow::new(self.topic.clone(), self.now),
+        };
 
         if self.partitions < topic_row.partitions {
             return Err(Error::invalid_user_input(
@@ -56,11 +59,11 @@ impl TopicConfigureOperation {
         topic_row.partitions = self.partitions;
 
         let mut batch = state.db.batch();
-        batch.insert(
+        batch.insert_row(
             &state.metadata_tables,
-            TopicRow::construct_key(self.namespace_id, &self.topic),
-            topic_row.to_fjall_value()?,
-        );
+            TopicRow::key_for(self.namespace_id, &self.topic),
+            &topic_row,
+        )?;
         batch.commit().map_err(Error::from)?;
 
         Ok(TopicConfigureResponseData {

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -1,39 +1,21 @@
-use byteorder::{BigEndian, ByteOrder};
 use coyote_namespace::entities::NamespaceId;
 use std::collections::HashMap;
 
 use coyote_error::{Error, Result};
+use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::entities::{ConsumerGroup, Offset, Partition, TopicId, TopicName};
 
+#[repr(u8)]
+enum RowType {
+    Topic = 0,
+    StreamLease = 1,
+    Msg = 2,
+}
+
 const SIZE_U64: usize = size_of::<u64>();
-
-fn construct_key(parts: &[&[u8]]) -> Vec<u8> {
-    let len = parts.iter().fold(0, |acc, e| acc + e.len());
-    let mut ret = Vec::with_capacity(len);
-    for part in parts {
-        ret.extend_from_slice(part);
-    }
-    ret
-}
-
-pub(crate) trait TableRow: serde::de::DeserializeOwned + Serialize {
-    fn from_fjall_value(value: fjall::UserValue) -> Result<Self> {
-        rmp_serde::from_slice(&value).map_err(Error::generic)
-    }
-
-    fn to_fjall_value(&self) -> Result<fjall::UserValue> {
-        rmp_serde::to_vec(&self)
-            .map(fjall::UserValue::from)
-            .map_err(Error::generic)
-    }
-
-    fn fjall_fetch(keyspace: &fjall::Keyspace, key: &[u8]) -> Result<Option<Self>> {
-        keyspace.get(key)?.map(Self::from_fjall_value).transpose()
-    }
-}
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct TopicRow {
@@ -42,11 +24,13 @@ pub(crate) struct TopicRow {
     pub partitions: u16,
 }
 
-impl TopicRow {
-    pub(crate) fn construct_key(namespace_id: NamespaceId, topic: &TopicName) -> Vec<u8> {
-        let parts = ["top".as_bytes(), namespace_id.as_bytes(), topic.as_bytes()];
+impl TableRow for TopicRow {
+    const ROW_TYPE: u8 = RowType::Topic as u8;
+}
 
-        construct_key(&parts)
+impl TopicRow {
+    pub(crate) fn key_for(namespace_id: NamespaceId, topic: &TopicName) -> TableKey<Self> {
+        TableKey::init_key(Self::ROW_TYPE, &[namespace_id.as_bytes()], &[topic])
     }
 
     pub(crate) fn new(name: TopicName, now: Timestamp) -> Self {
@@ -60,18 +44,7 @@ impl TopicRow {
             partitions: 1,
         }
     }
-
-    pub(crate) fn fetch(
-        keyspace: &fjall::Keyspace,
-        namespace_id: NamespaceId,
-        topic: &TopicName,
-    ) -> Result<Option<Self>> {
-        let key = Self::construct_key(namespace_id, topic);
-        Self::fjall_fetch(keyspace, &key)
-    }
 }
-
-impl TableRow for TopicRow {}
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct StreamLeaseRow {
@@ -83,23 +56,16 @@ pub(crate) struct StreamLeaseRow {
 }
 
 impl StreamLeaseRow {
-    fn construct_key_(topic_id: TopicId, partition: Partition, consumer_group: &str) -> Vec<u8> {
-        let parts = [
-            "strmleas".as_bytes(),
-            topic_id.as_bytes(),
-            &partition.get().to_be_bytes(),
-            consumer_group.as_bytes(),
-        ];
-
-        construct_key(&parts)
-    }
-
-    pub(crate) fn construct_key(
+    pub(crate) fn key_for(
         topic_id: TopicId,
         partition: Partition,
         consumer_group: &ConsumerGroup,
-    ) -> Vec<u8> {
-        Self::construct_key_(topic_id, partition, &consumer_group.0)
+    ) -> TableKey<Self> {
+        TableKey::init_key(
+            Self::ROW_TYPE,
+            &[topic_id.as_bytes(), &partition.get().to_be_bytes()],
+            &[consumer_group],
+        )
     }
 
     pub(crate) fn new() -> Result<Self> {
@@ -109,19 +75,11 @@ impl StreamLeaseRow {
             end_offset: 0,
         })
     }
-
-    pub(crate) fn fetch(
-        keyspace: &fjall::Keyspace,
-        topic_id: TopicId,
-        partition: Partition,
-        consumer_group: &ConsumerGroup,
-    ) -> Result<Option<Self>> {
-        let key = Self::construct_key(topic_id, partition, consumer_group);
-        Self::fjall_fetch(keyspace, &key)
-    }
 }
 
-impl TableRow for StreamLeaseRow {}
+impl TableRow for StreamLeaseRow {
+    const ROW_TYPE: u8 = RowType::StreamLease as u8;
+}
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct MsgRow {
@@ -131,22 +89,20 @@ pub(crate) struct MsgRow {
 }
 
 impl MsgRow {
-    pub(crate) fn construct_key(
+    pub(crate) fn key_for(
         topic_id: TopicId,
         partition: Partition,
         offset: Offset,
-    ) -> Vec<u8> {
-        let mut offset_buf = [0u8; SIZE_U64];
-        BigEndian::write_u64(&mut offset_buf, offset);
-
-        let parts = [
-            "msg".as_bytes(),
-            topic_id.as_bytes(),
-            &partition.get().to_be_bytes(),
-            &offset_buf,
-        ];
-
-        construct_key(&parts)
+    ) -> TableKey<Self> {
+        TableKey::init_key(
+            Self::ROW_TYPE,
+            &[
+                topic_id.as_bytes(),
+                &partition.get().to_be_bytes(),
+                &offset.to_be_bytes(),
+            ],
+            &[],
+        )
     }
 
     #[tracing::instrument(skip_all, level = "debug")]
@@ -155,8 +111,8 @@ impl MsgRow {
         topic_id: TopicId,
         partition: Partition,
     ) -> Result<Offset> {
-        let start = Self::construct_key(topic_id, partition, Offset::MIN);
-        let end = Self::construct_key(topic_id, partition, Offset::MAX);
+        let start = Self::key_for(topic_id, partition, Offset::MIN).into_fjall_key();
+        let end = Self::key_for(topic_id, partition, Offset::MAX).into_fjall_key();
         let item = keyspace.range(start..=end).next_back();
         match item {
             Some(kv) => {
@@ -181,8 +137,8 @@ impl MsgRow {
         batch_size: u16,
     ) -> Result<Vec<Self>> {
         let mut results = Vec::with_capacity(batch_size as usize);
-        let start = Self::construct_key(topic_id, partition, offset);
-        let end = Self::construct_key(topic_id, partition, offset + batch_size as u64);
+        let start = Self::key_for(topic_id, partition, offset).into_fjall_key();
+        let end = Self::key_for(topic_id, partition, offset + batch_size as u64).into_fjall_key();
         for entry in keyspace.range(start..end) {
             let val = entry.value()?;
             let msg = rmp_serde::from_slice(&val).map_err(Error::generic)?;
@@ -195,4 +151,6 @@ impl MsgRow {
     }
 }
 
-impl TableRow for MsgRow {}
+impl TableRow for MsgRow {
+    const ROW_TYPE: u8 = RowType::Msg as u8;
+}

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::entities::{ConsumerGroup, Offset, Partition, TopicId, TopicName};
 
+/// These values can never change. Only additions are allowed.
 #[repr(u8)]
 enum RowType {
     Topic = 0,

--- a/crates/rate-limiter/Cargo.toml
+++ b/crates/rate-limiter/Cargo.toml
@@ -13,7 +13,6 @@ fjall-utils.workspace = true
 jiff.workspace = true
 schemars.workspace = true
 serde.workspace = true
-static_assertions.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -67,14 +67,13 @@ impl RateLimiter {
                 let window_start = fw_config.get_window_start(now);
                 let max_tokens = fw_config.tokens;
 
-                let identifier_key = identifier.to_string();
-                let mut state = FixedWindowState::fetch(&self.tables, &identifier_key)?.unwrap_or(
-                    FixedWindowState {
-                        key: identifier_key.clone(),
-                        count: 0,
-                        window_start,
-                    },
-                );
+                let mut state =
+                    FixedWindowState::fetch(&self.tables, FixedWindowState::key_for(identifier))?
+                        .unwrap_or(FixedWindowState {
+                            key: identifier.to_owned(),
+                            count: 0,
+                            window_start,
+                        });
 
                 if state.window_start != window_start {
                     state.count = 0;
@@ -93,21 +92,24 @@ impl RateLimiter {
                 };
 
                 if update {
-                    FixedWindowState::insert(&self.tables, &state)?;
+                    FixedWindowState::insert(
+                        &self.tables,
+                        FixedWindowState::key_for(identifier),
+                        &state,
+                    )?;
                 }
 
                 Ok((result, remaining, retry_after))
             }
 
             RateLimitConfig::TokenBucket(tb_config) => {
-                let identifier_key = identifier.to_string();
-                let mut bucket = TokenBucketState::fetch(&self.tables, &identifier_key)?.unwrap_or(
-                    TokenBucketState {
-                        key: identifier_key.clone(),
-                        tokens: tb_config.bucket_size,
-                        last_refill: now,
-                    },
-                );
+                let mut bucket =
+                    TokenBucketState::fetch(&self.tables, TokenBucketState::key_for(identifier))?
+                        .unwrap_or(TokenBucketState {
+                            key: identifier.to_owned(),
+                            tokens: tb_config.bucket_size,
+                            last_refill: now,
+                        });
 
                 let (capacity, new_last_refill) =
                     tb_config.get_new_capacity(bucket.tokens, now, bucket.last_refill);
@@ -128,7 +130,11 @@ impl RateLimiter {
                 bucket.tokens = capacity - delta;
 
                 if update {
-                    TokenBucketState::insert(&self.tables, &bucket)?;
+                    TokenBucketState::insert(
+                        &self.tables,
+                        TokenBucketState::key_for(identifier),
+                        &bucket,
+                    )?;
                 }
 
                 Ok((RateLimitStatus::Ok, bucket.tokens, None))
@@ -156,13 +162,12 @@ impl RateLimiter {
     }
 
     pub fn reset(&self, identifier: &str, algorithm: RateLimitConfig) -> Result<()> {
-        let identifier_key = identifier.to_string();
         match algorithm {
             RateLimitConfig::FixedWindow(_) => {
-                FixedWindowState::remove(&self.tables, &identifier_key)?;
+                FixedWindowState::remove(&self.tables, FixedWindowState::key_for(identifier))?;
             }
             RateLimitConfig::TokenBucket(_) => {
-                TokenBucketState::remove(&self.tables, &identifier_key)?;
+                TokenBucketState::remove(&self.tables, TokenBucketState::key_for(identifier))?;
             }
         }
         Ok(())

--- a/crates/rate-limiter/src/tables.rs
+++ b/crates/rate-limiter/src/tables.rs
@@ -2,6 +2,7 @@ use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
+/// These values can never change. Only additions are allowed.
 #[repr(u8)]
 enum RowType {
     FixedWindow = 0,

--- a/crates/rate-limiter/src/tables.rs
+++ b/crates/rate-limiter/src/tables.rs
@@ -1,14 +1,12 @@
-use std::borrow::Cow;
-
-use fjall_utils::TableRow;
+use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-// IMPORTANT. Since these are all shared in the same fjall::Keyspace, the table prefixes must be unique.
-static_assertions::const_assert!(fjall_utils::are_all_unique(&[
-    FixedWindowState::TABLE_PREFIX,
-    TokenBucketState::TABLE_PREFIX,
-]));
+#[repr(u8)]
+enum RowType {
+    FixedWindow = 0,
+    TokenBucket = 1,
+}
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct FixedWindowState {
@@ -18,11 +16,12 @@ pub struct FixedWindowState {
 }
 
 impl TableRow for FixedWindowState {
-    const TABLE_PREFIX: &'static str = "_FIXED_WINDOW_";
-    type Key = String;
+    const ROW_TYPE: u8 = RowType::FixedWindow as u8;
+}
 
-    fn get_key(&self) -> Cow<'_, Self::Key> {
-        Cow::Borrowed(&self.key)
+impl FixedWindowState {
+    pub(crate) fn key_for(key: &str) -> TableKey<Self> {
+        TableKey::init_key(Self::ROW_TYPE, &[], &[key])
     }
 }
 
@@ -34,10 +33,11 @@ pub struct TokenBucketState {
 }
 
 impl TableRow for TokenBucketState {
-    const TABLE_PREFIX: &'static str = "_TOKEN_BUCKET_";
-    type Key = String;
+    const ROW_TYPE: u8 = RowType::TokenBucket as u8;
+}
 
-    fn get_key(&self) -> Cow<'_, Self::Key> {
-        Cow::Borrowed(&self.key)
+impl TokenBucketState {
+    pub(crate) fn key_for(key: &str) -> TableKey<Self> {
+        TableKey::init_key(Self::ROW_TYPE, &[], &[key])
     }
 }

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -9,7 +9,10 @@ use std::{
 
 use anyhow::Context;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
-use fjall_utils::{FjallFixedKey, MonotonicTableRowExt, TableRow};
+use fjall_utils::{
+    FjallFixedKey,
+    table_row2::{MonotonicTableRowExt, TableRow},
+};
 use jiff::Timestamp;
 use openraft::{
     Entry, LogId, OptionalSend, RaftLogReader, RaftTypeConfig, StorageError, Vote,


### PR DESCRIPTION
This is based on discussions I've had with Gabriel, but would love other people's feedback.

The main goals:
1. Enforce (in the type system) that key and values belong together.
2. Make it harder to structure keys wrong by having a helper.
3. Have a consistent way of structuring keys.
4. Mostly fixed size keys (where possible) so that they are easy to parse.

I spend a few hours trying to change logs.rs to this, but gave up and just kept table_row2. The main problem was that I wasn't familiar with the codebase so it was hard for me to confirm I'm setting the right values. Though changing it to explicitly use the bounds with fjall (without the range_helper) shouldn't be too hard, I just gave up because I didn't trust *ME* doing those changes.