### PR TITLE
Clean up most unwrap() calls in tests

### DIFF
--- a/crates/test-utils/src/json.rs
+++ b/crates/test-utils/src/json.rs
@@ -1,0 +1,24 @@
+#![allow(clippy::disallowed_types)]
+
+pub trait JsonFastAndLoose {
+    fn assert_u64(&self) -> u64;
+    fn assert_str(&self) -> &str;
+    fn assert_array(&self) -> &[serde_json::Value];
+}
+
+impl JsonFastAndLoose for serde_json::Value {
+    #[track_caller]
+    fn assert_u64(&self) -> u64 {
+        self.as_u64().unwrap()
+    }
+
+    #[track_caller]
+    fn assert_str(&self) -> &str {
+        self.as_str().unwrap()
+    }
+
+    #[track_caller]
+    fn assert_array(&self) -> &[serde_json::Value] {
+        self.as_array().unwrap()
+    }
+}

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -2,10 +2,14 @@ use std::fmt::{Debug, Display};
 
 pub use reqwest::StatusCode;
 
+mod json;
 pub mod server;
 mod test_client;
 
-pub use self::test_client::{TestClient, TestRequestBuilder, TestResponse};
+pub use self::{
+    json::JsonFastAndLoose,
+    test_client::{TestClient, TestRequestBuilder, TestResponse},
+};
 
 #[derive(Debug)] // needed to be able to return TestResult from #[test] fns
 pub enum TestError {}

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -7,7 +7,7 @@ use test_utils::{
 
 #[tokio::test]
 async fn test_bootstrap() -> TestResult {
-    let workdir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir()?;
     let mut cfg = default_server_config(workdir.path());
     cfg.bootstrap_cfg_path = Some("./tests/it/static/bootstrap.test.yaml".to_string());
 

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestClient, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestClient, TestResult,
     server::{TestContext, start_server},
 };
 
@@ -175,7 +175,7 @@ async fn create_namespace_upserts() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let created_ts = first["created"].as_str().unwrap().to_owned();
+    let created_ts = first["created"].assert_str().to_owned();
     assert_eq!(first["name"], "upsert-ns");
     assert_eq!(first["storage_type"], "Ephemeral");
 

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestClient, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestClient, TestResult,
     server::{TestContext, start_server},
 };
 
@@ -288,7 +288,7 @@ async fn create_namespace_upserts() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let created_ts = first["created"].as_str().unwrap().to_owned();
+    let created_ts = first["created"].assert_str().to_owned();
     assert_eq!(first["name"], "upsert-ns");
     assert_eq!(first["storage_type"], "Ephemeral");
 

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use jiff::Timestamp;
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestClient, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestClient, TestResult,
     server::{TestContext, start_server},
 };
 
