### PR TITLE
Implement stream.seek

### DIFF
--- a/clients/cli/src/cmds/api/msgs_stream.rs
+++ b/clients/cli/src/cmds/api/msgs_stream.rs
@@ -29,6 +29,16 @@ pub enum MsgsStreamCommands {
         consumer_group: String,
         msg_stream_commit_in: crate::json::JsonOf<coyote_client::models::MsgStreamCommitIn>,
     },
+    /// Repositions a consumer group's read cursor on a topic.
+    ///
+    /// Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
+    /// partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
+    /// `"latest"` and may be used with or without a partition suffix.
+    Seek {
+        topic: String,
+        consumer_group: String,
+        msg_stream_seek_in: crate::json::JsonOf<coyote_client::models::MsgStreamSeekIn>,
+    },
 }
 
 impl MsgsStreamCommands {
@@ -59,6 +69,18 @@ impl MsgsStreamCommands {
                     .msgs()
                     .stream()
                     .commit(topic, consumer_group, msg_stream_commit_in.into_inner())
+                    .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Seek {
+                topic,
+                consumer_group,
+                msg_stream_seek_in,
+            } => {
+                let resp = client
+                    .msgs()
+                    .stream()
+                    .seek(topic, consumer_group, msg_stream_seek_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }

--- a/clients/go/internal/apis/msgs_stream.go
+++ b/clients/go/internal/apis/msgs_stream.go
@@ -54,3 +54,23 @@ func (msgsStream MsgsStream) Commit(
 		&msgStreamCommitIn,
 	)
 }
+
+// Repositions a consumer group's read cursor on a topic.
+//
+// Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
+// partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
+// `"latest"` and may be used with or without a partition suffix.
+func (msgsStream MsgsStream) Seek(
+	ctx context.Context,
+	msgStreamSeekIn coyote_models.MsgStreamSeekIn,
+) (*coyote_models.MsgStreamSeekOut, error) {
+	return coyote_proto.ExecuteRequest[coyote_models.MsgStreamSeekIn, coyote_models.MsgStreamSeekOut](
+		ctx,
+		msgsStream.client,
+		"POST",
+		"/api/v1/msgs/stream/seek",
+		nil,
+		nil,
+		&msgStreamSeekIn,
+	)
+}

--- a/clients/go/internal/models/msg_stream_seek_in.go
+++ b/clients/go/internal/models/msg_stream_seek_in.go
@@ -1,0 +1,10 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type MsgStreamSeekIn struct {
+	Topic         string  `json:"topic"`
+	ConsumerGroup string  `json:"consumer_group"`
+	Offset        *uint64 `json:"offset,omitempty"`
+	Position      *string `json:"position,omitempty"`
+}

--- a/clients/go/internal/models/msg_stream_seek_out.go
+++ b/clients/go/internal/models/msg_stream_seek_out.go
@@ -1,0 +1,6 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type MsgStreamSeekOut struct {
+}

--- a/clients/go/models.go
+++ b/clients/go/models.go
@@ -49,6 +49,8 @@ type (
 	MsgStreamCommitOut            = coyote_models.MsgStreamCommitOut
 	MsgStreamReceiveIn            = coyote_models.MsgStreamReceiveIn
 	MsgStreamReceiveOut           = coyote_models.MsgStreamReceiveOut
+	MsgStreamSeekIn               = coyote_models.MsgStreamSeekIn
+	MsgStreamSeekOut              = coyote_models.MsgStreamSeekOut
 	MsgTopicConfigureIn           = coyote_models.MsgTopicConfigureIn
 	MsgTopicConfigureOut          = coyote_models.MsgTopicConfigureOut
 	OperationBehavior             = coyote_models.OperationBehavior

--- a/clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
@@ -17,6 +17,8 @@ import com.svix.coyote.models.MsgStreamCommitIn;
 import com.svix.coyote.models.MsgStreamCommitOut;
 import com.svix.coyote.models.MsgStreamReceiveIn;
 import com.svix.coyote.models.MsgStreamReceiveOut;
+import com.svix.coyote.models.MsgStreamSeekIn;
+import com.svix.coyote.models.MsgStreamSeekOut;
 
 public class MsgsStream {
     private final HttpClient client;
@@ -60,6 +62,26 @@ public class MsgsStream {
             null,
             msgStreamCommitIn,
             MsgStreamCommitOut.class
+            );
+    }
+
+    /**
+* Repositions a consumer group's read cursor on a topic.
+* 
+* Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
+* partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
+* `"latest"` and may be used with or without a partition suffix.
+*/
+    public MsgStreamSeekOut seek(
+        final MsgStreamSeekIn msgStreamSeekIn
+    ) throws IOException, ApiException {
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/stream/seek");
+        return this.client.executeRequest(
+            "POST",
+            url.build(),
+            null,
+            msgStreamSeekIn,
+            MsgStreamSeekOut.class
             );
     }
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgStreamSeekIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgStreamSeekIn.java
@@ -1,0 +1,132 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
+public class MsgStreamSeekIn {
+@JsonProperty private String topic;
+@JsonProperty("consumer_group") private String consumerGroup;
+@JsonProperty private Long offset;
+@JsonProperty private String position;
+public MsgStreamSeekIn () {}
+
+ public MsgStreamSeekIn topic(String topic) {
+        this.topic = topic;
+        return this;
+    }
+
+    /**
+    * Get topic
+    *
+     * @return topic
+     */
+    @javax.annotation.Nonnull
+     public String getTopic() {
+        return topic;
+    }
+
+     public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+     public MsgStreamSeekIn consumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+        return this;
+    }
+
+    /**
+    * Get consumerGroup
+    *
+     * @return consumerGroup
+     */
+    @javax.annotation.Nonnull
+     public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+     public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+    }
+
+     public MsgStreamSeekIn offset(Long offset) {
+        this.offset = offset;
+        return this;
+    }
+
+    /**
+    * Get offset
+    *
+     * @return offset
+     */
+    @javax.annotation.Nullable
+     public Long getOffset() {
+        return offset;
+    }
+
+     public void setOffset(Long offset) {
+        this.offset = offset;
+    }
+
+     public MsgStreamSeekIn position(String position) {
+        this.position = position;
+        return this;
+    }
+
+    /**
+    * Get position
+    *
+     * @return position
+     */
+    @javax.annotation.Nullable
+     public String getPosition() {
+        return position;
+    }
+
+     public void setPosition(String position) {
+        this.position = position;
+    }
+
+    /**
+     * Create an instance of MsgStreamSeekIn given an JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of MsgStreamSeekIn
+     * @throws JsonProcessingException if the JSON string is invalid with respect to MsgStreamSeekIn
+     */
+    public static MsgStreamSeekIn fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, MsgStreamSeekIn.class);
+    }
+
+    /**
+     * Convert an instance of MsgStreamSeekIn to an JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgStreamSeekOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgStreamSeekOut.java
@@ -1,0 +1,52 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
+public class MsgStreamSeekOut {
+public MsgStreamSeekOut () {}
+
+/**
+     * Create an instance of MsgStreamSeekOut given an JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of MsgStreamSeekOut
+     * @throws JsonProcessingException if the JSON string is invalid with respect to MsgStreamSeekOut
+     */
+    public static MsgStreamSeekOut fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, MsgStreamSeekOut.class);
+    }
+
+    /**
+     * Convert an instance of MsgStreamSeekOut to an JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/clients/javascript/src/apis/msgsStream.ts
+++ b/clients/javascript/src/apis/msgsStream.ts
@@ -16,6 +16,14 @@ import {
     type MsgStreamReceiveOut,
     MsgStreamReceiveOutSerializer,
 } from '../models/msgStreamReceiveOut';
+import {
+    type MsgStreamSeekIn,
+    MsgStreamSeekInSerializer,
+} from '../models/msgStreamSeekIn';
+import {
+    type MsgStreamSeekOut,
+    MsgStreamSeekOutSerializer,
+} from '../models/msgStreamSeekOut';
 import { HttpMethod, CoyoteRequest, type CoyoteRequestContext } from "../request";
 
 export class MsgsStream {
@@ -66,6 +74,32 @@ export class MsgsStream {
                 return request.send(
                     this.requestCtx,
                     MsgStreamCommitOutSerializer._fromJsonObject,
+                );
+            }
+
+        
+
+    /**
+* Repositions a consumer group's read cursor on a topic.
+* 
+* Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
+* partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
+* `"latest"` and may be used with or without a partition suffix.
+*/
+        public seek(
+            msgStreamSeekIn: MsgStreamSeekIn,
+            ): Promise<MsgStreamSeekOut> {
+            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/seek");
+
+            request.setBody(
+                    MsgStreamSeekInSerializer._toJsonObject(
+                        msgStreamSeekIn,
+                    )
+                );
+            
+                return request.send(
+                    this.requestCtx,
+                    MsgStreamSeekOutSerializer._fromJsonObject,
                 );
             }
 

