### PR TITLE
tests: allow slow tests to be slower on gha

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,4 +16,4 @@ path = "junit.xml"
 
 [[profile.ci.overrides]]
 filter = 'test(~openraft_slow)'
-slow-timeout = { period = "60s", terminate-after = 1}
+slow-timeout = { period = "60s", terminate-after = 2}


### PR DESCRIPTION
sometimes we get a GHA worker that's just dogshit and takes >60s instead of the usual ~25s for the slow openraft self-test.