### PR TITLE
Really set TCP_NODELAY on all connections

### DIFF
--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -6,7 +6,7 @@ use coyote::{
         ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, LogFormat, LogLevel,
     },
     core::cluster::proto::HealthResponse,
-    run_with_prefix,
+    run_with_listeners,
 };
 use tempfile::TempDir;
 use tokio::{
@@ -108,7 +108,7 @@ impl TestServerBuilder {
         let server_handle = tokio::spawn({
             let cfg = cfg.clone();
             async move {
-                run_with_prefix(cfg, Some(listener), Some(repl_listener)).await;
+                run_with_listeners(cfg, Some(listener), Some(repl_listener)).await;
             }
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,6 +345,12 @@ pub async fn run_with_prefix(
         .await
         .expect("bootstrapping failed");
 
+    let listener = listener.tap_io(|tcp_stream| {
+        if let Err(err) = tcp_stream.set_nodelay(true) {
+            tracing::warn!("failed to set TCP_NODELAY on incoming connection: {err:#}");
+        }
+    });
+
     axum::serve(listener, make_svc)
         .with_graceful_shutdown(shutting_down_token().cancelled_owned())
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ async fn graceful_shutdown_handler() {
 
 pub async fn run(cfg: Configuration) {
     setup_metrics(&cfg);
-    run_with_prefix(cfg, None, None).await
+    run_with_listeners(cfg, None, None).await
 }
 
 #[derive(Clone)]
@@ -254,7 +254,7 @@ impl AppState {
 
 // Made public for the purpose of E2E testing in which a queue prefix is necessary to avoid tests
 // consuming from each others' queues
-pub async fn run_with_prefix(
+pub async fn run_with_listeners(
     cfg: Configuration,
     listener: Option<TcpListener>,
     interserver_listener: Option<TcpListener>,


### PR DESCRIPTION
#350 did it only for the interserver accept loop.
This does it for the public API accept loop.