### PR TITLE
Namespaces: change them back to be Option<String>

### DIFF
--- a/crates/coyote-namespace/src/lib.rs
+++ b/crates/coyote-namespace/src/lib.rs
@@ -9,7 +9,7 @@ mod tables;
 
 pub use self::tables::Namespace;
 
-pub const DEFAULT_NAMESPACE_NAME: &str = "default";
+pub(crate) const DEFAULT_NAMESPACE_NAME: &str = "default";
 
 pub fn parse_namespace(key: &str) -> (Option<&str>, &str) {
     match key.split_once(":") {
@@ -79,9 +79,23 @@ impl State {
 
     pub fn fetch_namespace<C: ModuleConfig>(
         &self,
-        namespace_name: &str,
+        namespace_name: Option<&str>,
     ) -> Result<Option<Namespace<C>>> {
-        Namespace::fetch(&self.keyspace, namespace_name)
+        if let Some(ns) = namespace_name
+            && ns == DEFAULT_NAMESPACE_NAME
+        {
+            return Err(coyote_error::Error::http(
+                coyote_error::HttpError::bad_request(
+                    Some("no_explicit_default_namespace".to_owned()),
+                    Some("Explicitly setting the \"default\" namespace is not allowed.".to_owned()),
+                ),
+            ));
+        }
+
+        Namespace::fetch(
+            &self.keyspace,
+            namespace_name.unwrap_or(DEFAULT_NAMESPACE_NAME),
+        )
     }
 
     /// Like `fetch_namespace` but allows passing `default` explicitly for admin purposes.

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt, ops::Deref, str::FromStr};
 
 use coyote_error::Error;
-use coyote_namespace::{DEFAULT_NAMESPACE_NAME, entities::NamespaceName, parse_namespace};
+use coyote_namespace::{entities::NamespaceName, parse_namespace};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{
@@ -59,12 +59,12 @@ impl FromStr for Partition {
 /// `"topic"` when the namespace is the default.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TopicName {
-    namespace: NamespaceName,
+    namespace: Option<NamespaceName>,
     topic: String,
 }
 
 impl TopicName {
-    pub fn new(namespace: NamespaceName, topic: String) -> Result<Self, Error> {
+    pub fn new(namespace: Option<NamespaceName>, topic: String) -> Result<Self, Error> {
         if topic.contains(TOPIC_PARTITION_DELIMITER) {
             Err(Error::generic("invalid topic"))
         } else if topic.len() > 64 {
@@ -74,8 +74,8 @@ impl TopicName {
         }
     }
 
-    pub fn namespace(&self) -> &str {
-        &self.namespace
+    pub fn namespace(&self) -> Option<&str> {
+        self.namespace.as_ref().map(|x| &x[..])
     }
 }
 
@@ -90,8 +90,8 @@ impl Deref for TopicName {
 
 impl fmt::Display for TopicName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.namespace != DEFAULT_NAMESPACE_NAME {
-            write!(f, "{}{}{}", self.namespace, NAMESPACE_DELIMITER, self.topic)
+        if let Some(namespace) = &self.namespace {
+            write!(f, "{}{}{}", namespace, NAMESPACE_DELIMITER, self.topic)
         } else {
             write!(f, "{}", self.topic)
         }
@@ -114,11 +114,7 @@ impl<'de> Deserialize<'de> for TopicName {
     {
         let s = String::deserialize(deserializer)?;
         let (ns, topic) = parse_namespace(&s);
-        Self::new(
-            ns.unwrap_or(DEFAULT_NAMESPACE_NAME).to_owned(),
-            topic.to_owned(),
-        )
-        .map_err(de::Error::custom)
+        Self::new(ns.map(|x| x.to_owned()), topic.to_owned()).map_err(de::Error::custom)
     }
 }
 
@@ -147,7 +143,7 @@ impl TopicPartition {
         Self { raw, partition }
     }
 
-    pub fn namespace(&self) -> &str {
+    pub fn namespace(&self) -> Option<&str> {
         self.raw.namespace()
     }
 }
@@ -164,10 +160,7 @@ impl TryFrom<String> for TopicPartition {
             .parse()
             .map_err(|_| Error::generic("invalid partition index in topic"))?;
         let partition = Partition::new(idx)?;
-        let raw = TopicName::new(
-            ns.unwrap_or(DEFAULT_NAMESPACE_NAME).to_owned(),
-            topic.to_owned(),
-        )?;
+        let raw = TopicName::new(ns.map(|x| x.to_owned()), topic.to_owned())?;
         Ok(Self { raw, partition })
     }
 }
@@ -231,7 +224,7 @@ impl TopicIn {
         }
     }
 
-    pub fn namespace(&self) -> &str {
+    pub fn namespace(&self) -> Option<&str> {
         self.topic_name().namespace()
     }
 }
@@ -249,12 +242,9 @@ impl<'de> Deserialize<'de> for TopicIn {
                 .map(TopicIn::TopicPartition)
                 .map_err(de::Error::custom)
         } else {
-            TopicName::new(
-                ns.unwrap_or(DEFAULT_NAMESPACE_NAME).to_owned(),
-                rest.to_owned(),
-            )
-            .map(TopicIn::TopicName)
-            .map_err(de::Error::custom)
+            TopicName::new(ns.map(|x| x.to_owned()), rest.to_owned())
+                .map(TopicIn::TopicName)
+                .map_err(de::Error::custom)
         }
     }
 }

--- a/crates/msgs/src/operations/mod.rs
+++ b/crates/msgs/src/operations/mod.rs
@@ -67,17 +67,7 @@ mod tests {
         let op = PublishOperation::new(
             Uuid::nil(),
             TopicIn::TopicName(
-                TopicName::new("default".to_string(), "my-topic".to_string()).unwrap(),
-            ),
-            vec![],
-        )
-        .unwrap();
-        assert_eq!(MsgsOperation::Publish(op).key_name(), "my-topic");
-
-        let op = PublishOperation::new(
-            Uuid::nil(),
-            TopicIn::TopicName(
-                TopicName::new("my-ns".to_string(), "my-topic".to_string()).unwrap(),
+                TopicName::new(Some("my-ns".to_string()), "my-topic".to_string()).unwrap(),
             ),
             vec![],
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use cfg::ConfigurationInner;
 use coyote_error::{Error, HttpError, Result};
 use coyote_kv::KvStore;
 use coyote_namespace::{
-    BothDatabases, DEFAULT_NAMESPACE_NAME,
+    BothDatabases,
     entities::{CacheConfig, IdempotencyConfig, KeyValueConfig, ModuleConfig},
     parse_namespace,
 };
@@ -223,7 +223,7 @@ impl AppState {
             .try_get_or_insert(ns_name.map(|s| s.to_string()), || -> Result<KvStore> {
                 let namespace = self
                     .namespace_state
-                    .fetch_namespace::<C>(ns_name.unwrap_or(DEFAULT_NAMESPACE_NAME))?
+                    .fetch_namespace::<C>(ns_name)?
                     .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
                 let policy = namespace.config.eviction_policy();


### PR DESCRIPTION
As discussed with Gabriel, reverting this as we want to abstract the concept of namespaces away from modules. They don't need to think about it, what's default, and what's not. This would be done by the namespace helpers.

Partial revert of #337