@@ -80,7 +80,7 @@ async fn test_kv_set_and_get() -> TestResult {
     .await?;
     let response = kv_get(&client, "kv-key-1").await?;
 
-    let expires_at: Timestamp = serde_json::from_value(response["expiry"].clone()).unwrap();
+    let expires_at: Timestamp = serde_json::from_value(response["expiry"].clone())?;
     let expected = now + Duration::from_millis(expires_in);
     assert!(
         expires_at
@@ -170,7 +170,7 @@ async fn test_kv_update_expiration() -> TestResult {
     kv_set(&client, "kv4", Some(3000), "v4", "upsert").await?;
 
     let response = kv_get(&client, "kv4").await?;
-    let expires_at = response["expiry"].as_str().unwrap();
+    let expires_at = response["expiry"].assert_str();
 
     tokio::time::sleep(Duration::from_millis(1500)).await;
 
@@ -400,7 +400,7 @@ async fn create_namespace_upserts() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let created_ts = first["created"].as_str().unwrap().to_owned();
+    let created_ts = first["created"].assert_str().to_owned();
     assert_eq!(first["name"], "upsert-ns");
     assert_eq!(first["storage_type"], "Ephemeral");
 

--- a/tests/it/msgs/namespace.rs
+++ b/tests/it/msgs/namespace.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestResult,
     server::{TestContext, start_server},
 };
 
@@ -89,7 +89,7 @@ async fn create_namespace_upserts() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let created_ts = first["created"].as_str().unwrap().to_owned();
+    let created_ts = first["created"].assert_str().to_owned();
     assert_eq!(first["name"], "upsert-ns");
     assert_eq!(first["storage_type"], "Ephemeral");
     assert_eq!(first["retention"]["bytes"], 1024);

--- a/tests/it/msgs/publish.rs
+++ b/tests/it/msgs/publish.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestResult,
     server::{TestContext, start_server},
 };
 
@@ -31,22 +31,17 @@ async fn publish_to_topic() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let topics = response["topics"].as_array().unwrap();
+    let topics = response["topics"].assert_array();
     assert_eq!(topics.len(), 1);
     let topic = &topics[0];
     assert_eq!(
-        topic["offset"].as_u64().unwrap() - topic["start_offset"].as_u64().unwrap(),
+        topic["offset"].assert_u64() - topic["start_offset"].assert_u64(),
         2
     );
 
     // Each topic should have a partition
     for topic in topics {
-        assert!(
-            topic["topic"]
-                .as_str()
-                .unwrap()
-                .starts_with("ns1:my-topic~")
-        );
+        assert!(topic["topic"].assert_str().starts_with("ns1:my-topic~"));
     }
 
     Ok(())
@@ -80,11 +75,11 @@ async fn publish_with_partition_key() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let topics = response["topics"].as_array().unwrap();
+    let topics = response["topics"].assert_array();
     assert_eq!(topics.len(), 1);
     let topic = &topics[0];
     assert_eq!(
-        topic["offset"].as_u64().unwrap() - topic["start_offset"].as_u64().unwrap(),
+        topic["offset"].assert_u64() - topic["start_offset"].assert_u64(),
         3
     );
 
@@ -92,8 +87,7 @@ async fn publish_with_partition_key() -> TestResult {
     for topic in topics {
         assert!(
             topic["topic"]
-                .as_str()
-                .unwrap()
+                .assert_str()
                 .starts_with("ns-key:keyed-topic~")
         );
     }
@@ -135,11 +129,11 @@ async fn publish_directly_to_partition() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let topics = response["topics"].as_array().unwrap();
+    let topics = response["topics"].assert_array();
     assert_eq!(topics.len(), 1);
     let topic = &topics[0];
     assert_eq!(
-        topic["offset"].as_u64().unwrap() - topic["start_offset"].as_u64().unwrap(),
+        topic["offset"].assert_u64() - topic["start_offset"].assert_u64(),
         2
     );
 
@@ -147,8 +141,7 @@ async fn publish_directly_to_partition() -> TestResult {
     for topic in topics {
         assert!(
             topic["topic"]
-                .as_str()
-                .unwrap()
+                .assert_str()
                 .starts_with("ns-direct:my-topic~2")
         );
     }
@@ -258,11 +251,11 @@ async fn publish_keyless_same_partition() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let topics = response["topics"].as_array().unwrap();
+    let topics = response["topics"].assert_array();
     assert_eq!(topics.len(), 1);
     let topic = &topics[0];
     assert_eq!(
-        topic["offset"].as_u64().unwrap() - topic["start_offset"].as_u64().unwrap(),
+        topic["offset"].assert_u64() - topic["start_offset"].assert_u64(),
         3
     );
 
@@ -270,8 +263,7 @@ async fn publish_keyless_same_partition() -> TestResult {
     for topic in topics {
         assert!(
             topic["topic"]
-                .as_str()
-                .unwrap()
+                .assert_str()
                 .starts_with("ns-kl:keyless-topic~")
         );
     }
@@ -301,17 +293,17 @@ async fn publish_to_default_namespace() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let topics = response["topics"].as_array().unwrap();
+    let topics = response["topics"].assert_array();
     assert_eq!(topics.len(), 1);
     let topic = &topics[0];
     assert_eq!(
-        topic["offset"].as_u64().unwrap() - topic["start_offset"].as_u64().unwrap(),
+        topic["offset"].assert_u64() - topic["start_offset"].assert_u64(),
         2
     );
 
     // Each topic should have a partition
     for topic in topics {
-        assert!(topic["topic"].as_str().unwrap().starts_with("my-topic~"));
+        assert!(topic["topic"].assert_str().starts_with("my-topic~"));
     }
 
     Ok(())
@@ -381,12 +373,11 @@ async fn default_namespace_isolated_from_named() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let default_msgs = response["msgs"].as_array().unwrap();
+    let default_msgs = response["msgs"].assert_array();
     assert_eq!(default_msgs.len(), 1);
     assert!(
         default_msgs[0]["topic"]
-            .as_str()
-            .unwrap()
+            .assert_str()
             .starts_with("shared-name~"),
         "default namespace response topics should not have a namespace prefix"
     );
@@ -402,12 +393,11 @@ async fn default_namespace_isolated_from_named() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let other_msgs = response["msgs"].as_array().unwrap();
+    let other_msgs = response["msgs"].assert_array();
     assert_eq!(other_msgs.len(), 1);
     assert!(
         other_msgs[0]["topic"]
-            .as_str()
-            .unwrap()
+            .assert_str()
             .starts_with("other:shared-name~"),
         "other namespace messages should have other: prefix"
     );

--- a/tests/it/msgs/queue.rs
+++ b/tests/it/msgs/queue.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestResult,
     server::{TestContext, start_server},
 };
 use tokio::time::sleep;
@@ -44,7 +44,7 @@ async fn queue_receive_returns_published_messages() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     for m in msgs {
@@ -94,7 +94,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs1 = r1["msgs"].as_array().unwrap();
+    let msgs1 = r1["msgs"].assert_array();
     assert_eq!(msgs1.len(), 1);
     assert_eq!(msgs1[0]["value"], json!("a".as_bytes()));
 
@@ -110,7 +110,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs2 = r2["msgs"].as_array().unwrap();
+    let msgs2 = r2["msgs"].assert_array();
     assert_eq!(msgs2.len(), 1);
     assert_eq!(msgs2[0]["value"], json!("b".as_bytes()));
 
@@ -125,7 +125,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r3["msgs"].as_array().unwrap().len(),
+        r3["msgs"].assert_array().len(),
         0,
         "no messages available when all are leased"
     );
@@ -172,11 +172,11 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     // Ack all messages
-    let msg_ids: Vec<&str> = msgs.iter().map(|m| m["msg_id"].as_str().unwrap()).collect();
+    let msg_ids: Vec<&str> = msgs.iter().map(|m| m["msg_id"].assert_str()).collect();
     client
         .post("msgs/queue/ack")
         .json(json!({
@@ -201,7 +201,7 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r2["msgs"].as_array().unwrap().len(),
+        r2["msgs"].assert_array().len(),
         0,
         "acked messages should not be re-delivered"
     );
@@ -246,7 +246,7 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r1["msgs"].as_array().unwrap().len(), 2);
+    assert_eq!(r1["msgs"].assert_array().len(), 2);
 
     // Don't ack — wait for lease to expire
     sleep(Duration::from_millis(1500)).await;
@@ -262,7 +262,7 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r2["msgs"].as_array().unwrap();
+    let msgs = r2["msgs"].assert_array();
     assert_eq!(
         msgs.len(),
         2,
@@ -271,12 +271,11 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
 
     // Should have the same msg_ids as before
     let ids_r1: Vec<&str> = r1["msgs"]
-        .as_array()
-        .unwrap()
+        .assert_array()
         .iter()
-        .map(|m| m["msg_id"].as_str().unwrap())
+        .map(|m| m["msg_id"].assert_str())
         .collect();
-    let ids_r2: Vec<&str> = msgs.iter().map(|m| m["msg_id"].as_str().unwrap()).collect();
+    let ids_r2: Vec<&str> = msgs.iter().map(|m| m["msg_id"].assert_str()).collect();
     assert_eq!(ids_r1, ids_r2);
 
     Ok(())
@@ -339,7 +338,7 @@ async fn queue_starts_from_earliest() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(
         msgs.len(),
         5,
@@ -388,12 +387,12 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     // Ack only the first and last messages (skip the middle one)
-    let first_id = msgs[0]["msg_id"].as_str().unwrap();
-    let last_id = msgs[2]["msg_id"].as_str().unwrap();
+    let first_id = msgs[0]["msg_id"].assert_str();
+    let last_id = msgs[2]["msg_id"].assert_str();
     client
         .post("msgs/queue/ack")
         .json(json!({
@@ -418,7 +417,7 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs2 = r2["msgs"].as_array().unwrap();
+    let msgs2 = r2["msgs"].assert_array();
     assert_eq!(
         msgs2.len(),
         1,
@@ -426,8 +425,8 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
     );
 
     // The re-delivered message should be the middle one (value "b")
-    let middle_id = msgs[1]["msg_id"].as_str().unwrap();
-    assert_eq!(msgs2[0]["msg_id"].as_str().unwrap(), middle_id);
+    let middle_id = msgs[1]["msg_id"].assert_str();
+    assert_eq!(msgs2[0]["msg_id"].assert_str(), middle_id);
     assert_eq!(msgs2[0]["value"], json!("b".as_bytes()));
 
     Ok(())
@@ -475,7 +474,7 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs_a = r_a["msgs"].as_array().unwrap();
+    let msgs_a = r_a["msgs"].assert_array();
     assert_eq!(msgs_a.len(), 3);
 
     // Consumer B receives remaining 3 messages (first 3 are leased)
@@ -490,18 +489,14 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs_b = r_b["msgs"].as_array().unwrap();
+    let msgs_b = r_b["msgs"].assert_array();
     assert_eq!(msgs_b.len(), 3);
 
     // Verify no overlap in msg_ids between the two consumers
-    let ids_a: std::collections::HashSet<&str> = msgs_a
-        .iter()
-        .map(|m| m["msg_id"].as_str().unwrap())
-        .collect();
-    let ids_b: std::collections::HashSet<&str> = msgs_b
-        .iter()
-        .map(|m| m["msg_id"].as_str().unwrap())
-        .collect();
+    let ids_a: std::collections::HashSet<&str> =
+        msgs_a.iter().map(|m| m["msg_id"].assert_str()).collect();
+    let ids_b: std::collections::HashSet<&str> =
+        msgs_b.iter().map(|m| m["msg_id"].assert_str()).collect();
     assert!(
         ids_a.is_disjoint(&ids_b),
         "consumers must receive different messages"
@@ -518,7 +513,7 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r_c["msgs"].as_array().unwrap().len(),
+        r_c["msgs"].assert_array().len(),
         0,
         "no messages available when all are leased"
     );
@@ -564,14 +559,11 @@ async fn queue_consumer_groups_independent() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs_a = r_a["msgs"].as_array().unwrap();
+    let msgs_a = r_a["msgs"].assert_array();
     assert_eq!(msgs_a.len(), 3);
 
     // Ack all messages for group A
-    let msg_ids_a: Vec<&str> = msgs_a
-        .iter()
-        .map(|m| m["msg_id"].as_str().unwrap())
-        .collect();
+    let msg_ids_a: Vec<&str> = msgs_a.iter().map(|m| m["msg_id"].assert_str()).collect();
     client
         .post("msgs/queue/ack")
         .json(json!({
@@ -593,7 +585,7 @@ async fn queue_consumer_groups_independent() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs_b = r_b["msgs"].as_array().unwrap();
+    let msgs_b = r_b["msgs"].assert_array();
     assert_eq!(
         msgs_b.len(),
         3,
@@ -641,11 +633,11 @@ async fn nack_sends_to_dlq() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 2);
 
     // Nack all messages
-    let msg_ids: Vec<&str> = msgs.iter().map(|m| m["msg_id"].as_str().unwrap()).collect();
+    let msg_ids: Vec<&str> = msgs.iter().map(|m| m["msg_id"].assert_str()).collect();
     client
         .post("msgs/queue/nack")
         .json(json!({
@@ -671,7 +663,7 @@ async fn nack_sends_to_dlq() -> TestResult {
         .json();
 
     assert_eq!(
-        r2["msgs"].as_array().unwrap().len(),
+        r2["msgs"].assert_array().len(),
         0,
         "nacked messages should be in DLQ and not re-delivered"
     );
@@ -717,10 +709,9 @@ async fn nack_then_redrive_makes_available() -> TestResult {
         .json();
 
     let msg_ids: Vec<&str> = r1["msgs"]
-        .as_array()
-        .unwrap()
+        .assert_array()
         .iter()
-        .map(|m| m["msg_id"].as_str().unwrap())
+        .map(|m| m["msg_id"].assert_str())
         .collect();
 
     client
@@ -755,7 +746,7 @@ async fn nack_then_redrive_makes_available() -> TestResult {
         .json();
 
     assert_eq!(
-        r2["msgs"].as_array().unwrap().len(),
+        r2["msgs"].assert_array().len(),
         2,
         "redriven messages should be available again"
     );
@@ -934,9 +925,9 @@ async fn nack_retries_before_dlq() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 1);
-    let msg_id = msgs[0]["msg_id"].as_str().unwrap();
+    let msg_id = msgs[0]["msg_id"].assert_str();
 
     // Nack — should schedule for retry, NOT DLQ
     client
@@ -960,7 +951,7 @@ async fn nack_retries_before_dlq() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r2["msgs"].as_array().unwrap().len(),
+        r2["msgs"].assert_array().len(),
         0,
         "message should be delayed, not immediately available"
     );
@@ -980,13 +971,13 @@ async fn nack_retries_before_dlq() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs3 = r3["msgs"].as_array().unwrap();
+    let msgs3 = r3["msgs"].assert_array();
     assert_eq!(
         msgs3.len(),
         1,
         "message should be redelivered after retry delay"
     );
-    assert_eq!(msgs3[0]["msg_id"].as_str().unwrap(), msg_id);
+    assert_eq!(msgs3[0]["msg_id"].assert_str(), msg_id);
 
     // Nack again — retries exhausted, should go to DLQ
     client
@@ -1014,7 +1005,7 @@ async fn nack_retries_before_dlq() -> TestResult {
         .json();
 
     assert_eq!(
-        r4["msgs"].as_array().unwrap().len(),
+        r4["msgs"].assert_array().len(),
         0,
         "message should be in DLQ after exhausting retries"
     );
@@ -1069,9 +1060,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msg_id = r1["msgs"].as_array().unwrap()[0]["msg_id"]
-        .as_str()
-        .unwrap();
+    let msg_id = r1["msgs"].assert_array()[0]["msg_id"].assert_str();
 
     client
         .post("msgs/queue/nack")
@@ -1098,7 +1087,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    assert_eq!(r2["msgs"].as_array().unwrap().len(), 1);
+    assert_eq!(r2["msgs"].assert_array().len(), 1);
 
     client
         .post("msgs/queue/nack")
@@ -1121,7 +1110,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r3["msgs"].as_array().unwrap().len(), 0);
+    assert_eq!(r3["msgs"].assert_array().len(), 0);
 
     // The DLQ topic should have the message
     let r_dlq = client
@@ -1134,7 +1123,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let dlq_msgs = r_dlq["msgs"].as_array().unwrap();
+    let dlq_msgs = r_dlq["msgs"].assert_array();
     assert_eq!(dlq_msgs.len(), 1, "message should appear in DLQ topic");
     assert_eq!(dlq_msgs[0]["value"], json!("a".as_bytes()));
 

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, time::Duration};
 
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestResult,
     server::{TestContext, start_server},
 };
 use tokio::time::sleep;
@@ -54,12 +54,12 @@ async fn stream_receive_returns_published_messages() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     for m in msgs {
         assert!(m["offset"].is_u64());
-        let topic = m["topic"].as_str().unwrap();
+        let topic = m["topic"].assert_str();
         assert!(
             topic.starts_with("ns-recv:my-topic~"),
             "topic should be partition-level: {topic}"
@@ -69,7 +69,7 @@ async fn stream_receive_returns_published_messages() -> TestResult {
     }
 
     // Offsets should be sequential within the same partition
-    let offsets: Vec<u64> = msgs.iter().map(|m| m["offset"].as_u64().unwrap()).collect();
+    let offsets: Vec<u64> = msgs.iter().map(|m| m["offset"].assert_u64()).collect();
     assert_eq!(offsets[1], offsets[0] + 1);
     assert_eq!(offsets[2], offsets[1] + 1);
 
@@ -122,7 +122,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r1["msgs"].as_array().unwrap().len(), 2);
+    assert_eq!(r1["msgs"].assert_array().len(), 2);
 
     // Second receive with the same CG — partition is locked, returns error
     let _r2 = client
@@ -136,9 +136,9 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
 
     // Commit the first batch to unlock the partition.
     // The response topic already includes the namespace, so we can pass it directly.
-    let msgs = r1["msgs"].as_array().unwrap();
-    let partition_topic = msgs[0]["topic"].as_str().unwrap();
-    let last_offset = msgs[1]["offset"].as_u64().unwrap();
+    let msgs = r1["msgs"].assert_array();
+    let partition_topic = msgs[0]["topic"].assert_str();
+    let last_offset = msgs[1]["offset"].assert_u64();
 
     client
         .post("msgs/stream/commit")
@@ -172,7 +172,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r3["msgs"].as_array().unwrap().len(), 1);
+    assert_eq!(r3["msgs"].assert_array().len(), 1);
 
     Ok(())
 }
@@ -242,21 +242,15 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs_a = r_a["msgs"].as_array().unwrap();
-    let msgs_b = r_b["msgs"].as_array().unwrap();
+    let msgs_a = r_a["msgs"].assert_array();
+    let msgs_b = r_b["msgs"].assert_array();
 
     assert_eq!(msgs_a.len(), 2);
     assert_eq!(msgs_b.len(), 2);
 
     // Both groups should get the same offsets
-    let offsets_a: Vec<u64> = msgs_a
-        .iter()
-        .map(|m| m["offset"].as_u64().unwrap())
-        .collect();
-    let offsets_b: Vec<u64> = msgs_b
-        .iter()
-        .map(|m| m["offset"].as_u64().unwrap())
-        .collect();
+    let offsets_a: Vec<u64> = msgs_a.iter().map(|m| m["offset"].assert_u64()).collect();
+    let offsets_b: Vec<u64> = msgs_b.iter().map(|m| m["offset"].assert_u64()).collect();
     assert_eq!(offsets_a, offsets_b);
 
     Ok(())
@@ -326,7 +320,7 @@ async fn stream_receive_with_defaults() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 1);
 
     Ok(())
@@ -382,7 +376,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r_a["msgs"].as_array().unwrap().len(), 2);
+    assert_eq!(r_a["msgs"].assert_array().len(), 2);
 
     // Consumer B (same CG) — partition is locked, returns error
     let _ = client
@@ -396,9 +390,9 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
 
     // Consumer A commits — unlocks the partition.
     // The response topic already includes the namespace.
-    let msgs_a = r_a["msgs"].as_array().unwrap();
-    let partition_topic = msgs_a[0]["topic"].as_str().unwrap();
-    let last_offset = msgs_a[1]["offset"].as_u64().unwrap();
+    let msgs_a = r_a["msgs"].assert_array();
+    let partition_topic = msgs_a[0]["topic"].assert_str();
+    let last_offset = msgs_a[1]["offset"].assert_u64();
 
     client
         .post("msgs/stream/commit")
@@ -421,7 +415,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r_b["msgs"].as_array().unwrap().len(),
+        r_b["msgs"].assert_array().len(),
         3,
         "after commit, remaining messages should be available"
     );
@@ -496,7 +490,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
         .expect(StatusCode::OK)
         .json();
 
-    let msgs_a = r_a["msgs"].as_array().unwrap();
+    let msgs_a = r_a["msgs"].assert_array();
     assert_eq!(msgs_a.len(), 5);
 
     // Consumer B: same CG, should get the other partition
@@ -511,18 +505,12 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
         .expect(StatusCode::OK)
         .json();
 
-    let msgs_b = r_b["msgs"].as_array().unwrap();
+    let msgs_b = r_b["msgs"].assert_array();
     assert_eq!(msgs_b.len(), 5);
 
     // Each consumer should have messages from a single (different) partition
-    let topics_a: HashSet<&str> = msgs_a
-        .iter()
-        .map(|m| m["topic"].as_str().unwrap())
-        .collect();
-    let topics_b: HashSet<&str> = msgs_b
-        .iter()
-        .map(|m| m["topic"].as_str().unwrap())
-        .collect();
+    let topics_a: HashSet<&str> = msgs_a.iter().map(|m| m["topic"].assert_str()).collect();
+    let topics_b: HashSet<&str> = msgs_b.iter().map(|m| m["topic"].assert_str()).collect();
 
     assert_eq!(
         topics_a.len(),
@@ -590,13 +578,13 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     // Extract partition-level topic and last offset in the batch.
     // The response topic already includes the namespace.
-    let partition_topic = msgs[0]["topic"].as_str().unwrap();
-    let last_offset = msgs[2]["offset"].as_u64().unwrap();
+    let partition_topic = msgs[0]["topic"].assert_str();
+    let last_offset = msgs[2]["offset"].assert_u64();
 
     // Commit the last offset we processed
     client
@@ -619,7 +607,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r2["msgs"].as_array().unwrap().len(), 0);
+    assert_eq!(r2["msgs"].assert_array().len(), 0);
 
     // Publish more
     client
@@ -645,7 +633,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r3["msgs"].as_array().unwrap().len(), 1);
+    assert_eq!(r3["msgs"].assert_array().len(), 1);
 
     Ok(())
 }
@@ -748,16 +736,15 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
                     "consumer_group": "cg1",
                 }))
                 .await
-                .unwrap()
         }));
     }
 
     let mut total_msgs = 0usize;
     for handle in handles {
-        let resp = handle.await.unwrap();
+        let resp = handle.await??;
         if matches!(resp.status(), StatusCode::OK) {
             let body = resp.json();
-            let msgs = body["msgs"].as_array().unwrap();
+            let msgs = body["msgs"].assert_array();
             total_msgs += msgs.len();
         } else {
             assert!(matches!(resp.status(), StatusCode::BAD_REQUEST));
@@ -821,12 +808,12 @@ async fn partial_commit_preserves_lease() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 5);
 
-    let partition_topic = msgs[0]["topic"].as_str().unwrap();
-    let first_offset = msgs[0]["offset"].as_u64().unwrap();
-    let last_offset = msgs[4]["offset"].as_u64().unwrap();
+    let partition_topic = msgs[0]["topic"].assert_str();
+    let first_offset = msgs[0]["offset"].assert_u64();
+    let last_offset = msgs[4]["offset"].assert_u64();
 
     // Partial commit: only commit the first message
     client
@@ -871,7 +858,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r2["msgs"].as_array().unwrap().len(),
+        r2["msgs"].assert_array().len(),
         5,
         "remaining messages should be available after lease release"
     );
@@ -916,7 +903,7 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r1["msgs"].as_array().unwrap().len(),
+        r1["msgs"].assert_array().len(),
         0,
         "new consumer group should not see pre-existing messages"
     );