--- a/clients/javascript/src/models/msgStreamSeekIn.ts
+++ b/clients/javascript/src/models/msgStreamSeekIn.ts
@@ -1,0 +1,30 @@
+// this file is @generated
+
+export interface MsgStreamSeekIn {
+    topic: string;
+    consumerGroup: string;
+    offset?: number | null;
+    position?: string | null;
+}
+
+export const MsgStreamSeekInSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(object: any): MsgStreamSeekIn {
+        return {
+            topic: object['topic'],
+            consumerGroup: object['consumer_group'],
+            offset: object['offset'],
+            position: object['position'],
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(self: MsgStreamSeekIn): any {
+        return {
+            'topic': self.topic,
+            'consumer_group': self.consumerGroup,
+            'offset': self.offset,
+            'position': self.position,
+        };
+    }
+}

--- a/clients/javascript/src/models/msgStreamSeekOut.ts
+++ b/clients/javascript/src/models/msgStreamSeekOut.ts
@@ -1,0 +1,19 @@
+// this file is @generated
+// biome-ignore-all lint/suspicious/noEmptyInterface: forwards compat
+
+export interface MsgStreamSeekOut {
+}
+
+export const MsgStreamSeekOutSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(_object: any): MsgStreamSeekOut {
+        return {
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(_self: MsgStreamSeekOut): any {
+        return {
+        };
+    }
+}

--- a/clients/python/coyote/apis/msgs_stream.py
+++ b/clients/python/coyote/apis/msgs_stream.py
@@ -6,10 +6,13 @@ from ..models import (
     MsgStreamCommitOut,
     MsgStreamReceiveIn,
     MsgStreamReceiveOut,
+    MsgStreamSeekIn,
+    MsgStreamSeekOut,
 )
 
 from ..models.msg_stream_receive_in import _MsgStreamReceiveIn
 from ..models.msg_stream_commit_in import _MsgStreamCommitIn
+from ..models.msg_stream_seek_in import _MsgStreamSeekIn
 
 
 class MsgsStreamAsync(ApiBase):
@@ -60,6 +63,31 @@ class MsgsStreamAsync(ApiBase):
             response_type=MsgStreamCommitOut,
         )
 
+    async def seek(
+        self,
+        topic: str,
+        consumer_group: str,
+        msg_stream_seek_in: MsgStreamSeekIn = MsgStreamSeekIn(),
+    ) -> MsgStreamSeekOut:
+        """Repositions a consumer group's read cursor on a topic.
+
+        Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
+        partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
+        `"latest"` and may be used with or without a partition suffix."""
+        body = _MsgStreamSeekIn(
+            topic=topic,
+            consumer_group=consumer_group,
+            offset=msg_stream_seek_in.offset,
+            position=msg_stream_seek_in.position,
+        ).model_dump(exclude_none=True)
+
+        return await self._request_asyncio(
+            method="post",
+            path="/api/v1/msgs/stream/seek",
+            body=body,
+            response_type=MsgStreamSeekOut,
+        )
+
 
 class MsgsStream(ApiBase):
     def receive(
@@ -107,4 +135,29 @@ class MsgsStream(ApiBase):
             path="/api/v1/msgs/stream/commit",
             body=body,
             response_type=MsgStreamCommitOut,
+        )
+
+    def seek(
+        self,
+        topic: str,
+        consumer_group: str,
+        msg_stream_seek_in: MsgStreamSeekIn = MsgStreamSeekIn(),
+    ) -> MsgStreamSeekOut:
+        """Repositions a consumer group's read cursor on a topic.
+
+        Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
+        partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
+        `"latest"` and may be used with or without a partition suffix."""
+        body = _MsgStreamSeekIn(
+            topic=topic,
+            consumer_group=consumer_group,
+            offset=msg_stream_seek_in.offset,
+            position=msg_stream_seek_in.position,
+        ).model_dump(exclude_none=True)
+
+        return self._request_sync(
+            method="post",
+            path="/api/v1/msgs/stream/seek",
+            body=body,
+            response_type=MsgStreamSeekOut,
         )

--- a/clients/python/coyote/models/__init__.py
+++ b/clients/python/coyote/models/__init__.py
@@ -43,6 +43,8 @@ from .msg_stream_commit_in import MsgStreamCommitIn
 from .msg_stream_commit_out import MsgStreamCommitOut
 from .msg_stream_receive_in import MsgStreamReceiveIn
 from .msg_stream_receive_out import MsgStreamReceiveOut
+from .msg_stream_seek_in import MsgStreamSeekIn
+from .msg_stream_seek_out import MsgStreamSeekOut
 from .msg_topic_configure_in import MsgTopicConfigureIn
 from .msg_topic_configure_out import MsgTopicConfigureOut
 from .operation_behavior import OperationBehavior
@@ -105,6 +107,8 @@ __all__ = [
     "MsgStreamCommitOut",
     "MsgStreamReceiveIn",
     "MsgStreamReceiveOut",
+    "MsgStreamSeekIn",
+    "MsgStreamSeekOut",
     "MsgTopicConfigureIn",
     "MsgTopicConfigureOut",
     "OperationBehavior",

--- a/clients/python/coyote/models/msg_stream_seek_in.py
+++ b/clients/python/coyote/models/msg_stream_seek_in.py
@@ -1,0 +1,21 @@
+# this file is @generated
+import typing as t
+from pydantic import Field
+
+from ..internal.base_model import BaseModel
+
+
+class MsgStreamSeekIn(BaseModel):
+    offset: t.Optional[int] = None
+
+    position: t.Optional[str] = None
+
+
+class _MsgStreamSeekIn(BaseModel):
+    topic: str
+
+    consumer_group: str = Field(alias="consumer_group")
+
+    offset: t.Optional[int] = None
+
+    position: t.Optional[str] = None

--- a/clients/python/coyote/models/msg_stream_seek_out.py
+++ b/clients/python/coyote/models/msg_stream_seek_out.py
@@ -1,0 +1,7 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class MsgStreamSeekOut(BaseModel):
+    pass

--- a/clients/rust/src/api/msgs_stream.rs
+++ b/clients/rust/src/api/msgs_stream.rs
@@ -54,4 +54,28 @@ impl<'a> MsgsStream<'a> {
             .execute(self.cfg)
             .await
     }
+
+    /// Repositions a consumer group's read cursor on a topic.
+    ///
+    /// Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
+    /// partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
+    /// `"latest"` and may be used with or without a partition suffix.
+    pub async fn seek(
+        &self,
+        topic: String,
+        consumer_group: String,
+        msg_stream_seek_in: MsgStreamSeekIn,
+    ) -> Result<MsgStreamSeekOut> {
+        let msg_stream_seek_in = MsgStreamSeekIn_ {
+            topic,
+            consumer_group,
+            offset: msg_stream_seek_in.offset,
+            position: msg_stream_seek_in.position,
+        };
+
+        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/stream/seek")
+            .with_body(msg_stream_seek_in)
+            .execute(self.cfg)
+            .await
+    }
 }

--- a/clients/rust/src/models/mod.rs
+++ b/clients/rust/src/models/mod.rs
@@ -45,6 +45,8 @@ mod msg_stream_commit_in;
 mod msg_stream_commit_out;
 mod msg_stream_receive_in;
 mod msg_stream_receive_out;
+mod msg_stream_seek_in;
+mod msg_stream_seek_out;
 mod msg_topic_configure_in;
 mod msg_topic_configure_out;
 mod operation_behavior;
@@ -106,6 +108,8 @@ pub use self::{
     msg_stream_commit_out::MsgStreamCommitOut,
     msg_stream_receive_in::MsgStreamReceiveIn,
     msg_stream_receive_out::MsgStreamReceiveOut,
+    msg_stream_seek_in::MsgStreamSeekIn,
+    msg_stream_seek_out::MsgStreamSeekOut,
     msg_topic_configure_in::MsgTopicConfigureIn,
     msg_topic_configure_out::MsgTopicConfigureOut,
     operation_behavior::OperationBehavior,
@@ -130,5 +134,5 @@ pub(crate) use self::{
     msg_namespace_get_in::MsgNamespaceGetIn_, msg_publish_in::MsgPublishIn_,
     msg_queue_ack_in::MsgQueueAckIn_, msg_queue_receive_in::MsgQueueReceiveIn_,
     msg_stream_commit_in::MsgStreamCommitIn_, msg_stream_receive_in::MsgStreamReceiveIn_,
-    msg_topic_configure_in::MsgTopicConfigureIn_,
+    msg_stream_seek_in::MsgStreamSeekIn_, msg_topic_configure_in::MsgTopicConfigureIn_,
 };

--- a/clients/rust/src/models/msg_stream_seek_in.rs
+++ b/clients/rust/src/models/msg_stream_seek_in.rs
@@ -1,0 +1,43 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct MsgStreamSeekIn {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<String>,
+}
+
+impl MsgStreamSeekIn {
+    pub fn new() -> Self {
+        Self {
+            offset: None,
+            position: None,
+        }
+    }
+
+    pub fn with_offset(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.offset = value.into();
+        self
+    }
+
+    pub fn with_position(mut self, value: impl Into<Option<String>>) -> Self {
+        self.position = value.into();
+        self
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct MsgStreamSeekIn_ {
+    pub topic: String,
+
+    pub consumer_group: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<String>,
+}

--- a/clients/rust/src/models/msg_stream_seek_out.rs
+++ b/clients/rust/src/models/msg_stream_seek_out.rs
@@ -1,0 +1,11 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MsgStreamSeekOut {}
+
+impl MsgStreamSeekOut {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -374,6 +374,34 @@ pub struct QueueMsgOut {
     pub timestamp: Timestamp,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SeekPosition {
+    Earliest,
+    Latest,
+}
+
+/// FIXME(@svix-gabriel): making this look like a string in the SDK for expediency.
+/// I had trouble getting the enum version to work. There's definitely a way to do it
+/// though.
+impl JsonSchema for SeekPosition {
+    fn inline_schema() -> bool {
+        String::inline_schema()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        String::schema_id()
+    }
+
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        String::schema_name()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
+    }
+}
+
 /// A validated consumer group identifier.
 ///
 /// Must be at most 64 bytes and only contain ASCII alphanumeric characters, `_`, or `-`.

--- a/crates/msgs/src/operations/mod.rs
+++ b/crates/msgs/src/operations/mod.rs
@@ -25,6 +25,7 @@ raft_module_operations!(
         QueueReceive(QueueReceiveOperation) -> QueueReceiveResponseData,
         StreamCommit(StreamCommitOperation) -> StreamCommitResponseData,
         StreamReceive(StreamReceiveOperation) -> StreamReceiveResponseData,
+        StreamSeek(StreamSeekOperation) -> StreamSeekResponseData,
         TopicConfigure(TopicConfigureOperation) -> TopicConfigureResponseData,
     },
     state = MsgsRaftState<'_>,
@@ -39,6 +40,7 @@ impl MsgsOperation {
             MsgsOperation::QueueReceive(op) => op.topic.to_string(),
             MsgsOperation::StreamCommit(op) => op.topic.to_string(),
             MsgsOperation::StreamReceive(op) => op.topic.to_string(),
+            MsgsOperation::StreamSeek(op) => op.topic.to_string(),
             MsgsOperation::TopicConfigure(op) => op.topic.to_string(),
         }
     }

--- a/crates/msgs/src/operations/stream/mod.rs
+++ b/crates/msgs/src/operations/stream/mod.rs
@@ -1,4 +1,5 @@
 mod commit;
 mod receive;
+mod seek;
 
-pub use self::{commit::*, receive::*};
+pub use self::{commit::*, receive::*, seek::*};

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -1,0 +1,113 @@
+use coyote_error::Error;
+use coyote_namespace::entities::NamespaceId;
+use fjall_utils::{TableRow, WriteBatchExt};
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    State,
+    entities::{ConsumerGroup, Offset, Partition, SeekPosition, TopicIn, TopicName},
+    tables::{MsgRow, StreamLeaseRow, TopicRow},
+};
+
+use super::super::{MsgsRaftState, MsgsRequest, StreamSeekResponse};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SeekTarget {
+    Offset(Offset),
+    Position(SeekPosition),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamSeekOperation {
+    namespace_id: NamespaceId,
+    pub(crate) topic: TopicName,
+    partition: Option<Partition>,
+    consumer_group: ConsumerGroup,
+    target: SeekTarget,
+}
+
+impl StreamSeekOperation {
+    pub fn new(
+        namespace_id: NamespaceId,
+        topic: TopicIn,
+        consumer_group: ConsumerGroup,
+        target: SeekTarget,
+    ) -> coyote_error::Result<Self> {
+        let (topic, partition) = match topic {
+            TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
+            TopicIn::TopicName(tn) => (tn, None),
+        };
+
+        if matches!(target, SeekTarget::Offset(_)) && partition.is_none() {
+            return Err(Error::invalid_user_input(
+                "offset-based seek requires a partition-level topic (e.g. topic~0)",
+            ));
+        }
+
+        Ok(Self {
+            namespace_id,
+            topic,
+            partition,
+            consumer_group,
+            target,
+        })
+    }
+
+    #[tracing::instrument(skip_all, level = "debug")]
+    fn apply_real(
+        self,
+        state: &State,
+        _now: Timestamp,
+    ) -> coyote_operations::Result<StreamSeekResponseData> {
+        let mut batch = state.db.batch();
+
+        let topic_row = TopicRow::fetch(
+            &state.metadata_tables,
+            TopicRow::key_for(self.namespace_id, &self.topic),
+        )?
+        .ok_or_else(|| Error::invalid_user_input("topic must exist"))?;
+
+        let partitions = self
+            .partition
+            .map(|p| vec![p.get()])
+            .unwrap_or_else(|| (0..topic_row.partitions).collect());
+
+        for partition_idx in partitions {
+            let partition = Partition::new(partition_idx)?;
+
+            let offset = match &self.target {
+                SeekTarget::Position(SeekPosition::Earliest) => 0,
+                SeekTarget::Position(SeekPosition::Latest) => {
+                    MsgRow::next_offset(&state.msg_table, topic_row.id, partition)?
+                }
+                SeekTarget::Offset(o) => *o,
+            };
+
+            let lease = StreamLeaseRow {
+                offset,
+                expiry: Timestamp::MIN,
+                end_offset: 0,
+            };
+
+            batch.insert_row(
+                &state.metadata_tables,
+                StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
+                &lease,
+            )?;
+        }
+
+        batch.commit().map_err(Error::from)?;
+
+        Ok(StreamSeekResponseData {})
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamSeekResponseData {}
+
+impl MsgsRequest for StreamSeekOperation {
+    fn apply(self, state: MsgsRaftState<'_>, timestamp: Timestamp) -> StreamSeekResponse {
+        StreamSeekResponse(self.apply_real(state.msgs, timestamp))
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -851,6 +851,43 @@
         ]
       }
     },
+    "/api/v1/msgs/stream/seek": {
+      "post": {
+        "tags": [
+          "Msgs"
+        ],
+        "summary": "Stream Seek",
+        "description": "Repositions a consumer group's read cursor on a topic.\n\nProvide exactly one of `offset` or `position`. When using `offset`, the topic must include a\npartition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `\"earliest\"` or\n`\"latest\"` and may be used with or without a partition suffix.",
+        "operationId": "v1.msgs.stream.seek",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MsgStreamSeekIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MsgStreamSeekOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/msgs/queue/receive": {
       "post": {
         "tags": [
@@ -1990,6 +2027,38 @@
         "required": [
           "msgs"
         ]
+      },
+      "MsgStreamSeekIn": {
+        "type": "object",
+        "properties": {
+          "topic": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "offset": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "nullable": true
+          },
+          "position": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "topic",
+          "consumer_group"
+        ],
+        "x-positional": [
+          "topic",
+          "consumer_group"
+        ]
+      },
+      "MsgStreamSeekOut": {
+        "type": "object"
       },
       "MsgTopicConfigureIn": {
         "type": "object",

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -4,16 +4,17 @@ use crate::{AppState, core::cluster::RaftState, v1::utils::openapi_tag};
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_derive::aide_annotate;
-use coyote_error::{OptionExt as _, Result, ResultExt};
+use coyote_error::{Error, OptionExt, Result, ResultExt};
 use coyote_msgs::{
     MsgsNamespace,
     entities::{
-        ConsumerGroup, MsgId, Offset, QueueMsgOut, Retention, StreamMsgOut, TopicIn, TopicName,
-        TopicPartition, default_retention_bytes, default_retention_millis,
+        ConsumerGroup, MsgId, Offset, QueueMsgOut, Retention, SeekPosition, StreamMsgOut, TopicIn,
+        TopicName, TopicPartition, default_retention_bytes, default_retention_millis,
     },
     operations::{
         CreateNamespaceOperation, PublishOperation, QueueAckOperation, QueueReceiveOperation,
-        StreamCommitOperation, StreamReceiveOperation, TopicConfigureOperation,
+        SeekTarget, StreamCommitOperation, StreamReceiveOperation, StreamSeekOperation,
+        TopicConfigureOperation,
     },
 };
 use coyote_namespace::entities::StorageType;
@@ -259,6 +260,55 @@ async fn stream_commit(
 }
 
 // ---------------------------------------------------------------------------
+// stream/seek
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Validate, JsonSchema)]
+#[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
+struct MsgStreamSeekIn {
+    pub topic: TopicIn,
+    pub consumer_group: ConsumerGroup,
+    pub offset: Option<Offset>,
+    pub position: Option<SeekPosition>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+struct MsgStreamSeekOut {}
+
+/// Repositions a consumer group's read cursor on a topic.
+///
+/// Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
+/// partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
+/// `"latest"` and may be used with or without a partition suffix.
+#[aide_annotate(op_id = "v1.msgs.stream.seek")]
+async fn stream_seek(
+    State(state): State<AppState>,
+    Extension(repl): Extension<RaftState>,
+    MsgPackOrJson(data): MsgPackOrJson<MsgStreamSeekIn>,
+) -> Result<MsgPackOrJson<MsgStreamSeekOut>> {
+    let namespace: MsgsNamespace = state
+        .namespace_state
+        .fetch_namespace(data.topic.namespace())?
+        .ok_or_not_found()?;
+
+    let target = match (data.offset, data.position) {
+        (Some(offset), None) => SeekTarget::Offset(offset),
+        (None, Some(position)) => SeekTarget::Position(position),
+        _ => {
+            return Err(Error::invalid_user_input(
+                "exactly one of 'offset' or 'position' must be provided",
+            ));
+        }
+    };
+
+    let operation =
+        StreamSeekOperation::new(namespace.id, data.topic, data.consumer_group, target)?;
+    repl.client_write(operation).await.map_err_generic()?.0?;
+
+    Ok(MsgPackOrJson(MsgStreamSeekOut {}))
+}
+
+// ---------------------------------------------------------------------------
 // queue/receive
 // ---------------------------------------------------------------------------
 
@@ -418,6 +468,11 @@ pub fn router() -> ApiRouter<AppState> {
         .api_route_with(
             "/msgs/stream/commit",
             post_with(stream_commit, stream_commit_operation),
+            &tag,
+        )
+        .api_route_with(
+            "/msgs/stream/seek",
+            post_with(stream_seek, stream_seek_operation),
             &tag,
         )
         .api_route_with(

--- a/tests/it/msgs/mod.rs
+++ b/tests/it/msgs/mod.rs
@@ -2,4 +2,5 @@ mod namespace;
 mod publish;
 mod queue;
 mod stream_receive;
+mod stream_seek;
 mod topic_configure;

--- a/tests/it/msgs/stream_seek.rs
+++ b/tests/it/msgs/stream_seek.rs
@@ -1,11 +1,8 @@
-use std::time::Duration;
-
 use serde_json::json;
 use test_utils::{
     StatusCode, TestResult,
     server::{TestContext, start_server},
 };
-use tokio::time::sleep;
 
 #[tokio::test]
 async fn seek_earliest_replays_all_messages() -> TestResult {
@@ -287,7 +284,11 @@ async fn seek_to_specific_offset() -> TestResult {
         .json();
 
     let msgs2 = r2["msgs"].as_array().unwrap();
-    assert_eq!(msgs2.len(), 3, "should get 3 messages starting from offset 2");
+    assert_eq!(
+        msgs2.len(),
+        3,
+        "should get 3 messages starting from offset 2"
+    );
     assert_eq!(msgs2[0]["offset"].as_u64().unwrap(), 2);
 
     Ok(())

--- a/tests/it/msgs/stream_seek.rs
+++ b/tests/it/msgs/stream_seek.rs
@@ -1,0 +1,513 @@
+use std::time::Duration;
+
+use serde_json::json;
+use test_utils::{
+    StatusCode, TestResult,
+    server::{TestContext, start_server},
+};
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn seek_earliest_replays_all_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-seek-earliest" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group
+    client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-earliest:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish messages
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "topic": "ns-seek-earliest:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+                { "value": "c".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive all messages
+    let r1 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-earliest:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r1["msgs"].as_array().unwrap();
+    assert_eq!(msgs.len(), 3);
+
+    // Commit to advance past all messages
+    let partition_topic = msgs[0]["topic"].as_str().unwrap();
+    let last_offset = msgs[2]["offset"].as_u64().unwrap();
+    client
+        .post("msgs/stream/commit")
+        .json(json!({
+            "topic": partition_topic,
+            "consumer_group": "cg1",
+            "offset": last_offset,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Verify nothing left to consume
+    let r2 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-earliest:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(r2["msgs"].as_array().unwrap().len(), 0);
+
+    // Seek to earliest
+    client
+        .post("msgs/stream/seek")
+        .json(json!({
+            "topic": "ns-seek-earliest:t1",
+            "consumer_group": "cg1",
+            "position": "earliest",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive again — should replay all 3 messages
+    let r3 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-earliest:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(
+        r3["msgs"].as_array().unwrap().len(),
+        3,
+        "seek to earliest should replay all messages"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_latest_skips_existing() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-seek-latest" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish messages before any consumer exists
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "topic": "ns-seek-latest:t1",
+            "msgs": [
+                { "value": "old-a".as_bytes(), "key": "k1" },
+                { "value": "old-b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Seek to latest (creates consumer group at the end of the stream)
+    client
+        .post("msgs/stream/seek")
+        .json(json!({
+            "topic": "ns-seek-latest:t1",
+            "consumer_group": "cg1",
+            "position": "latest",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should get nothing (all messages are before "latest")
+    let r1 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-latest:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(
+        r1["msgs"].as_array().unwrap().len(),
+        0,
+        "seek to latest should skip existing messages"
+    );
+
+    // Publish new messages
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "topic": "ns-seek-latest:t1",
+            "msgs": [
+                { "value": "new-a".as_bytes(), "key": "k1" },
+                { "value": "new-b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should get only the new messages
+    let r2 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-latest:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(
+        r2["msgs"].as_array().unwrap().len(),
+        2,
+        "should receive only messages published after seek to latest"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_to_specific_offset() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-seek-offset" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group
+    client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-offset:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish 5 messages
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "topic": "ns-seek-offset:t1",
+            "msgs": (0..5)
+                .map(|i| json!({ "value": format!("msg-{i}").as_bytes(), "key": "k1" }))
+                .collect::<Vec<_>>(),
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive to discover the partition topic
+    let r1 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-offset:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r1["msgs"].as_array().unwrap();
+    assert_eq!(msgs.len(), 5);
+    let partition_topic = msgs[0]["topic"].as_str().unwrap();
+
+    // Commit past all messages
+    let last_offset = msgs[4]["offset"].as_u64().unwrap();
+    client
+        .post("msgs/stream/commit")
+        .json(json!({
+            "topic": partition_topic,
+            "consumer_group": "cg1",
+            "offset": last_offset,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Seek to offset 2 (next-to-read semantics: will read from offset 2)
+    client
+        .post("msgs/stream/seek")
+        .json(json!({
+            "topic": partition_topic,
+            "consumer_group": "cg1",
+            "offset": 2,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should get messages starting at offset 2 (3 messages: 2, 3, 4)
+    let r2 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-offset:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = r2["msgs"].as_array().unwrap();
+    assert_eq!(msgs2.len(), 3, "should get 3 messages starting from offset 2");
+    assert_eq!(msgs2[0]["offset"].as_u64().unwrap(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_offset_requires_partition_topic() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-seek-pt" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Offset-based seek on a bare topic (no ~partition) should fail
+    client
+        .post("msgs/stream/seek")
+        .json(json!({
+            "topic": "ns-seek-pt:t1",
+            "consumer_group": "cg1",
+            "offset": 0,
+        }))
+        .await?
+        .expect(StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_position_works_on_topic_level() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-seek-topic" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Configure 2 partitions
+    client
+        .post("msgs/topic/configure")
+        .json(json!({
+            "topic": "ns-seek-topic:t1",
+            "partitions": 16,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group
+    client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-topic:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish messages to different partitions
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "topic": "ns-seek-topic:t1",
+            "msgs": [
+                { "value": "a1".as_bytes(), "key": "k1" },
+                { "value": "a2".as_bytes(), "key": "k1" },
+                { "value": "b1".as_bytes(), "key": "k2" },
+                { "value": "b2".as_bytes(), "key": "k2" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Seek to earliest on the topic level (applies to all partitions)
+    client
+        .post("msgs/stream/seek")
+        .json(json!({
+            "topic": "ns-seek-topic:t1",
+            "consumer_group": "cg1",
+            "position": "earliest",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should get all messages from all partitions
+    let r1 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-topic:t1",
+            "consumer_group": "cg1",
+            "batch_size": 10,
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r1["msgs"].as_array().unwrap();
+    assert!(
+        msgs.len() >= 2,
+        "should receive messages from at least one partition after topic-level seek"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_nonexistent_namespace() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/stream/seek")
+        .json(json!({
+            "topic": "does-not-exist:t1",
+            "consumer_group": "cg1",
+            "position": "earliest",
+        }))
+        .await?
+        .expect(StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_clears_lease() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-seek-lease" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group
+    client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-lease:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "topic": "ns-seek-lease:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — locks the partition
+    let r1 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-lease:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(r1["msgs"].as_array().unwrap().len(), 2);
+
+    // Verify partition is locked
+    client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-lease:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::BAD_REQUEST);
+
+    // Seek to earliest — should clear the lease
+    client
+        .post("msgs/stream/seek")
+        .json(json!({
+            "topic": "ns-seek-lease:t1",
+            "consumer_group": "cg1",
+            "position": "earliest",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive again — should succeed (lease cleared) and replay messages
+    let r2 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-seek-lease:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(
+        r2["msgs"].as_array().unwrap().len(),
+        2,
+        "seek should clear lease and allow re-receive"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This implements seek functionality, so you can change positions of a consumer group in a topic (in stream).

There's two ways to seek

```
{
    "position": "earliest" | "latest"
    // XOR
    "offset": 1
}
```

`position` based seeking works on both a parent topic (eg `topic="my-topic"`), and on a per-partition level (eg `topic="my-topic~5"`). `offset` based seeking only works per partition, for obvious reasons.