### PR TITLE
Kv/cache: return value=null when not found instead of error.

### DIFF
--- a/clients/cli/src/cmds/benchmark.rs
+++ b/clients/cli/src/cmds/benchmark.rs
@@ -482,7 +482,7 @@ impl BenchShard for BenchKvGet {
         // Start of real code
         let t = Instant::now();
         let ret = client.kv().get(key.clone(), KvGetIn::new()).await?;
-        let bytes = ret.value.len() as u64;
+        let bytes = ret.value.expect("key should exist").len() as u64;
         self.bench_result.process(t.elapsed(), bytes)?;
         Ok(())
     }
@@ -604,7 +604,7 @@ impl BenchShard for BenchCacheGet {
         // Start of real code
         let t = Instant::now();
         let ret = client.cache().get(key.clone(), CacheGetIn::new()).await?;
-        let bytes = ret.value.len() as u64;
+        let bytes = ret.value.expect("key should exist").len() as u64;
         self.bench_result.process(t.elapsed(), bytes)?;
         Ok(())
     }

--- a/clients/go/internal/models/cache_get_out.go
+++ b/clients/go/internal/models/cache_get_out.go
@@ -7,7 +7,6 @@ import (
 )
 
 type CacheGetOut struct {
-	Key    string     `json:"key"`
 	Expiry *time.Time `json:"expiry,omitempty"` // Time of expiry
-	Value  []uint8    `json:"value"`
+	Value  []uint8    `json:"value,omitempty"`
 }