@@ -944,7 +931,7 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r2["msgs"].as_array().unwrap().len(),
+        r2["msgs"].assert_array().len(),
         3,
         "consumer group should only see messages published after registration"
     );
@@ -996,11 +983,11 @@ async fn default_namespace_receive_and_commit() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     for m in msgs {
-        let topic = m["topic"].as_str().unwrap();
+        let topic = m["topic"].assert_str();
         assert!(
             topic.starts_with("def-topic~"),
             "default namespace response topics should not have a namespace prefix: {topic}"
@@ -1009,8 +996,8 @@ async fn default_namespace_receive_and_commit() -> TestResult {
 
     // Commit using the response topic directly
     let last = msgs.last().unwrap();
-    let partition_topic = last["topic"].as_str().unwrap();
-    let last_offset = last["offset"].as_u64().unwrap();
+    let partition_topic = last["topic"].assert_str();
+    let last_offset = last["offset"].assert_u64();
 
     client
         .post("msgs/stream/commit")
@@ -1033,7 +1020,7 @@ async fn default_namespace_receive_and_commit() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 0, "all messages should be committed");
 
     Ok(())

--- a/tests/it/msgs/stream_seek.rs
+++ b/tests/it/msgs/stream_seek.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestResult,
     server::{TestContext, start_server},
 };
 
@@ -53,12 +53,12 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     // Commit to advance past all messages
-    let partition_topic = msgs[0]["topic"].as_str().unwrap();
-    let last_offset = msgs[2]["offset"].as_u64().unwrap();
+    let partition_topic = msgs[0]["topic"].assert_str();
+    let last_offset = msgs[2]["offset"].assert_u64();
     client
         .post("msgs/stream/commit")
         .json(json!({
@@ -79,7 +79,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r2["msgs"].as_array().unwrap().len(), 0);
+    assert_eq!(r2["msgs"].assert_array().len(), 0);
 
     // Seek to earliest
     client
@@ -104,7 +104,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
         .json();
 
     assert_eq!(
-        r3["msgs"].as_array().unwrap().len(),
+        r3["msgs"].assert_array().len(),
         3,
         "seek to earliest should replay all messages"
     );
@@ -161,7 +161,7 @@ async fn seek_latest_skips_existing() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r1["msgs"].as_array().unwrap().len(),
+        r1["msgs"].assert_array().len(),
         0,
         "seek to latest should skip existing messages"
     );
@@ -190,7 +190,7 @@ async fn seek_latest_skips_existing() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(
-        r2["msgs"].as_array().unwrap().len(),
+        r2["msgs"].assert_array().len(),
         2,
         "should receive only messages published after seek to latest"
     );
@@ -245,12 +245,12 @@ async fn seek_to_specific_offset() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 5);
-    let partition_topic = msgs[0]["topic"].as_str().unwrap();
+    let partition_topic = msgs[0]["topic"].assert_str();
 
     // Commit past all messages
-    let last_offset = msgs[4]["offset"].as_u64().unwrap();
+    let last_offset = msgs[4]["offset"].assert_u64();
     client
         .post("msgs/stream/commit")
         .json(json!({
@@ -283,13 +283,13 @@ async fn seek_to_specific_offset() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs2 = r2["msgs"].as_array().unwrap();
+    let msgs2 = r2["msgs"].assert_array();
     assert_eq!(
         msgs2.len(),
         3,
         "should get 3 messages starting from offset 2"
     );
-    assert_eq!(msgs2[0]["offset"].as_u64().unwrap(), 2);
+    assert_eq!(msgs2[0]["offset"].assert_u64(), 2);
 
     Ok(())
 }
@@ -394,7 +394,7 @@ async fn seek_position_works_on_topic_level() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = r1["msgs"].as_array().unwrap();
+    let msgs = r1["msgs"].assert_array();
     assert!(
         msgs.len() >= 2,
         "should receive messages from at least one partition after topic-level seek"
@@ -470,7 +470,7 @@ async fn seek_clears_lease() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(r1["msgs"].as_array().unwrap().len(), 2);
+    assert_eq!(r1["msgs"].assert_array().len(), 2);
 
     // Verify partition is locked
     client
@@ -505,7 +505,7 @@ async fn seek_clears_lease() -> TestResult {
         .json();
 
     assert_eq!(
-        r2["msgs"].as_array().unwrap().len(),
+        r2["msgs"].assert_array().len(),
         2,
         "seek should clear lease and allow re-receive"
     );

--- a/tests/it/msgs/topic_configure.rs
+++ b/tests/it/msgs/topic_configure.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use serde_json::json;
 use test_utils::{
-    StatusCode, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestResult,
     server::{TestContext, start_server},
 };
 
@@ -54,11 +54,11 @@ async fn default_is_one_partition() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     // All messages should be on the same single partition
-    let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].as_str().unwrap()).collect();
+    let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].assert_str()).collect();
     assert_eq!(topics.len(), 1, "all messages should be on one partition");
     assert!(
         topics.contains("ns-def-part:t1~0"),
@@ -92,7 +92,7 @@ async fn configure_topic_partitions() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    assert_eq!(response["partitions"].as_u64().unwrap(), 4);
+    assert_eq!(response["partitions"].assert_u64(), 4);
 
     // Register consumer group before publishing
     client
@@ -128,17 +128,17 @@ async fn configure_topic_partitions() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     // All partition-level topics should be within ns-conf:t1~0..ns-conf:t1~3
     for m in msgs {
-        let topic = m["topic"].as_str().unwrap();
+        let topic = m["topic"].assert_str();
         assert!(
             topic.starts_with("ns-conf:t1~"),
             "expected partition-level topic: {topic}"
         );
-        let partition: u16 = topic.strip_prefix("ns-conf:t1~").unwrap().parse().unwrap();
+        let partition: u16 = topic.strip_prefix("ns-conf:t1~").unwrap().parse()?;
         assert!(partition < 4, "partition {partition} should be < 4");
     }
 
@@ -309,11 +309,11 @@ async fn receive_respects_configured_partitions() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 2);
 
     // Messages should come from different partition-level topics
-    let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].as_str().unwrap()).collect();
+    let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].assert_str()).collect();
     assert_eq!(
         topics.len(),
         2,
@@ -325,11 +325,7 @@ async fn receive_respects_configured_partitions() -> TestResult {
             topic.starts_with("ns-recv-conf:t1~"),
             "expected partition-level topic: {topic}"
         );
-        let partition: u16 = topic
-            .strip_prefix("ns-recv-conf:t1~")
-            .unwrap()
-            .parse()
-            .unwrap();
+        let partition: u16 = topic.strip_prefix("ns-recv-conf:t1~").unwrap().parse()?;
         assert!(partition < 16, "partition {partition} should be < 16");
     }
 
