### PR TITLE
server: hoist monotonic time up to the top of requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "coyote-error",
  "http",
  "http-serde",
+ "jiff",
  "opentelemetry",
  "paste",
  "serde",

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -48,9 +48,10 @@ impl CreateCacheOperation {
     fn apply_real(
         self,
         namespace_state: &coyote_namespace::State,
+        now: Timestamp,
     ) -> coyote_operations::Result<CreateCacheResponseData> {
         let op: CreateNamespace<CacheConfig> = self.into();
-        let out = op.apply_operation(namespace_state)?;
+        let out = op.apply_operation(namespace_state, now)?;
         Ok(out.into())
     }
 }
@@ -79,7 +80,7 @@ impl From<CreateNamespaceOutput<CacheConfig>> for CreateCacheResponseData {
 }
 
 impl CacheRequest for CreateCacheOperation {
-    fn apply(self, state: CacheRaftState<'_>) -> CreateCacheResponse {
-        CreateCacheResponse(self.apply_real(state.namespace))
+    fn apply(self, state: CacheRaftState<'_>, now: Timestamp) -> CreateCacheResponse {
+        CreateCacheResponse(self.apply_real(state.namespace, now))
     }
 }

--- a/crates/cache/src/operations/delete.rs
+++ b/crates/cache/src/operations/delete.rs
@@ -33,7 +33,7 @@ impl DeleteOperation {
 }
 
 impl CacheRequest for DeleteOperation {
-    fn apply(self, state: CacheRaftState<'_>) -> DeleteResponse {
+    fn apply(self, state: CacheRaftState<'_>, _now: jiff::Timestamp) -> DeleteResponse {
         DeleteResponse(self.apply_real(&state))
     }
 }

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -13,7 +13,6 @@ pub struct SetOperation {
     storage_type: StorageType,
     pub(crate) key: String,
     model: CacheModel,
-    now: Timestamp,
 }
 
 impl SetOperation {
@@ -23,27 +22,26 @@ impl SetOperation {
             storage_type: namespace.storage_type,
             key,
             model,
-            now: Timestamp::now(),
         }
     }
 }
 
 impl SetOperation {
-    fn apply_real(self, state: &CacheRaftState<'_>) -> Result<()> {
+    fn apply_real(self, state: &CacheRaftState<'_>, now: Timestamp) -> Result<()> {
         state.state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
             self.model.value,
             self.model.expiry,
             OperationBehavior::Upsert,
-            self.now,
+            now,
         )?;
         Ok(())
     }
 }
 
 impl CacheRequest for SetOperation {
-    fn apply(self, state: CacheRaftState<'_>) -> SetResponse {
-        SetResponse(self.apply_real(&state))
+    fn apply(self, state: CacheRaftState<'_>, now: Timestamp) -> SetResponse {
+        SetResponse(self.apply_real(&state, now))
     }
 }

--- a/crates/coyote-namespace/src/operations/create_namespace.rs
+++ b/crates/coyote-namespace/src/operations/create_namespace.rs
@@ -14,7 +14,6 @@ use crate::{
 #[derive(Deserialize, Serialize)]
 #[serde(bound = "C: ModuleConfig")]
 pub struct CreateNamespace<C: ModuleConfig> {
-    timestamp: Timestamp,
     name: String,
     #[serde(default)]
     storage_type: StorageType,
@@ -42,7 +41,6 @@ impl<C: ModuleConfig> CreateNamespace<C> {
         max_storage_bytes: Option<NonZeroU64>,
     ) -> Self {
         Self {
-            timestamp: Timestamp::now(),
             name,
             config,
             storage_type,
@@ -50,13 +48,17 @@ impl<C: ModuleConfig> CreateNamespace<C> {
         }
     }
 
-    pub fn apply_operation(self, state: &State) -> Result<CreateNamespaceOutput<C>> {
+    pub fn apply_operation(
+        self,
+        state: &State,
+        timestamp: Timestamp,
+    ) -> Result<CreateNamespaceOutput<C>> {
         let db = state.db();
         let keyspace = state.keyspace();
         let namespace = match Namespace::<C>::fetch(keyspace, &self.name)? {
             Some(mut namespace) => {
                 namespace.storage_type = self.storage_type;
-                namespace.updated_at = self.timestamp;
+                namespace.updated_at = timestamp;
                 namespace.max_storage_bytes = self.max_storage_bytes;
                 namespace.config = self.config;
                 namespace
@@ -64,16 +66,16 @@ impl<C: ModuleConfig> CreateNamespace<C> {
             None => {
                 let id = NamespaceId::new_v7(uuid::Timestamp::from_unix(
                     uuid::NoContext,
-                    self.timestamp.as_second() as u64,
-                    self.timestamp.subsec_nanosecond() as u32,
+                    timestamp.as_second() as u64,
+                    timestamp.subsec_nanosecond() as u32,
                 ));
                 Namespace {
                     id,
                     name: self.name,
                     storage_type: self.storage_type,
                     max_storage_bytes: self.max_storage_bytes,
-                    created_at: self.timestamp,
-                    updated_at: self.timestamp,
+                    created_at: timestamp,
+                    updated_at: timestamp,
                     config: self.config,
                 }
             }

--- a/crates/coyote-operations/Cargo.toml
+++ b/crates/coyote-operations/Cargo.toml
@@ -10,6 +10,7 @@ axum.workspace = true
 coyote-error.workspace = true
 http.workspace = true
 http-serde.workspace = true
+jiff.workspace = true
 opentelemetry.workspace = true
 paste.workspace = true
 serde.workspace = true

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -10,6 +10,9 @@ pub mod __reexports {
     pub use paste;
 }
 
+mod monotime;
+pub use monotime::Monotime;
+
 #[macro_use]
 mod macros;
 pub trait OperationResponse: Serialize + DeserializeOwned + Clone + Debug {

--- a/crates/coyote-operations/src/macros.rs
+++ b/crates/coyote-operations/src/macros.rs
@@ -34,7 +34,7 @@ macro_rules! raft_module_operations {
             where
                 Self: 'static,
             {
-                fn apply(self, state: $state_type) -> Self::Response;
+                fn apply(self, state: $state_type, timestamp: jiff::Timestamp) -> Self::Response;
             }
 
             $(
@@ -95,9 +95,9 @@ macro_rules! raft_module_operations {
             )*
 
             impl $module_op_name {
-                pub fn apply(self, state: $state_type) -> $response_name {
+                pub fn apply(self, state: $state_type, timestamp: jiff::Timestamp) -> $response_name {
                     match self {
-                        $(Self::$variant(req) => $response_name::$variant(req.apply(state)),)*
+                        $(Self::$variant(req) => $response_name::$variant(req.apply(state, timestamp)),)*
                     }
                 }
             }
@@ -141,7 +141,7 @@ macro_rules! async_raft_module_operations {
             where
                 Self: 'static,
             {
-                async fn apply(self, state: $state_type) -> Self::Response;
+                async fn apply(self, state: $state_type, timestamp: jiff::Timestamp) -> Self::Response;
             }
 
             $(
@@ -202,9 +202,9 @@ macro_rules! async_raft_module_operations {
             )*
 
             impl $module_op_name {
-                pub async fn apply(self, state: $state_type) -> $response_name {
+                pub async fn apply(self, state: $state_type, timestamp: jiff::Timestamp) -> $response_name {
                     match self {
-                        $(Self::$variant(req) => $response_name::$variant(req.apply(state).await),)*
+                        $(Self::$variant(req) => $response_name::$variant(req.apply(state, timestamp).await),)*
                     }
                 }
             }

--- a/crates/coyote-operations/src/monotime.rs
+++ b/crates/coyote-operations/src/monotime.rs
@@ -30,16 +30,21 @@ impl Monotime {
     }
 
     /// Get a monotonic version of the current time as the number of millis since epoch, updating our internal knowledge about time.
-    pub fn now_raw(&self) -> i64 {
+    fn now_raw(&self) -> i64 {
         let now = Timestamp::now().as_millisecond();
-        self.bump(now)
+        self.bump_raw(now)
     }
 
-    pub fn bump(&self, other: i64) -> i64 {
+    /// Ingest another timestamp
+    pub fn bump(&self, other: Timestamp) {
+        self.bump_raw(other.as_millisecond());
+    }
+
+    fn bump_raw(&self, other: i64) -> i64 {
         self.0.fetch_max(other, Ordering::AcqRel).max(other)
     }
 
-    pub fn as_i64(&self) -> i64 {
+    fn as_i64(&self) -> i64 {
         self.0.load(Ordering::Acquire)
     }
 }

--- a/crates/coyote-operations/src/monotime.rs
+++ b/crates/coyote-operations/src/monotime.rs
@@ -1,0 +1,45 @@
+use jiff::Timestamp;
+use std::sync::{
+    Arc,
+    atomic::{AtomicI64, Ordering},
+};
+
+/// A monotonic clock. Stores time internally as milliseconds since Unix epoch. In the event that
+/// wall clock goes backwards, this will stall until the clock catches up.
+///
+/// This structure is cheaply cloneable and clones all point at the same underlying data
+/// (internally, this is an Arc).
+#[derive(Debug, Clone)]
+pub struct Monotime(Arc<AtomicI64>);
+
+impl Monotime {
+    pub fn initial() -> Self {
+        Self(Arc::new(AtomicI64::new(0)))
+    }
+
+    /// Get the last time that the leader set
+    pub fn last(&self) -> Timestamp {
+        Timestamp::from_millisecond(self.as_i64())
+            .expect("time was wildly outside of acceptable ranges, I must crash")
+    }
+
+    /// Get a monotonic version of the current time, updating our internal knowledge about time.
+    pub fn now(&self) -> Timestamp {
+        Timestamp::from_millisecond(self.now_raw())
+            .expect("time was wildly outside of acceptable ranges, I must crash")
+    }
+
+    /// Get a monotonic version of the current time as the number of millis since epoch, updating our internal knowledge about time.
+    pub fn now_raw(&self) -> i64 {
+        let now = Timestamp::now().as_millisecond();
+        self.bump(now)
+    }
+
+    pub fn bump(&self, other: i64) -> i64 {
+        self.0.fetch_max(other, Ordering::AcqRel).max(other)
+    }
+
+    pub fn as_i64(&self) -> i64 {
+        self.0.load(Ordering::Acquire)
+    }
+}

--- a/crates/idempotency/src/operations/abort.rs
+++ b/crates/idempotency/src/operations/abort.rs
@@ -34,7 +34,7 @@ impl AbortOperation {
 }
 
 impl IdempotencyRequest for AbortOperation {
-    fn apply(self, state: IdempotencyRaftState<'_>) -> AbortResponse {
+    fn apply(self, state: IdempotencyRaftState<'_>, _now: jiff::Timestamp) -> AbortResponse {
         AbortResponse(self.apply_real(&state))
     }
 }

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -16,7 +16,6 @@ pub struct CompleteOperation {
     pub(crate) key: String,
     pub(crate) response: Vec<u8>,
     pub(crate) ttl_seconds: u64,
-    now: Timestamp,
 }
 
 impl CompleteOperation {
@@ -32,14 +31,13 @@ impl CompleteOperation {
             key,
             response,
             ttl_seconds,
-            now: Timestamp::now(),
         }
     }
 }
 
 impl CompleteOperation {
-    fn apply_real(self, state: &IdempotencyRaftState<'_>) -> Result<()> {
-        let expiry = self.now + Duration::from_secs(self.ttl_seconds);
+    fn apply_real(self, state: &IdempotencyRaftState<'_>, now: Timestamp) -> Result<()> {
+        let expiry = now + Duration::from_secs(self.ttl_seconds);
         state.state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
@@ -49,7 +47,7 @@ impl CompleteOperation {
             .into(),
             Some(expiry),
             OperationBehavior::Upsert,
-            self.now,
+            now,
         )?;
 
         Ok(())
@@ -57,7 +55,7 @@ impl CompleteOperation {
 }
 
 impl IdempotencyRequest for CompleteOperation {
-    fn apply(self, state: IdempotencyRaftState<'_>) -> CompleteResponse {
-        CompleteResponse(self.apply_real(&state))
+    fn apply(self, state: IdempotencyRaftState<'_>, now: Timestamp) -> CompleteResponse {
+        CompleteResponse(self.apply_real(&state, now))
     }
 }

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -43,9 +43,10 @@ impl CreateIdempotencyOperation {
     fn apply_real(
         self,
         namespace_state: &coyote_namespace::State,
+        now: Timestamp,
     ) -> coyote_operations::Result<CreateIdempotencyResponseData> {
         let op: CreateNamespace<IdempotencyConfig> = self.into();
-        let out = op.apply_operation(namespace_state)?;
+        let out = op.apply_operation(namespace_state, now)?;
         Ok(out.into())
     }
 }
@@ -72,7 +73,7 @@ impl From<CreateNamespaceOutput<IdempotencyConfig>> for CreateIdempotencyRespons
 }
 
 impl IdempotencyRequest for CreateIdempotencyOperation {
-    fn apply(self, state: IdempotencyRaftState<'_>) -> CreateIdempotencyResponse {
-        CreateIdempotencyResponse(self.apply_real(state.namespace))
+    fn apply(self, state: IdempotencyRaftState<'_>, now: Timestamp) -> CreateIdempotencyResponse {
+        CreateIdempotencyResponse(self.apply_real(state.namespace, now))
     }
 }

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -15,7 +15,6 @@ pub struct TryStartOperation {
     storage_type: StorageType,
     pub(crate) key: String,
     pub(crate) ttl_seconds: u64,
-    now: Timestamp,
 }
 
 impl TryStartOperation {
@@ -25,7 +24,6 @@ impl TryStartOperation {
             storage_type: namespace.storage_type,
             key,
             ttl_seconds,
-            now: Timestamp::now(),
         }
     }
 }
@@ -36,8 +34,11 @@ pub struct TryStartResponseData {
 }
 
 impl TryStartOperation {
-    fn apply_real(self, state: &IdempotencyRaftState<'_>) -> Result<TryStartResponseData> {
-        let now = self.now;
+    fn apply_real(
+        self,
+        state: &IdempotencyRaftState<'_>,
+        now: Timestamp,
+    ) -> Result<TryStartResponseData> {
         let expiry = now + Duration::from_secs(self.ttl_seconds);
 
         let controller = state.state.controller(self.storage_type);
@@ -71,7 +72,7 @@ impl TryStartOperation {
 }
 
 impl IdempotencyRequest for TryStartOperation {
-    fn apply(self, state: IdempotencyRaftState<'_>) -> TryStartResponse {
-        TryStartResponse(self.apply_real(&state))
+    fn apply(self, state: IdempotencyRaftState<'_>, now: Timestamp) -> TryStartResponse {
+        TryStartResponse(self.apply_real(&state, now))
     }
 }

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -43,9 +43,10 @@ impl CreateKvOperation {
     fn apply_real(
         self,
         namespace_state: &coyote_namespace::State,
+        now: Timestamp,
     ) -> coyote_operations::Result<CreateKvResponseData> {
         let op: CreateNamespace<KeyValueConfig> = self.into();
-        let out = op.apply_operation(namespace_state)?;
+        let out = op.apply_operation(namespace_state, now)?;
         Ok(out.into())
     }
 }
@@ -72,7 +73,7 @@ impl From<CreateNamespaceOutput<KeyValueConfig>> for CreateKvResponseData {
 }
 
 impl KvRequest for CreateKvOperation {
-    fn apply(self, state: KvRaftState<'_>) -> CreateKvResponse {
-        CreateKvResponse(self.apply_real(state.namespace))
+    fn apply(self, state: KvRaftState<'_>, now: Timestamp) -> CreateKvResponse {
+        CreateKvResponse(self.apply_real(state.namespace, now))
     }
 }

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -33,7 +33,7 @@ impl DeleteOperation {
 }
 
 impl KvRequest for DeleteOperation {
-    fn apply(self, state: KvRaftState<'_>) -> DeleteResponse {
+    fn apply(self, state: KvRaftState<'_>, _timestamp: jiff::Timestamp) -> DeleteResponse {
         DeleteResponse(self.apply_real(state.state))
     }
 }

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -18,7 +18,6 @@ pub struct SetOperation {
     expiry: Option<Timestamp>,
     value: Vec<u8>,
     behavior: OperationBehavior,
-    now: Timestamp,
 }
 
 impl SetOperation {
@@ -36,27 +35,26 @@ impl SetOperation {
             expiry: ttl.map(|ttl| Timestamp::now() + Duration::from_millis(ttl)),
             value,
             behavior,
-            now: Timestamp::now(),
         }
     }
 }
 
 impl SetOperation {
-    fn apply_real(self, state: &State) -> Result<()> {
+    fn apply_real(self, state: &State, now: Timestamp) -> Result<()> {
         state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
             self.value,
             self.expiry,
             self.behavior,
-            self.now,
+            now,
         )?;
         Ok(())
     }
 }
 
 impl KvRequest for SetOperation {
-    fn apply(self, state: KvRaftState<'_>) -> SetResponse {
-        SetResponse(self.apply_real(state.state))
+    fn apply(self, state: KvRaftState<'_>, timestamp: Timestamp) -> SetResponse {
+        SetResponse(self.apply_real(state.state, timestamp))
     }
 }

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -30,6 +30,7 @@ impl CreateNamespaceOperation {
     fn apply_real(
         self,
         namespace_state: &coyote_namespace::State,
+        now: Timestamp,
     ) -> coyote_operations::Result<CreateNamespaceResponseData> {
         let op = CreateNamespace::new(
             self.name,
@@ -39,7 +40,7 @@ impl CreateNamespaceOperation {
             self.storage_type,
             Some(self.retention.bytes),
         );
-        let out = op.apply_operation(namespace_state)?;
+        let out = op.apply_operation(namespace_state, now)?;
         Ok(out.into())
     }
 }
@@ -74,7 +75,7 @@ impl From<CreateNamespaceOutput<StreamConfig>> for CreateNamespaceResponseData {
 }
 
 impl MsgsRequest for CreateNamespaceOperation {
-    fn apply(self, state: MsgsRaftState<'_>) -> CreateNamespaceResponse {
-        CreateNamespaceResponse(self.apply_real(state.namespace))
+    fn apply(self, state: MsgsRaftState<'_>, now: Timestamp) -> CreateNamespaceResponse {
+        CreateNamespaceResponse(self.apply_real(state.namespace, now))
     }
 }

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -23,7 +23,6 @@ pub struct PublishOperation {
     pub(crate) topic: TopicName,
     partition: Option<Partition>,
     msgs: Vec<MsgIn>,
-    now: Timestamp,
 }
 
 impl PublishOperation {
@@ -49,12 +48,15 @@ impl PublishOperation {
             topic,
             partition,
             msgs,
-            now: Timestamp::now(),
         })
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(msg_count = self.msgs.len()))]
-    fn apply_real(self, state: &State) -> coyote_operations::Result<PublishResponseData> {
+    fn apply_real(
+        self,
+        state: &State,
+        now: Timestamp,
+    ) -> coyote_operations::Result<PublishResponseData> {
         let topic_row = TopicRow::fetch(
             &state.metadata_tables,
             TopicRow::key_for(self.namespace_id, &self.topic),
@@ -71,7 +73,7 @@ impl PublishOperation {
                 return Err(Error::invalid_user_input("topic does not exist").into());
             }
             (None, None) => {
-                let row = TopicRow::new(self.topic.clone(), self.now);
+                let row = TopicRow::new(self.topic.clone(), now);
                 batch.insert_row(
                     &state.metadata_tables,
                     TopicRow::key_for(self.namespace_id, &self.topic),
@@ -92,7 +94,7 @@ impl PublishOperation {
             &self.topic,
             topic_row.id,
             msgs_by_partition,
-            self.now,
+            now,
         )?;
 
         batch.commit().map_err(Error::from)?;
@@ -116,8 +118,8 @@ pub struct PublishResponseData {
 }
 
 impl MsgsRequest for PublishOperation {
-    fn apply(self, state: MsgsRaftState<'_>) -> PublishResponse {
-        PublishResponse(self.apply_real(state.msgs))
+    fn apply(self, state: MsgsRaftState<'_>, timestamp: Timestamp) -> PublishResponse {
+        PublishResponse(self.apply_real(state.msgs, timestamp))
     }
 }
 

--- a/crates/msgs/src/operations/queue/ack.rs
+++ b/crates/msgs/src/operations/queue/ack.rs
@@ -21,7 +21,6 @@ pub struct QueueAckOperation {
     pub(crate) topic: TopicName,
     consumer_group: ConsumerGroup,
     msg_ids: Vec<MsgId>,
-    now: Timestamp,
 }
 
 impl QueueAckOperation {
@@ -36,7 +35,6 @@ impl QueueAckOperation {
             topic,
             consumer_group,
             msg_ids,
-            now: Timestamp::now(),
         }
     }
 
@@ -100,7 +98,7 @@ impl QueueAckOperation {
 pub struct QueueAckResponseData {}
 
 impl MsgsRequest for QueueAckOperation {
-    fn apply(self, state: MsgsRaftState<'_>) -> QueueAckResponse {
+    fn apply(self, state: MsgsRaftState<'_>, _now: Timestamp) -> QueueAckResponse {
         QueueAckResponse(self.apply_real(state.msgs))
     }
 }

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -23,7 +23,6 @@ pub struct QueueReceiveOperation {
     consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
     lease_duration_millis: u64,
-    now: Timestamp,
 }
 
 impl QueueReceiveOperation {
@@ -45,17 +44,20 @@ impl QueueReceiveOperation {
             consumer_group,
             batch_size,
             lease_duration_millis,
-            now: Timestamp::now(),
         })
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size = self.batch_size))]
-    fn apply_real(self, state: &State) -> coyote_operations::Result<QueueReceiveResponseData> {
+    fn apply_real(
+        self,
+        state: &State,
+        now: Timestamp,
+    ) -> coyote_operations::Result<QueueReceiveResponseData> {
         let lease_duration = Duration::from_millis(self.lease_duration_millis);
         let mut remaining = self.batch_size.get();
         let mut all_msgs: Vec<QueueReceiveMsg> = Vec::with_capacity(remaining.into());
 
-        let expiry = self.now + lease_duration;
+        let expiry = now + lease_duration;
 
         let mut batch = state.db.batch();
 
@@ -64,7 +66,7 @@ impl QueueReceiveOperation {
             &mut batch,
             self.namespace_id,
             &self.topic,
-            self.now,
+            now,
         )?;
 
         Span::current().record("partition_count", topic_row.partitions);
@@ -118,7 +120,7 @@ impl QueueReceiveOperation {
                     partition,
                     topic_row.id,
                     &self.consumer_group,
-                    self.now,
+                    now,
                     expiry,
                 )?;
                 remaining = remaining.saturating_sub(n);
@@ -245,7 +247,7 @@ pub struct QueueReceiveResponseData {
 }
 
 impl MsgsRequest for QueueReceiveOperation {
-    fn apply(self, state: MsgsRaftState<'_>) -> QueueReceiveResponse {
-        QueueReceiveResponse(self.apply_real(state.msgs))
+    fn apply(self, state: MsgsRaftState<'_>, now: Timestamp) -> QueueReceiveResponse {
+        QueueReceiveResponse(self.apply_real(state.msgs, now))
     }
 }

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -19,7 +19,6 @@ pub struct StreamCommitOperation {
     pub(crate) topic: TopicPartition,
     consumer_group: ConsumerGroup,
     offset: Offset,
-    now: Timestamp,
 }
 
 impl StreamCommitOperation {
@@ -34,7 +33,6 @@ impl StreamCommitOperation {
             topic,
             consumer_group,
             offset,
-            now: Timestamp::now(),
         }
     }
 
@@ -76,7 +74,7 @@ impl StreamCommitOperation {
 pub struct StreamCommitResponseData {}
 
 impl MsgsRequest for StreamCommitOperation {
-    fn apply(self, state: MsgsRaftState<'_>) -> StreamCommitResponse {
+    fn apply(self, state: MsgsRaftState<'_>, _timestamp: Timestamp) -> StreamCommitResponse {
         StreamCommitResponse(self.apply_real(state.msgs))
     }
 }

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -23,7 +23,6 @@ pub struct StreamReceiveOperation {
     consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
     lease_duration_millis: u64,
-    now: Timestamp,
 }
 
 impl StreamReceiveOperation {
@@ -45,16 +44,19 @@ impl StreamReceiveOperation {
             consumer_group,
             batch_size,
             lease_duration_millis,
-            now: Timestamp::now(),
         })
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size = self.batch_size))]
-    fn apply_real(self, state: &State) -> coyote_operations::Result<StreamReceiveResponseData> {
+    fn apply_real(
+        self,
+        state: &State,
+        now: Timestamp,
+    ) -> coyote_operations::Result<StreamReceiveResponseData> {
         let lease_duration = Duration::from_millis(self.lease_duration_millis);
         let mut remaining = self.batch_size.get();
         let mut all_msgs: Vec<StreamReceiveMsg> = Vec::with_capacity(remaining as usize);
-        let expiry = self.now + lease_duration;
+        let expiry = now + lease_duration;
 
         let mut batch = state.db.batch();
 
@@ -63,7 +65,7 @@ impl StreamReceiveOperation {
             &mut batch,
             self.namespace_id,
             &self.topic,
-            self.now,
+            now,
         )?;
 
         Span::current().record("partition_count", topic_row.partitions);
@@ -90,7 +92,7 @@ impl StreamReceiveOperation {
                 }
             };
 
-            if lease.expiry > self.now {
+            if lease.expiry > now {
                 continue;
             }
             no_lease_available = false;
@@ -175,7 +177,7 @@ pub struct StreamReceiveResponseData {
 }
 
 impl MsgsRequest for StreamReceiveOperation {
-    fn apply(self, state: MsgsRaftState<'_>) -> StreamReceiveResponse {
-        StreamReceiveResponse(self.apply_real(state.msgs))
+    fn apply(self, state: MsgsRaftState<'_>, now: Timestamp) -> StreamReceiveResponse {
+        StreamReceiveResponse(self.apply_real(state.msgs, now))
     }
 }

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -18,7 +18,6 @@ pub struct TopicConfigureOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,
     partitions: u16,
-    now: Timestamp,
 }
 
 impl TopicConfigureOperation {
@@ -36,17 +35,20 @@ impl TopicConfigureOperation {
             namespace_id,
             topic,
             partitions,
-            now: Timestamp::now(),
         })
     }
 
-    fn apply_real(self, state: &State) -> coyote_operations::Result<TopicConfigureResponseData> {
+    fn apply_real(
+        self,
+        state: &State,
+        now: Timestamp,
+    ) -> coyote_operations::Result<TopicConfigureResponseData> {
         let mut topic_row = match TopicRow::fetch(
             &state.metadata_tables,
             TopicRow::key_for(self.namespace_id, &self.topic),
         )? {
             Some(topic_row) => topic_row,
-            None => TopicRow::new(self.topic.clone(), self.now),
+            None => TopicRow::new(self.topic.clone(), now),
         };
 
         if self.partitions < topic_row.partitions {
@@ -78,7 +80,7 @@ pub struct TopicConfigureResponseData {
 }
 
 impl MsgsRequest for TopicConfigureOperation {
-    fn apply(self, state: MsgsRaftState<'_>) -> TopicConfigureResponse {
-        TopicConfigureResponse(self.apply_real(state.msgs))
+    fn apply(self, state: MsgsRaftState<'_>, timestamp: Timestamp) -> TopicConfigureResponse {
+        TopicConfigureResponse(self.apply_real(state.msgs, timestamp))
     }
 }

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -174,8 +174,7 @@ impl RateLimiter {
     }
 
     pub fn limit_operation(key: String, units: u64, method: RateLimitConfig) -> LimitOperation {
-        let now = Timestamp::now();
-        LimitOperation::new(key, now, units, method)
+        LimitOperation::new(key, units, method)
     }
 
     pub fn reset_operation(key: String, method: RateLimitConfig) -> ResetOperation {

--- a/crates/rate-limiter/src/operations/limit.rs
+++ b/crates/rate-limiter/src/operations/limit.rs
@@ -9,16 +9,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LimitOperation {
     pub(crate) key: String,
-    pub(crate) now: Timestamp,
     pub(crate) tokens: u64,
     pub(crate) method: RateLimitConfig,
 }
 
 impl LimitOperation {
-    pub fn new(key: String, now: Timestamp, tokens: u64, method: RateLimitConfig) -> Self {
+    pub fn new(key: String, tokens: u64, method: RateLimitConfig) -> Self {
         Self {
             key,
-            now,
             tokens,
             method,
         }
@@ -33,9 +31,9 @@ pub struct LimitResponseData {
 }
 
 impl LimitOperation {
-    fn apply_real(self, state: &crate::RateLimiter) -> Result<LimitResponseData> {
+    fn apply_real(self, state: &crate::RateLimiter, now: Timestamp) -> Result<LimitResponseData> {
         let (status, remaining, retry_after) =
-            state.limit(self.now, &self.key, self.tokens, self.method)?;
+            state.limit(now, &self.key, self.tokens, self.method)?;
         Ok(LimitResponseData {
             status,
             remaining,
@@ -45,7 +43,7 @@ impl LimitOperation {
 }
 
 impl RateLimiterRequest for LimitOperation {
-    fn apply(self, state: &crate::RateLimiter) -> LimitResponse {
-        LimitResponse(self.apply_real(state))
+    fn apply(self, state: &crate::RateLimiter, now: Timestamp) -> LimitResponse {
+        LimitResponse(self.apply_real(state, now))
     }
 }

--- a/crates/rate-limiter/src/operations/reset.rs
+++ b/crates/rate-limiter/src/operations/reset.rs
@@ -23,7 +23,7 @@ impl ResetOperation {
 }
 
 impl RateLimiterRequest for ResetOperation {
-    fn apply(self, state: &crate::RateLimiter) -> ResetResponse {
+    fn apply(self, state: &crate::RateLimiter, _now: jiff::Timestamp) -> ResetResponse {
         ResetResponse(self.apply_real(state))
     }
 }

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -170,8 +170,11 @@ async fn stream_snapshot(
 #[tracing::instrument(skip_all)]
 async fn handle_forwarded_write(
     Extension(state): Extension<RaftState>,
-    MsgPack(req): MsgPack<ForwardedWriteRequest>,
+    MsgPack(mut req): MsgPack<ForwardedWriteRequest>,
 ) -> Result<MsgPack<ForwardedWriteResponse>, crate::Error> {
+    // reset the timestamp in case the forwarding node was out of sync
+    req.request.timestamp = state.state_machine.now();
+
     // intentionally do not use state.client_write because we don't want an infinite recursion
     // of forwardings
     let response =
@@ -284,6 +287,8 @@ async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {
     let leader = state.raft.current_leader().await;
     let me = state.node_id;
     let cluster_id = state.state_machine.cluster_id().await;
+    let wall_time = jiff::Timestamp::now();
+    let monotonic_time = state.state_machine.time.last();
     state
         .raft
         .with_raft_state(move |s| {
@@ -293,6 +298,8 @@ async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {
                 server_state: s.server_state,
                 cluster_id,
                 leader,
+                wall_time,
+                monotonic_time,
             };
             let status = if s.server_state.is_leader()
                 || s.server_state.is_follower()

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -32,6 +32,9 @@ pub(super) async fn apply_request(
     }
     let _exit = child_span.enter();
 
+    state_machine.time.bump(request.timestamp);
+    let timestamp = request.timestamp;
+
     Ok(match request.inner {
         Request::Kv(req) => {
             let stores = state_machine.db_handle();
@@ -39,11 +42,11 @@ pub(super) async fn apply_request(
                 state: &stores.kv_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Kv(req.apply(state))
+            Response::Kv(req.apply(state, timestamp))
         }
         Request::RateLimiter(req) => {
             // Rate limiter neither needs nor uses namespaces for now
-            Response::RateLimiter(req.apply(&state_machine.state.rate_limiter))
+            Response::RateLimiter(req.apply(&state_machine.state.rate_limiter, timestamp))
         }
         Request::Idempotency(req) => {
             let stores = state_machine.db_handle();
@@ -51,7 +54,7 @@ pub(super) async fn apply_request(
                 state: &stores.idempotency_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Idempotency(req.apply(state))
+            Response::Idempotency(req.apply(state, timestamp))
         }
         Request::Cache(req) => {
             let stores = state_machine.db_handle();
@@ -59,7 +62,7 @@ pub(super) async fn apply_request(
                 state: &stores.cache_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Cache(req.apply(state))
+            Response::Cache(req.apply(state, timestamp))
         }
         Request::Msgs(req) => {
             let stores = state_machine.db_handle();
@@ -67,10 +70,10 @@ pub(super) async fn apply_request(
                 msgs: &stores.msgs_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Msgs(req.apply(state))
+            Response::Msgs(req.apply(state, timestamp))
         }
         Request::ClusterInternal(req) => {
-            Response::ClusterInternal(req.apply((state_machine, log_id)).await)
+            Response::ClusterInternal(req.apply((state_machine, log_id), timestamp).await)
         }
     })
 }

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -27,9 +27,8 @@ impl BackgroundJob for RecordLogTimestamps {
         let mut ticker = tokio::time::interval(self.cfg.cluster.log_index_interval);
         loop {
             tracing::debug!("recording log timestamps");
-            let now = jiff::Timestamp::now();
             self.handle
-                .client_write(RecordLogTimestampOperation { timestamp: now })
+                .client_write(RecordLogTimestampOperation {})
                 .await?;
             ticker.tick().await;
         }

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -6,7 +6,7 @@ use std::{
 use super::{
     Node, NodeId,
     handle::{BackgroundCommand, RaftState},
-    operations::RecordLogTimestampOperation,
+    operations::{RecordLogTimestampOperation, TickOperation},
 };
 use crate::cfg::Configuration;
 use openraft::error::{ClientWriteError, RaftError};
@@ -26,10 +26,25 @@ impl BackgroundJob for RecordLogTimestamps {
     async fn run_on_leader(self) -> anyhow::Result<()> {
         let mut ticker = tokio::time::interval(self.cfg.cluster.log_index_interval);
         loop {
-            tracing::debug!("recording log timestamps");
+            tracing::trace!("recording log timestamps");
             self.handle
                 .client_write(RecordLogTimestampOperation {})
                 .await?;
+            ticker.tick().await;
+        }
+    }
+}
+
+struct Tick {
+    handle: RaftState,
+}
+
+impl BackgroundJob for Tick {
+    async fn run_on_leader(self) -> anyhow::Result<()> {
+        let mut ticker = tokio::time::interval(Duration::from_secs(10));
+        loop {
+            tracing::trace!("recording a no-op event");
+            self.handle.client_write(TickOperation {}).await?;
             ticker.tick().await;
         }
     }
@@ -50,7 +65,14 @@ fn is_forward_to_leader_err(e: &anyhow::Error) -> bool {
 impl BackgroundJobRunner {
     fn spawn_all(cfg: Configuration, handle: RaftState) -> Self {
         let mut jobs = JoinSet::new();
-        jobs.spawn(RecordLogTimestamps { cfg, handle }.run_on_leader());
+        jobs.spawn(
+            RecordLogTimestamps {
+                cfg,
+                handle: handle.clone(),
+            }
+            .run_on_leader(),
+        );
+        jobs.spawn(Tick { handle }.run_on_leader());
         Self { jobs }
     }
 
@@ -90,6 +112,7 @@ async fn leadership_changes(handle: RaftState) -> tokio::sync::broadcast::Receiv
                 |m| {
                     let mut l = last_leader.lock().unwrap();
                     if m.current_leader != *l {
+                        tracing::debug!(old_leader=?l, new_leader=?m, "leader has changed");
                         *l = m.current_leader;
                         if tx.send(m.current_leader).is_err() {
                             return true;

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -47,6 +47,11 @@ pub enum Request {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RequestWithContext {
     pub inner: Request,
+    #[serde(
+        rename = "t",
+        with = "jiff::fmt::serde::timestamp::millisecond::required"
+    )]
+    pub timestamp: jiff::Timestamp,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<OperationRequestMetadata>,
 }
@@ -65,9 +70,14 @@ impl fmt::Display for RequestWithContext {
 }
 
 impl RequestWithContext {
-    pub(crate) fn new(req: Request, ctx: Option<OperationRequestMetadata>) -> Self {
+    pub(crate) fn new(
+        req: Request,
+        timestamp: jiff::Timestamp,
+        ctx: Option<OperationRequestMetadata>,
+    ) -> Self {
         Self {
             inner: req,
+            timestamp,
             context: ctx,
         }
     }
@@ -228,8 +238,9 @@ impl RaftState {
         >>::Error: fmt::Debug,
     {
         let inner: Request = op.into().into();
+        let now = self.state_machine.now();
         let request =
-            RequestWithContext::new(inner, Some(opentelemetry::Context::current().into()));
+            RequestWithContext::new(inner, now, Some(opentelemetry::Context::current().into()));
         let response = match self.raft.client_write(request.clone()).await {
             Ok(resp) => {
                 tracing::trace!(log_id=?resp.log_id(), "request applied to log");

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -15,7 +15,7 @@ use fjall_utils::{
 };
 use jiff::Timestamp;
 use openraft::{
-    Entry, LogId, OptionalSend, RaftLogReader, RaftTypeConfig, StorageError, Vote,
+    Entry, EntryPayload, LogId, OptionalSend, RaftLogReader, RaftTypeConfig, StorageError, Vote,
     storage::{LogFlushed, RaftLogStorage},
 };
 use parking_lot::Mutex;
@@ -663,6 +663,22 @@ impl CoyoteLogs {
             }
         })
         .await?
+    }
+
+    pub(super) async fn get_last_timestamp(&self) -> anyhow::Result<Option<Timestamp>> {
+        let log_keyspace = self.log_keyspace.clone();
+        spawn_blocking_in_current_span(move || {
+            for guard in Log::range(&log_keyspace, ..).rev() {
+                if let Ok(guard) = guard
+                    && let EntryPayload::Normal(req) = guard.1.0.payload
+                {
+                    return Some(req.timestamp);
+                }
+            }
+            None
+        })
+        .await
+        .context("failed to join")
     }
 }
 

--- a/src/core/cluster/operations/mod.rs
+++ b/src/core/cluster/operations/mod.rs
@@ -6,15 +6,18 @@ use coyote_operations::async_raft_module_operations;
 
 mod record_log_timestamp;
 mod set_cluster_uuid;
+mod tick;
 
 pub(super) use record_log_timestamp::RecordLogTimestampOperation;
 pub(super) use set_cluster_uuid::SetClusterUuidOperation;
+pub(super) use tick::TickOperation;
 
 async_raft_module_operations!(
     InternalRequest,
     InternalOperation {
         SetClusterUuid(SetClusterUuidOperation) -> (),
         RecordLogTimestamp(RecordLogTimestampOperation) -> (),
+        Tick(TickOperation) -> (),
     },
     state = (&mut Store, LogId<NodeId>)
 );

--- a/src/core/cluster/operations/record_log_timestamp.rs
+++ b/src/core/cluster/operations/record_log_timestamp.rs
@@ -1,21 +1,22 @@
 use super::{InternalRequest, RecordLogTimestampResponse as Response};
 use crate::core::cluster::{NodeId, state_machine::Store};
 use coyote_error::Error;
-use jiff::Timestamp;
 use openraft::LogId;
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RecordLogTimestampOperation {
-    pub timestamp: Timestamp,
-}
+pub struct RecordLogTimestampOperation {}
 
 impl InternalRequest for RecordLogTimestampOperation {
-    async fn apply(self, (state, log_id): (&mut Store, LogId<NodeId>)) -> Response {
+    async fn apply(
+        self,
+        (state, log_id): (&mut Store, LogId<NodeId>),
+        timestamp: jiff::Timestamp,
+    ) -> Response {
         state
             .logs
-            .record_log_timestamp(self.timestamp, log_id.index)
+            .record_log_timestamp(timestamp, log_id.index)
             .await
             .map_err(|e| Error::generic(e).into())
             .pipe(Response)

--- a/src/core/cluster/operations/set_cluster_uuid.rs
+++ b/src/core/cluster/operations/set_cluster_uuid.rs
@@ -12,7 +12,11 @@ use tap::Pipe;
 pub struct SetClusterUuidOperation(pub ClusterId);
 
 impl InternalRequest for SetClusterUuidOperation {
-    async fn apply(self, (state, _): (&mut Store, LogId<NodeId>)) -> Response {
+    async fn apply(
+        self,
+        (state, _): (&mut Store, LogId<NodeId>),
+        _timestamp: jiff::Timestamp,
+    ) -> Response {
         state
             .set_cluster_id(self.0)
             .await

--- a/src/core/cluster/operations/tick.rs
+++ b/src/core/cluster/operations/tick.rs
@@ -1,0 +1,19 @@
+use super::{InternalRequest, TickResponse as Response};
+use crate::core::cluster::{NodeId, state_machine::Store};
+use openraft::LogId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TickOperation {}
+
+impl InternalRequest for TickOperation {
+    async fn apply(
+        self,
+        _state: (&mut Store, LogId<NodeId>),
+        _timestamp: jiff::Timestamp,
+    ) -> Response {
+        // This job does nothing except periodically write something to the log
+        // (because openraft doesn't let us customize the existing Heartbeat event)
+        Response(Ok(()))
+    }
+}

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use jiff::Timestamp;
 use openraft::{LogId, ServerState};
 use serde::{Deserialize, Serialize};
 
@@ -54,6 +55,8 @@ pub struct HealthResponse {
     pub server_state: ServerState,
     pub leader: Option<NodeId>,
     pub cluster_id: Option<ClusterId>,
+    pub wall_time: Timestamp,
+    pub monotonic_time: Timestamp,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -56,6 +56,7 @@ pub(super) async fn initialize_cluster(
     tracing::debug!(cluster_id=?new_id, "cluster initialized, setting cluster_id");
     raft.client_write(RequestWithContext::new(
         Request::ClusterInternal(SetClusterUuidOperation(new_id).into()),
+        jiff::Timestamp::now(),
         None,
     ))
     .await

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use anyhow::Context;
 use coyote_namespace::entities::StorageType;
+use coyote_operations::Monotime;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
 use fjall_utils::{Databases, FjallFixedKey, ReadonlyKeyspace};
 use openraft::{
@@ -50,7 +51,10 @@ impl ClusterId {
 }
 
 #[derive(Clone)]
-pub struct StoreHandle(Arc<TokioRwLock<Store>>);
+pub struct StoreHandle {
+    inner: Arc<TokioRwLock<Store>>,
+    pub time: Monotime,
+}
 
 /// The actual meat of the database; a wrapper around fjall state
 /// and any number of module states
@@ -64,7 +68,11 @@ pub struct Stores {
 
 impl From<Store> for StoreHandle {
     fn from(value: Store) -> Self {
-        Self(Arc::new(TokioRwLock::new(value)))
+        let time = value.time.clone();
+        Self {
+            inner: Arc::new(TokioRwLock::new(value)),
+            time,
+        }
     }
 }
 
@@ -88,6 +96,7 @@ pub struct Store {
     last_membership: StoredMembership<NodeId, Node>,
     last_snapshot: Arc<RwLock<Option<LastSnapshot>>>,
     cluster_id: Option<ClusterId>,
+    pub(super) time: Monotime,
     pub(super) logs: CoyoteLogs,
 }
 
@@ -141,6 +150,13 @@ impl Store {
                 .context("initializing idempotency state")?,
         };
 
+        let time = Monotime::initial();
+        // if we've ever committed anything, make sure we don't rewind time on restarting
+        if let Some(timestamp) = logs.get_last_timestamp().await? {
+            time.bump(timestamp);
+        }
+        let _ = time.now();
+
         let mut this = Self {
             stores: Arc::new(RwLock::new(stores)),
             state: app_state,
@@ -152,6 +168,7 @@ impl Store {
             last_applied_log_id: None,
             last_membership: Default::default(),
             cluster_id: None,
+            time,
             logs,
         };
         this.load_information().await?;
@@ -580,7 +597,7 @@ impl StoredSnapshot {
 
 impl RaftSnapshotBuilder<TypeConfig> for StoreHandle {
     async fn build_snapshot(&mut self) -> StorageResult<Snapshot<TypeConfig>> {
-        self.0.write().await.build_snapshot_().await
+        self.inner.write().await.build_snapshot_().await
     }
 }
 
@@ -590,7 +607,7 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
     async fn applied_state(
         &mut self,
     ) -> StorageResult<(Option<LogId<NodeId>>, StoredMembership<NodeId, Node>)> {
-        let this = self.0.read().await;
+        let this = self.inner.read().await;
         Ok((this.last_applied_log_id, this.last_membership.clone()))
     }
 
@@ -599,23 +616,23 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
         I: IntoIterator<Item = <TypeConfig as RaftTypeConfig>::Entry> + openraft::OptionalSend,
         I::IntoIter: openraft::OptionalSend,
     {
-        self.0.write().await.apply_(entries).await
+        self.inner.write().await.apply_(entries).await
     }
 
     async fn begin_receiving_snapshot(
         &mut self,
     ) -> StorageResult<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>> {
-        self.0.write().await.begin_receiving_snapshot_().await
+        self.inner.write().await.begin_receiving_snapshot_().await
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
-        self.0.write().await.prep_snapshot_builder_();
+        self.inner.write().await.prep_snapshot_builder_();
         self.clone()
     }
 
     #[tracing::instrument(skip(self))]
     async fn get_current_snapshot(&mut self) -> StorageResult<Option<Snapshot<TypeConfig>>> {
-        self.0.write().await.get_current_snapshot_().await
+        self.inner.write().await.get_current_snapshot_().await
     }
 
     #[tracing::instrument(skip(self, meta))]
@@ -624,7 +641,7 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
         meta: &SnapshotMeta<NodeId, Node>,
         snapshot: Box<StoredSnapshot>,
     ) -> StorageResult<()> {
-        self.0
+        self.inner
             .write()
             .await
             .install_snapshot_(meta, snapshot)
@@ -635,13 +652,22 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
 
 impl StoreHandle {
     pub async fn cluster_id(&self) -> Option<ClusterId> {
-        self.0.read().await.cluster_id().copied()
+        self.inner.read().await.cluster_id().copied()
     }
 
     pub async fn log_id_before_time(
         &self,
         timestamp: jiff::Timestamp,
     ) -> anyhow::Result<Option<u64>> {
-        self.0.read().await.logs.log_index_before(timestamp).await
+        self.inner
+            .read()
+            .await
+            .logs
+            .log_index_before(timestamp)
+            .await
+    }
+
+    pub fn now(&self) -> jiff::Timestamp {
+        self.time.now()
     }
 }

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -151,11 +151,10 @@ impl Store {
         };
 
         let time = Monotime::initial();
-        // if we've ever committed anything, make sure we don't rewind time on restarting
         if let Some(timestamp) = logs.get_last_timestamp().await? {
+            // if we've ever committed anything, make sure we don't rewind time on restarting
             time.bump(timestamp);
         }
-        let _ = time.now();
 
         let mut this = Self {
             stores: Arc::new(RwLock::new(stores)),


### PR DESCRIPTION
This does a few things:

 1. It introduces a notion of a monotonic time that won't go down even if we go to a leader whose clock is substantially behind our own. The rationale for having a non-rewinding time is described in https://github.com/svix/rfc/pull/48
 2. It hoists the operation timestamp to be a top-level property of the raft request so that modules don't need to include in every op.

Because we're internally storing time as an i64, we drop down to millisecond resolution. I think that's probably okay. The alternative would be to drop the atomic (since there's no AtomicU128) and switch to a mutex, but yuck.

Fixes #405.