### PR TITLE
cluster: refactor apply to take a context pointer instead of just a timestamp

### DIFF
--- a/crates/cache/src/operations/clear_expired.rs
+++ b/crates/cache/src/operations/clear_expired.rs
@@ -1,6 +1,6 @@
 use super::{CacheRequest, ClearExpiredResponse};
 use crate::{State, operations::CacheRaftState};
-use coyote_operations::Result;
+use coyote_operations::{OpContext, Result};
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
 
@@ -31,7 +31,7 @@ impl ClearExpiredOperation {
 }
 
 impl CacheRequest for ClearExpiredOperation {
-    fn apply(self, state: CacheRaftState<'_>, timestamp: jiff::Timestamp) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, timestamp))
+    fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> ClearExpiredResponse {
+        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp))
     }
 }

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -80,7 +80,11 @@ impl From<CreateNamespaceOutput<CacheConfig>> for CreateCacheResponseData {
 }
 
 impl CacheRequest for CreateCacheOperation {
-    fn apply(self, state: CacheRaftState<'_>, now: Timestamp) -> CreateCacheResponse {
-        CreateCacheResponse(self.apply_real(state.namespace, now))
+    fn apply(
+        self,
+        state: CacheRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> CreateCacheResponse {
+        CreateCacheResponse(self.apply_real(state.namespace, ctx.timestamp))
     }
 }

--- a/crates/cache/src/operations/delete.rs
+++ b/crates/cache/src/operations/delete.rs
@@ -1,7 +1,7 @@
 use super::{CacheRaftState, CacheRequest, DeleteResponse};
 use crate::CacheNamespace;
 use coyote_namespace::entities::NamespaceId;
-use coyote_operations::Result;
+use coyote_operations::{OpContext, Result};
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
 
@@ -33,7 +33,7 @@ impl DeleteOperation {
 }
 
 impl CacheRequest for DeleteOperation {
-    fn apply(self, state: CacheRaftState<'_>, _now: jiff::Timestamp) -> DeleteResponse {
+    fn apply(self, state: CacheRaftState<'_>, _ctx: &OpContext) -> DeleteResponse {
         DeleteResponse(self.apply_real(&state))
     }
 }

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -2,7 +2,7 @@ use super::{CacheRaftState, CacheRequest, SetResponse};
 use crate::{CacheModel, CacheNamespace};
 use coyote_kv::kvcontroller::OperationBehavior;
 use coyote_namespace::entities::NamespaceId;
-use coyote_operations::Result;
+use coyote_operations::{OpContext, Result};
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -41,7 +41,7 @@ impl SetOperation {
 }
 
 impl CacheRequest for SetOperation {
-    fn apply(self, state: CacheRaftState<'_>, now: Timestamp) -> SetResponse {
-        SetResponse(self.apply_real(&state, now))
+    fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> SetResponse {
+        SetResponse(self.apply_real(&state, ctx.timestamp))
     }
 }

--- a/crates/coyote-operations/src/context.rs
+++ b/crates/coyote-operations/src/context.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone)]
+pub struct OpContext {
+    /// The (monotonic) timestamp at which this object was enqueued for application.
+    pub timestamp: jiff::Timestamp,
+    /// The Raft log index. This is monotonically-increasing with every commit.
+    pub log_index: u64,
+    /// The raft term. This is monotonically-increasing with every leadership change.
+    pub term: u64,
+}

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -4,6 +4,9 @@ use std::{collections::HashMap, fmt::Debug};
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+mod context;
+pub use context::OpContext;
+
 #[derive(Debug)]
 pub enum BackgroundError {
     NotLeader,

--- a/crates/coyote-operations/src/macros.rs
+++ b/crates/coyote-operations/src/macros.rs
@@ -34,7 +34,7 @@ macro_rules! raft_module_operations {
             where
                 Self: 'static,
             {
-                fn apply(self, state: $state_type, timestamp: jiff::Timestamp) -> Self::Response;
+                fn apply(self, state: $state_type, ctx: &::coyote_operations::OpContext) -> Self::Response;
             }
 
             $(
@@ -95,9 +95,9 @@ macro_rules! raft_module_operations {
             )*
 
             impl $module_op_name {
-                pub fn apply(self, state: $state_type, timestamp: jiff::Timestamp) -> $response_name {
+                pub fn apply(self, state: $state_type, ctx: &::coyote_operations::OpContext) -> $response_name {
                     match self {
-                        $(Self::$variant(req) => $response_name::$variant(req.apply(state, timestamp)),)*
+                        $(Self::$variant(req) => $response_name::$variant(req.apply(state, ctx)),)*
                     }
                 }
             }
@@ -141,7 +141,7 @@ macro_rules! async_raft_module_operations {
             where
                 Self: 'static,
             {
-                async fn apply(self, state: $state_type, timestamp: jiff::Timestamp) -> Self::Response;
+                async fn apply(self, state: $state_type, ctx: &::coyote_operations::OpContext) -> Self::Response;
             }
 
             $(
@@ -202,9 +202,9 @@ macro_rules! async_raft_module_operations {
             )*
 
             impl $module_op_name {
-                pub async fn apply(self, state: $state_type, timestamp: jiff::Timestamp) -> $response_name {
+                pub async fn apply(self, state: $state_type, ctx: &::coyote_operations::OpContext) -> $response_name {
                     match self {
-                        $(Self::$variant(req) => $response_name::$variant(req.apply(state, timestamp).await),)*
+                        $(Self::$variant(req) => $response_name::$variant(req.apply(state, ctx).await),)*
                     }
                 }
             }

--- a/crates/idempotency/src/operations/abort.rs
+++ b/crates/idempotency/src/operations/abort.rs
@@ -34,7 +34,11 @@ impl AbortOperation {
 }
 
 impl IdempotencyRequest for AbortOperation {
-    fn apply(self, state: IdempotencyRaftState<'_>, _now: jiff::Timestamp) -> AbortResponse {
+    fn apply(
+        self,
+        state: IdempotencyRaftState<'_>,
+        _ctx: &coyote_operations::OpContext,
+    ) -> AbortResponse {
         AbortResponse(self.apply_real(&state))
     }
 }

--- a/crates/idempotency/src/operations/clear_expired.rs
+++ b/crates/idempotency/src/operations/clear_expired.rs
@@ -34,8 +34,8 @@ impl IdempotencyRequest for ClearExpiredOperation {
     fn apply(
         self,
         state: IdempotencyRaftState<'_>,
-        timestamp: jiff::Timestamp,
+        ctx: &coyote_operations::OpContext,
     ) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, timestamp))
+        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp))
     }
 }

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -55,7 +55,11 @@ impl CompleteOperation {
 }
 
 impl IdempotencyRequest for CompleteOperation {
-    fn apply(self, state: IdempotencyRaftState<'_>, now: Timestamp) -> CompleteResponse {
-        CompleteResponse(self.apply_real(&state, now))
+    fn apply(
+        self,
+        state: IdempotencyRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> CompleteResponse {
+        CompleteResponse(self.apply_real(&state, ctx.timestamp))
     }
 }

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -73,7 +73,11 @@ impl From<CreateNamespaceOutput<IdempotencyConfig>> for CreateIdempotencyRespons
 }
 
 impl IdempotencyRequest for CreateIdempotencyOperation {
-    fn apply(self, state: IdempotencyRaftState<'_>, now: Timestamp) -> CreateIdempotencyResponse {
-        CreateIdempotencyResponse(self.apply_real(state.namespace, now))
+    fn apply(
+        self,
+        state: IdempotencyRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> CreateIdempotencyResponse {
+        CreateIdempotencyResponse(self.apply_real(state.namespace, ctx.timestamp))
     }
 }

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -72,7 +72,11 @@ impl TryStartOperation {
 }
 
 impl IdempotencyRequest for TryStartOperation {
-    fn apply(self, state: IdempotencyRaftState<'_>, now: Timestamp) -> TryStartResponse {
-        TryStartResponse(self.apply_real(&state, now))
+    fn apply(
+        self,
+        state: IdempotencyRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> TryStartResponse {
+        TryStartResponse(self.apply_real(&state, ctx.timestamp))
     }
 }

--- a/crates/kv/src/operations/clear_expired.rs
+++ b/crates/kv/src/operations/clear_expired.rs
@@ -31,7 +31,11 @@ impl ClearExpiredOperation {
 }
 
 impl KvRequest for ClearExpiredOperation {
-    fn apply(self, state: KvRaftState<'_>, timestamp: jiff::Timestamp) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, timestamp))
+    fn apply(
+        self,
+        state: KvRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> ClearExpiredResponse {
+        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp))
     }
 }

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -73,7 +73,7 @@ impl From<CreateNamespaceOutput<KeyValueConfig>> for CreateKvResponseData {
 }
 
 impl KvRequest for CreateKvOperation {
-    fn apply(self, state: KvRaftState<'_>, now: Timestamp) -> CreateKvResponse {
-        CreateKvResponse(self.apply_real(state.namespace, now))
+    fn apply(self, state: KvRaftState<'_>, ctx: &coyote_operations::OpContext) -> CreateKvResponse {
+        CreateKvResponse(self.apply_real(state.namespace, ctx.timestamp))
     }
 }

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -33,7 +33,7 @@ impl DeleteOperation {
 }
 
 impl KvRequest for DeleteOperation {
-    fn apply(self, state: KvRaftState<'_>, _timestamp: jiff::Timestamp) -> DeleteResponse {
+    fn apply(self, state: KvRaftState<'_>, _ctx: &coyote_operations::OpContext) -> DeleteResponse {
         DeleteResponse(self.apply_real(state.state))
     }
 }

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -5,7 +5,7 @@ use crate::{KvNamespace, State, kvcontroller::OperationBehavior, operations::KvR
 use super::{KvRequest, SetResponse};
 use coyote_core::types::EntityKey;
 use coyote_namespace::entities::NamespaceId;
-use coyote_operations::Result;
+use coyote_operations::{OpContext, Result};
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -58,7 +58,7 @@ impl SetOperation {
 }
 
 impl KvRequest for SetOperation {
-    fn apply(self, state: KvRaftState<'_>, timestamp: Timestamp) -> SetResponse {
-        SetResponse(self.apply_real(state.state, timestamp))
+    fn apply(self, state: KvRaftState<'_>, ctx: &OpContext) -> SetResponse {
+        SetResponse(self.apply_real(state.state, ctx.timestamp))
     }
 }

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -75,7 +75,11 @@ impl From<CreateNamespaceOutput<StreamConfig>> for CreateNamespaceResponseData {
 }
 
 impl MsgsRequest for CreateNamespaceOperation {
-    fn apply(self, state: MsgsRaftState<'_>, now: Timestamp) -> CreateNamespaceResponse {
-        CreateNamespaceResponse(self.apply_real(state.namespace, now))
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> CreateNamespaceResponse {
+        CreateNamespaceResponse(self.apply_real(state.namespace, ctx.timestamp))
     }
 }

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -118,8 +118,12 @@ pub struct PublishResponseData {
 }
 
 impl MsgsRequest for PublishOperation {
-    fn apply(self, state: MsgsRaftState<'_>, timestamp: Timestamp) -> PublishResponse {
-        PublishResponse(self.apply_real(state.msgs, timestamp))
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> PublishResponse {
+        PublishResponse(self.apply_real(state.msgs, ctx.timestamp))
     }
 }
 

--- a/crates/msgs/src/operations/queue/ack.rs
+++ b/crates/msgs/src/operations/queue/ack.rs
@@ -1,7 +1,6 @@
 use coyote_error::Error;
 use coyote_namespace::entities::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
-use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -98,7 +97,11 @@ impl QueueAckOperation {
 pub struct QueueAckResponseData {}
 
 impl MsgsRequest for QueueAckOperation {
-    fn apply(self, state: MsgsRaftState<'_>, _now: Timestamp) -> QueueAckResponse {
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        _ctx: &coyote_operations::OpContext,
+    ) -> QueueAckResponse {
         QueueAckResponse(self.apply_real(state.msgs))
     }
 }

--- a/crates/msgs/src/operations/queue/configure.rs
+++ b/crates/msgs/src/operations/queue/configure.rs
@@ -80,7 +80,11 @@ pub struct QueueConfigureResponseData {
 }
 
 impl MsgsRequest for QueueConfigureOperation {
-    fn apply(self, state: MsgsRaftState<'_>, now: Timestamp) -> QueueConfigureResponse {
-        QueueConfigureResponse(self.apply_real(state.msgs, now))
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> QueueConfigureResponse {
+        QueueConfigureResponse(self.apply_real(state.msgs, ctx.timestamp))
     }
 }

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -159,7 +159,11 @@ fn forward_to_dlq(
 pub struct QueueNackResponseData {}
 
 impl MsgsRequest for QueueNackOperation {
-    fn apply(self, state: MsgsRaftState<'_>, timestamp: Timestamp) -> QueueNackResponse {
-        QueueNackResponse(self.apply_real(state.msgs, timestamp))
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> QueueNackResponse {
+        QueueNackResponse(self.apply_real(state.msgs, ctx.timestamp))
     }
 }

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -262,7 +262,11 @@ pub struct QueueReceiveResponseData {
 }
 
 impl MsgsRequest for QueueReceiveOperation {
-    fn apply(self, state: MsgsRaftState<'_>, now: Timestamp) -> QueueReceiveResponse {
-        QueueReceiveResponse(self.apply_real(state.msgs, now))
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> QueueReceiveResponse {
+        QueueReceiveResponse(self.apply_real(state.msgs, ctx.timestamp))
     }
 }

--- a/crates/msgs/src/operations/queue/redrive_dlq.rs
+++ b/crates/msgs/src/operations/queue/redrive_dlq.rs
@@ -1,7 +1,6 @@
 use coyote_error::Error;
 use coyote_namespace::entities::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
-use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -90,7 +89,11 @@ impl QueueRedriveDlqOperation {
 pub struct QueueRedriveDlqResponseData {}
 
 impl MsgsRequest for QueueRedriveDlqOperation {
-    fn apply(self, state: MsgsRaftState<'_>, _timestamp: Timestamp) -> QueueRedriveDlqResponse {
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        _ctx: &coyote_operations::OpContext,
+    ) -> QueueRedriveDlqResponse {
         QueueRedriveDlqResponse(self.apply_real(state.msgs))
     }
 }

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -1,6 +1,5 @@
 use coyote_namespace::entities::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
-use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use coyote_error::Error;
@@ -55,7 +54,7 @@ impl StreamCommitOperation {
 
         lease.offset = self.offset + 1;
         if self.offset >= lease.end_offset {
-            lease.expiry = Timestamp::UNIX_EPOCH;
+            lease.expiry = jiff::Timestamp::UNIX_EPOCH;
         }
 
         batch.insert_row(
@@ -74,7 +73,11 @@ impl StreamCommitOperation {
 pub struct StreamCommitResponseData {}
 
 impl MsgsRequest for StreamCommitOperation {
-    fn apply(self, state: MsgsRaftState<'_>, _timestamp: Timestamp) -> StreamCommitResponse {
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        _ctx: &coyote_operations::OpContext,
+    ) -> StreamCommitResponse {
         StreamCommitResponse(self.apply_real(state.msgs))
     }
 }

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -177,7 +177,11 @@ pub struct StreamReceiveResponseData {
 }
 
 impl MsgsRequest for StreamReceiveOperation {
-    fn apply(self, state: MsgsRaftState<'_>, now: Timestamp) -> StreamReceiveResponse {
-        StreamReceiveResponse(self.apply_real(state.msgs, now))
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> StreamReceiveResponse {
+        StreamReceiveResponse(self.apply_real(state.msgs, ctx.timestamp))
     }
 }

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -103,7 +103,11 @@ impl StreamSeekOperation {
 pub struct StreamSeekResponseData {}
 
 impl MsgsRequest for StreamSeekOperation {
-    fn apply(self, state: MsgsRaftState<'_>, _timestamp: Timestamp) -> StreamSeekResponse {
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        _ctx: &coyote_operations::OpContext,
+    ) -> StreamSeekResponse {
         StreamSeekResponse(self.apply_real(state.msgs))
     }
 }

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -80,7 +80,11 @@ pub struct TopicConfigureResponseData {
 }
 
 impl MsgsRequest for TopicConfigureOperation {
-    fn apply(self, state: MsgsRaftState<'_>, timestamp: Timestamp) -> TopicConfigureResponse {
-        TopicConfigureResponse(self.apply_real(state.msgs, timestamp))
+    fn apply(
+        self,
+        state: MsgsRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> TopicConfigureResponse {
+        TopicConfigureResponse(self.apply_real(state.msgs, ctx.timestamp))
     }
 }

--- a/crates/rate-limit/src/operations/create_namespace.rs
+++ b/crates/rate-limit/src/operations/create_namespace.rs
@@ -73,7 +73,11 @@ impl From<CreateNamespaceOutput<RateLimitConfig>> for CreateRateLimitResponseDat
 }
 
 impl RateLimitRequest for CreateRateLimitOperation {
-    fn apply(self, state: RateLimitRaftState<'_>, now: Timestamp) -> CreateRateLimitResponse {
-        CreateRateLimitResponse(self.apply_real(state.namespace, now))
+    fn apply(
+        self,
+        state: RateLimitRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> CreateRateLimitResponse {
+        CreateRateLimitResponse(self.apply_real(state.namespace, ctx.timestamp))
     }
 }

--- a/crates/rate-limit/src/operations/limit.rs
+++ b/crates/rate-limit/src/operations/limit.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use super::{LimitResponse, RateLimitRaftState, RateLimitRequest};
 use crate::{RateLimitNamespace, TokenBucket};
 use coyote_namespace::entities::NamespaceId;
-use coyote_operations::Result;
+use coyote_operations::{OpContext, Result};
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -63,7 +63,7 @@ impl LimitOperation {
 }
 
 impl RateLimitRequest for LimitOperation {
-    fn apply(self, state: RateLimitRaftState<'_>, now: Timestamp) -> LimitResponse {
-        LimitResponse(self.apply_real(&state, now))
+    fn apply(self, state: RateLimitRaftState<'_>, ctx: &OpContext) -> LimitResponse {
+        LimitResponse(self.apply_real(&state, ctx.timestamp))
     }
 }

--- a/crates/rate-limit/src/operations/reset.rs
+++ b/crates/rate-limit/src/operations/reset.rs
@@ -35,7 +35,11 @@ impl ResetOperation {
 }
 
 impl RateLimitRequest for ResetOperation {
-    fn apply(self, state: RateLimitRaftState<'_>, _now: jiff::Timestamp) -> ResetResponse {
+    fn apply(
+        self,
+        state: RateLimitRaftState<'_>,
+        _ctx: &coyote_operations::OpContext,
+    ) -> ResetResponse {
         ResetResponse(self.apply_real(&state))
     }
 }

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -1,14 +1,12 @@
-use crate::core::cluster::handle::Request;
-
 use super::{
     NodeId,
-    handle::{RequestWithContext, Response},
+    handle::{Request, RequestWithContext, Response},
     state_machine::Store,
 };
 use openraft::LogId;
 use opentelemetry::{Value, propagation::TextMapPropagator};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use tracing::info_span;
+use tracing::{Instrument, info_span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub(super) async fn apply_request(
@@ -16,7 +14,12 @@ pub(super) async fn apply_request(
     state_machine: &mut Store,
     log_id: LogId<NodeId>,
 ) -> anyhow::Result<Response> {
-    let child_span = info_span!("apply_request");
+    let child_span = info_span!(
+        "apply_request",
+        module = request.module(),
+        timestamp = %request.timestamp,
+        log_index = log_id.index
+    );
     let trace_ctx = request
         .context
         .as_ref()
@@ -30,19 +33,33 @@ pub(super) async fn apply_request(
     if let Some(hash) = request.hashed_key() {
         child_span.set_attribute("hashed_key", Value::String(hash.into()));
     }
-    let _exit = child_span.enter();
 
     state_machine.time.bump(request.timestamp);
-    let timestamp = request.timestamp;
 
-    Ok(match request.inner {
+    let context = coyote_operations::OpContext {
+        timestamp: request.timestamp,
+        log_index: log_id.index,
+        term: log_id.leader_id.term,
+    };
+
+    apply_request_with_context(state_machine, context, request.inner)
+        .instrument(child_span)
+        .await
+}
+
+async fn apply_request_with_context(
+    state_machine: &mut Store,
+    context: coyote_operations::OpContext,
+    request: Request,
+) -> anyhow::Result<Response> {
+    Ok(match request {
         Request::Kv(req) => {
             let stores = state_machine.db_handle();
             let state = coyote_kv::operations::KvRaftState {
                 state: &stores.kv_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Kv(req.apply(state, timestamp))
+            Response::Kv(req.apply(state, &context))
         }
         Request::RateLimit(req) => {
             let stores = state_machine.db_handle();
@@ -50,7 +67,7 @@ pub(super) async fn apply_request(
                 state: &stores.rate_limit_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::RateLimit(req.apply(state, timestamp))
+            Response::RateLimit(req.apply(state, &context))
         }
         Request::Idempotency(req) => {
             let stores = state_machine.db_handle();
@@ -58,7 +75,7 @@ pub(super) async fn apply_request(
                 state: &stores.idempotency_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Idempotency(req.apply(state, timestamp))
+            Response::Idempotency(req.apply(state, &context))
         }
         Request::Cache(req) => {
             let stores = state_machine.db_handle();
@@ -66,7 +83,7 @@ pub(super) async fn apply_request(
                 state: &stores.cache_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Cache(req.apply(state, timestamp))
+            Response::Cache(req.apply(state, &context))
         }
         Request::Msgs(req) => {
             let stores = state_machine.db_handle();
@@ -74,10 +91,10 @@ pub(super) async fn apply_request(
                 msgs: &stores.msgs_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Msgs(req.apply(state, timestamp))
+            Response::Msgs(req.apply(state, &context))
         }
         Request::ClusterInternal(req) => {
-            Response::ClusterInternal(req.apply((state_machine, log_id), timestamp).await)
+            Response::ClusterInternal(req.apply(state_machine, &context).await)
         }
     })
 }

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -93,6 +93,17 @@ impl RequestWithContext {
         };
         Some(hex::encode(digest))
     }
+
+    pub(crate) fn module(&self) -> &'static str {
+        match self.inner {
+            Request::Cache(_) => "cache",
+            Request::ClusterInternal(_) => "cluster-internal",
+            Request::Idempotency(_) => "idempotency",
+            Request::Kv(_) => "kv",
+            Request::Msgs(_) => "msgs",
+            Request::RateLimit(_) => "rate-limit",
+        }
+    }
 }
 
 impl From<coyote_kv::operations::KvOperation> for Request {

--- a/src/core/cluster/operations/mod.rs
+++ b/src/core/cluster/operations/mod.rs
@@ -1,5 +1,4 @@
-use crate::core::cluster::{NodeId, state_machine::Store};
-use openraft::LogId;
+use crate::core::cluster::state_machine::Store;
 use serde::{Deserialize, Serialize};
 
 use coyote_operations::async_raft_module_operations;
@@ -19,5 +18,5 @@ async_raft_module_operations!(
         RecordLogTimestamp(RecordLogTimestampOperation) -> (),
         Tick(TickOperation) -> (),
     },
-    state = (&mut Store, LogId<NodeId>)
+    state = &mut Store
 );

--- a/src/core/cluster/operations/record_log_timestamp.rs
+++ b/src/core/cluster/operations/record_log_timestamp.rs
@@ -1,7 +1,6 @@
 use super::{InternalRequest, RecordLogTimestampResponse as Response};
-use crate::core::cluster::{NodeId, state_machine::Store};
+use crate::core::cluster::state_machine::Store;
 use coyote_error::Error;
-use openraft::LogId;
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
@@ -9,14 +8,10 @@ use tap::Pipe;
 pub struct RecordLogTimestampOperation {}
 
 impl InternalRequest for RecordLogTimestampOperation {
-    async fn apply(
-        self,
-        (state, log_id): (&mut Store, LogId<NodeId>),
-        timestamp: jiff::Timestamp,
-    ) -> Response {
+    async fn apply(self, state: &mut Store, context: &coyote_operations::OpContext) -> Response {
         state
             .logs
-            .record_log_timestamp(timestamp, log_id.index)
+            .record_log_timestamp(context.timestamp, context.log_index)
             .await
             .map_err(|e| Error::internal(e).into())
             .pipe(Response)

--- a/src/core/cluster/operations/set_cluster_uuid.rs
+++ b/src/core/cluster/operations/set_cluster_uuid.rs
@@ -1,10 +1,6 @@
 use super::{InternalRequest, SetClusterUuidResponse as Response};
-use crate::core::cluster::{
-    NodeId,
-    state_machine::{ClusterId, Store},
-};
+use crate::core::cluster::state_machine::{ClusterId, Store};
 use coyote_error::Error;
-use openraft::LogId;
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
@@ -12,11 +8,7 @@ use tap::Pipe;
 pub struct SetClusterUuidOperation(pub ClusterId);
 
 impl InternalRequest for SetClusterUuidOperation {
-    async fn apply(
-        self,
-        (state, _): (&mut Store, LogId<NodeId>),
-        _timestamp: jiff::Timestamp,
-    ) -> Response {
+    async fn apply(self, state: &mut Store, _ctx: &coyote_operations::OpContext) -> Response {
         state
             .set_cluster_id(self.0)
             .await

--- a/src/core/cluster/operations/tick.rs
+++ b/src/core/cluster/operations/tick.rs
@@ -1,17 +1,12 @@
 use super::{InternalRequest, TickResponse as Response};
-use crate::core::cluster::{NodeId, state_machine::Store};
-use openraft::LogId;
+use crate::core::cluster::state_machine::Store;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TickOperation {}
 
 impl InternalRequest for TickOperation {
-    async fn apply(
-        self,
-        _state: (&mut Store, LogId<NodeId>),
-        _timestamp: jiff::Timestamp,
-    ) -> Response {
+    async fn apply(self, _state: &mut Store, _context: &coyote_operations::OpContext) -> Response {
         // This job does nothing except periodically write something to the log
         // (because openraft doesn't let us customize the existing Heartbeat event)
         Response(Ok(()))


### PR DESCRIPTION
This allows downstream modules to do stuff with the Raft term & log index easily.

I also cleaned up a little tracing stuff while testing this.

Fixes #463.