### PR TITLE
Remove support for path params in Rust, Python clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,6 @@ dependencies = [
  "hyper-tls",
  "hyper-util",
  "jiff",
- "percent-encoding",
  "rand 0.9.2",
  "rmp-serde",
  "rustls",

--- a/clients/python/coyote/internal/api_common.py
+++ b/clients/python/coyote/internal/api_common.py
@@ -52,12 +52,9 @@ class ApiBase:
         method: str,
         path: str,
         *,
-        path_params: t.Optional[t.Dict[str, str]],
         header_params: t.Optional[t.Dict[str, str]],
         body: t.Optional[t.Any],
     ) -> t.Dict[str, t.Any]:
-        if path_params is not None:
-            path = path.format(**path_params)
         url = f"{self._client.base_url}{path}"
 
         headers: t.Dict[str, str] = {
@@ -92,7 +89,6 @@ class ApiBase:
         method: str,
         path: str,
         *,
-        path_params: t.Optional[t.Dict[str, str]] = None,
         header_params: t.Optional[t.Dict[str, str]] = None,
         body: t.Optional[t.Any] = None,
         response_type: t.Optional[type[T]] = None,
@@ -100,7 +96,6 @@ class ApiBase:
         httpx_kwargs = self._get_httpx_kwargs(
             method,
             path,
-            path_params=path_params,
             header_params=header_params,
             body=body,
         )
@@ -122,7 +117,6 @@ class ApiBase:
         method: str,
         path: str,
         *,
-        path_params: t.Optional[t.Dict[str, str]] = None,
         header_params: t.Optional[t.Dict[str, str]] = None,
         body: t.Optional[t.Any] = None,
         response_type: t.Optional[type[T]] = None,
@@ -130,7 +124,6 @@ class ApiBase:
         httpx_kwargs = self._get_httpx_kwargs(
             method,
             path,
-            path_params=path_params,
             header_params=header_params,
             body=body,
         )

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -25,7 +25,6 @@ hyper-rustls = { workspace = true, optional = true }
 hyper-tls = { workspace = true, optional = true }
 hyper-util.workspace = true
 jiff.workspace = true
-percent-encoding.workspace = true
 rand.workspace = true
 rmp-serde.workspace = true
 rustls = { workspace = true, optional = true }

--- a/clients/rust/src/request.rs
+++ b/clients/rust/src/request.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, time::Duration};
 use http::header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use http_body_util::{BodyExt as _, Full};
 use hyper::body::Bytes;
-use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use rand::Rng;
 use serde::de::DeserializeOwned;
 
@@ -29,7 +28,6 @@ pub(crate) struct Request {
     path: &'static str,
     query_params: HashMap<&'static str, String>,
     no_return_type: bool,
-    path_params: HashMap<&'static str, String>,
     header_params: HashMap<&'static str, String>,
     serialized_body: Option<Vec<u8>>,
 }
