### PR TITLE
repl: improve linearizable reads

### DIFF
--- a/clients/go/internal/models/cache_get_in.go
+++ b/clients/go/internal/models/cache_get_in.go
@@ -3,11 +3,6 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type CacheGetIn struct {
-	Key string `json:"key"`
-	// Whether or not the read should be linearizable
-	//
-	// If this is `true`, the read is guaranteed to see all previous operations, but will
-	// have to make at least one additional round-trip to the leader. If this is false, stale
-	// reads will be performed against the replica which receives this request.
-	Linearizable *bool `json:"linearizable,omitempty"`
+	Key         string       `json:"key"`
+	Consistency *Consistency `json:"consistency,omitempty"`
 }

--- a/clients/go/internal/models/cache_get_in.go
+++ b/clients/go/internal/models/cache_get_in.go
@@ -4,4 +4,10 @@ package coyote_models
 
 type CacheGetIn struct {
 	Key string `json:"key"`
+	// Whether or not the read should be linearizable
+	//
+	// If this is `true`, the read is guaranteed to see all previous operations, but will
+	// have to make at least one additional round-trip to the leader. If this is false, stale
+	// reads will be performed against the replica which receives this request.
+	Linearizable *bool `json:"linearizable,omitempty"`
 }

--- a/clients/go/internal/models/consistency.go
+++ b/clients/go/internal/models/consistency.go
@@ -1,0 +1,45 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+)
+
+// Consistency level for reads.
+//
+// Strong consistency (also known as linearizability) guarantees that a read will see all previous
+// writes. Weak consistency allows stale reads, but can save one or more round trip to the leader.
+type Consistency string
+
+const (
+	CONSISTENCY_STRONG Consistency = "strong"
+	CONSISTENCY_WEAK   Consistency = "weak"
+)
+
+var allowedConsistency = []Consistency{
+	"strong",
+	"weak",
+}
+
+func (v *Consistency) UnmarshalJSON(src []byte) error {
+	var value string
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumVal := Consistency(value)
+	if slices.Contains(allowedConsistency, enumVal) {
+		*v = enumVal
+		return nil
+	}
+	return fmt.Errorf("`%+v` is not a valid Consistency", value)
+
+}
+
+var ConsistencyFromString = map[string]Consistency{
+	"strong": CONSISTENCY_STRONG,
+	"weak":   CONSISTENCY_WEAK,
+}

--- a/clients/go/internal/models/kv_get_in.go
+++ b/clients/go/internal/models/kv_get_in.go
@@ -4,4 +4,10 @@ package coyote_models
 
 type KvGetIn struct {
 	Key string `json:"key"`
+	// Whether or not the read should be linearizable
+	//
+	// If this is `true`, the read is guaranteed to see all previous operations, but will
+	// have to make at least one additional round-trip to the leader. If this is false, stale
+	// reads will be performed against the replica which receives this request.
+	Linearizable *bool `json:"linearizable,omitempty"`
 }

--- a/clients/go/internal/models/kv_get_in.go
+++ b/clients/go/internal/models/kv_get_in.go
@@ -3,11 +3,6 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type KvGetIn struct {
-	Key string `json:"key"`
-	// Whether or not the read should be linearizable
-	//
-	// If this is `true`, the read is guaranteed to see all previous operations, but will
-	// have to make at least one additional round-trip to the leader. If this is false, stale
-	// reads will be performed against the replica which receives this request.
-	Linearizable *bool `json:"linearizable,omitempty"`
+	Key         string       `json:"key"`
+	Consistency *Consistency `json:"consistency,omitempty"`
 }

