### PR TITLE
kv/cache/idempotency: update missing places for storage type selection.

### DIFF
--- a/crates/cache/src/operations/delete.rs
+++ b/crates/cache/src/operations/delete.rs
@@ -26,7 +26,7 @@ impl DeleteOperation {
     fn apply_real(self, state: &CacheRaftState<'_>) -> Result<()> {
         state
             .state
-            .controller(StorageType::Persistent)
+            .controller(self.storage_type)
             .delete(self.namespace_id, &self.key)?;
         Ok(())
     }

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -30,7 +30,7 @@ impl SetOperation {
 
 impl SetOperation {
     fn apply_real(self, state: &CacheRaftState<'_>) -> Result<()> {
-        state.state.controller(StorageType::Persistent).set(
+        state.state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
             self.model.value,

--- a/crates/idempotency/src/operations/abort.rs
+++ b/crates/idempotency/src/operations/abort.rs
@@ -26,7 +26,7 @@ impl AbortOperation {
     fn apply_real(self, state: &IdempotencyRaftState<'_>) -> Result<()> {
         state
             .state
-            .controller(StorageType::Persistent)
+            .controller(self.storage_type)
             .delete(self.namespace_id, &self.key)?;
 
         Ok(())

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -40,7 +40,7 @@ impl CompleteOperation {
 impl CompleteOperation {
     fn apply_real(self, state: &IdempotencyRaftState<'_>) -> Result<()> {
         let expiry = self.now + Duration::from_secs(self.ttl_seconds);
-        state.state.controller(StorageType::Persistent).set(
+        state.state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
             IdempotencyState::Completed {

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -40,7 +40,7 @@ impl TryStartOperation {
         let now = self.now;
         let expiry = now + Duration::from_secs(self.ttl_seconds);
 
-        let controller = state.state.controller(StorageType::Persistent);
+        let controller = state.state.controller(self.storage_type);
 
         match controller.fetch(self.namespace_id, &self.key, now)? {
             None => {

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -26,7 +26,7 @@ impl DeleteOperation {
 impl DeleteOperation {
     fn apply_real(self, state: &State) -> Result<()> {
         state
-            .controller(StorageType::Persistent)
+            .controller(self.storage_type)
             .delete(self.namespace_id, &self.key)?;
         Ok(())
     }

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -43,7 +43,7 @@ impl SetOperation {
 
 impl SetOperation {
     fn apply_real(self, state: &State) -> Result<()> {
-        state.controller(StorageType::Persistent).set(
+        state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
             self.value,


### PR DESCRIPTION
My previous PR added it to the struct, but didn't actually use it.

Follow up on #380