### PR TITLE
KV: remove key from stored data.

### DIFF
--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -84,11 +84,7 @@ impl KvController {
     ) -> Result<()> {
         let mut batch = self.db.batch();
 
-        let row = KvPairRow {
-            key: key.to_string(),
-            value,
-            expiry,
-        };
+        let row = KvPairRow { value, expiry };
 
         batch.insert_row(&self.keyspace, KvPairRow::key_for(namespace_id, key), &row)?;
 

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -13,7 +13,6 @@ enum RowType {
 
 #[derive(Serialize, Deserialize)]
 pub struct KvPairRow {
-    pub key: String,
     pub value: Vec<u8>,
     pub expiry: Option<Timestamp>,
 }


### PR DESCRIPTION
We don't actually need it, it's stored on the fjall key itself. I missed this when previously refactoring.