### PR TITLE
codegen: do not leak a docker/podman container on every invocation

### DIFF
--- a/codegen/src/utils.rs
+++ b/codegen/src/utils.rs
@@ -107,7 +107,7 @@ impl ContainerizedFormatter<'_> {
         let ctx_dir = "codegen/formatters";
         let args = vec!["build", "-t", &tag, "-f", &containerfile_path, ctx_dir];
         exec(base, args).await?;
-        let args = ["run"]
+        let args = ["run", "--rm"]
             .into_iter()
             .chain(mounts.iter().map(|m| m.as_str()))
             .chain([tag.as_str()])


### PR DESCRIPTION
ugh.

both docker and podman leave the (stopped) container behind forever unless you invoke `run` with the `--rm` arg. I just looked and I head 96 stopped containers from `just codegen` cluttering up my system.

If you also have them, you can fix it with `docker ps -a | grep coyote-formatter | cut -d' ' -f 1 | xargs docker rm`