--- a/clients/go/models.go
+++ b/clients/go/models.go
@@ -15,6 +15,7 @@ type (
 	CacheGetOut                   = coyote_models.CacheGetOut
 	CacheSetIn                    = coyote_models.CacheSetIn
 	CacheSetOut                   = coyote_models.CacheSetOut
+	Consistency                   = coyote_models.Consistency
 	EvictionPolicy                = coyote_models.EvictionPolicy
 	IdempotencyAbortIn            = coyote_models.IdempotencyAbortIn
 	IdempotencyAbortOut           = coyote_models.IdempotencyAbortOut

--- a/clients/java/src/main/java/com/svix/coyote/models/CacheGetIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/CacheGetIn.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class CacheGetIn {
 @JsonProperty private String key;
-@JsonProperty private Boolean linearizable;
+@JsonProperty private Consistency consistency;
 public CacheGetIn () {}
 
  public CacheGetIn key(String key) {
@@ -51,27 +51,23 @@ public CacheGetIn () {}
         this.key = key;
     }
 
-     public CacheGetIn linearizable(Boolean linearizable) {
-        this.linearizable = linearizable;
+     public CacheGetIn consistency(Consistency consistency) {
+        this.consistency = consistency;
         return this;
     }
 
     /**
-    * Whether or not the read should be linearizable
-
-If this is `true`, the read is guaranteed to see all previous operations, but will
-have to make at least one additional round-trip to the leader. If this is false, stale
-reads will be performed against the replica which receives this request.
+    * Get consistency
     *
-     * @return linearizable
+     * @return consistency
      */
     @javax.annotation.Nullable
-     public Boolean getLinearizable() {
-        return linearizable;
+     public Consistency getConsistency() {
+        return consistency;
     }
 
-     public void setLinearizable(Boolean linearizable) {
-        this.linearizable = linearizable;
+     public void setConsistency(Consistency consistency) {
+        this.consistency = consistency;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/CacheGetIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/CacheGetIn.java
@@ -29,6 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class CacheGetIn {
 @JsonProperty private String key;
+@JsonProperty private Boolean linearizable;
 public CacheGetIn () {}
 
  public CacheGetIn key(String key) {
@@ -48,6 +49,29 @@ public CacheGetIn () {}
 
      public void setKey(String key) {
         this.key = key;
+    }
+
+     public CacheGetIn linearizable(Boolean linearizable) {
+        this.linearizable = linearizable;
+        return this;
+    }
+
+    /**
+    * Whether or not the read should be linearizable
+
+If this is `true`, the read is guaranteed to see all previous operations, but will
+have to make at least one additional round-trip to the leader. If this is false, stale
+reads will be performed against the replica which receives this request.
+    *
+     * @return linearizable
+     */
+    @javax.annotation.Nullable
+     public Boolean getLinearizable() {
+        return linearizable;
+    }
+
+     public void setLinearizable(Boolean linearizable) {
+        this.linearizable = linearizable;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/Consistency.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/Consistency.java
@@ -1,0 +1,19 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Consistency {
+    STRONG("strong"),
+    WEAK("weak");
+    private final String value;
+
+    Consistency(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/clients/java/src/main/java/com/svix/coyote/models/KvGetIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvGetIn.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class KvGetIn {
 @JsonProperty private String key;
-@JsonProperty private Boolean linearizable;
+@JsonProperty private Consistency consistency;
 public KvGetIn () {}
 
  public KvGetIn key(String key) {
@@ -51,27 +51,23 @@ public KvGetIn () {}
         this.key = key;
     }
 
-     public KvGetIn linearizable(Boolean linearizable) {
-        this.linearizable = linearizable;
+     public KvGetIn consistency(Consistency consistency) {
+        this.consistency = consistency;
         return this;
     }
 
     /**
-    * Whether or not the read should be linearizable
-
-If this is `true`, the read is guaranteed to see all previous operations, but will
-have to make at least one additional round-trip to the leader. If this is false, stale
-reads will be performed against the replica which receives this request.
+    * Get consistency
     *
-     * @return linearizable
+     * @return consistency
      */
     @javax.annotation.Nullable
-     public Boolean getLinearizable() {
-        return linearizable;
+     public Consistency getConsistency() {
+        return consistency;
     }
 
-     public void setLinearizable(Boolean linearizable) {
-        this.linearizable = linearizable;
+     public void setConsistency(Consistency consistency) {
+        this.consistency = consistency;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/KvGetIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvGetIn.java
@@ -29,6 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class KvGetIn {
 @JsonProperty private String key;
+@JsonProperty private Boolean linearizable;
 public KvGetIn () {}
 
  public KvGetIn key(String key) {
@@ -48,6 +49,29 @@ public KvGetIn () {}
 
      public void setKey(String key) {
         this.key = key;
+    }
+
+     public KvGetIn linearizable(Boolean linearizable) {
+        this.linearizable = linearizable;
+        return this;
+    }
+
+    /**
+    * Whether or not the read should be linearizable
+
+If this is `true`, the read is guaranteed to see all previous operations, but will
+have to make at least one additional round-trip to the leader. If this is false, stale
+reads will be performed against the replica which receives this request.
+    *
+     * @return linearizable
+     */
+    @javax.annotation.Nullable
+     public Boolean getLinearizable() {
+        return linearizable;
+    }
+
+     public void setLinearizable(Boolean linearizable) {
+        this.linearizable = linearizable;
     }
 
     /**

--- a/clients/javascript/src/models/cacheGetIn.ts
+++ b/clients/javascript/src/models/cacheGetIn.ts
@@ -2,6 +2,14 @@
 
 export interface CacheGetIn {
     key: string;
+    /**
+* Whether or not the read should be linearizable
+* 
+* If this is `true`, the read is guaranteed to see all previous operations, but will
+* have to make at least one additional round-trip to the leader. If this is false, stale
+* reads will be performed against the replica which receives this request.
+*/
+    linearizable?: boolean;
 }
 
 export const CacheGetInSerializer = {
@@ -9,6 +17,7 @@ export const CacheGetInSerializer = {
     _fromJsonObject(object: any): CacheGetIn {
         return {
             key: object['key'],
+            linearizable: object['linearizable'],
         };
     },
 
@@ -16,6 +25,7 @@ export const CacheGetInSerializer = {
     _toJsonObject(self: CacheGetIn): any {
         return {
             'key': self.key,
+            'linearizable': self.linearizable,
         };
     }
 }

--- a/clients/javascript/src/models/cacheGetIn.ts
+++ b/clients/javascript/src/models/cacheGetIn.ts
@@ -1,15 +1,12 @@
 // this file is @generated
+import {
+    type Consistency,
+    ConsistencySerializer,
+} from './consistency';
 
 export interface CacheGetIn {
     key: string;
-    /**
-* Whether or not the read should be linearizable
-* 
-* If this is `true`, the read is guaranteed to see all previous operations, but will
-* have to make at least one additional round-trip to the leader. If this is false, stale
-* reads will be performed against the replica which receives this request.
-*/
-    linearizable?: boolean;
+    consistency?: Consistency;
 }
 
 export const CacheGetInSerializer = {
@@ -17,7 +14,7 @@ export const CacheGetInSerializer = {
     _fromJsonObject(object: any): CacheGetIn {
         return {
             key: object['key'],
-            linearizable: object['linearizable'],
+            consistency: object['consistency'] != null ? ConsistencySerializer._fromJsonObject(object['consistency']): undefined,
         };
     },
 
@@ -25,7 +22,7 @@ export const CacheGetInSerializer = {
     _toJsonObject(self: CacheGetIn): any {
         return {
             'key': self.key,
-            'linearizable': self.linearizable,
+            'consistency': self.consistency != null ? ConsistencySerializer._toJsonObject(self.consistency) : undefined,
         };
     }
 }

--- a/clients/javascript/src/models/consistency.ts
+++ b/clients/javascript/src/models/consistency.ts
@@ -1,0 +1,23 @@
+// this file is @generated
+/**
+* Consistency level for reads.
+* 
+* Strong consistency (also known as linearizability) guarantees that a read will see all previous
+* writes. Weak consistency allows stale reads, but can save one or more round trip to the leader.
+*/
+export enum Consistency {
+    Strong = 'strong',
+    Weak = 'weak',
+    }
+
+export const ConsistencySerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(object: any): Consistency {
+        return object;
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(self: Consistency): any {
+        return self;
+    }
+}

--- a/clients/javascript/src/models/kvGetIn.ts
+++ b/clients/javascript/src/models/kvGetIn.ts
@@ -2,6 +2,14 @@
 
 export interface KvGetIn {
     key: string;
+    /**
+* Whether or not the read should be linearizable
+* 
+* If this is `true`, the read is guaranteed to see all previous operations, but will
+* have to make at least one additional round-trip to the leader. If this is false, stale
+* reads will be performed against the replica which receives this request.
+*/
+    linearizable?: boolean;
 }
 
 export const KvGetInSerializer = {
@@ -9,6 +17,7 @@ export const KvGetInSerializer = {
     _fromJsonObject(object: any): KvGetIn {
         return {
             key: object['key'],
+            linearizable: object['linearizable'],
         };
     },
 
@@ -16,6 +25,7 @@ export const KvGetInSerializer = {
     _toJsonObject(self: KvGetIn): any {
         return {
             'key': self.key,
+            'linearizable': self.linearizable,
         };
     }
 }

--- a/clients/javascript/src/models/kvGetIn.ts
+++ b/clients/javascript/src/models/kvGetIn.ts
@@ -1,15 +1,12 @@
 // this file is @generated
+import {
+    type Consistency,
+    ConsistencySerializer,
+} from './consistency';
 
 export interface KvGetIn {
     key: string;
-    /**
-* Whether or not the read should be linearizable
-* 
-* If this is `true`, the read is guaranteed to see all previous operations, but will
-* have to make at least one additional round-trip to the leader. If this is false, stale
-* reads will be performed against the replica which receives this request.
-*/
-    linearizable?: boolean;
+    consistency?: Consistency;
 }
 
 export const KvGetInSerializer = {
@@ -17,7 +14,7 @@ export const KvGetInSerializer = {
     _fromJsonObject(object: any): KvGetIn {
         return {
             key: object['key'],
-            linearizable: object['linearizable'],
+            consistency: object['consistency'] != null ? ConsistencySerializer._fromJsonObject(object['consistency']): undefined,
         };
     },
 
@@ -25,7 +22,7 @@ export const KvGetInSerializer = {
     _toJsonObject(self: KvGetIn): any {
         return {
             'key': self.key,
-            'linearizable': self.linearizable,
+            'consistency': self.consistency != null ? ConsistencySerializer._toJsonObject(self.consistency) : undefined,
         };
     }
 }

--- a/clients/python/coyote/apis/cache.py
+++ b/clients/python/coyote/apis/cache.py
@@ -51,7 +51,7 @@ class CacheAsync(ApiBase):
         """Cache Get"""
         body = _CacheGetIn(
             key=key,
-            linearizable=cache_get_in.linearizable,
+            consistency=cache_get_in.consistency,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -111,7 +111,7 @@ class Cache(ApiBase):
         """Cache Get"""
         body = _CacheGetIn(
             key=key,
-            linearizable=cache_get_in.linearizable,
+            consistency=cache_get_in.consistency,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/clients/python/coyote/apis/cache.py
+++ b/clients/python/coyote/apis/cache.py
@@ -51,6 +51,7 @@ class CacheAsync(ApiBase):
         """Cache Get"""
         body = _CacheGetIn(
             key=key,
+            linearizable=cache_get_in.linearizable,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -110,6 +111,7 @@ class Cache(ApiBase):
         """Cache Get"""
         body = _CacheGetIn(
             key=key,
+            linearizable=cache_get_in.linearizable,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/clients/python/coyote/apis/kv.py
+++ b/clients/python/coyote/apis/kv.py
@@ -52,6 +52,7 @@ class KvAsync(ApiBase):
         """KV Get"""
         body = _KvGetIn(
             key=key,
+            linearizable=kv_get_in.linearizable,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -112,6 +113,7 @@ class Kv(ApiBase):
         """KV Get"""
         body = _KvGetIn(
             key=key,
+            linearizable=kv_get_in.linearizable,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/clients/python/coyote/apis/kv.py
+++ b/clients/python/coyote/apis/kv.py
@@ -52,7 +52,7 @@ class KvAsync(ApiBase):
         """KV Get"""
         body = _KvGetIn(
             key=key,
-            linearizable=kv_get_in.linearizable,
+            consistency=kv_get_in.consistency,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -113,7 +113,7 @@ class Kv(ApiBase):
         """KV Get"""
         body = _KvGetIn(
             key=key,
-            linearizable=kv_get_in.linearizable,
+            consistency=kv_get_in.consistency,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/clients/python/coyote/models/__init__.py
+++ b/clients/python/coyote/models/__init__.py
@@ -9,6 +9,7 @@ from .cache_get_namespace_out import CacheGetNamespaceOut
 from .cache_get_out import CacheGetOut
 from .cache_set_in import CacheSetIn
 from .cache_set_out import CacheSetOut
+from .consistency import Consistency
 from .eviction_policy import EvictionPolicy
 from .idempotency_abort_in import IdempotencyAbortIn
 from .idempotency_abort_out import IdempotencyAbortOut
@@ -70,6 +71,7 @@ __all__ = [
     "CacheGetOut",
     "CacheSetIn",
     "CacheSetOut",
+    "Consistency",
     "EvictionPolicy",
     "IdempotencyAbortIn",
     "IdempotencyAbortOut",

--- a/clients/python/coyote/models/cache_get_in.py
+++ b/clients/python/coyote/models/cache_get_in.py
@@ -3,22 +3,14 @@ import typing as t
 
 from ..internal.base_model import BaseModel
 
+from .consistency import Consistency
+
 
 class CacheGetIn(BaseModel):
-    linearizable: t.Optional[bool] = None
-    """Whether or not the read should be linearizable
-
-    If this is `true`, the read is guaranteed to see all previous operations, but will
-    have to make at least one additional round-trip to the leader. If this is false, stale
-    reads will be performed against the replica which receives this request."""
+    consistency: t.Optional[Consistency] = None
 
 
 class _CacheGetIn(BaseModel):
     key: str
 
-    linearizable: t.Optional[bool] = None
-    """Whether or not the read should be linearizable
-
-    If this is `true`, the read is guaranteed to see all previous operations, but will
-    have to make at least one additional round-trip to the leader. If this is false, stale
-    reads will be performed against the replica which receives this request."""
+    consistency: t.Optional[Consistency] = None

--- a/clients/python/coyote/models/cache_get_in.py
+++ b/clients/python/coyote/models/cache_get_in.py
@@ -1,11 +1,24 @@
 # this file is @generated
+import typing as t
 
 from ..internal.base_model import BaseModel
 
 
 class CacheGetIn(BaseModel):
-    pass
+    linearizable: t.Optional[bool] = None
+    """Whether or not the read should be linearizable
+
+    If this is `true`, the read is guaranteed to see all previous operations, but will
+    have to make at least one additional round-trip to the leader. If this is false, stale
+    reads will be performed against the replica which receives this request."""
 
 
 class _CacheGetIn(BaseModel):
     key: str
+
+    linearizable: t.Optional[bool] = None
+    """Whether or not the read should be linearizable
+
+    If this is `true`, the read is guaranteed to see all previous operations, but will
+    have to make at least one additional round-trip to the leader. If this is false, stale
+    reads will be performed against the replica which receives this request."""

--- a/clients/python/coyote/models/consistency.py
+++ b/clients/python/coyote/models/consistency.py
@@ -1,0 +1,15 @@
+# this file is @generated
+from enum import Enum
+
+
+class Consistency(str, Enum):
+    """Consistency level for reads.
+
+    Strong consistency (also known as linearizability) guarantees that a read will see all previous
+    writes. Weak consistency allows stale reads, but can save one or more round trip to the leader."""
+
+    STRONG = "strong"
+    WEAK = "weak"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/coyote/models/kv_get_in.py
+++ b/clients/python/coyote/models/kv_get_in.py
@@ -3,22 +3,14 @@ import typing as t
 
 from ..internal.base_model import BaseModel
 
+from .consistency import Consistency
+
 
 class KvGetIn(BaseModel):
-    linearizable: t.Optional[bool] = None
-    """Whether or not the read should be linearizable
-
-    If this is `true`, the read is guaranteed to see all previous operations, but will
-    have to make at least one additional round-trip to the leader. If this is false, stale
-    reads will be performed against the replica which receives this request."""
+    consistency: t.Optional[Consistency] = None
 
 
 class _KvGetIn(BaseModel):
     key: str
 
-    linearizable: t.Optional[bool] = None
-    """Whether or not the read should be linearizable
-
-    If this is `true`, the read is guaranteed to see all previous operations, but will
-    have to make at least one additional round-trip to the leader. If this is false, stale
-    reads will be performed against the replica which receives this request."""
+    consistency: t.Optional[Consistency] = None

--- a/clients/python/coyote/models/kv_get_in.py
+++ b/clients/python/coyote/models/kv_get_in.py
@@ -1,11 +1,24 @@
 # this file is @generated
+import typing as t
 
 from ..internal.base_model import BaseModel
 
 
 class KvGetIn(BaseModel):
-    pass
+    linearizable: t.Optional[bool] = None
+    """Whether or not the read should be linearizable
+
+    If this is `true`, the read is guaranteed to see all previous operations, but will
+    have to make at least one additional round-trip to the leader. If this is false, stale
+    reads will be performed against the replica which receives this request."""
 
 
 class _KvGetIn(BaseModel):
     key: str
+
+    linearizable: t.Optional[bool] = None
+    """Whether or not the read should be linearizable
+
+    If this is `true`, the read is guaranteed to see all previous operations, but will
+    have to make at least one additional round-trip to the leader. If this is false, stale
+    reads will be performed against the replica which receives this request."""

--- a/clients/rust/src/api/cache.rs
+++ b/clients/rust/src/api/cache.rs
@@ -31,8 +31,10 @@ impl<'a> Cache<'a> {
 
     /// Cache Get
     pub async fn get(&self, key: String, cache_get_in: CacheGetIn) -> Result<CacheGetOut> {
-        let _unused = cache_get_in;
-        let cache_get_in = CacheGetIn_ { key };
+        let cache_get_in = CacheGetIn_ {
+            key,
+            linearizable: cache_get_in.linearizable,
+        };
 
         crate::request::Request::new(http::Method::POST, "/api/v1/cache/get")
             .with_body(cache_get_in)

--- a/clients/rust/src/api/cache.rs
+++ b/clients/rust/src/api/cache.rs
@@ -33,7 +33,7 @@ impl<'a> Cache<'a> {
     pub async fn get(&self, key: String, cache_get_in: CacheGetIn) -> Result<CacheGetOut> {
         let cache_get_in = CacheGetIn_ {
             key,
-            linearizable: cache_get_in.linearizable,
+            consistency: cache_get_in.consistency,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1/cache/get")

--- a/clients/rust/src/api/kv.rs
+++ b/clients/rust/src/api/kv.rs
@@ -32,8 +32,10 @@ impl<'a> Kv<'a> {
 
     /// KV Get
     pub async fn get(&self, key: String, kv_get_in: KvGetIn) -> Result<KvGetOut> {
-        let _unused = kv_get_in;
-        let kv_get_in = KvGetIn_ { key };
+        let kv_get_in = KvGetIn_ {
+            key,
+            linearizable: kv_get_in.linearizable,
+        };
 
         crate::request::Request::new(http::Method::POST, "/api/v1/kv/get")
             .with_body(kv_get_in)

--- a/clients/rust/src/api/kv.rs
+++ b/clients/rust/src/api/kv.rs
@@ -34,7 +34,7 @@ impl<'a> Kv<'a> {
     pub async fn get(&self, key: String, kv_get_in: KvGetIn) -> Result<KvGetOut> {
         let kv_get_in = KvGetIn_ {
             key,
-            linearizable: kv_get_in.linearizable,
+            consistency: kv_get_in.consistency,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1/kv/get")

--- a/clients/rust/src/models/cache_get_in.rs
+++ b/clients/rust/src/models/cache_get_in.rs
@@ -1,24 +1,21 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
+use super::consistency::Consistency;
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct CacheGetIn {
-    /// Whether or not the read should be linearizable
-    ///
-    /// If this is `true`, the read is guaranteed to see all previous operations, but will
-    /// have to make at least one additional round-trip to the leader. If this is false, stale
-    /// reads will be performed against the replica which receives this request.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linearizable: Option<bool>,
+    pub consistency: Option<Consistency>,
 }
 
 impl CacheGetIn {
     pub fn new() -> Self {
-        Self { linearizable: None }
+        Self { consistency: None }
     }
 
-    pub fn with_linearizable(mut self, value: impl Into<Option<bool>>) -> Self {
-        self.linearizable = value.into();
+    pub fn with_consistency(mut self, value: impl Into<Option<Consistency>>) -> Self {
+        self.consistency = value.into();
         self
     }
 }
@@ -27,11 +24,6 @@ impl CacheGetIn {
 pub(crate) struct CacheGetIn_ {
     pub key: String,
 
-    /// Whether or not the read should be linearizable
-    ///
-    /// If this is `true`, the read is guaranteed to see all previous operations, but will
-    /// have to make at least one additional round-trip to the leader. If this is false, stale
-    /// reads will be performed against the replica which receives this request.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linearizable: Option<bool>,
+    pub consistency: Option<Consistency>,
 }

--- a/clients/rust/src/models/cache_get_in.rs
+++ b/clients/rust/src/models/cache_get_in.rs
@@ -2,15 +2,36 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct CacheGetIn {}
+pub struct CacheGetIn {
+    /// Whether or not the read should be linearizable
+    ///
+    /// If this is `true`, the read is guaranteed to see all previous operations, but will
+    /// have to make at least one additional round-trip to the leader. If this is false, stale
+    /// reads will be performed against the replica which receives this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linearizable: Option<bool>,
+}
 
 impl CacheGetIn {
     pub fn new() -> Self {
-        Self {}
+        Self { linearizable: None }
+    }
+
+    pub fn with_linearizable(mut self, value: impl Into<Option<bool>>) -> Self {
+        self.linearizable = value.into();
+        self
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct CacheGetIn_ {
     pub key: String,
+
+    /// Whether or not the read should be linearizable
+    ///
+    /// If this is `true`, the read is guaranteed to see all previous operations, but will
+    /// have to make at least one additional round-trip to the leader. If this is false, stale
+    /// reads will be performed against the replica which receives this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linearizable: Option<bool>,
 }

--- a/clients/rust/src/models/consistency.rs
+++ b/clients/rust/src/models/consistency.rs
@@ -1,0 +1,27 @@
+// this file is @generated
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Consistency level for reads.
+///
+/// Strong consistency (also known as linearizability) guarantees that a read will see all previous
+/// writes. Weak consistency allows stale reads, but can save one or more round trip to the leader.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum Consistency {
+    #[serde(rename = "strong")]
+    Strong,
+    #[serde(rename = "weak")]
+    Weak,
+}
+
+impl fmt::Display for Consistency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Strong => "strong",
+            Self::Weak => "weak",
+        };
+        f.write_str(value)
+    }
+}

--- a/clients/rust/src/models/kv_get_in.rs
+++ b/clients/rust/src/models/kv_get_in.rs
@@ -1,24 +1,21 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
+use super::consistency::Consistency;
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct KvGetIn {
-    /// Whether or not the read should be linearizable
-    ///
-    /// If this is `true`, the read is guaranteed to see all previous operations, but will
-    /// have to make at least one additional round-trip to the leader. If this is false, stale
-    /// reads will be performed against the replica which receives this request.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linearizable: Option<bool>,
+    pub consistency: Option<Consistency>,
 }
 
 impl KvGetIn {
     pub fn new() -> Self {
-        Self { linearizable: None }
+        Self { consistency: None }
     }
 
-    pub fn with_linearizable(mut self, value: impl Into<Option<bool>>) -> Self {
-        self.linearizable = value.into();
+    pub fn with_consistency(mut self, value: impl Into<Option<Consistency>>) -> Self {
+        self.consistency = value.into();
         self
     }
 }
@@ -27,11 +24,6 @@ impl KvGetIn {
 pub(crate) struct KvGetIn_ {
     pub key: String,
 
-    /// Whether or not the read should be linearizable
-    ///
-    /// If this is `true`, the read is guaranteed to see all previous operations, but will
-    /// have to make at least one additional round-trip to the leader. If this is false, stale
-    /// reads will be performed against the replica which receives this request.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linearizable: Option<bool>,
+    pub consistency: Option<Consistency>,
 }

--- a/clients/rust/src/models/kv_get_in.rs
+++ b/clients/rust/src/models/kv_get_in.rs
@@ -2,15 +2,36 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct KvGetIn {}
+pub struct KvGetIn {
+    /// Whether or not the read should be linearizable
+    ///
+    /// If this is `true`, the read is guaranteed to see all previous operations, but will
+    /// have to make at least one additional round-trip to the leader. If this is false, stale
+    /// reads will be performed against the replica which receives this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linearizable: Option<bool>,
+}
 
 impl KvGetIn {
     pub fn new() -> Self {
-        Self {}
+        Self { linearizable: None }
+    }
+
+    pub fn with_linearizable(mut self, value: impl Into<Option<bool>>) -> Self {
+        self.linearizable = value.into();
+        self
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct KvGetIn_ {
     pub key: String,
+
+    /// Whether or not the read should be linearizable
+    ///
+    /// If this is `true`, the read is guaranteed to see all previous operations, but will
+    /// have to make at least one additional round-trip to the leader. If this is false, stale
+    /// reads will be performed against the replica which receives this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linearizable: Option<bool>,
 }

--- a/clients/rust/src/models/mod.rs
+++ b/clients/rust/src/models/mod.rs
@@ -11,6 +11,7 @@ mod cache_get_namespace_out;
 mod cache_get_out;
 mod cache_set_in;
 mod cache_set_out;
+mod consistency;
 mod eviction_policy;
 mod idempotency_abort_in;
 mod idempotency_abort_out;
@@ -71,6 +72,7 @@ pub use self::{
     cache_get_out::CacheGetOut,
     cache_set_in::CacheSetIn,
     cache_set_out::CacheSetOut,
+    consistency::Consistency,
     eviction_policy::EvictionPolicy,
     idempotency_abort_in::IdempotencyAbortIn,
     idempotency_abort_out::IdempotencyAbortOut,

--- a/crates/coyote-core/src/types.rs
+++ b/crates/coyote-core/src/types.rs
@@ -334,6 +334,33 @@ impl Validate for EntityKey {
     }
 }
 
+/// Consistency level for reads.
+///
+/// Strong consistency (also known as linearizability) guarantees that a read will see all previous
+/// writes. Weak consistency allows stale reads, but can save one or more round trip to the leader.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, PartialOrd, Ord,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Consistency {
+    Strong,
+    Weak,
+}
+
+impl Consistency {
+    pub fn linearizable(&self) -> bool {
+        matches!(self, Self::Strong)
+    }
+
+    pub fn strong() -> Self {
+        Self::Strong
+    }
+
+    pub fn weak() -> Self {
+        Self::Weak
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use validator::Validate;

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -94,6 +94,12 @@ pub struct TableKey<Tag: TableRow> {
     _table: PhantomData<Tag>,
 }
 
+impl<Tag: TableRow> ::std::fmt::Debug for TableKey<Tag> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.key.fmt(f)
+    }
+}
+
 impl<'a, Tag: TableRow> TableKey<Tag> {
     /// Construct the key to be used for fjall
     ///

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -94,6 +94,7 @@ pub struct TableKey<Tag: TableRow> {
     _table: PhantomData<Tag>,
 }
 
+#[cfg(debug_assertions)]
 impl<Tag: TableRow> ::std::fmt::Debug for TableKey<Tag> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.key.fmt(f)

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -57,6 +57,7 @@ impl KvController {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn fetch(
         &self,
         namespace_id: NamespaceId,
@@ -102,6 +103,7 @@ impl KvController {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, value))]
     pub fn set(
         &self,
         namespace_id: NamespaceId,
@@ -137,6 +139,7 @@ impl KvController {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn delete(&self, namespace_id: NamespaceId, key: &str) -> Result<()> {
         let mut batch = self.db.batch();
 

--- a/openapi.json
+++ b/openapi.json
@@ -1068,6 +1068,11 @@
             "maxLength": 256,
             "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
             "example": "some_key"
+          },
+          "linearizable": {
+            "description": "Whether or not the read should be linearizable\n\nIf this is `true`, the read is guaranteed to see all previous operations, but will\nhave to make at least one additional round-trip to the leader. If this is false, stale\nreads will be performed against the replica which receives this request.",
+            "type": "boolean",
+            "default": false
           }
         },
         "required": [
@@ -1520,6 +1525,11 @@
             "maxLength": 256,
             "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
             "example": "some_key"
+          },
+          "linearizable": {
+            "description": "Whether or not the read should be linearizable\n\nIf this is `true`, the read is guaranteed to see all previous operations, but will\nhave to make at least one additional round-trip to the leader. If this is false, stale\nreads will be performed against the replica which receives this request.",
+            "type": "boolean",
+            "default": true
           }
         },
         "required": [

--- a/openapi.json
+++ b/openapi.json
@@ -1069,10 +1069,9 @@
             "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
             "example": "some_key"
           },
-          "linearizable": {
-            "description": "Whether or not the read should be linearizable\n\nIf this is `true`, the read is guaranteed to see all previous operations, but will\nhave to make at least one additional round-trip to the leader. If this is false, stale\nreads will be performed against the replica which receives this request.",
-            "type": "boolean",
-            "default": false
+          "consistency": {
+            "default": "weak",
+            "$ref": "#/components/schemas/Consistency"
           }
         },
         "required": [
@@ -1194,6 +1193,14 @@
       },
       "CacheSetOut": {
         "type": "object"
+      },
+      "Consistency": {
+        "description": "Consistency level for reads.\n\nStrong consistency (also known as linearizability) guarantees that a read will see all previous\nwrites. Weak consistency allows stale reads, but can save one or more round trip to the leader.",
+        "type": "string",
+        "enum": [
+          "strong",
+          "weak"
+        ]
       },
       "EvictionPolicy": {
         "type": "string",
@@ -1526,10 +1533,9 @@
             "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
             "example": "some_key"
           },
-          "linearizable": {
-            "description": "Whether or not the read should be linearizable\n\nIf this is `true`, the read is guaranteed to see all previous operations, but will\nhave to make at least one additional round-trip to the leader. If this is false, stale\nreads will be performed against the replica which receives this request.",
-            "type": "boolean",
-            "default": true
+          "consistency": {
+            "default": "strong",
+            "$ref": "#/components/schemas/Consistency"
           }
         },
         "required": [

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -58,6 +58,7 @@ pub fn router(cfg: &Configuration) -> axum::Router<AppState> {
             "/repl/raft/handle-forwarded-write",
             post(handle_forwarded_write),
         )
+        .route("/repl/raft/last-id", get(last_id))
         .route("/repl/raft/admin/add-learner", post(add_learner))
         .route("/repl/raft/admin/upgrade-learner", post(upgrade_learner))
         .route(
@@ -278,6 +279,16 @@ async fn initialize(
 
 async fn force_snapshot(Extension(state): Extension<RaftState>) -> impl IntoResponse {
     state.trigger_snapshot().await.pipe(admin_response)
+}
+
+async fn last_id(Extension(state): Extension<RaftState>) -> impl IntoResponse {
+    state
+        .raft
+        .with_raft_state(move |s| LastIdResponse {
+            last_committed_log_id: s.committed,
+        })
+        .await
+        .pipe(rpc_response)
 }
 
 async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, time::Duration};
 
 use crate::{cfg::Configuration, core::cluster::state_machine::StoreHandle};
 
@@ -320,5 +320,52 @@ impl RaftState {
             .send(BackgroundCommand::Snapshot)
             .await
             .context("attempting to send background command to trigger snapshot")
+    }
+
+    /// Accomplish a linearizable wait for the caller
+    ///
+    /// On the leader, this is implemented by calling `openraft::Raft::ensure_linearizable`.
+    pub async fn wait_linearizable(&self) -> anyhow::Result<()> {
+        let leader_id = match self.raft.current_leader().await {
+            Some(n) if n == self.node_id => {
+                tracing::trace!("performing a linearizable read on the leader");
+                self.raft.ensure_linearizable().await?;
+                return Ok(());
+            }
+            Some(leader) => leader,
+            None => anyhow::bail!("no cluster leader, cannot perform linearizable operations"),
+        };
+        let leader_id_for_lookup = leader_id.clone();
+        let leader_node = self
+            .raft
+            .with_raft_state(move |s| {
+                s.membership_state
+                    .effective()
+                    .get_node(&leader_id_for_lookup)
+                    .cloned()
+            })
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("unable to look up leader node IP"))?;
+        tracing::trace!(?leader_id, "performing a linearizable read on a follower");
+        let mut network_handle = self.network.clone();
+        let client = network_handle.new_client(leader_id, &leader_node).await;
+        let Some(last_committed_log_id) = client.get_last_committed_log_id().await? else {
+            tracing::warn!(
+                "attempted to do a linearizable read, but nothing has ever been written"
+            );
+            return Ok(());
+        };
+
+        const DEFAULT_WAIT_TIME: Duration = Duration::from_secs(1);
+
+        tracing::trace!(?last_committed_log_id, "waiting for follower to apply logs");
+        self.raft
+            .wait(Some(DEFAULT_WAIT_TIME))
+            .applied_index_at_least(
+                Some(last_committed_log_id.index),
+                "waiting for linearizability",
+            )
+            .await?;
+        Ok(())
     }
 }

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -178,6 +178,17 @@ impl NetworkClient {
         self.send_request("/repl/raft/admin/upgrade-learner", req)
             .await
     }
+
+    pub(super) async fn get_last_committed_log_id(
+        &self,
+    ) -> Result<Option<openraft::LogId<NodeId>>, RPCError<NodeId, Node, UnreachableError>> {
+        let proto::LastIdResponse {
+            last_committed_log_id,
+        } = self
+            .send_request("/repl/raft/last-id", proto::LastIdRequest {})
+            .await?;
+        Ok(last_committed_log_id)
+    }
 }
 
 impl RaftNetwork<TypeConfig> for NetworkClient {

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -67,3 +67,11 @@ pub struct ForwardedWriteResponse {
     pub log_id: LogId<NodeId>,
     pub response: Response,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LastIdRequest {}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LastIdResponse {
+    pub last_committed_log_id: Option<LogId<NodeId>>,
+}

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -57,6 +57,13 @@ pub struct CacheSetOut {}
 pub struct CacheGetIn {
     #[validate(nested)]
     pub key: EntityKey,
+    /// Whether or not the read should be linearizable
+    ///
+    /// If this is `true`, the read is guaranteed to see all previous operations, but will
+    /// have to make at least one additional round-trip to the leader. If this is false, stale
+    /// reads will be performed against the replica which receives this request.
+    #[serde(default)]
+    pub linearizable: bool,
 }
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]
@@ -153,7 +160,9 @@ async fn cache_get(
         .fetch_namespace(data.key.namespace())?
         .ok_or_not_found()?;
 
-    repl.raft.ensure_linearizable().await.map_err_generic()?;
+    if data.linearizable {
+        repl.wait_linearizable().await.map_err_generic()?;
+    }
 
     // FIXME: support more than just persistent, etc.
     let cache_state = coyote_cache::State::init(state.do_not_use_dbs.clone())?;
@@ -225,7 +234,7 @@ async fn cache_get_namespace(
     MsgPackOrJson(data): MsgPackOrJson<CacheGetNamespaceIn>,
 ) -> Result<MsgPackOrJson<CacheGetNamespaceOut>> {
     // Ensure we have the latest version of namespace
-    repl.raft.ensure_linearizable().await.map_err_generic()?;
+    repl.wait_linearizable().await.map_err_generic()?;
 
     let namespace: CacheNamespace = state
         .namespace_state

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -9,7 +9,7 @@ use coyote_cache::{
     CacheModel,
     operations::{CreateCacheOperation, DeleteOperation, SetOperation},
 };
-use coyote_core::types::EntityKey;
+use coyote_core::types::{Consistency, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{Error, HttpError, OptionExt, ResultExt};
 use coyote_kv::kvcontroller::KvModel;
@@ -57,13 +57,8 @@ pub struct CacheSetOut {}
 pub struct CacheGetIn {
     #[validate(nested)]
     pub key: EntityKey,
-    /// Whether or not the read should be linearizable
-    ///
-    /// If this is `true`, the read is guaranteed to see all previous operations, but will
-    /// have to make at least one additional round-trip to the leader. If this is false, stale
-    /// reads will be performed against the replica which receives this request.
-    #[serde(default)]
-    pub linearizable: bool,
+    #[serde(default = "Consistency::weak")]
+    pub consistency: Consistency,
 }
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]
@@ -160,7 +155,7 @@ async fn cache_get(
         .fetch_namespace(data.key.namespace())?
         .ok_or_not_found()?;
 
-    if data.linearizable {
+    if data.consistency.linearizable() {
         repl.wait_linearizable().await.map_err_generic()?;
     }
 

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -211,7 +211,7 @@ async fn idempotency_get_namespace(
     MsgPackOrJson(data): MsgPackOrJson<IdempotencyGetNamespaceIn>,
 ) -> Result<MsgPackOrJson<IdempotencyGetNamespaceOut>> {
     // Ensure we have the latest version of namespace
-    repl.raft.ensure_linearizable().await.map_err_generic()?;
+    repl.wait_linearizable().await.map_err_generic()?;
 
     let namespace: IdempotencyNamespace = state
         .namespace_state

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -54,8 +54,12 @@ pub struct KvGetIn {
     /// If this is `true`, the read is guaranteed to see all previous operations, but will
     /// have to make at least one additional round-trip to the leader. If this is false, stale
     /// reads will be performed against the replica which receives this request.
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub linearizable: bool,
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -49,6 +49,13 @@ pub struct KvSetOut {}
 pub struct KvGetIn {
     #[validate(nested)]
     pub key: EntityKey,
+    /// Whether or not the read should be linearizable
+    ///
+    /// If this is `true`, the read is guaranteed to see all previous operations, but will
+    /// have to make at least one additional round-trip to the leader. If this is false, stale
+    /// reads will be performed against the replica which receives this request.
+    #[serde(default)]
+    pub linearizable: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -115,7 +122,9 @@ async fn kv_get(
         .fetch_namespace(data.key.namespace())?
         .ok_or_not_found()?;
 
-    repl.raft.ensure_linearizable().await.map_err_generic()?;
+    if data.linearizable {
+        repl.wait_linearizable().await.map_err_generic()?;
+    }
 
     // FIXME: this state should be passed, not created every time.
     let kv_state = coyote_kv::State::init(state.do_not_use_dbs.clone())?;
@@ -212,7 +221,7 @@ async fn kv_get_namespace(
     MsgPackOrJson(data): MsgPackOrJson<KvGetNamespaceIn>,
 ) -> Result<MsgPackOrJson<KvGetNamespaceOut>> {
     // Ensure we have the latest version of namespace
-    repl.raft.ensure_linearizable().await.map_err_generic()?;
+    repl.wait_linearizable().await.map_err_generic()?;
 
     let namespace: KvNamespace = state
         .namespace_state

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU64;
 
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
-use coyote_core::types::EntityKey;
+use coyote_core::types::{Consistency, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{Error, HttpError, OptionExt, ResultExt};
 use coyote_kv::{
@@ -49,17 +49,8 @@ pub struct KvSetOut {}
 pub struct KvGetIn {
     #[validate(nested)]
     pub key: EntityKey,
-    /// Whether or not the read should be linearizable
-    ///
-    /// If this is `true`, the read is guaranteed to see all previous operations, but will
-    /// have to make at least one additional round-trip to the leader. If this is false, stale
-    /// reads will be performed against the replica which receives this request.
-    #[serde(default = "default_true")]
-    pub linearizable: bool,
-}
-
-const fn default_true() -> bool {
-    true
+    #[serde(default = "Consistency::strong")]
+    pub consistency: Consistency,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -126,7 +117,7 @@ async fn kv_get(
         .fetch_namespace(data.key.namespace())?
         .ok_or_not_found()?;
 
-    if data.linearizable {
+    if data.consistency.linearizable() {
         repl.wait_linearizable().await.map_err_generic()?;
     }
 

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -83,7 +83,7 @@ async fn get_namespace(
     MsgPackOrJson(data): MsgPackOrJson<MsgNamespaceGetIn>,
 ) -> Result<MsgPackOrJson<MsgNamespaceGetOut>> {
     // Ensure we have the latest version of namespace
-    repl.raft.ensure_linearizable().await.map_err_generic()?;
+    repl.wait_linearizable().await.map_err_generic()?;
 
     let namespace: MsgsNamespace = state
         .namespace_state


### PR DESCRIPTION
This makes it possible to do either linearizable **or** stale reads from replicas for both KV and Cache, and also to read namespaces from replicas.