### PR TITLE
server: use Timestamp::UNIX_EPOCH as the beginning of time instead of Timestamp::MIN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ dependencies = [
  "jiff",
  "schemars 1.2.1",
  "serde",
+ "tap",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -60,7 +60,7 @@ where
 
         let now = Timestamp::now();
         match controller.clear_expired(now) {
-            Ok(()) => {}
+            Ok(_) => {}
             Err(e) => {
                 tracing::error!(error = ?e, "Failed to clean.");
             }

--- a/crates/idempotency/src/lib.rs
+++ b/crates/idempotency/src/lib.rs
@@ -94,7 +94,7 @@ where
 
         let now = Timestamp::now();
         match controller.clear_expired(now) {
-            Ok(()) => {}
+            Ok(_) => {}
             Err(e) => {
                 tracing::error!(error = ?e, "Failed to clean.");
             }

--- a/crates/kv/Cargo.toml
+++ b/crates/kv/Cargo.toml
@@ -16,6 +16,7 @@ itertools.workspace = true
 jiff.workspace = true
 schemars.workspace = true
 serde.workspace = true
+tap.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -164,9 +164,12 @@ impl KvController {
         KvPairRow::values(&self.keyspace)
     }
 
-    pub fn clear_expired(&self, now: Timestamp) -> Result<()> {
-        let start = ExpirationRow::key_for(NamespaceId::nil(), Timestamp::MIN, "").into_fjall_key();
+    pub fn clear_expired(&self, now: Timestamp) -> Result<usize> {
+        let start =
+            ExpirationRow::key_for(NamespaceId::nil(), Timestamp::UNIX_EPOCH, "").into_fjall_key();
         let end = ExpirationRow::key_for(NamespaceId::max(), now, "").into_fjall_key();
+
+        let mut cleared = 0;
 
         for chunk in &self
             .keyspace
@@ -180,6 +183,7 @@ impl KvController {
             // is deleted here even though it's not expired.
             // See https://svixhq.slack.com/archives/C0A72988962/p1772685631571679
             for item in chunk {
+                cleared += 1;
                 let k = item.key()?;
                 let (namespace_id, main_key) = ExpirationRow::extract_key_from_fjall_key(&k)?;
                 batch.remove_row(&self.keyspace, KvPairRow::key_for(namespace_id, main_key))?;
@@ -189,7 +193,7 @@ impl KvController {
             batch.commit()?;
         }
 
-        Ok(())
+        Ok(cleared)
     }
 }
 
@@ -429,7 +433,7 @@ mod tests {
 
         assert_eq!(controller.iter().unwrap().count(), 6);
 
-        controller.clear_expired(Timestamp::now()).unwrap();
+        assert_eq!(controller.clear_expired(Timestamp::now()).unwrap(), 4);
 
         for (key, _, _) in &expired_models {
             assert!(!key_exists(&controller, key));

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -65,7 +65,7 @@ where
 
         let now = Timestamp::now();
         match controller.clear_expired(now) {
-            Ok(()) => {}
+            Ok(_) => {}
             Err(e) => {
                 tracing::error!(error = ?e, "Failed to clean.");
             }

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -9,6 +9,7 @@ use coyote_operations::Result;
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
+use tap::TapOptional;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetOperation {
@@ -28,11 +29,14 @@ impl SetOperation {
         ttl: Option<u64>,
         behavior: OperationBehavior,
     ) -> Self {
+        let expiry = ttl
+            .map(|ttl| Timestamp::now() + Duration::from_millis(ttl))
+            .tap_some(|v| debug_assert!(*v >= Timestamp::UNIX_EPOCH));
         Self {
             namespace_id: namespace.id,
             storage_type: namespace.storage_type,
             key,
-            expiry: ttl.map(|ttl| Timestamp::now() + Duration::from_millis(ttl)),
+            expiry,
             value,
             behavior,
         }

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -55,7 +55,7 @@ impl StreamCommitOperation {
 
         lease.offset = self.offset + 1;
         if self.offset >= lease.end_offset {
-            lease.expiry = Timestamp::MIN;
+            lease.expiry = Timestamp::UNIX_EPOCH;
         }
 
         batch.insert_row(

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -82,7 +82,7 @@ impl StreamSeekOperation {
 
             let lease = StreamLeaseRow {
                 offset,
-                expiry: Timestamp::MIN,
+                expiry: Timestamp::UNIX_EPOCH,
                 end_offset: 0,
             };
 

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -96,7 +96,7 @@ impl StreamLeaseRow {
     pub(crate) fn new() -> Result<Self> {
         Ok(Self {
             offset: 0,
-            expiry: Timestamp::MIN,
+            expiry: Timestamp::UNIX_EPOCH,
             end_offset: 0,
         })
     }

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -41,6 +41,7 @@ pub struct CacheSetIn {
 impl CacheSetIn {
     fn into_model(self) -> CacheModel {
         let expiry = Timestamp::now() + Duration::from_millis(self.ttl);
+        debug_assert!(expiry > Timestamp::UNIX_EPOCH);
 
         CacheModel {
             expiry: Some(expiry),


### PR DESCRIPTION
Timestamps are signed, so when encoded as big-endian bytes, `Timestamp::MIN` is actually sorts at the end. `Timestamp::UNIX_EPOCH` is the one that corresponds to all zeros.

This was totally breaking expiry for KV/Cache/Idempotency. It wasn't breaking anything immediately for `msgs` (since the key doesn't include the lease expiry in it), but I'm changing it there too because I suspect we will at some point have an index by expiry for pruning old rows.

Unfortunately, while clippy has `disallowed-types` and `disallowed-names`, there's no `disallowed-consts`, so I can't block this with clippy. 😢 