--- a/clients/go/internal/models/kv_get_out.go
+++ b/clients/go/internal/models/kv_get_out.go
@@ -7,7 +7,6 @@ import (
 )
 
 type KvGetOut struct {
-	Key    string     `json:"key"`
 	Expiry *time.Time `json:"expiry,omitempty"` // Time of expiry
-	Value  []uint8    `json:"value"`
+	Value  []uint8    `json:"value,omitempty"`
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/CacheGetOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/CacheGetOut.java
@@ -28,31 +28,11 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class CacheGetOut {
-@JsonProperty private String key;
 @JsonProperty private OffsetDateTime expiry;
 @JsonProperty private List<Byte> value;
 public CacheGetOut () {}
 
- public CacheGetOut key(String key) {
-        this.key = key;
-        return this;
-    }
-
-    /**
-    * Get key
-    *
-     * @return key
-     */
-    @javax.annotation.Nonnull
-     public String getKey() {
-        return key;
-    }
-
-     public void setKey(String key) {
-        this.key = key;
-    }
-
-     public CacheGetOut expiry(OffsetDateTime expiry) {
+ public CacheGetOut expiry(OffsetDateTime expiry) {
         this.expiry = expiry;
         return this;
     }
@@ -88,7 +68,7 @@ public CacheGetOut () {}
     *
      * @return value
      */
-    @javax.annotation.Nonnull
+    @javax.annotation.Nullable
      public List<Byte> getValue() {
         return value;
     }

--- a/clients/java/src/main/java/com/svix/coyote/models/KvGetOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvGetOut.java
@@ -28,31 +28,11 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class KvGetOut {
-@JsonProperty private String key;
 @JsonProperty private OffsetDateTime expiry;
 @JsonProperty private List<Byte> value;
 public KvGetOut () {}
 
- public KvGetOut key(String key) {
-        this.key = key;
-        return this;
-    }
-
-    /**
-    * Get key
-    *
-     * @return key
-     */
-    @javax.annotation.Nonnull
-     public String getKey() {
-        return key;
-    }
-
-     public void setKey(String key) {
-        this.key = key;
-    }
-
-     public KvGetOut expiry(OffsetDateTime expiry) {
+ public KvGetOut expiry(OffsetDateTime expiry) {
         this.expiry = expiry;
         return this;
     }
@@ -88,7 +68,7 @@ public KvGetOut () {}
     *
      * @return value
      */
-    @javax.annotation.Nonnull
+    @javax.annotation.Nullable
      public List<Byte> getValue() {
         return value;
     }

--- a/clients/javascript/src/models/cacheGetOut.ts
+++ b/clients/javascript/src/models/cacheGetOut.ts
@@ -1,17 +1,15 @@
 // this file is @generated
 
 export interface CacheGetOut {
-    key: string;
     /** Time of expiry */
     expiry?: Date | null;
-    value: number[];
+    value?: number[] | null;
 }
 
 export const CacheGetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject(object: any): CacheGetOut {
         return {
-            key: object['key'],
             expiry: object['expiry'] ? new Date(object['expiry']) : null,
             value: object['value'],
         };
@@ -20,7 +18,6 @@ export const CacheGetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _toJsonObject(self: CacheGetOut): any {
         return {
-            'key': self.key,
             'expiry': self.expiry,
             'value': self.value,
         };

--- a/clients/javascript/src/models/kvGetOut.ts
+++ b/clients/javascript/src/models/kvGetOut.ts
@@ -1,17 +1,15 @@
 // this file is @generated
 
 export interface KvGetOut {
-    key: string;
     /** Time of expiry */
     expiry?: Date | null;
-    value: number[];
+    value?: number[] | null;
 }
 
 export const KvGetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject(object: any): KvGetOut {
         return {
-            key: object['key'],
             expiry: object['expiry'] ? new Date(object['expiry']) : null,
             value: object['value'],
         };
@@ -20,7 +18,6 @@ export const KvGetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _toJsonObject(self: KvGetOut): any {
         return {
-            'key': self.key,
             'expiry': self.expiry,
             'value': self.value,
         };

--- a/clients/python/coyote/models/cache_get_out.py
+++ b/clients/python/coyote/models/cache_get_out.py
@@ -6,9 +6,7 @@ from ..internal.base_model import BaseModel
 
 
 class CacheGetOut(BaseModel):
-    key: str
-
     expiry: t.Optional[datetime] = None
     """Time of expiry"""
 
-    value: bytes
+    value: t.Optional[bytes] = None

--- a/clients/python/coyote/models/kv_get_out.py
+++ b/clients/python/coyote/models/kv_get_out.py
@@ -6,9 +6,7 @@ from ..internal.base_model import BaseModel
 
 
 class KvGetOut(BaseModel):
-    key: str
-
     expiry: t.Optional[datetime] = None
     """Time of expiry"""
 
-    value: bytes
+    value: t.Optional[bytes] = None

--- a/clients/rust/src/models/cache_get_out.rs
+++ b/clients/rust/src/models/cache_get_out.rs
@@ -3,26 +3,29 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CacheGetOut {
-    pub key: String,
-
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiry: Option<jiff::Timestamp>,
 
-    pub value: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Vec<u8>>,
 }
 
 impl CacheGetOut {
-    pub fn new(key: String, value: Vec<u8>) -> Self {
+    pub fn new() -> Self {
         Self {
-            key,
             expiry: None,
-            value,
+            value: None,
         }
     }
 
     pub fn with_expiry(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
         self.expiry = value.into();
+        self
+    }
+
+    pub fn with_value(mut self, value: impl Into<Option<Vec<u8>>>) -> Self {
+        self.value = value.into();
         self
     }
 }

--- a/clients/rust/src/models/kv_get_out.rs
+++ b/clients/rust/src/models/kv_get_out.rs
@@ -3,26 +3,29 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KvGetOut {
-    pub key: String,
-
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiry: Option<jiff::Timestamp>,
 
-    pub value: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Vec<u8>>,
 }
 
 impl KvGetOut {
-    pub fn new(key: String, value: Vec<u8>) -> Self {
+    pub fn new() -> Self {
         Self {
-            key,
             expiry: None,
-            value,
+            value: None,
         }
     }
 
     pub fn with_expiry(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
         self.expiry = value.into();
+        self
+    }
+
+    pub fn with_value(mut self, value: impl Into<Option<Vec<u8>>>) -> Self {
+        self.value = value.into();
         self
     }
 }

--- a/clients/rust/tests/kv.rs
+++ b/clients/rust/tests/kv.rs
@@ -22,5 +22,5 @@ async fn test_kv_set_get() {
 
     let resp = client.kv().get(test_key, KvGetIn::new()).await.unwrap();
 
-    assert_eq!(resp.value, test_val);
+    assert_eq!(resp.value, Some(test_val));
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1389,12 +1389,6 @@
       "CacheGetOut": {
         "type": "object",
         "properties": {
-          "key": {
-            "type": "string",
-            "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
-            "example": "some_key"
-          },
           "expiry": {
             "description": "Time of expiry",
             "type": "string",
@@ -1408,13 +1402,10 @@
               "format": "uint8",
               "minimum": 0,
               "maximum": 255
-            }
+            },
+            "nullable": true
           }
-        },
-        "required": [
-          "key",
-          "value"
-        ]
+        }
       },
       "CacheSetIn": {
         "type": "object",
@@ -1849,12 +1840,6 @@
       "KvGetOut": {
         "type": "object",
         "properties": {
-          "key": {
-            "type": "string",
-            "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
-            "example": "some_key"
-          },
           "expiry": {
             "description": "Time of expiry",
             "type": "string",
@@ -1868,13 +1853,10 @@
               "format": "uint8",
               "minimum": 0,
               "maximum": 255
-            }
+            },
+            "nullable": true
           }
-        },
-        "required": [
-          "key",
-          "value"
-        ]
+        }
       },
       "KvSetIn": {
         "type": "object",

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -11,7 +11,7 @@ use coyote_cache::{
 };
 use coyote_core::types::{Consistency, EntityKey};
 use coyote_derive::aide_annotate;
-use coyote_error::{Error, OptionExt, ResultExt};
+use coyote_error::{OptionExt, ResultExt};
 use coyote_kv::kvcontroller::KvModel;
 use coyote_namespace::{
     Namespace,
@@ -64,21 +64,17 @@ pub struct CacheGetIn {
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 pub struct CacheGetOut {
-    #[validate(nested)]
-    pub key: EntityKey,
-
     /// Time of expiry
     pub expiry: Option<Timestamp>,
 
-    pub value: Vec<u8>,
+    pub value: Option<Vec<u8>>,
 }
 
 impl CacheGetOut {
-    fn from_model(key: EntityKey, model: KvModel) -> Self {
+    fn from_model(model: KvModel) -> Self {
         Self {
-            key,
             expiry: model.expiry,
-            value: model.value,
+            value: Some(model.value),
         }
     }
 }
@@ -167,10 +163,11 @@ async fn cache_get(
     let model = controller.fetch(namespace.id, &data.key, Timestamp::now())?;
 
     let ret = match model {
-        Some(m) => CacheGetOut::from_model(data.key, m),
-        None => {
-            return Err(Error::not_found("Key not found".to_owned()));
-        }
+        Some(m) => CacheGetOut::from_model(m),
+        None => CacheGetOut {
+            expiry: None,
+            value: None,
+        },
     };
     Ok(MsgPackOrJson(ret))
 }

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -7,7 +7,7 @@ use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_core::types::{Consistency, EntityKey};
 use coyote_derive::aide_annotate;
-use coyote_error::{Error, OptionExt, ResultExt};
+use coyote_error::{OptionExt, ResultExt};
 use coyote_kv::{
     KvNamespace,
     kvcontroller::{KvModel, OperationBehavior},
@@ -55,21 +55,17 @@ pub struct KvGetIn {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct KvGetOut {
-    #[validate(nested)]
-    pub key: EntityKey,
-
     /// Time of expiry
     pub expiry: Option<Timestamp>,
 
-    pub value: Vec<u8>,
+    pub value: Option<Vec<u8>>,
 }
 
 impl KvGetOut {
-    fn from_model(key: EntityKey, model: KvModel) -> Self {
+    fn from_model(model: KvModel) -> Self {
         Self {
-            key,
             expiry: model.expiry,
-            value: model.value,
+            value: Some(model.value),
         }
     }
 }
@@ -128,10 +124,11 @@ async fn kv_get(
     let model = controller.fetch(namespace.id, &data.key, Timestamp::now())?;
 
     let ret = match model {
-        Some(m) => KvGetOut::from_model(data.key, m),
-        None => {
-            return Err(Error::not_found("Key not found".to_owned()));
-        }
+        Some(m) => KvGetOut::from_model(m),
+        None => KvGetOut {
+            expiry: None,
+            value: None,
+        },
     };
     Ok(MsgPackOrJson(ret))
 }

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -42,7 +42,6 @@ async fn test_cache_set_and_get() -> TestResult {
 
     let response = cache_get(&client, "test-key-1").await?;
 
-    assert_eq!(response["key"], "test-key-1");
     assert_eq!(response["value"], json!("test-value-123".as_bytes()));
     assert!(response["expiry"].is_string());
 
@@ -85,13 +84,15 @@ async fn test_cache_set_get_and_delete() -> TestResult {
 
     assert_eq!(delete_response["deleted"], true);
 
-    client
+    let response = client
         .post("cache/get")
         .json(json!({
             "key": "test-key-2"
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .expect(StatusCode::OK)
+        .json();
+    assert!(response["value"].is_null());
 
     Ok(())
 }

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -41,14 +41,15 @@ async fn kv_get(client: &TestClient, key: &str) -> TestResult<serde_json::Value>
 }
 
 async fn kv_not_found(client: &TestClient, key: &str) -> TestResult<()> {
-    let _ = client
+    let response = client
         .post("kv/get")
         .json(json!({
             "key": key
         }))
         .await?
-        .ensure(StatusCode::NOT_FOUND)?
+        .ensure(StatusCode::OK)?
         .json();
+    assert!(response["value"].is_null());
     Ok(())
 }
 
@@ -64,7 +65,6 @@ async fn test_kv_set_and_get() -> TestResult {
 
     let response = kv_get(&client, "kv-key-1").await?;
 
-    assert_eq!(response["key"], "kv-key-1");
     assert_eq!(response["value"], json!("kv-value-456".as_bytes()));
     assert!(response["expiry"].is_null());
 

--- a/tests/it/msgpack.rs
+++ b/tests/it/msgpack.rs
@@ -45,7 +45,6 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    assert_eq!(response["key"], "test-key-1");
     assert_eq!(response["value"], json!(b"test-value-123"));
     assert!(response["expiry"].is_string());
 
@@ -54,8 +53,7 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
 
 #[derive(Deserialize)]
 struct CacheGetOut {
-    key: String,
-    value: Vec<u8>,
+    value: Option<Vec<u8>>,
     #[allow(unused)]
     expiry: Option<String>,
 }
@@ -92,8 +90,10 @@ async fn test_cache_set_and_get_msgpack_out() -> TestResult {
     assert_eq!(response_content_type, "application/msgpack");
 
     let response_body: CacheGetOut = rmp_serde::from_slice(response.body())?;
-    assert_eq!(response_body.key, "test-key-1");
-    assert_eq!(response_body.value, b"test-value-123");
+    assert_eq!(
+        response_body.value.as_deref(),
+        Some(b"test-value-123" as &[u8])
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This makes working with cache/kv much easier, and anyway a cache/kv miss are not errors, they are part of normal operation. So making them be errors feels cumbersome.