@@ -355,7 +351,7 @@ async fn configure_default_namespace_topic() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    assert_eq!(response["partitions"].as_u64().unwrap(), 4);
+    assert_eq!(response["partitions"].assert_u64(), 4);
 
     // Register consumer group before publishing
     client
@@ -391,16 +387,16 @@ async fn configure_default_namespace_topic() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let msgs = response["msgs"].as_array().unwrap();
+    let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
     for m in msgs {
-        let topic = m["topic"].as_str().unwrap();
+        let topic = m["topic"].assert_str();
         assert!(
             topic.starts_with("def-t1~"),
             "default namespace topic should not have namespace prefix: {topic}"
         );
-        let partition: u16 = topic.strip_prefix("def-t1~").unwrap().parse().unwrap();
+        let partition: u16 = topic.strip_prefix("def-t1~").unwrap().parse()?;
         assert!(partition < 4, "partition {partition} should be < 4");
     }
 

--- a/tests/it/stream.rs
+++ b/tests/it/stream.rs
@@ -117,7 +117,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 3);
 //     assert_eq!(
 //         msgs1[0],
@@ -157,7 +157,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 2);
 //     assert_eq!(
 //         msgs2[0],
@@ -214,7 +214,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 2);
 //     assert_eq!(
 //         msgs1[0],
