### PR TITLE
Rate-limit: remove 'key' field from value.

### DIFF
--- a/crates/rate-limit/src/lib.rs
+++ b/crates/rate-limit/src/lib.rs
@@ -70,7 +70,6 @@ impl RateLimiter {
                 let mut state =
                     FixedWindowState::fetch(&self.tables, FixedWindowState::key_for(identifier))?
                         .unwrap_or(FixedWindowState {
-                            key: identifier.to_owned(),
                             count: 0,
                             window_start,
                         });
@@ -106,7 +105,6 @@ impl RateLimiter {
                 let mut bucket =
                     TokenBucketState::fetch(&self.tables, TokenBucketState::key_for(identifier))?
                         .unwrap_or(TokenBucketState {
-                            key: identifier.to_owned(),
                             tokens: tb_config.bucket_size,
                             last_refill: now,
                         });

--- a/crates/rate-limit/src/tables.rs
+++ b/crates/rate-limit/src/tables.rs
@@ -11,7 +11,6 @@ enum RowType {
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct FixedWindowState {
-    pub key: String,
     pub count: u64,
     pub window_start: Timestamp,
 }
@@ -28,7 +27,6 @@ impl FixedWindowState {
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TokenBucketState {
-    pub key: String,
     pub tokens: u64,
     pub last_refill: Timestamp,
 }


### PR DESCRIPTION
We did it in other modules as well, it's not actually needed in the body.