### PR TITLE
Disable CI benchmarks for now

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -6,9 +6,11 @@ jobs:
   ci:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
-  benchmark:
-    uses: ./.github/workflows/benchmark.yml
-    secrets: inherit
+    # Disabling for now because results are too inconsistent
+    # on github runners. Will revisit later.
+    #  benchmark:
+    #    uses: ./.github/workflows/benchmark.yml
+    #    secrets: inherit
   docker_publish:
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit


### PR DESCRIPTION
They waste energy and don't buy us anything at the moment. We can revisit if/when we get some dedicated hardware for this.