### PR TITLE
Fix namespace/topic id creation

### DIFF
--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 
 use coyote_namespace::{
-    entities::{CacheConfig, EvictionPolicy, StorageType},
+    entities::{CacheConfig, EvictionPolicy, NamespaceId, StorageType, gen_namespace_id},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 use jiff::Timestamp;
@@ -15,11 +15,13 @@ pub struct CreateCacheOperation {
     eviction_policy: EvictionPolicy,
     storage_type: StorageType,
     max_storage_bytes: Option<NonZeroU64>,
+    id: NamespaceId,
 }
 
 impl From<CreateCacheOperation> for CreateNamespace<CacheConfig> {
     fn from(value: CreateCacheOperation) -> Self {
         CreateNamespace::new(
+            value.id,
             value.name,
             CacheConfig {
                 eviction_policy: value.eviction_policy,
@@ -38,6 +40,7 @@ impl CreateCacheOperation {
         max_storage_bytes: Option<NonZeroU64>,
     ) -> Self {
         Self {
+            id: gen_namespace_id(),
             name,
             eviction_policy,
             storage_type,

--- a/crates/coyote-namespace/src/entities.rs
+++ b/crates/coyote-namespace/src/entities.rs
@@ -12,6 +12,15 @@ pub use fjall_utils::StorageType;
 pub type NamespaceId = Uuid;
 pub type NamespaceName = String;
 
+pub fn gen_namespace_id() -> NamespaceId {
+    let ts = jiff::Timestamp::now();
+    Uuid::new_v7(uuid::Timestamp::from_unix(
+        uuid::NoContext,
+        ts.as_second() as u64,
+        ts.subsec_nanosecond() as u32,
+    ))
+}
+
 #[derive(Serialize, Deserialize)]
 #[repr(u8)]
 pub enum Module {

--- a/crates/coyote-namespace/src/operations/create_namespace.rs
+++ b/crates/coyote-namespace/src/operations/create_namespace.rs
@@ -20,6 +20,7 @@ pub struct CreateNamespace<C: ModuleConfig> {
     storage_type: StorageType,
     max_storage_bytes: Option<NonZeroU64>,
     config: C,
+    id: NamespaceId,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -36,6 +37,7 @@ pub struct CreateNamespaceOutput<C: ModuleConfig> {
 
 impl<C: ModuleConfig> CreateNamespace<C> {
     pub fn new(
+        id: NamespaceId,
         name: String,
         config: C,
         storage_type: StorageType,
@@ -43,6 +45,7 @@ impl<C: ModuleConfig> CreateNamespace<C> {
     ) -> Self {
         Self {
             timestamp: Timestamp::now(),
+            id,
             name,
             config,
             storage_type,
@@ -61,22 +64,15 @@ impl<C: ModuleConfig> CreateNamespace<C> {
                 namespace.config = self.config;
                 namespace
             }
-            None => {
-                let id = NamespaceId::new_v7(uuid::Timestamp::from_unix(
-                    uuid::NoContext,
-                    self.timestamp.as_second() as u64,
-                    self.timestamp.subsec_nanosecond() as u32,
-                ));
-                Namespace {
-                    id,
-                    name: self.name,
-                    storage_type: self.storage_type,
-                    max_storage_bytes: self.max_storage_bytes,
-                    created_at: self.timestamp,
-                    updated_at: self.timestamp,
-                    config: self.config,
-                }
-            }
+            None => Namespace {
+                id: self.id,
+                name: self.name,
+                storage_type: self.storage_type,
+                max_storage_bytes: self.max_storage_bytes,
+                created_at: self.timestamp,
+                updated_at: self.timestamp,
+                config: self.config,
+            },
         };
 
         {

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 
 use coyote_namespace::{
-    entities::{IdempotencyConfig, StorageType},
+    entities::{IdempotencyConfig, NamespaceId, StorageType, gen_namespace_id},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 use jiff::Timestamp;
@@ -14,11 +14,13 @@ pub struct CreateIdempotencyOperation {
     pub(crate) name: String,
     storage_type: StorageType,
     max_storage_bytes: Option<NonZeroU64>,
+    id: NamespaceId,
 }
 
 impl From<CreateIdempotencyOperation> for CreateNamespace<IdempotencyConfig> {
     fn from(value: CreateIdempotencyOperation) -> Self {
         CreateNamespace::new(
+            value.id,
             value.name,
             IdempotencyConfig {},
             value.storage_type,
@@ -34,6 +36,7 @@ impl CreateIdempotencyOperation {
         max_storage_bytes: Option<NonZeroU64>,
     ) -> Self {
         Self {
+            id: gen_namespace_id(),
             name,
             storage_type,
             max_storage_bytes,

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 
 use coyote_namespace::{
-    entities::{KeyValueConfig, StorageType},
+    entities::{KeyValueConfig, NamespaceId, StorageType, gen_namespace_id},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 use jiff::Timestamp;
@@ -14,11 +14,13 @@ pub struct CreateKvOperation {
     pub(crate) name: String,
     storage_type: StorageType,
     max_storage_bytes: Option<NonZeroU64>,
+    id: NamespaceId,
 }
 
 impl From<CreateKvOperation> for CreateNamespace<KeyValueConfig> {
     fn from(value: CreateKvOperation) -> Self {
         CreateNamespace::new(
+            value.id,
             value.name,
             KeyValueConfig {},
             value.storage_type,
@@ -34,6 +36,7 @@ impl CreateKvOperation {
         max_storage_bytes: Option<NonZeroU64>,
     ) -> Self {
         Self {
+            id: gen_namespace_id(),
             name,
             storage_type,
             max_storage_bytes,

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -460,6 +460,10 @@ impl JsonSchema for ConsumerGroup {
 // FIXME: should be a newtype
 pub type TopicId = Uuid;
 
+pub fn gen_topic_id() -> TopicId {
+    coyote_namespace::entities::gen_namespace_id()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct Retention {
     #[serde(default = "default_retention_millis")]

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use coyote_namespace::{
-    entities::{NamespaceName, StorageType, StreamConfig},
+    entities::{NamespaceId, NamespaceName, StorageType, StreamConfig, gen_namespace_id},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 
@@ -16,11 +16,13 @@ pub struct CreateNamespaceOperation {
     pub name: NamespaceName,
     pub retention: Retention,
     pub storage_type: StorageType,
+    id: NamespaceId,
 }
 
 impl CreateNamespaceOperation {
     pub fn new(name: NamespaceName, retention: Retention, storage_type: StorageType) -> Self {
         Self {
+            id: gen_namespace_id(),
             name,
             retention,
             storage_type,
@@ -32,6 +34,7 @@ impl CreateNamespaceOperation {
         namespace_state: &coyote_namespace::State,
     ) -> coyote_operations::Result<CreateNamespaceResponseData> {
         let op = CreateNamespace::new(
+            self.id,
             self.name,
             StreamConfig {
                 retention_period: Duration::from_millis(self.retention.millis.get()),

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 use crate::{
     State,
     entities::{
-        MsgIn, Offset, Partition, TopicId, TopicIn, TopicName, TopicPartition, partition_for_key,
+        MsgIn, Offset, Partition, TopicId, TopicIn, TopicName, TopicPartition, gen_topic_id,
+        partition_for_key,
     },
     tables::{MsgRow, TopicRow},
 };
@@ -24,6 +25,7 @@ pub struct PublishOperation {
     partition: Option<Partition>,
     msgs: Vec<MsgIn>,
     now: Timestamp,
+    topic_id: TopicId,
 }
 
 impl PublishOperation {
@@ -50,6 +52,7 @@ impl PublishOperation {
             partition,
             msgs,
             now: Timestamp::now(),
+            topic_id: gen_topic_id(),
         })
     }
 
@@ -71,7 +74,7 @@ impl PublishOperation {
                 return Err(Error::invalid_user_input("topic does not exist").into());
             }
             (None, None) => {
-                let row = TopicRow::new(self.topic.clone(), self.now);
+                let row = TopicRow::new(self.topic_id, self.topic.clone());
                 batch.insert_row(
                     &state.metadata_tables,
                     TopicRow::key_for(self.namespace_id, &self.topic),

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -9,7 +9,7 @@ use tracing::Span;
 
 use crate::{
     State,
-    entities::{ConsumerGroup, MsgId, Partition, TopicId, TopicIn, TopicName},
+    entities::{ConsumerGroup, MsgId, Partition, TopicId, TopicIn, TopicName, gen_topic_id},
     tables::{MsgRow, QueueLeaseRow, StreamLeaseRow, TopicRow},
 };
 
@@ -24,6 +24,8 @@ pub struct QueueReceiveOperation {
     batch_size: NonZeroU16,
     lease_duration_millis: u64,
     now: Timestamp,
+    // Only used if topic doesn't already exist
+    maybe_topic_id: TopicId,
 }
 
 impl QueueReceiveOperation {
@@ -46,6 +48,7 @@ impl QueueReceiveOperation {
             batch_size,
             lease_duration_millis,
             now: Timestamp::now(),
+            maybe_topic_id: gen_topic_id(),
         })
     }
 
@@ -64,7 +67,7 @@ impl QueueReceiveOperation {
             &mut batch,
             self.namespace_id,
             &self.topic,
-            self.now,
+            self.maybe_topic_id,
         )?;
 
         Span::current().record("partition_count", topic_row.partitions);

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -9,7 +9,9 @@ use tracing::Span;
 
 use crate::{
     State,
-    entities::{ConsumerGroup, Offset, Partition, TopicIn, TopicName, TopicPartition},
+    entities::{
+        ConsumerGroup, Offset, Partition, TopicId, TopicIn, TopicName, TopicPartition, gen_topic_id,
+    },
     tables::{MsgRow, StreamLeaseRow, TopicRow},
 };
 
@@ -24,6 +26,8 @@ pub struct StreamReceiveOperation {
     batch_size: NonZeroU16,
     lease_duration_millis: u64,
     now: Timestamp,
+    // Only used if topic doesn't already exist
+    maybe_topic_id: TopicId,
 }
 
 impl StreamReceiveOperation {
@@ -46,6 +50,7 @@ impl StreamReceiveOperation {
             batch_size,
             lease_duration_millis,
             now: Timestamp::now(),
+            maybe_topic_id: gen_topic_id(),
         })
     }
 
@@ -63,7 +68,7 @@ impl StreamReceiveOperation {
             &mut batch,
             self.namespace_id,
             &self.topic,
-            self.now,
+            self.maybe_topic_id,
         )?;
 
         Span::current().record("partition_count", topic_row.partitions);

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -7,7 +7,7 @@ use coyote_error::Error;
 
 use crate::{
     State,
-    entities::{MAX_PARTITION_COUNT, TopicName},
+    entities::{MAX_PARTITION_COUNT, TopicId, TopicName, gen_topic_id},
     tables::TopicRow,
 };
 
@@ -19,6 +19,7 @@ pub struct TopicConfigureOperation {
     pub(crate) topic: TopicName,
     partitions: u16,
     now: Timestamp,
+    topic_id: TopicId,
 }
 
 impl TopicConfigureOperation {
@@ -37,6 +38,7 @@ impl TopicConfigureOperation {
             topic,
             partitions,
             now: Timestamp::now(),
+            topic_id: gen_topic_id(),
         })
     }
 
@@ -46,7 +48,7 @@ impl TopicConfigureOperation {
             TopicRow::key_for(self.namespace_id, &self.topic),
         )? {
             Some(topic_row) => topic_row,
-            None => TopicRow::new(self.topic.clone(), self.now),
+            None => TopicRow::new(self.topic_id, self.topic.clone()),
         };
 
         if self.partitions < topic_row.partitions {

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -35,13 +35,9 @@ impl TopicRow {
         TableKey::init_key(Self::ROW_TYPE, &[namespace_id.as_bytes()], &[topic])
     }
 
-    pub(crate) fn new(name: TopicName, now: Timestamp) -> Self {
+    pub(crate) fn new(id: TopicId, name: TopicName) -> Self {
         Self {
-            id: uuid::Uuid::new_v7(uuid::Timestamp::from_unix(
-                uuid::NoContext,
-                now.as_second() as u64,
-                now.subsec_nanosecond() as u32,
-            )),
+            id,
             name,
             partitions: 1,
         }
@@ -60,12 +56,12 @@ impl TopicRow {
         batch: &mut fjall::OwnedWriteBatch,
         namespace_id: NamespaceId,
         topic: &TopicName,
-        now: Timestamp,
+        maybe_topic_id: TopicId,
     ) -> Result<Self> {
         if let Some(row) = Self::fetch(metadata_tables, Self::key_for(namespace_id, topic))? {
             return Ok(row);
         }
-        let row = Self::new(topic.clone(), now);
+        let row = Self::new(maybe_topic_id, topic.clone());
         batch.insert_row(metadata_tables, Self::key_for(namespace_id, topic), &row)?;
         Ok(row)
     }


### PR DESCRIPTION
Create relevant IDs before operations are applied, else
each node will create different IDs when it processes the 
operations.