@@ -241,7 +241,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 2);
 //     assert_eq!(
 //         msgs2[0],
@@ -299,7 +299,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 2);
 //     assert_eq!(
 //         msgs1[0],
@@ -335,7 +335,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 1);
 //     assert_eq!(
 //         msgs2[0],
@@ -388,7 +388,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 1);
 //     assert_eq!(
 //         msgs1[0],
@@ -408,7 +408,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 1);
 //     assert_eq!(
 //         msgs2[0],
@@ -431,7 +431,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs3 = fetch3["msgs"].as_array().unwrap();
+//     let msgs3 = fetch3["msgs"].assert_array();
 //     assert_eq!(msgs3.len(), 1);
 //     assert_eq!(
 //         msgs3[0],
@@ -492,7 +492,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 2);
 //     assert_eq!(msgs1[0]["headers"]["msg"], "A");
 //     assert_eq!(msgs1[1]["headers"]["msg"], "B");
@@ -510,7 +510,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 2);
 //     assert_eq!(msgs2[0]["headers"]["msg"], "C");
 //     assert_eq!(msgs2[1]["headers"]["msg"], "D");
@@ -528,7 +528,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs3 = fetch3["msgs"].as_array().unwrap();
+//     let msgs3 = fetch3["msgs"].assert_array();
 //     assert_eq!(msgs3.len(), 2);
 //     assert_eq!(msgs3[0]["headers"]["msg"], "E");
 //     assert_eq!(msgs3[1]["headers"]["msg"], "F");
