### PR TITLE
ci: Change cargo-sort to not format TOML files beyond sorting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@cargo-sort
       - uses: taiki-e/install-action@cargo-machete
-      - run: cargo sort --check --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
+      - run: cargo sort --check --no-format --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
       - run: cargo machete
   clippy:
     name: Clippy

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ lint:
     cargo +beta clippy --workspace --fix --allow-dirty --all-features --all-targets
     # this has to be nightly to get import sorting working correctly
     cargo +nightly fmt
-    cargo sort --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
+    cargo sort --no-format --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
 
 # Test the backend
 test *args='':


### PR DESCRIPTION
Latest release changes arrays to single line / multiline based on length of the items, which is somewhat annoying when there is no format-on-save.