### PR TITLE
Add `key_count` metric

### DIFF
--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -161,6 +161,12 @@ impl KvController {
         KvPairRow::values(&self.keyspace)
     }
 
+    pub fn count_for_namespace(&self, namespace_id: NamespaceId) -> Result<usize> {
+        let mut prefix = vec![KvPairRow::ROW_TYPE];
+        prefix.extend_from_slice(namespace_id.as_bytes());
+        Ok(self.keyspace.prefix(prefix).count())
+    }
+
     pub fn clear_expired(&self, now: Timestamp) -> Result<()> {
         let start = ExpirationRow::key_for(NamespaceId::nil(), Timestamp::MIN, "").into_fjall_key();
         let end = ExpirationRow::key_for(NamespaceId::max(), now, "").into_fjall_key();

--- a/example-configs/three-node-cluster/.gitignore
+++ b/example-configs/three-node-cluster/.gitignore
@@ -1,3 +1,4 @@
 db-*
 logs-*
 snapshots-*
+diom-incoming-snapshot-*

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -8,10 +8,10 @@ use std::{
 
 use crate::{
     cfg::Dir,
-    core::metrics::{DbMetrics, DbType},
+    core::metrics::{DbMetrics, DbType, Module},
 };
 use anyhow::Context;
-use diom_namespace::entities::StorageType;
+use diom_namespace::entities::{CacheConfig, IdempotencyConfig, KeyValueConfig, StorageType};
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
 use fjall_utils::{Databases, FjallFixedKey, ReadonlyKeyspace};
 use openraft::{
@@ -169,6 +169,7 @@ impl Store {
 
     pub fn start_metrics(&self, metrics: DbMetrics) {
         let stores = Arc::clone(&self.stores);
+        let namespace_state = self.state.namespace_state.clone();
         let shutdown = crate::shutting_down_token();
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_secs(60));
@@ -178,23 +179,85 @@ impl Store {
                     _ = shutdown.cancelled() => break,
                 }
 
-                match tokio::task::spawn_blocking({
+                if let Err(err) = tokio::task::spawn_blocking({
                     let stores = Arc::clone(&stores);
-                    move || {
-                        let guard = stores.read();
-                        let persistent_bytes = guard.databases.persistent.disk_space()?;
-                        let ephemeral_bytes = guard.databases.ephemeral.disk_space()?;
-                        Ok::<_, fjall::Error>((persistent_bytes, ephemeral_bytes))
+                    let namespace_state = namespace_state.clone();
+                    let metrics = metrics.clone();
+                    move || -> anyhow::Result<()> {
+                        let stores = stores.read();
+
+                        let persistent_bytes = stores.databases.persistent.disk_space()?;
+                        let ephemeral_bytes = stores.databases.ephemeral.disk_space()?;
+                        metrics.bytes_used(persistent_bytes, DbType::Persistent);
+                        metrics.bytes_used(ephemeral_bytes, DbType::Ephemeral);
+
+                        for ns in namespace_state.fetch_all_namespaces::<KeyValueConfig>()? {
+                            match stores
+                                .kv_state
+                                .controller(ns.storage_type)
+                                .count_for_namespace(ns.id)
+                            {
+                                Ok(count) => metrics.key_count(
+                                    Module::KeyValue,
+                                    &ns.name,
+                                    ns.storage_type,
+                                    count,
+                                ),
+                                Err(err) => tracing::warn!(
+                                    ?err,
+                                    namespace = ns.name,
+                                    "failed to count kv namespace keys"
+                                ),
+                            }
+                        }
+
+                        for ns in namespace_state.fetch_all_namespaces::<CacheConfig>()? {
+                            match stores
+                                .cache_state
+                                .controller(ns.storage_type)
+                                .count_for_namespace(ns.id)
+                            {
+                                Ok(count) => metrics.key_count(
+                                    Module::Cache,
+                                    &ns.name,
+                                    ns.storage_type,
+                                    count,
+                                ),
+                                Err(err) => tracing::warn!(
+                                    ?err,
+                                    namespace = ns.name,
+                                    "failed to count cache namespace keys"
+                                ),
+                            }
+                        }
+
+                        for ns in namespace_state.fetch_all_namespaces::<IdempotencyConfig>()? {
+                            match stores
+                                .idempotency_state
+                                .controller(ns.storage_type)
+                                .count_for_namespace(ns.id)
+                            {
+                                Ok(count) => metrics.key_count(
+                                    Module::Idempotency,
+                                    &ns.name,
+                                    ns.storage_type,
+                                    count,
+                                ),
+                                Err(err) => tracing::warn!(
+                                    ?err,
+                                    namespace = ns.name,
+                                    "failed to count idempotency namespace keys"
+                                ),
+                            }
+                        }
+
+                        Ok(())
                     }
                 })
                 .await
                 .expect("Failed joining blocking task")
                 {
-                    Ok((persistent_bytes, ephemeral_bytes)) => {
-                        metrics.bytes_used(persistent_bytes, DbType::Persistent);
-                        metrics.bytes_used(ephemeral_bytes, DbType::Ephemeral);
-                    }
-                    Err(err) => tracing::info!(?err, "failed to read db disk space"),
+                    tracing::info!(?err, "Failed to record db metrics");
                 }
             }
         });

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
+use fjall_utils::StorageType;
 use http::StatusCode;
 use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
 
@@ -19,8 +20,30 @@ impl From<DbType> for opentelemetry::Value {
     }
 }
 
+pub enum Module {
+    Cache,
+    Idempotency,
+    KeyValue,
+    RateLimiter,
+    Stream,
+}
+
+impl From<Module> for opentelemetry::Value {
+    fn from(module: Module) -> Self {
+        match module {
+            Module::Cache => "cache".into(),
+            Module::Idempotency => "idempotency".into(),
+            Module::KeyValue => "kv".into(),
+            Module::RateLimiter => "ratelimiter".into(),
+            Module::Stream => "stream".into(),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct DbMetrics {
     bytes_used: Gauge<u64>,
+    key_count: Gauge<u64>,
     node_id: NodeId,
 }
 
@@ -32,6 +55,10 @@ impl DbMetrics {
                 .with_description("DB size in bytes")
                 .with_unit("By")
                 .build(),
+            key_count: meter
+                .u64_gauge("diom.key_count")
+                .with_description("Number of keys by namespace/module")
+                .build(),
             node_id,
         }
     }
@@ -42,6 +69,28 @@ impl DbMetrics {
             &[
                 opentelemetry::KeyValue::new("node_id", self.node_id.to_string()),
                 opentelemetry::KeyValue::new("db_type", db_type),
+            ],
+        );
+    }
+
+    pub fn key_count(
+        &self,
+        module: Module,
+        namespace: &str,
+        storage_type: StorageType,
+        count: usize,
+    ) {
+        let storage_type_str: &'static str = match storage_type {
+            StorageType::Persistent => "persistent",
+            StorageType::Ephemeral => "ephemeral",
+        };
+        self.key_count.record(
+            count as _,
+            &[
+                opentelemetry::KeyValue::new("node_id", self.node_id.to_string()),
+                opentelemetry::KeyValue::new("module", module),
+                opentelemetry::KeyValue::new("namespace", namespace.to_owned()),
+                opentelemetry::KeyValue::new("storage_type", storage_type_str),
             ],
         );
     }


### PR DESCRIPTION
This adds metrics to get the number of keys in a namespace, scoped by 
module (which right now is only idempotency/kv/cache).