@@ -40,7 +38,6 @@ impl Request {
             method,
             path,
             query_params: HashMap::new(),
-            path_params: HashMap::new(),
             header_params: HashMap::new(),
             serialized_body: None,
             no_return_type: false,
@@ -142,19 +139,7 @@ impl Request {
     }
 
     fn build_request(self, conf: &Configuration) -> Result<http::Request<Full<Bytes>>, Error> {
-        const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
-        const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'?').add(b'{').add(b'}');
-        const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
-
-        let mut path = self.path.to_owned();
-        for (k, v) in self.path_params {
-            // replace {id} with the value of the id path param
-            let percent_encoded_path_param_value =
-                utf8_percent_encode(&v, PATH_SEGMENT).to_string();
-            path = path.replace(&format!("{{{k}}}"), &percent_encoded_path_param_value);
-        }
-
-        let mut uri = format!("{}{}", conf.base_path, path);
+        let mut uri = format!("{}{}", conf.base_path, self.path);
 
         let mut query_string = form_urlencoded::Serializer::new("".to_owned());
         for (key, val) in self.query_params {

--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -32,15 +32,6 @@ pub enum {{ resource_type_name }}Commands {
             {{ op.description | to_doc_comment(style="rust") }}
         {% endif -%}
         {{ op.name | to_upper_camel_case }} {
-            {# path parameters -#}
-            {% for p in op.path_params -%}
-                {% if p == resource_id_name -%}
-                    id: String,
-                {% else -%}
-                    {{ p }}: String,
-                {% endif -%}
-            {% endfor -%}
-
             {% if op.request_body_schema_name is defined -%}
                 {# positional body parameters -#}
                 {% set body_schema = api.types[op.request_body_schema_name] -%}
@@ -75,15 +66,6 @@ impl {{ resource_type_name }}Commands {
                 {% set has_params = (op.query_params | length > 0) or (op.header_params | length > 0) -%}
 
                 Self::{{ op.name | to_upper_camel_case }} {
-                    {# path parameters -#}
-                    {% for p in op.path_params -%}
-                        {% if p == resource_id_name -%}
-                            id,
-                        {% else -%}
-                            {{ p }},
-                        {% endif -%}
-                    {% endfor -%}
-
                     {% if op.request_body_schema_name is defined -%}
                         {# positional body parameters -#}
                         {% set body_schema = api.types[op.request_body_schema_name] -%}
@@ -109,15 +91,6 @@ impl {{ resource_type_name }}Commands {
                         .{{ segment | to_snake_case }}()
                         {% endfor -%}
                         .{{ op.name | to_snake_case }}(
-                            {# path parameters -#}
-                            {% for p in op.path_params -%}
-                                {% if p == resource_id_name -%}
-                                    id,
-                                {% else -%}
-                                    {{ p }},
-                                {% endif -%}
-                            {% endfor -%}
-
                             {% if op.request_body_schema_name is defined -%}
                                 {# positional body parameters -#}
                                 {% set body_schema = api.types[op.request_body_schema_name] -%}

--- a/codegen/templates/python/api_resource.py.jinja
+++ b/codegen/templates/python/api_resource.py.jinja
@@ -55,10 +55,6 @@ class {{ resource.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}
         {%- endif %}
     {{ async -}} def {{ op.name | to_snake_case }}(
         self,
-        {#- path parameters are non optional strings #}
-        {%- for p in op.path_params %}
-        {{ p }}: str,
-        {%- endfor %}
         {%- if op.request_body_schema_name is defined %}
         {% set req_body_schema_snake = op.request_body_schema_name | to_snake_case -%}
         {# positional body parameters -#}
@@ -111,13 +107,6 @@ class {{ resource.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}
         self.{{ internal_func_name }}(
             method="{{ op.method }}",
             path="{{ op.path }}",
-            {%- if op.path_params | length > 0 %}
-            path_params={
-            {%- for path_param in op.path_params %}
-                "{{ path_param }}":{{ path_param }},
-            {% endfor -%}
-            }
-            {%- endif %}
             {%- if op.request_body_schema_name is defined %}
             body=body,
             {%- endif %}

--- a/codegen/templates/rust/api_resource.rs.jinja
+++ b/codegen/templates/rust/api_resource.rs.jinja
@@ -44,12 +44,6 @@ impl<'a> {{ resource_type_name }}<'a> {
     {% endif -%}
     pub async fn {{ op.name | to_snake_case }}(
         &self,
-
-        {#- path parameters #}
-        {% for p in op.path_params -%}
-            {{ p }}: String,
-        {% endfor -%}
-
         {% if op.request_body_schema_name is defined -%}
             {# positional body parameters -#}
             {% set body_schema = api.types[op.request_body_schema_name] -%}


### PR DESCRIPTION
I don't want to create merge conflicts for the other clients that I'm more actively working on, so changes for them will be in separate PRs.