### PR TITLE
gha: only push to docker if CI passes

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -16,6 +16,7 @@ jobs:
   docker_publish:
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
+    needs: [ci, clients]
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Doesn't seem that useful to have a CI job if you still tag releases on Docker even if it fails. :-)