### PR TITLE
js: Clean up whitespace in generated code

### DIFF
--- a/clients/javascript/src/apis/cache.ts
+++ b/clients/javascript/src/apis/cache.ts
@@ -35,64 +35,50 @@ export class Cache {
     }
 
     /** Cache Set */
-        public set(
-            cacheSetIn: CacheSetIn,
-            ): Promise<CacheSetOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/set");
+    public set(
+        cacheSetIn: CacheSetIn,
+        ): Promise<CacheSetOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/set");
 
-            request.setBody(
-                    CacheSetInSerializer._toJsonObject(
-                        cacheSetIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    CacheSetOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            CacheSetInSerializer._toJsonObject(
+                cacheSetIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            CacheSetOutSerializer._fromJsonObject,
+        );
+    }/** Cache Get */
+    public get(
+        cacheGetIn: CacheGetIn,
+        ): Promise<CacheGetOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/get");
 
-        
+        request.setBody(
+            CacheGetInSerializer._toJsonObject(
+                cacheGetIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            CacheGetOutSerializer._fromJsonObject,
+        );
+    }/** Cache Delete */
+    public delete(
+        cacheDeleteIn: CacheDeleteIn,
+        ): Promise<CacheDeleteOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/delete");
 
-    /** Cache Get */
-        public get(
-            cacheGetIn: CacheGetIn,
-            ): Promise<CacheGetOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/get");
-
-            request.setBody(
-                    CacheGetInSerializer._toJsonObject(
-                        cacheGetIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    CacheGetOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
-    /** Cache Delete */
-        public delete(
-            cacheDeleteIn: CacheDeleteIn,
-            ): Promise<CacheDeleteOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/delete");
-
-            request.setBody(
-                    CacheDeleteInSerializer._toJsonObject(
-                        cacheDeleteIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    CacheDeleteOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            CacheDeleteInSerializer._toJsonObject(
+                cacheDeleteIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            CacheDeleteOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/cacheNamespace.ts
+++ b/clients/javascript/src/apis/cacheNamespace.ts
@@ -22,44 +22,35 @@ export class CacheNamespace {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Create cache namespace */
-        public create(
-            cacheCreateNamespaceIn: CacheCreateNamespaceIn,
-            ): Promise<CacheCreateNamespaceOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/namespace/create");
+    public create(
+        cacheCreateNamespaceIn: CacheCreateNamespaceIn,
+        ): Promise<CacheCreateNamespaceOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/namespace/create");
 
-            request.setBody(
-                    CacheCreateNamespaceInSerializer._toJsonObject(
-                        cacheCreateNamespaceIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    CacheCreateNamespaceOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            CacheCreateNamespaceInSerializer._toJsonObject(
+                cacheCreateNamespaceIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            CacheCreateNamespaceOutSerializer._fromJsonObject,
+        );
+    }/** Get cache namespace */
+    public get(
+        cacheGetNamespaceIn: CacheGetNamespaceIn,
+        ): Promise<CacheGetNamespaceOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/namespace/get");
 
-        
-
-    /** Get cache namespace */
-        public get(
-            cacheGetNamespaceIn: CacheGetNamespaceIn,
-            ): Promise<CacheGetNamespaceOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/namespace/get");
-
-            request.setBody(
-                    CacheGetNamespaceInSerializer._toJsonObject(
-                        cacheGetNamespaceIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    CacheGetNamespaceOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            CacheGetNamespaceInSerializer._toJsonObject(
+                cacheGetNamespaceIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            CacheGetNamespaceOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/health.ts
+++ b/clients/javascript/src/apis/health.ts
@@ -10,18 +10,15 @@ export class Health {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Verify the server is up and running. */
-        public ping(
-            ): Promise<PingOut> {
-            const request = new CoyoteRequest(HttpMethod.GET, "/api/v1/health/ping");
-
-            
-                return request.send(
-                    this.requestCtx,
-                    PingOutSerializer._fromJsonObject,
-                );
-            }
+    public ping(
+        ): Promise<PingOut> {
+        const request = new CoyoteRequest(HttpMethod.GET, "/api/v1/health/ping");
 
         
-
+        return request.send(
+            this.requestCtx,
+            PingOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/idempotency.ts
+++ b/clients/javascript/src/apis/idempotency.ts
@@ -19,24 +19,20 @@ export class Idempotency {
     }
 
     /** Abandon an idempotent request (remove lock without saving response) */
-        public abort(
-            idempotencyAbortIn: IdempotencyAbortIn,
-            ): Promise<IdempotencyAbortOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/abort");
+    public abort(
+        idempotencyAbortIn: IdempotencyAbortIn,
+        ): Promise<IdempotencyAbortOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/abort");
 
-            request.setBody(
-                    IdempotencyAbortInSerializer._toJsonObject(
-                        idempotencyAbortIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    IdempotencyAbortOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            IdempotencyAbortInSerializer._toJsonObject(
+                idempotencyAbortIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            IdempotencyAbortOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/idempotencyNamespace.ts
+++ b/clients/javascript/src/apis/idempotencyNamespace.ts
@@ -22,44 +22,35 @@ export class IdempotencyNamespace {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Create idempotency namespace */
-        public create(
-            idempotencyCreateNamespaceIn: IdempotencyCreateNamespaceIn,
-            ): Promise<IdempotencyCreateNamespaceOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/namespace/create");
+    public create(
+        idempotencyCreateNamespaceIn: IdempotencyCreateNamespaceIn,
+        ): Promise<IdempotencyCreateNamespaceOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/namespace/create");
 
-            request.setBody(
-                    IdempotencyCreateNamespaceInSerializer._toJsonObject(
-                        idempotencyCreateNamespaceIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    IdempotencyCreateNamespaceOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            IdempotencyCreateNamespaceInSerializer._toJsonObject(
+                idempotencyCreateNamespaceIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            IdempotencyCreateNamespaceOutSerializer._fromJsonObject,
+        );
+    }/** Get idempotency namespace */
+    public get(
+        idempotencyGetNamespaceIn: IdempotencyGetNamespaceIn,
+        ): Promise<IdempotencyGetNamespaceOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/namespace/get");
 
-        
-
-    /** Get idempotency namespace */
-        public get(
-            idempotencyGetNamespaceIn: IdempotencyGetNamespaceIn,
-            ): Promise<IdempotencyGetNamespaceOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/namespace/get");
-
-            request.setBody(
-                    IdempotencyGetNamespaceInSerializer._toJsonObject(
-                        idempotencyGetNamespaceIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    IdempotencyGetNamespaceOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            IdempotencyGetNamespaceInSerializer._toJsonObject(
+                idempotencyGetNamespaceIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            IdempotencyGetNamespaceOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/kv.ts
+++ b/clients/javascript/src/apis/kv.ts
@@ -35,64 +35,50 @@ export class Kv {
     }
 
     /** KV Set */
-        public set(
-            kvSetIn: KvSetIn,
-            ): Promise<KvSetOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/set");
+    public set(
+        kvSetIn: KvSetIn,
+        ): Promise<KvSetOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/set");
 
-            request.setBody(
-                    KvSetInSerializer._toJsonObject(
-                        kvSetIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    KvSetOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            KvSetInSerializer._toJsonObject(
+                kvSetIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            KvSetOutSerializer._fromJsonObject,
+        );
+    }/** KV Get */
+    public get(
+        kvGetIn: KvGetIn,
+        ): Promise<KvGetOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/get");
 
-        
+        request.setBody(
+            KvGetInSerializer._toJsonObject(
+                kvGetIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            KvGetOutSerializer._fromJsonObject,
+        );
+    }/** KV Delete */
+    public delete(
+        kvDeleteIn: KvDeleteIn,
+        ): Promise<KvDeleteOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/delete");
 
-    /** KV Get */
-        public get(
-            kvGetIn: KvGetIn,
-            ): Promise<KvGetOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/get");
-
-            request.setBody(
-                    KvGetInSerializer._toJsonObject(
-                        kvGetIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    KvGetOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
-    /** KV Delete */
-        public delete(
-            kvDeleteIn: KvDeleteIn,
-            ): Promise<KvDeleteOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/delete");
-
-            request.setBody(
-                    KvDeleteInSerializer._toJsonObject(
-                        kvDeleteIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    KvDeleteOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            KvDeleteInSerializer._toJsonObject(
+                kvDeleteIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            KvDeleteOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/kvNamespace.ts
+++ b/clients/javascript/src/apis/kvNamespace.ts
@@ -22,44 +22,35 @@ export class KvNamespace {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Create KV namespace */
-        public create(
-            kvCreateNamespaceIn: KvCreateNamespaceIn,
-            ): Promise<KvCreateNamespaceOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/namespace/create");
+    public create(
+        kvCreateNamespaceIn: KvCreateNamespaceIn,
+        ): Promise<KvCreateNamespaceOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/namespace/create");
 
-            request.setBody(
-                    KvCreateNamespaceInSerializer._toJsonObject(
-                        kvCreateNamespaceIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    KvCreateNamespaceOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            KvCreateNamespaceInSerializer._toJsonObject(
+                kvCreateNamespaceIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            KvCreateNamespaceOutSerializer._fromJsonObject,
+        );
+    }/** Get KV namespace */
+    public get(
+        kvGetNamespaceIn: KvGetNamespaceIn,
+        ): Promise<KvGetNamespaceOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/namespace/get");
 
-        
-
-    /** Get KV namespace */
-        public get(
-            kvGetNamespaceIn: KvGetNamespaceIn,
-            ): Promise<KvGetNamespaceOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/namespace/get");
-
-            request.setBody(
-                    KvGetNamespaceInSerializer._toJsonObject(
-                        kvGetNamespaceIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    KvGetNamespaceOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            KvGetNamespaceInSerializer._toJsonObject(
+                kvGetNamespaceIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            KvGetNamespaceOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/msgs.ts
+++ b/clients/javascript/src/apis/msgs.ts
@@ -34,24 +34,20 @@ export class Msgs {
     }
 
     /** Publishes messages to a topic within a namespace. */
-        public publish(
-            msgPublishIn: MsgPublishIn,
-            ): Promise<MsgPublishOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/publish");
+    public publish(
+        msgPublishIn: MsgPublishIn,
+        ): Promise<MsgPublishOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/publish");
 
-            request.setBody(
-                    MsgPublishInSerializer._toJsonObject(
-                        msgPublishIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgPublishOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            MsgPublishInSerializer._toJsonObject(
+                msgPublishIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgPublishOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/msgsNamespace.ts
+++ b/clients/javascript/src/apis/msgsNamespace.ts
@@ -22,44 +22,35 @@ export class MsgsNamespace {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Creates or updates a msgs namespace with the given name. */
-        public create(
-            msgNamespaceCreateIn: MsgNamespaceCreateIn,
-            ): Promise<MsgNamespaceCreateOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/namespace/create");
+    public create(
+        msgNamespaceCreateIn: MsgNamespaceCreateIn,
+        ): Promise<MsgNamespaceCreateOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/namespace/create");
 
-            request.setBody(
-                    MsgNamespaceCreateInSerializer._toJsonObject(
-                        msgNamespaceCreateIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgNamespaceCreateOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            MsgNamespaceCreateInSerializer._toJsonObject(
+                msgNamespaceCreateIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgNamespaceCreateOutSerializer._fromJsonObject,
+        );
+    }/** Gets a msgs namespace by name. */
+    public get(
+        msgNamespaceGetIn: MsgNamespaceGetIn,
+        ): Promise<MsgNamespaceGetOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/namespace/get");
 
-        
-
-    /** Gets a msgs namespace by name. */
-        public get(
-            msgNamespaceGetIn: MsgNamespaceGetIn,
-            ): Promise<MsgNamespaceGetOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/namespace/get");
-
-            request.setBody(
-                    MsgNamespaceGetInSerializer._toJsonObject(
-                        msgNamespaceGetIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgNamespaceGetOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            MsgNamespaceGetInSerializer._toJsonObject(
+                msgNamespaceGetIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgNamespaceGetOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/msgsQueue.ts
+++ b/clients/javascript/src/apis/msgsQueue.ts
@@ -52,118 +52,94 @@ export class MsgsQueue {
 * different messages from the same topic concurrently. Leased messages are skipped until they
 * are acked or their lease expires.
 */
-        public receive(
-            msgQueueReceiveIn: MsgQueueReceiveIn,
-            ): Promise<MsgQueueReceiveOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/receive");
+    public receive(
+        msgQueueReceiveIn: MsgQueueReceiveIn,
+        ): Promise<MsgQueueReceiveOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/receive");
 
-            request.setBody(
-                    MsgQueueReceiveInSerializer._toJsonObject(
-                        msgQueueReceiveIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgQueueReceiveOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
-    /**
+        request.setBody(
+            MsgQueueReceiveInSerializer._toJsonObject(
+                msgQueueReceiveIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgQueueReceiveOutSerializer._fromJsonObject,
+        );
+    }/**
 * Acknowledges messages by their opaque msg_ids.
 * 
 * Acked messages are permanently removed from the queue and will never be re-delivered.
 */
-        public ack(
-            msgQueueAckIn: MsgQueueAckIn,
-            ): Promise<MsgQueueAckOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/ack");
+    public ack(
+        msgQueueAckIn: MsgQueueAckIn,
+        ): Promise<MsgQueueAckOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/ack");
 
-            request.setBody(
-                    MsgQueueAckInSerializer._toJsonObject(
-                        msgQueueAckIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgQueueAckOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
-    /**
+        request.setBody(
+            MsgQueueAckInSerializer._toJsonObject(
+                msgQueueAckIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgQueueAckOutSerializer._fromJsonObject,
+        );
+    }/**
 * Configures retry and DLQ behavior for a consumer group on a topic.
 * 
 * `retry_schedule` is a list of delays (in millis) between retries after a nack. Once exhausted,
 * the message is moved to the DLQ (or forwarded to `dlq_topic` if set).
 */
-        public configure(
-            msgQueueConfigureIn: MsgQueueConfigureIn,
-            ): Promise<MsgQueueConfigureOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/configure");
+    public configure(
+        msgQueueConfigureIn: MsgQueueConfigureIn,
+        ): Promise<MsgQueueConfigureOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/configure");
 
-            request.setBody(
-                    MsgQueueConfigureInSerializer._toJsonObject(
-                        msgQueueConfigureIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgQueueConfigureOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
-    /**
+        request.setBody(
+            MsgQueueConfigureInSerializer._toJsonObject(
+                msgQueueConfigureIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgQueueConfigureOutSerializer._fromJsonObject,
+        );
+    }/**
 * Rejects messages, sending them to the dead-letter queue.
 * 
 * Nacked messages will not be re-delivered by `queue/receive`. Use `queue/redrive-dlq` to
 * move them back to the queue for reprocessing.
 */
-        public nack(
-            msgQueueNackIn: MsgQueueNackIn,
-            ): Promise<MsgQueueNackOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/nack");
+    public nack(
+        msgQueueNackIn: MsgQueueNackIn,
+        ): Promise<MsgQueueNackOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/nack");
 
-            request.setBody(
-                    MsgQueueNackInSerializer._toJsonObject(
-                        msgQueueNackIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgQueueNackOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            MsgQueueNackInSerializer._toJsonObject(
+                msgQueueNackIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgQueueNackOutSerializer._fromJsonObject,
+        );
+    }/** Moves all dead-letter queue messages back to the main queue for reprocessing. */
+    public redriveDlq(
+        msgQueueRedriveDlqIn: MsgQueueRedriveDlqIn,
+        ): Promise<MsgQueueRedriveDlqOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/redrive-dlq");
 
-        
-
-    /** Moves all dead-letter queue messages back to the main queue for reprocessing. */
-        public redriveDlq(
-            msgQueueRedriveDlqIn: MsgQueueRedriveDlqIn,
-            ): Promise<MsgQueueRedriveDlqOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/redrive-dlq");
-
-            request.setBody(
-                    MsgQueueRedriveDlqInSerializer._toJsonObject(
-                        msgQueueRedriveDlqIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgQueueRedriveDlqOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            MsgQueueRedriveDlqInSerializer._toJsonObject(
+                msgQueueRedriveDlqIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgQueueRedriveDlqOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/msgsStream.ts
+++ b/clients/javascript/src/apis/msgsStream.ts
@@ -35,75 +35,61 @@ export class MsgsStream {
 * Each consumer in the group reads from all partitions. Messages are locked by leases for the
 * specified duration to prevent duplicate delivery within the same consumer group.
 */
-        public receive(
-            msgStreamReceiveIn: MsgStreamReceiveIn,
-            ): Promise<MsgStreamReceiveOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/receive");
+    public receive(
+        msgStreamReceiveIn: MsgStreamReceiveIn,
+        ): Promise<MsgStreamReceiveOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/receive");
 
-            request.setBody(
-                    MsgStreamReceiveInSerializer._toJsonObject(
-                        msgStreamReceiveIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgStreamReceiveOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
-    /**
+        request.setBody(
+            MsgStreamReceiveInSerializer._toJsonObject(
+                msgStreamReceiveIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgStreamReceiveOutSerializer._fromJsonObject,
+        );
+    }/**
 * Commits an offset for a consumer group on a specific partition.
 * 
 * The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
 * successfully processed offset; future receives will start after it.
 */
-        public commit(
-            msgStreamCommitIn: MsgStreamCommitIn,
-            ): Promise<MsgStreamCommitOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/commit");
+    public commit(
+        msgStreamCommitIn: MsgStreamCommitIn,
+        ): Promise<MsgStreamCommitOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/commit");
 
-            request.setBody(
-                    MsgStreamCommitInSerializer._toJsonObject(
-                        msgStreamCommitIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgStreamCommitOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
-    /**
+        request.setBody(
+            MsgStreamCommitInSerializer._toJsonObject(
+                msgStreamCommitIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgStreamCommitOutSerializer._fromJsonObject,
+        );
+    }/**
 * Repositions a consumer group's read cursor on a topic.
 * 
 * Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
 * partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
 * `"latest"` and may be used with or without a partition suffix.
 */
-        public seek(
-            msgStreamSeekIn: MsgStreamSeekIn,
-            ): Promise<MsgStreamSeekOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/seek");
+    public seek(
+        msgStreamSeekIn: MsgStreamSeekIn,
+        ): Promise<MsgStreamSeekOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/seek");
 
-            request.setBody(
-                    MsgStreamSeekInSerializer._toJsonObject(
-                        msgStreamSeekIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgStreamSeekOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            MsgStreamSeekInSerializer._toJsonObject(
+                msgStreamSeekIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgStreamSeekOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/msgsTopic.ts
+++ b/clients/javascript/src/apis/msgsTopic.ts
@@ -18,24 +18,20 @@ export class MsgsTopic {
 * 
 * Partition count can only be increased, never decreased. The default for a new topic is 1.
 */
-        public configure(
-            msgTopicConfigureIn: MsgTopicConfigureIn,
-            ): Promise<MsgTopicConfigureOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/topic/configure");
+    public configure(
+        msgTopicConfigureIn: MsgTopicConfigureIn,
+        ): Promise<MsgTopicConfigureOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/topic/configure");
 
-            request.setBody(
-                    MsgTopicConfigureInSerializer._toJsonObject(
-                        msgTopicConfigureIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    MsgTopicConfigureOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            MsgTopicConfigureInSerializer._toJsonObject(
+                msgTopicConfigureIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            MsgTopicConfigureOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/rateLimit.ts
+++ b/clients/javascript/src/apis/rateLimit.ts
@@ -35,64 +35,50 @@ export class RateLimit {
     }
 
     /** Rate Limiter Check and Consume */
-        public limit(
-            rateLimitCheckIn: RateLimitCheckIn,
-            ): Promise<RateLimitCheckOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/limit");
+    public limit(
+        rateLimitCheckIn: RateLimitCheckIn,
+        ): Promise<RateLimitCheckOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/limit");
 
-            request.setBody(
-                    RateLimitCheckInSerializer._toJsonObject(
-                        rateLimitCheckIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    RateLimitCheckOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            RateLimitCheckInSerializer._toJsonObject(
+                rateLimitCheckIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            RateLimitCheckOutSerializer._fromJsonObject,
+        );
+    }/** Rate Limiter Get Remaining */
+    public getRemaining(
+        rateLimitGetRemainingIn: RateLimitGetRemainingIn,
+        ): Promise<RateLimitGetRemainingOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/get-remaining");
 
-        
+        request.setBody(
+            RateLimitGetRemainingInSerializer._toJsonObject(
+                rateLimitGetRemainingIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            RateLimitGetRemainingOutSerializer._fromJsonObject,
+        );
+    }/** Rate Limiter Reset */
+    public reset(
+        rateLimitResetIn: RateLimitResetIn,
+        ): Promise<RateLimitResetOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/reset");
 
-    /** Rate Limiter Get Remaining */
-        public getRemaining(
-            rateLimitGetRemainingIn: RateLimitGetRemainingIn,
-            ): Promise<RateLimitGetRemainingOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/get-remaining");
-
-            request.setBody(
-                    RateLimitGetRemainingInSerializer._toJsonObject(
-                        rateLimitGetRemainingIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    RateLimitGetRemainingOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
-    /** Rate Limiter Reset */
-        public reset(
-            rateLimitResetIn: RateLimitResetIn,
-            ): Promise<RateLimitResetOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/reset");
-
-            request.setBody(
-                    RateLimitResetInSerializer._toJsonObject(
-                        rateLimitResetIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    RateLimitResetOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            RateLimitResetInSerializer._toJsonObject(
+                rateLimitResetIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            RateLimitResetOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/clients/javascript/src/apis/rateLimitNamespace.ts
+++ b/clients/javascript/src/apis/rateLimitNamespace.ts
@@ -22,44 +22,35 @@ export class RateLimitNamespace {
     public constructor(private readonly requestCtx: CoyoteRequestContext) {}
 
     /** Create rate limiter namespace */
-        public create(
-            rateLimitCreateNamespaceIn: RateLimitCreateNamespaceIn,
-            ): Promise<RateLimitCreateNamespaceOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/namespace/create");
+    public create(
+        rateLimitCreateNamespaceIn: RateLimitCreateNamespaceIn,
+        ): Promise<RateLimitCreateNamespaceOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/namespace/create");
 
-            request.setBody(
-                    RateLimitCreateNamespaceInSerializer._toJsonObject(
-                        rateLimitCreateNamespaceIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    RateLimitCreateNamespaceOutSerializer._fromJsonObject,
-                );
-            }
+        request.setBody(
+            RateLimitCreateNamespaceInSerializer._toJsonObject(
+                rateLimitCreateNamespaceIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            RateLimitCreateNamespaceOutSerializer._fromJsonObject,
+        );
+    }/** Get rate limiter namespace */
+    public get(
+        rateLimitGetNamespaceIn: RateLimitGetNamespaceIn,
+        ): Promise<RateLimitGetNamespaceOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/namespace/get");
 
-        
-
-    /** Get rate limiter namespace */
-        public get(
-            rateLimitGetNamespaceIn: RateLimitGetNamespaceIn,
-            ): Promise<RateLimitGetNamespaceOut> {
-            const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/namespace/get");
-
-            request.setBody(
-                    RateLimitGetNamespaceInSerializer._toJsonObject(
-                        rateLimitGetNamespaceIn,
-                    )
-                );
-            
-                return request.send(
-                    this.requestCtx,
-                    RateLimitGetNamespaceOutSerializer._fromJsonObject,
-                );
-            }
-
-        
-
+        request.setBody(
+            RateLimitGetNamespaceInSerializer._toJsonObject(
+                rateLimitGetNamespaceIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            RateLimitGetNamespaceOutSerializer._fromJsonObject,
+        );
     }
+}
 

--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -28,11 +28,6 @@ export class {{ resource_type_name }} {
             op.response_body_schema_name | default("void") | replace("_", "") -%}
         {{ op.description | with_javadoc_deprecation(op.deprecated) | to_doc_comment(style="js") }}
         public {{ op.name | to_lower_camel_case }}(
-            {# path parameters -#}
-            {% for p in op.path_params -%}
-                {{ p | to_lower_camel_case }}: string,
-            {% endfor -%}
-
             {# body parameter interface -#}
             {% if op.request_body_schema_name is defined -%}
                 {% set field_name = op.request_body_schema_name | to_lower_camel_case -%}
@@ -41,11 +36,6 @@ export class {{ resource_type_name }} {
 
         ): Promise<{{ response_type }}> {
             const request = new CoyoteRequest(HttpMethod.{{ op.method | upper }}, "{{ op.path }}");
-
-            {# path parameters -#}
-            {% for p in op.path_params -%}
-                request.setPathParam("{{ p }}", {{ p | to_lower_camel_case }});
-            {% endfor -%}
 
             {# body parameter -#}
             {% if op.request_body_schema_name is defined -%}

--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -23,45 +23,45 @@ export class {{ resource_type_name }} {
 
     {% endfor -%}
 
-    {% for op in resource.operations -%}
-        {% set response_type =
-            op.response_body_schema_name | default("void") | replace("_", "") -%}
-        {{ op.description | with_javadoc_deprecation(op.deprecated) | to_doc_comment(style="js") }}
-        public {{ op.name | to_lower_camel_case }}(
-            {# body parameter interface -#}
-            {% if op.request_body_schema_name is defined -%}
-                {% set field_name = op.request_body_schema_name | to_lower_camel_case -%}
-                {{ field_name }}: {{ op.request_body_schema_name }},
-            {% endif -%}
+    {%- for op in resource.operations %}
+    {%- set response_type =
+        op.response_body_schema_name | default("void") | replace("_", "") %}
+    {{- op.description | with_javadoc_deprecation(op.deprecated) | to_doc_comment(style="js") }}
+    public {{ op.name | to_lower_camel_case }}(
+        {# body parameter interface -#}
+        {% if op.request_body_schema_name is defined -%}
+            {% set field_name = op.request_body_schema_name | to_lower_camel_case -%}
+            {{ field_name }}: {{ op.request_body_schema_name }},
+        {% endif -%}
 
-        ): Promise<{{ response_type }}> {
-            const request = new CoyoteRequest(HttpMethod.{{ op.method | upper }}, "{{ op.path }}");
+    ): Promise<{{ response_type }}> {
+        const request = new CoyoteRequest(HttpMethod.{{ op.method | upper }}, "{{ op.path }}");
 
-            {# body parameter -#}
-            {% if op.request_body_schema_name is defined -%}
-                request.setBody(
-                    {{ op.request_body_schema_name | to_upper_camel_case }}Serializer._toJsonObject(
-                        {{ op.request_body_schema_name | to_lower_camel_case }},
-                    )
-                );
-            {% endif -%}
+        {# body parameter -#}
+        {% if op.request_body_schema_name is defined -%}
+        request.setBody(
+            {{ op.request_body_schema_name | to_upper_camel_case }}Serializer._toJsonObject(
+                {{ op.request_body_schema_name | to_lower_camel_case }},
+            )
+        );
+        {%- endif %}
 
-            {% if op.response_body_schema_name is defined %}
-                return request.send(
-                    this.requestCtx,
-                    {{ op.response_body_schema_name | to_upper_camel_case }}Serializer._fromJsonObject,
-                );
-            {% else %}
-                return request.sendNoResponseBody(this.requestCtx);
-            {% endif -%}
-        }
+        {%- if op.response_body_schema_name is defined %}
+        return request.send(
+            this.requestCtx,
+            {{ op.response_body_schema_name | to_upper_camel_case }}Serializer._fromJsonObject,
+        );
+        {%- else %}
+        return request.sendNoResponseBody(this.requestCtx);
+        {%- endif %}
+    }
 
-        {% set extra_path -%}
-            api_extra/{{ resource.name | to_snake_case }}_{{ op.name | to_snake_case }}.ts
-        {%- endset -%}
-        {% include extra_path ignore missing %}
+    {%- set extra_path -%}
+        api_extra/{{ resource.name | to_snake_case }}_{{ op.name | to_snake_case }}.ts
+    {%- endset -%}
+    {%- include extra_path ignore missing %}
 
-    {% endfor -%}
+    {%- endfor %}
 }
 
 {% set extra_path -%}


### PR DESCRIPTION
Originally meant for testing the new CI job in #416, then I realized I should just have a filter condition on the workflow file itself. Extracted this to reduce the diff on the other PR.