### PR TITLE
Make bootstrapping support env var

### DIFF
--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -247,6 +247,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
             log_sync_interval_duration: Duration::from_secs(30),
             log_ack_immediately: true,
         },
+        bootstrap_cfg: None,
         bootstrap_cfg_path: None,
     }
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -84,13 +84,19 @@ struct BootstrapConfig {
 }
 
 impl BootstrapConfig {
-    fn load(config_path: Option<&str>) -> anyhow::Result<BootstrapConfig> {
-        let mut config = match config_path {
-            Some(path) => {
-                let config_file = File::open(path).context("opening bootstrap config")?;
+    fn load(
+        config_path: Option<&str>,
+        config_content: Option<&str>,
+    ) -> anyhow::Result<BootstrapConfig> {
+        let mut config = match (config_content, config_path) {
+            (Some(content), _) => {
+                yaml_serde::from_str(content).context("parsing bootstrap config")?
+            }
+            (None, Some(path)) => {
+                let config_file = File::open(path).context("opening bootstrap config file")?;
                 yaml_serde::from_reader(config_file).context("parsing bootstrap config")?
             }
-            None => BootstrapConfig::default(),
+            (None, None) => BootstrapConfig::default(),
         };
 
         // Configure default namespace for cache, if not part of the config file
@@ -158,8 +164,10 @@ pub async fn run(app_config: AppConfig, raft_state: RaftState) -> anyhow::Result
         }
     }
 
-    let bootstrap = BootstrapConfig::load(app_config.bootstrap_cfg_path.as_deref())
-        .expect("Failed to load bootstrap config");
+    let bootstrap = BootstrapConfig::load(
+        app_config.bootstrap_cfg_path.as_deref(),
+        app_config.bootstrap_cfg.as_deref(),
+    )?;
 
     tracing::debug!(
         ?bootstrap,

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -454,8 +454,13 @@ pub struct ConfigurationInner {
     #[serde(default)]
     pub cluster: ClusterConfiguration,
 
+    /// The path to a YAML bootstrap file
     #[serde(default)]
     pub bootstrap_cfg_path: Option<String>,
+
+    /// YAML bootstrap data. Takes precedence over `bootstrap_cfg_path`
+    #[serde(default)]
+    pub bootstrap_cfg: Option<String>,
 }
 
 impl Default for ConfigurationInner {
@@ -598,6 +603,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         opentelemetry_service_name,
         environment,
         bootstrap_cfg_path,
+        bootstrap_cfg,
         cluster:
             ClusterConfiguration {
                 advertised_address: cluster_advertised_address,
@@ -648,6 +654,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         opentelemetry_metrics_address: "COYOTE_OPENTELEMETRY_METRICS_ADDRESS",
         opentelemetry_sample_ratio: "COYOTE_OPENTELEMETRY_SAMPLE_RATIO",
         bootstrap_cfg_path: "COYOTE_BOOTSTRAP_CFG_PATH",
+        bootstrap_cfg: "COYOTE_BOOTSTRAP_CFG",
         cluster_listen_address: "COYOTE_CLUSTER_LISTEN_ADDRESS",
         cluster_advertised_address: "COYOTE_CLUSTER_ADVERTISED_ADDRESS",
         cluster_snapshot_path: "COYOTE_CLUSTER_SNAPSHOT_PATH",

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -1,58 +1,40 @@
 use http::StatusCode;
 use serde_json::json;
 use test_utils::{
-    TestResult,
+    TestClient, TestResult,
     server::{TestServerBuilder, default_server_config},
 };
 
-#[tokio::test]
-async fn test_bootstrap() -> TestResult {
-    let workdir = tempfile::tempdir()?;
-    let mut cfg = default_server_config(workdir.path());
-    cfg.bootstrap_cfg_path = Some("./tests/it/static/bootstrap.test.yaml".to_string());
-
-    let test_server = TestServerBuilder::new().cfg(cfg).build().await;
-    let client = test_server.client;
-
-    let default_kv_namespace = client
+async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
+    let default_kv = client
         .post("kv/namespace/get")
-        .json(json!({
-            "name": "default",
-        }))
+        .json(json!({"name": "default"}))
         .await?
         .expect(StatusCode::OK)
         .json();
+    assert_eq!(default_kv["max_storage_bytes"], 1000);
+    assert_eq!(default_kv["storage_type"], "Ephemeral");
 
-    assert_eq!(default_kv_namespace["max_storage_bytes"], 1000);
-    assert_eq!(default_kv_namespace["storage_type"], "Ephemeral");
-
-    let default_cache_namespace = client
+    let default_cache = client
         .post("cache/namespace/get")
-        .json(json!({
-            "name": "default",
-        }))
+        .json(json!({"name": "default"}))
         .await?
         .expect(StatusCode::OK)
         .json();
+    assert_eq!(default_cache["name"], "default");
+    assert_eq!(default_cache["eviction_policy"], "NoEviction");
 
-    assert_eq!(default_cache_namespace["name"], "default");
-    assert_eq!(default_cache_namespace["eviction_policy"], "NoEviction");
-
-    let default_idempotency_namespace = client
+    let default_idempotency = client
         .post("idempotency/namespace/get")
-        .json(json!({
-            "name": "default",
-        }))
+        .json(json!({"name": "default"}))
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(default_idempotency_namespace["name"], "default");
+    assert_eq!(default_idempotency["name"], "default");
 
     let kv1 = client
         .post("kv/namespace/get")
-        .json(json!({
-            "name": "kv1",
-        }))
+        .json(json!({"name": "kv1"}))
         .await?
         .expect(StatusCode::OK)
         .json();
@@ -62,9 +44,7 @@ async fn test_bootstrap() -> TestResult {
 
     let kv2 = client
         .post("kv/namespace/get")
-        .json(json!({
-            "name": "kv2",
-        }))
+        .json(json!({"name": "kv2"}))
         .await?
         .expect(StatusCode::OK)
         .json();
@@ -73,22 +53,17 @@ async fn test_bootstrap() -> TestResult {
 
     let cache1 = client
         .post("cache/namespace/get")
-        .json(json!({
-            "name": "cache1",
-        }))
+        .json(json!({"name": "cache1"}))
         .await?
         .expect(StatusCode::OK)
         .json();
-
     assert_eq!(cache1["name"], "cache1");
     assert_eq!(cache1["eviction_policy"], "LeastRecentlyUsed");
     assert_eq!(cache1["storage_type"], "Persistent");
 
     let stream2 = client
         .post("msgs/namespace/get")
-        .json(json!({
-            "name": "stream2",
-        }))
+        .json(json!({"name": "stream2"}))
         .await?
         .expect(StatusCode::OK)
         .json();
@@ -97,4 +72,24 @@ async fn test_bootstrap() -> TestResult {
     assert_eq!(stream2["storage_type"], "Persistent");
 
     Ok(())
+}
+
+#[tokio::test]
+async fn test_bootstrap_file_based() -> TestResult {
+    let workdir = tempfile::tempdir()?;
+    let mut cfg = default_server_config(workdir.path());
+    cfg.bootstrap_cfg_path = Some("./tests/it/static/bootstrap.test.yaml".to_string());
+
+    let test_server = TestServerBuilder::new().cfg(cfg).build().await;
+    assert_bootstrap_namespaces(&test_server.client).await
+}
+
+#[tokio::test]
+async fn test_bootstrap_env_var_based() -> TestResult {
+    let workdir = tempfile::tempdir()?;
+    let mut cfg = default_server_config(workdir.path());
+    cfg.bootstrap_cfg = Some(include_str!("static/bootstrap.test.yaml").to_string());
+
+    let test_server = TestServerBuilder::new().cfg(cfg).build().await;
+    assert_bootstrap_namespaces(&test_server.client).await
 }


### PR DESCRIPTION
Support passing the bootstrap config as an env var instead of just a file, which doesn't work well in k8s.

This will ultimately not be YAML, btw, but it's what we have right now.