### PR TITLE
Implement consumer groups for Queues

### DIFF
--- a/benchmarks/benches/queue.rs
+++ b/benchmarks/benches/queue.rs
@@ -59,6 +59,7 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                             .queue()
                             .receive(
                                 topic.clone(),
+                                "bench-cg".to_owned(),
                                 MsgQueueReceiveIn::new().with_batch_size(100u16),
                             )
                             .await
@@ -72,7 +73,11 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                         client
                             .msgs()
                             .queue()
-                            .ack(topic.clone(), MsgQueueAckIn::new(msg_ids))
+                            .ack(
+                                topic.clone(),
+                                "bench-cg".to_owned(),
+                                MsgQueueAckIn::new(msg_ids),
+                            )
                             .await
                             .unwrap(),
                     );
@@ -112,6 +117,7 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                             .queue()
                             .receive(
                                 topic.clone(),
+                                "bench-cg".to_owned(),
                                 MsgQueueReceiveIn::new()
                                     .with_batch_size(100u16)
                                     .with_lease_duration_millis(100u64),

--- a/clients/cli/src/cmds/api/msgs_queue.rs
+++ b/clients/cli/src/cmds/api/msgs_queue.rs
@@ -18,6 +18,7 @@ pub enum MsgsQueueCommands {
     /// are acked or their lease expires.
     Receive {
         topic: String,
+        consumer_group: String,
         msg_queue_receive_in: crate::json::JsonOf<coyote_client::models::MsgQueueReceiveIn>,
     },
     /// Acknowledges messages by their opaque msg_ids.
@@ -25,6 +26,7 @@ pub enum MsgsQueueCommands {
     /// Acked messages are permanently removed from the queue and will never be re-delivered.
     Ack {
         topic: String,
+        consumer_group: String,
         msg_queue_ack_in: crate::json::JsonOf<coyote_client::models::MsgQueueAckIn>,
     },
 }
@@ -38,23 +40,25 @@ impl MsgsQueueCommands {
         match self {
             Self::Receive {
                 topic,
+                consumer_group,
                 msg_queue_receive_in,
             } => {
                 let resp = client
                     .msgs()
                     .queue()
-                    .receive(topic, msg_queue_receive_in.into_inner())
+                    .receive(topic, consumer_group, msg_queue_receive_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
             Self::Ack {
                 topic,
+                consumer_group,
                 msg_queue_ack_in,
             } => {
                 let resp = client
                     .msgs()
                     .queue()
-                    .ack(topic, msg_queue_ack_in.into_inner())
+                    .ack(topic, consumer_group, msg_queue_ack_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }

--- a/clients/cli/src/cmds/benchmark.rs
+++ b/clients/cli/src/cmds/benchmark.rs
@@ -818,7 +818,7 @@ struct BenchMsgsQueueReceive<'a> {
     bench_result_ack: BenchResult,
     batch_size: u16,
     topics: &'a [String],
-    _consumer_group: &'a str,
+    consumer_group: &'a str,
 }
 
 impl<'a> BenchMsgsQueueReceive<'a> {
@@ -828,7 +828,7 @@ impl<'a> BenchMsgsQueueReceive<'a> {
             bench_result_ack: BenchResult::new().set_batch_size(batch_size),
             batch_size,
             topics,
-            _consumer_group: consumer_group,
+            consumer_group,
         }
     }
 }
@@ -853,6 +853,7 @@ impl<'a> BenchShard for BenchMsgsQueueReceive<'a> {
             .queue()
             .receive(
                 topic.clone(),
+                self.consumer_group.to_owned(),
                 MsgQueueReceiveIn::new()
                     .with_batch_size(self.batch_size)
                     .with_lease_duration_millis(300_000u64),
@@ -866,7 +867,11 @@ impl<'a> BenchShard for BenchMsgsQueueReceive<'a> {
         client
             .msgs()
             .queue()
-            .ack(topic, MsgQueueAckIn::new(msg_ids))
+            .ack(
+                topic,
+                self.consumer_group.to_owned(),
+                MsgQueueAckIn::new(msg_ids),
+            )
             .await?;
         self.bench_result_ack.process(t.elapsed(), 0)?;
 

--- a/clients/go/internal/models/msg_queue_ack_in.go
+++ b/clients/go/internal/models/msg_queue_ack_in.go
@@ -3,6 +3,7 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type MsgQueueAckIn struct {
-	Topic  string   `json:"topic"`
-	MsgIds []string `json:"msg_ids"`
+	Topic         string   `json:"topic"`
+	ConsumerGroup string   `json:"consumer_group"`
+	MsgIds        []string `json:"msg_ids"`
 }

--- a/clients/go/internal/models/msg_queue_receive_in.go
+++ b/clients/go/internal/models/msg_queue_receive_in.go
@@ -4,6 +4,7 @@ package coyote_models
 
 type MsgQueueReceiveIn struct {
 	Topic               string  `json:"topic"`
+	ConsumerGroup       string  `json:"consumer_group"`
 	BatchSize           *uint16 `json:"batch_size,omitempty"`
 	LeaseDurationMillis *uint64 `json:"lease_duration_millis,omitempty"`
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgQueueAckIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgQueueAckIn.java
@@ -29,6 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class MsgQueueAckIn {
 @JsonProperty private String topic;
+@JsonProperty("consumer_group") private String consumerGroup;
 @JsonProperty("msg_ids") private List<String> msgIds;
 public MsgQueueAckIn () {}
 
@@ -49,6 +50,25 @@ public MsgQueueAckIn () {}
 
      public void setTopic(String topic) {
         this.topic = topic;
+    }
+
+     public MsgQueueAckIn consumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+        return this;
+    }
+
+    /**
+    * Get consumerGroup
+    *
+     * @return consumerGroup
+     */
+    @javax.annotation.Nonnull
+     public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+     public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
     }
 
      public MsgQueueAckIn msgIds(List<String> msgIds) {

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn.java
@@ -29,6 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class MsgQueueReceiveIn {
 @JsonProperty private String topic;
+@JsonProperty("consumer_group") private String consumerGroup;
 @JsonProperty("batch_size") private Short batchSize;
 @JsonProperty("lease_duration_millis") private Long leaseDurationMillis;
 public MsgQueueReceiveIn () {}
@@ -50,6 +51,25 @@ public MsgQueueReceiveIn () {}
 
      public void setTopic(String topic) {
         this.topic = topic;
+    }
+
+     public MsgQueueReceiveIn consumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+        return this;
+    }
+
+    /**
+    * Get consumerGroup
+    *
+     * @return consumerGroup
+     */
+    @javax.annotation.Nonnull
+     public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+     public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
     }
 
      public MsgQueueReceiveIn batchSize(Short batchSize) {

--- a/clients/javascript/src/models/msgQueueAckIn.ts
+++ b/clients/javascript/src/models/msgQueueAckIn.ts
@@ -2,6 +2,7 @@
 
 export interface MsgQueueAckIn {
     topic: string;
+    consumerGroup: string;
     msgIds: string[];
 }
 
@@ -9,6 +10,7 @@ export const MsgQueueAckInSerializer = {
     _fromJsonObject(object: any): MsgQueueAckIn {
         return {
             topic: object['topic'],
+            consumerGroup: object['consumer_group'],
             msgIds: object['msg_ids'],
         };
     },
@@ -16,6 +18,7 @@ export const MsgQueueAckInSerializer = {
     _toJsonObject(self: MsgQueueAckIn): any {
         return {
             'topic': self.topic,
+            'consumer_group': self.consumerGroup,
             'msg_ids': self.msgIds,
         };
     }

--- a/clients/javascript/src/models/msgQueueReceiveIn.ts
+++ b/clients/javascript/src/models/msgQueueReceiveIn.ts
@@ -2,6 +2,7 @@
 
 export interface MsgQueueReceiveIn {
     topic: string;
+    consumerGroup: string;
     batchSize?: number;
     leaseDurationMillis?: number;
 }
@@ -10,6 +11,7 @@ export const MsgQueueReceiveInSerializer = {
     _fromJsonObject(object: any): MsgQueueReceiveIn {
         return {
             topic: object['topic'],
+            consumerGroup: object['consumer_group'],
             batchSize: object['batch_size'],
             leaseDurationMillis: object['lease_duration_millis'],
         };
@@ -18,6 +20,7 @@ export const MsgQueueReceiveInSerializer = {
     _toJsonObject(self: MsgQueueReceiveIn): any {
         return {
             'topic': self.topic,
+            'consumer_group': self.consumerGroup,
             'batch_size': self.batchSize,
             'lease_duration_millis': self.leaseDurationMillis,
         };

--- a/clients/python/coyote/apis/msgs_queue.py
+++ b/clients/python/coyote/apis/msgs_queue.py
@@ -16,6 +16,7 @@ class MsgsQueueAsync(ApiBase):
     async def receive(
         self,
         topic: str,
+        consumer_group: str,
         msg_queue_receive_in: MsgQueueReceiveIn = MsgQueueReceiveIn(),
     ) -> MsgQueueReceiveOut:
         """Receives messages from a topic as competing consumers.
@@ -25,6 +26,7 @@ class MsgsQueueAsync(ApiBase):
         are acked or their lease expires."""
         body = _MsgQueueReceiveIn(
             topic=topic,
+            consumer_group=consumer_group,
             batch_size=msg_queue_receive_in.batch_size,
             lease_duration_millis=msg_queue_receive_in.lease_duration_millis,
         ).model_dump(exclude_none=True)
@@ -39,6 +41,7 @@ class MsgsQueueAsync(ApiBase):
     async def ack(
         self,
         topic: str,
+        consumer_group: str,
         msg_queue_ack_in: MsgQueueAckIn,
     ) -> MsgQueueAckOut:
         """Acknowledges messages by their opaque msg_ids.
@@ -46,6 +49,7 @@ class MsgsQueueAsync(ApiBase):
         Acked messages are permanently removed from the queue and will never be re-delivered."""
         body = _MsgQueueAckIn(
             topic=topic,
+            consumer_group=consumer_group,
             msg_ids=msg_queue_ack_in.msg_ids,
         ).model_dump(exclude_none=True)
 
@@ -61,6 +65,7 @@ class MsgsQueue(ApiBase):
     def receive(
         self,
         topic: str,
+        consumer_group: str,
         msg_queue_receive_in: MsgQueueReceiveIn = MsgQueueReceiveIn(),
     ) -> MsgQueueReceiveOut:
         """Receives messages from a topic as competing consumers.
@@ -70,6 +75,7 @@ class MsgsQueue(ApiBase):
         are acked or their lease expires."""
         body = _MsgQueueReceiveIn(
             topic=topic,
+            consumer_group=consumer_group,
             batch_size=msg_queue_receive_in.batch_size,
             lease_duration_millis=msg_queue_receive_in.lease_duration_millis,
         ).model_dump(exclude_none=True)
@@ -84,6 +90,7 @@ class MsgsQueue(ApiBase):
     def ack(
         self,
         topic: str,
+        consumer_group: str,
         msg_queue_ack_in: MsgQueueAckIn,
     ) -> MsgQueueAckOut:
         """Acknowledges messages by their opaque msg_ids.
@@ -91,6 +98,7 @@ class MsgsQueue(ApiBase):
         Acked messages are permanently removed from the queue and will never be re-delivered."""
         body = _MsgQueueAckIn(
             topic=topic,
+            consumer_group=consumer_group,
             msg_ids=msg_queue_ack_in.msg_ids,
         ).model_dump(exclude_none=True)
 

--- a/clients/python/coyote/models/msg_queue_ack_in.py
+++ b/clients/python/coyote/models/msg_queue_ack_in.py
@@ -12,4 +12,6 @@ class MsgQueueAckIn(BaseModel):
 class _MsgQueueAckIn(BaseModel):
     topic: str
 
+    consumer_group: str = Field(alias="consumer_group")
+
     msg_ids: t.List[str] = Field(alias="msg_ids")

--- a/clients/python/coyote/models/msg_queue_receive_in.py
+++ b/clients/python/coyote/models/msg_queue_receive_in.py
@@ -16,6 +16,8 @@ class MsgQueueReceiveIn(BaseModel):
 class _MsgQueueReceiveIn(BaseModel):
     topic: str
 
+    consumer_group: str = Field(alias="consumer_group")
+
     batch_size: t.Optional[int] = Field(default=None, alias="batch_size")
 
     lease_duration_millis: t.Optional[int] = Field(

--- a/clients/rust/src/api/msgs_queue.rs
+++ b/clients/rust/src/api/msgs_queue.rs
@@ -18,10 +18,12 @@ impl<'a> MsgsQueue<'a> {
     pub async fn receive(
         &self,
         topic: String,
+        consumer_group: String,
         msg_queue_receive_in: MsgQueueReceiveIn,
     ) -> Result<MsgQueueReceiveOut> {
         let msg_queue_receive_in = MsgQueueReceiveIn_ {
             topic,
+            consumer_group,
             batch_size: msg_queue_receive_in.batch_size,
             lease_duration_millis: msg_queue_receive_in.lease_duration_millis,
         };
@@ -38,10 +40,12 @@ impl<'a> MsgsQueue<'a> {
     pub async fn ack(
         &self,
         topic: String,
+        consumer_group: String,
         msg_queue_ack_in: MsgQueueAckIn,
     ) -> Result<MsgQueueAckOut> {
         let msg_queue_ack_in = MsgQueueAckIn_ {
             topic,
+            consumer_group,
             msg_ids: msg_queue_ack_in.msg_ids,
         };
 

--- a/clients/rust/src/models/msg_queue_ack_in.rs
+++ b/clients/rust/src/models/msg_queue_ack_in.rs
@@ -16,5 +16,7 @@ impl MsgQueueAckIn {
 pub(crate) struct MsgQueueAckIn_ {
     pub topic: String,
 
+    pub consumer_group: String,
+
     pub msg_ids: Vec<String>,
 }

--- a/clients/rust/src/models/msg_queue_receive_in.rs
+++ b/clients/rust/src/models/msg_queue_receive_in.rs
@@ -33,6 +33,8 @@ impl MsgQueueReceiveIn {
 pub(crate) struct MsgQueueReceiveIn_ {
     pub topic: String,
 
+    pub consumer_group: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_size: Option<u16>,
 

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -381,15 +381,8 @@ pub struct QueueMsgOut {
 #[serde(transparent)]
 pub struct ConsumerGroup(pub(crate) String);
 
-// FIXME: change ConsumerGroup inner type to Cow<'static, str> to avoid allocating for
-// the static `__queue__` sentinel.
 impl ConsumerGroup {
     const MAX_LEN: usize = 64;
-
-    /// Synthetic consumer group used internally by queue operations.
-    pub(crate) fn queue() -> Self {
-        Self("__queue__".to_owned())
-    }
 
     fn validate_str(s: &str) -> Result<(), &'static str> {
         if s.len() > Self::MAX_LEN {

--- a/crates/msgs/src/operations/queue/ack.rs
+++ b/crates/msgs/src/operations/queue/ack.rs
@@ -19,15 +19,22 @@ use super::{
 pub struct QueueAckOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,
+    consumer_group: ConsumerGroup,
     msg_ids: Vec<MsgId>,
     now: Timestamp,
 }
 
 impl QueueAckOperation {
-    pub fn new(namespace_id: NamespaceId, topic: TopicName, msg_ids: Vec<MsgId>) -> Self {
+    pub fn new(
+        namespace_id: NamespaceId,
+        topic: TopicName,
+        consumer_group: ConsumerGroup,
+        msg_ids: Vec<MsgId>,
+    ) -> Self {
         Self {
             namespace_id,
             topic,
+            consumer_group,
             msg_ids,
             now: Timestamp::now(),
         }
@@ -42,7 +49,6 @@ impl QueueAckOperation {
         .ok_or_else(|| Error::invalid_user_input("topic must exist"))?;
 
         let mut batch = state.db.batch();
-        let queue_cg = ConsumerGroup::queue();
 
         // Track which partitions were affected for cursor compaction
         let mut affected_partitions = std::collections::BTreeSet::new();
@@ -50,7 +56,7 @@ impl QueueAckOperation {
         for msg_id in &self.msg_ids {
             batch.insert_row(
                 &state.metadata_tables,
-                QueueLeaseRow::key_for(topic_row.id, msg_id),
+                QueueLeaseRow::key_for(topic_row.id, msg_id, &self.consumer_group),
                 &QueueLeaseRow {
                     expiry: Timestamp::MAX,
                 },
@@ -62,17 +68,24 @@ impl QueueAckOperation {
         for partition in affected_partitions {
             let Some(mut cursor) = StreamLeaseRow::fetch(
                 &state.metadata_tables,
-                StreamLeaseRow::key_for(topic_row.id, partition, &queue_cg),
+                StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
             )?
             else {
                 continue;
             };
 
-            compact_cursor(&mut cursor, &mut batch, state, topic_row.id, partition)?;
+            compact_cursor(
+                &mut cursor,
+                &mut batch,
+                state,
+                topic_row.id,
+                partition,
+                &self.consumer_group,
+            )?;
 
             batch.insert_row(
                 &state.metadata_tables,
-                StreamLeaseRow::key_for(topic_row.id, partition, &queue_cg),
+                StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
                 &cursor,
             )?;
         }

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -20,6 +20,7 @@ pub struct QueueReceiveOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,
     partition: Option<Partition>,
+    consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
     lease_duration_millis: u64,
     now: Timestamp,
@@ -29,6 +30,7 @@ impl QueueReceiveOperation {
     pub fn new(
         namespace_id: NamespaceId,
         topic: TopicIn,
+        consumer_group: ConsumerGroup,
         batch_size: NonZeroU16,
         lease_duration_millis: u64,
     ) -> coyote_error::Result<Self> {
@@ -40,6 +42,7 @@ impl QueueReceiveOperation {
             namespace_id,
             topic,
             partition,
+            consumer_group,
             batch_size,
             lease_duration_millis,
             now: Timestamp::now(),
@@ -53,7 +56,6 @@ impl QueueReceiveOperation {
         let mut all_msgs: Vec<QueueReceiveMsg> = Vec::with_capacity(remaining.into());
 
         let expiry = self.now + lease_duration;
-        let queue_cg = ConsumerGroup::queue();
 
         let mut batch = state.db.batch();
 
@@ -79,7 +81,7 @@ impl QueueReceiveOperation {
             // Queue starts from offset 0 (earliest), unlike stream which starts from latest.
             let mut cursor = match StreamLeaseRow::fetch(
                 &state.metadata_tables,
-                StreamLeaseRow::key_for(topic_row.id, partition, &queue_cg),
+                StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
             )? {
                 Some(cursor) => cursor,
                 None => StreamLeaseRow::new()?,
@@ -115,6 +117,7 @@ impl QueueReceiveOperation {
                     scan_offset,
                     partition,
                     topic_row.id,
+                    &self.consumer_group,
                     self.now,
                     expiry,
                 )?;
@@ -124,11 +127,18 @@ impl QueueReceiveOperation {
             }
 
             // Compact cursor: advance past contiguous acked messages
-            compact_cursor(&mut cursor, &mut batch, state, topic_row.id, partition)?;
+            compact_cursor(
+                &mut cursor,
+                &mut batch,
+                state,
+                topic_row.id,
+                partition,
+                &self.consumer_group,
+            )?;
 
             batch.insert_row(
                 &state.metadata_tables,
-                StreamLeaseRow::key_for(topic_row.id, partition, &queue_cg),
+                StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
                 &cursor,
             )?;
 
@@ -155,6 +165,7 @@ fn lease_available_msgs(
     scan_offset: u64,
     partition: Partition,
     topic_id: TopicId,
+    consumer_group: &ConsumerGroup,
     now: Timestamp,
     expiry: Timestamp,
 ) -> coyote_error::Result<u16> {
@@ -166,7 +177,7 @@ fn lease_available_msgs(
 
         if let Some(lease) = QueueLeaseRow::fetch(
             &state.metadata_tables,
-            QueueLeaseRow::key_for(topic_id, &msg_id),
+            QueueLeaseRow::key_for(topic_id, &msg_id, consumer_group),
         )? && !lease.is_available(now)
         {
             continue;
@@ -174,7 +185,7 @@ fn lease_available_msgs(
 
         batch.insert_row(
             &state.metadata_tables,
-            QueueLeaseRow::key_for(topic_id, &msg_id),
+            QueueLeaseRow::key_for(topic_id, &msg_id, consumer_group),
             &QueueLeaseRow { expiry },
         )?;
 
@@ -199,17 +210,18 @@ pub(crate) fn compact_cursor(
     state: &State,
     topic_id: TopicId,
     partition: Partition,
+    consumer_group: &ConsumerGroup,
 ) -> coyote_error::Result<()> {
     loop {
         let check_id = MsgId::new(partition, cursor.offset);
         match QueueLeaseRow::fetch(
             &state.metadata_tables,
-            QueueLeaseRow::key_for(topic_id, &check_id),
+            QueueLeaseRow::key_for(topic_id, &check_id, consumer_group),
         )? {
             Some(lease) if lease.is_acked() => {
                 batch.remove(
                     &state.metadata_tables,
-                    QueueLeaseRow::key_for(topic_id, &check_id).into_fjall_key(),
+                    QueueLeaseRow::key_for(topic_id, &check_id, consumer_group).into_fjall_key(),
                 );
                 cursor.offset += 1;
             }

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -77,7 +77,7 @@ impl QueueReceiveOperation {
         for partition_idx in partitions {
             let partition = Partition::new(partition_idx)?;
 
-            // Fetch or create cursor for this partition (using StreamLeaseRow with __queue__ CG).
+            // Fetch or create cursor for this partition.
             // Queue starts from offset 0 (earliest), unlike stream which starts from latest.
             let mut cursor = match StreamLeaseRow::fetch(
                 &state.metadata_tables,

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -120,7 +120,11 @@ pub(crate) struct QueueLeaseRow {
 }
 
 impl QueueLeaseRow {
-    pub(crate) fn key_for(topic_id: TopicId, msg_id: &MsgId) -> TableKey<Self> {
+    pub(crate) fn key_for(
+        topic_id: TopicId,
+        msg_id: &MsgId,
+        consumer_group: &ConsumerGroup,
+    ) -> TableKey<Self> {
         TableKey::init_key(
             Self::ROW_TYPE,
             &[
@@ -128,7 +132,7 @@ impl QueueLeaseRow {
                 &msg_id.partition.get().to_be_bytes(),
                 &msg_id.offset.to_be_bytes(),
             ],
-            &[],
+            &[consumer_group],
         )
     }
 

--- a/openapi.json
+++ b/openapi.json
@@ -1832,6 +1832,9 @@
           "topic": {
             "type": "string"
           },
+          "consumer_group": {
+            "type": "string"
+          },
           "msg_ids": {
             "type": "array",
             "items": {
@@ -1841,10 +1844,12 @@
         },
         "required": [
           "topic",
+          "consumer_group",
           "msg_ids"
         ],
         "x-positional": [
-          "topic"
+          "topic",
+          "consumer_group"
         ]
       },
       "MsgQueueAckOut": {
@@ -1854,6 +1859,9 @@
         "type": "object",
         "properties": {
           "topic": {
+            "type": "string"
+          },
+          "consumer_group": {
             "type": "string"
           },
           "batch_size": {
@@ -1871,10 +1879,12 @@
           }
         },
         "required": [
-          "topic"
+          "topic",
+          "consumer_group"
         ],
         "x-positional": [
-          "topic"
+          "topic",
+          "consumer_group"
         ]
       },
       "MsgQueueReceiveOut": {

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -267,9 +267,10 @@ fn default_queue_lease_duration_millis() -> u64 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
-#[schemars(extend("x-positional" = ["topic"]))]
+#[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgQueueReceiveIn {
     pub topic: TopicIn,
+    pub consumer_group: ConsumerGroup,
     #[serde(default = "default_batch_size")]
     pub batch_size: NonZeroU16,
     #[serde(default = "default_queue_lease_duration_millis")]
@@ -300,6 +301,7 @@ async fn queue_receive(
     let operation = QueueReceiveOperation::new(
         namespace.id,
         data.topic,
+        data.consumer_group,
         data.batch_size,
         data.lease_duration_millis,
     )?;
@@ -324,9 +326,10 @@ async fn queue_receive(
 // ---------------------------------------------------------------------------
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
-#[schemars(extend("x-positional" = ["topic"]))]
+#[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgQueueAckIn {
     pub topic: TopicName,
+    pub consumer_group: ConsumerGroup,
     pub msg_ids: Vec<MsgId>,
 }
 
@@ -347,7 +350,8 @@ async fn queue_ack(
         .fetch_namespace(data.topic.namespace())?
         .ok_or_else(|| Error::http(HttpError::not_found(None, None)))?;
 
-    let operation = QueueAckOperation::new(namespace.id, data.topic, data.msg_ids);
+    let operation =
+        QueueAckOperation::new(namespace.id, data.topic, data.consumer_group, data.msg_ids);
     repl.client_write(operation).await.map_err_generic()?.0?;
 
     Ok(MsgPackOrJson(MsgQueueAckOut {}))

--- a/tests/it/msgs/queue.rs
+++ b/tests/it/msgs/queue.rs
@@ -38,6 +38,7 @@ async fn queue_receive_returns_published_messages() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-queue:my-topic",
+            "consumer_group": "test-cg",
         }))
         .await?
         .expect(StatusCode::OK)
@@ -86,6 +87,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-lease:t1",
+            "consumer_group": "test-cg",
             "batch_size": 1,
         }))
         .await?
@@ -101,6 +103,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-lease:t1",
+            "consumer_group": "test-cg",
             "batch_size": 1,
         }))
         .await?
@@ -116,6 +119,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-lease:t1",
+            "consumer_group": "test-cg",
         }))
         .await?
         .expect(StatusCode::OK)
@@ -161,6 +165,7 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-ack:t1",
+            "consumer_group": "test-cg",
             "lease_duration_millis": 1000,
         }))
         .await?
@@ -176,6 +181,7 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
         .post("msgs/queue/ack")
         .json(json!({
             "topic": "ns-q-ack:t1",
+            "consumer_group": "test-cg",
             "msg_ids": msg_ids,
         }))
         .await?
@@ -189,6 +195,7 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-ack:t1",
+            "consumer_group": "test-cg",
         }))
         .await?
         .expect(StatusCode::OK)
@@ -233,6 +240,7 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-redeliver:t1",
+            "consumer_group": "test-cg",
             "lease_duration_millis": 1000,
         }))
         .await?
@@ -248,6 +256,7 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-redeliver:t1",
+            "consumer_group": "test-cg",
         }))
         .await?
         .expect(StatusCode::OK)
@@ -285,6 +294,7 @@ async fn queue_receive_nonexistent_namespace() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "does-not-exist:t1",
+            "consumer_group": "test-cg",
         }))
         .await?
         .expect(StatusCode::NOT_FOUND);
@@ -323,6 +333,7 @@ async fn queue_starts_from_earliest() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-earliest:t1",
+            "consumer_group": "test-cg",
         }))
         .await?
         .expect(StatusCode::OK)
@@ -370,6 +381,7 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-partial:t1",
+            "consumer_group": "test-cg",
             "lease_duration_millis": 1000,
         }))
         .await?
@@ -386,6 +398,7 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
         .post("msgs/queue/ack")
         .json(json!({
             "topic": "ns-q-partial:t1",
+            "consumer_group": "test-cg",
             "msg_ids": [first_id, last_id],
         }))
         .await?
@@ -399,6 +412,7 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-partial:t1",
+            "consumer_group": "test-cg",
         }))
         .await?
         .expect(StatusCode::OK)
@@ -454,6 +468,7 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-concurrent:t1",
+            "consumer_group": "test-cg",
             "batch_size": 3,
         }))
         .await?
@@ -468,6 +483,7 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-concurrent:t1",
+            "consumer_group": "test-cg",
             "batch_size": 3,
         }))
         .await?
@@ -496,6 +512,7 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
         .post("msgs/queue/receive")
         .json(json!({
             "topic": "ns-q-concurrent:t1",
+            "consumer_group": "test-cg",
         }))
         .await?
         .expect(StatusCode::OK)
@@ -504,6 +521,83 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
         r_c["msgs"].as_array().unwrap().len(),
         0,
         "no messages available when all are leased"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_consumer_groups_independent() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-q-cg" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "topic": "ns-q-cg:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+                { "value": "c".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Group A receives all messages
+    let r_a = client
+        .post("msgs/queue/receive")
+        .json(json!({
+            "topic": "ns-q-cg:t1",
+            "consumer_group": "group-a",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs_a = r_a["msgs"].as_array().unwrap();
+    assert_eq!(msgs_a.len(), 3);
+
+    // Ack all messages for group A
+    let msg_ids_a: Vec<&str> = msgs_a
+        .iter()
+        .map(|m| m["msg_id"].as_str().unwrap())
+        .collect();
+    client
+        .post("msgs/queue/ack")
+        .json(json!({
+            "topic": "ns-q-cg:t1",
+            "consumer_group": "group-a",
+            "msg_ids": msg_ids_a,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Group B should independently receive all the same messages
+    let r_b = client
+        .post("msgs/queue/receive")
+        .json(json!({
+            "topic": "ns-q-cg:t1",
+            "consumer_group": "group-b",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs_b = r_b["msgs"].as_array().unwrap();
+    assert_eq!(
+        msgs_b.len(),
+        3,
+        "different consumer group should get all messages independently"
     );
 
     Ok(())


### PR DESCRIPTION
That's it. That's the PR.

Being able to configure consumer groups, e.g. with retry-schedules, is coming in a later commit.