@@ -562,7 +562,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs4 = fetch4["msgs"].as_array().unwrap();
+//     let msgs4 = fetch4["msgs"].assert_array();
 //     assert_eq!(msgs4.len(), 6);
 //     assert_eq!(msgs4[0]["headers"]["msg"], "A");
 //     assert_eq!(msgs4[1]["headers"]["msg"], "B");
@@ -621,7 +621,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 3);
 //     assert_eq!(msgs1[0]["headers"]["msg"], "A");
 //     assert_eq!(msgs1[1]["headers"]["msg"], "B");
@@ -640,7 +640,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 3);
 //     assert_eq!(msgs2[0]["headers"]["msg"], "D");
 //     assert_eq!(msgs2[1]["headers"]["msg"], "E");
@@ -675,7 +675,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs3 = fetch3["msgs"].as_array().unwrap();
+//     let msgs3 = fetch3["msgs"].assert_array();
 //     assert_eq!(msgs3.len(), 2);
 //     assert_eq!(msgs3[0]["headers"]["msg"], "A");
 //     assert_eq!(msgs3[1]["headers"]["msg"], "F");
@@ -729,7 +729,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 6);
 //     assert_eq!(msgs1[0]["headers"]["msg"], "A");
 //     assert_eq!(msgs1[1]["headers"]["msg"], "B");
