### PR TITLE
go: Bump base image for formatting

### DIFF
--- a/codegen/formatters/goimports.Containerfile
+++ b/codegen/formatters/goimports.Containerfile
@@ -1,2 +1,2 @@
-FROM docker.io/golang:1.24-alpine
+FROM docker.io/golang:1.26-alpine
 RUN go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
Fixes a CI issue where goimports would refuse to build due to the toolchain being too old.

We should probably upload the resulting images at some point instead.