### PR TITLE
Mark .NOTES in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /target
 .claude
 .vscode
-.TODO.md
+.NOTES
 logs
 .data/
 __pycache__/


### PR DESCRIPTION
I had this in a separate PR, but it's worth just splitting out.

I like to keep things in the `.NOTES/` folder, but I don't want the `git status` pollution.