@@ -767,7 +767,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs3 = fetch3["msgs"].as_array().unwrap();
+//     let msgs3 = fetch3["msgs"].assert_array();
 //     assert_eq!(msgs3.len(), 4);
 //     assert_eq!(msgs3[0]["headers"]["msg"], "A");
 //     assert_eq!(msgs3[1]["headers"]["msg"], "B");
@@ -824,7 +824,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 6);
 
 //     // DLQ messages B and D (ids 1 and 3)
@@ -856,7 +856,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 4);
 //     assert_eq!(msgs2[0]["headers"]["msg"], "A");
 //     assert_eq!(msgs2[1]["headers"]["msg"], "C");
@@ -902,7 +902,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs3 = fetch3["msgs"].as_array().unwrap();
+//     let msgs3 = fetch3["msgs"].assert_array();
 //     assert_eq!(msgs3.len(), 2);
 //     assert_eq!(msgs3[0]["headers"]["msg"], "B");
 //     assert_eq!(msgs3[1]["headers"]["msg"], "D");
@@ -955,7 +955,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 3);
 //     assert_eq!(msgs1[0]["headers"]["msg"], "A");
 //     assert_eq!(msgs1[1]["headers"]["msg"], "B");
@@ -1008,7 +1008,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 2);
 //     assert_eq!(msgs2[0]["headers"]["msg"], "B");
 //     assert_eq!(msgs2[1]["headers"]["msg"], "D");
@@ -1057,7 +1057,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs1 = fetch1["msgs"].as_array().unwrap();
+//     let msgs1 = fetch1["msgs"].assert_array();
 //     assert_eq!(msgs1.len(), 1);
 //     assert_eq!(msgs1[0]["headers"]["msg"], "A");
 
@@ -1106,7 +1106,7 @@
 //         .expect(StatusCode::OK)
 //         .json();
 
-//     let msgs2 = fetch2["msgs"].as_array().unwrap();
+//     let msgs2 = fetch2["msgs"].assert_array();
 //     assert_eq!(msgs2.len(), 0);
 
 //     Ok(())


### PR DESCRIPTION
Using the same helper methods I recently added to webhooks-private.