### PR TITLE
cli: improve usability of CLI

### DIFF
--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -27,7 +27,7 @@ rustls-tls = ["coyote-client/rustls-tls"]
 
 [dependencies]
 anyhow.workspace = true
-clap.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
 clap_complete.workspace = true
 colored_json.workspace = true
 comfy-table = "7"

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -1,5 +1,7 @@
 use std::{fs, path::PathBuf};
 
+use super::Cli;
+
 use anyhow::Context as _;
 use config::FileFormat;
 use serde::{Deserialize, Serialize};
@@ -13,12 +15,10 @@ pub struct Config {
     #[cfg(all(feature = "http1", feature = "http2"))]
     #[serde(default)]
     pub http1: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    debug_url: Option<String>,
 }
 
 impl Config {
-    pub fn load() -> anyhow::Result<Config> {
+    pub fn load(cli: &Cli) -> anyhow::Result<Config> {
         let cfg_file = get_config_file_path()?;
         let cfg_file = cfg_file
             .as_os_str()
@@ -30,24 +30,29 @@ impl Config {
             builder = builder.add_source(config::File::new(cfg_file, FileFormat::Toml));
         }
 
+        let cli_config = config::Config::builder()
+            .set_override("server_url", cli.server_url.clone())?
+            .set_override("auth_token", cli.auth_token.clone())?
+            .build()?;
+
         builder
+            .add_source(cli_config)
             .add_source(config::Environment::with_prefix("COYOTE"))
             .build()?
             .try_deserialize()
             .context("failed to extract configuration")
     }
 
-    /// Gives the `server_url` for a Svix client with fallback to the legacy `SVIX_DEBUG_URL` variable/config.
     pub fn server_url(&self) -> Option<&str> {
-        match self.server_url.as_deref() {
-            Some(s) if s.trim().is_empty() => self.debug_url.as_deref(),
-            server_url @ Some(_) => server_url,
-            None => self.debug_url.as_deref(),
-        }
+        self.server_url.as_deref()
+    }
+
+    pub fn auth_token(&self) -> String {
+        self.auth_token.as_deref().unwrap_or("xxx").to_owned()
     }
 }
 
-const FILE_NAME: &str = "config.toml";
+const FILE_NAME: &str = "coyote-cli-config.toml";
 
 fn get_folder() -> anyhow::Result<PathBuf> {
     Ok(dirs::config_dir()

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 use colored_json::{ColorMode, Output};
 use concolor_clap::{Color, ColorChoice};
-use coyote_client::{CoyoteClient, CoyoteOptions};
+use coyote_client::{CoyoteClient, CoyoteOptions, DEFAULT_URL};
 use mimalloc::MiMalloc;
 
 #[global_allocator]
@@ -39,6 +39,19 @@ struct Cli {
         help = "Log more. This option may be repeated up to 3 times"
     )]
     verbose: u8,
+    #[arg(
+        short,
+        long,
+        help = format!("Base url for server. Overrides any config file. If not passed, {DEFAULT_URL} is used"),
+        env = "COYOTE_SERVER_URL"
+    )]
+    server_url: Option<String>,
+    #[arg(
+        long,
+        help = "Authentication token. Overrides any config file.",
+        env = "COYOTE_AUTH_TOKEN"
+    )]
+    auth_token: Option<String>,
     #[command(subcommand)]
     command: RootCommands,
 }
@@ -104,7 +117,7 @@ async fn main() -> Result<()> {
     // Assigning the variable here since several match arms need a `&Config` but the rest of them
     // won't care/are still usable if the config doesn't exist.
     // To this, the `?` is deferred until the point inside a given match arm needs the config value.
-    let cfg = Config::load();
+    let cfg = Config::load(&cli);
     match cli.command {
         // Local-only things
         RootCommands::Version => println!("{VERSION}"),
@@ -142,7 +155,7 @@ async fn main() -> Result<()> {
             if let Some(url) = args.server_url.clone() {
                 opts.server_url = Some(url);
             }
-            let client = Arc::new(CoyoteClient::new("xxx".to_owned(), Some(opts)));
+            let client = Arc::new(CoyoteClient::new(cfg.auth_token(), Some(opts)));
             args.exec(client).await?;
         }
     }
@@ -156,7 +169,7 @@ fn get_client(cfg: &Config) -> Result<CoyoteClient> {
         anyhow::anyhow!("No auth token set. Try running `{BIN_NAME} login` to get started.")
     })?; */
     let opts = get_client_options(cfg)?;
-    Ok(CoyoteClient::new("xxx".to_owned(), Some(opts)))
+    Ok(CoyoteClient::new(cfg.auth_token(), Some(opts)))
 }
 
 fn get_client_options(cfg: &Config) -> Result<CoyoteOptions> {

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -6,6 +6,8 @@ use crate::{Configuration, connector::make_connector};
 
 const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+pub const DEFAULT_URL: &str = "http://localhost:8050";
+
 pub struct CoyoteOptions {
     pub debug: bool,
 
@@ -110,7 +112,7 @@ impl CoyoteClient {
         let base_path = self
             .server_url
             .clone()
-            .unwrap_or_else(|| "http://localhost:8050".to_owned());
+            .unwrap_or_else(|| DEFAULT_URL.to_owned());
         let cfg = Arc::new(Configuration {
             base_path,
             user_agent: self.cfg.user_agent.clone(),

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -12,7 +12,7 @@ mod request;
 
 use self::connector::Connector;
 pub use self::{
-    client::{CoyoteClient, CoyoteOptions},
+    client::{CoyoteClient, CoyoteOptions, DEFAULT_URL},
     error::{Error, Result},
 };
 


### PR DESCRIPTION
Changes:

 1. Add command-line flags for server URL and auth token (the two most likely things someone is going to want to override)
 2. Make sure that the environment variable names used to set them appear in `--help`
 3. Change config path to be read from `~/.config/coyote-cli-config.toml` instead of `~/.config/config.toml`
 4. Remove `debug_url` concept entirely, which doesn't really make sense for this application