### PR TITLE
Kv: return success status on insert/update conflicts.

### DIFF
--- a/clients/go/internal/models/cache_delete_out.go
+++ b/clients/go/internal/models/cache_delete_out.go
@@ -3,5 +3,5 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type CacheDeleteOut struct {
-	Deleted bool `json:"deleted"`
+	Success bool `json:"success"`
 }

--- a/clients/go/internal/models/kv_delete_out.go
+++ b/clients/go/internal/models/kv_delete_out.go
@@ -3,5 +3,5 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type KvDeleteOut struct {
-	Deleted bool `json:"deleted"`
+	Success bool `json:"success"` // Whether the operation succeeded or was a noop due to pre-conditions.
 }

--- a/clients/go/internal/models/kv_set_out.go
+++ b/clients/go/internal/models/kv_set_out.go
@@ -3,4 +3,5 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type KvSetOut struct {
+	Success bool `json:"success"` // Whether the operation succeeded or was a noop due to pre-conditions.
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/CacheDeleteOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/CacheDeleteOut.java
@@ -28,26 +28,26 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class CacheDeleteOut {
-@JsonProperty private Boolean deleted;
+@JsonProperty private Boolean success;
 public CacheDeleteOut () {}
 
- public CacheDeleteOut deleted(Boolean deleted) {
-        this.deleted = deleted;
+ public CacheDeleteOut success(Boolean success) {
+        this.success = success;
         return this;
     }
 
     /**
-    * Get deleted
+    * Get success
     *
-     * @return deleted
+     * @return success
      */
     @javax.annotation.Nonnull
-     public Boolean getDeleted() {
-        return deleted;
+     public Boolean getSuccess() {
+        return success;
     }
 
-     public void setDeleted(Boolean deleted) {
-        this.deleted = deleted;
+     public void setSuccess(Boolean success) {
+        this.success = success;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/KvDeleteOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvDeleteOut.java
@@ -28,26 +28,26 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class KvDeleteOut {
-@JsonProperty private Boolean deleted;
+@JsonProperty private Boolean success;
 public KvDeleteOut () {}
 
- public KvDeleteOut deleted(Boolean deleted) {
-        this.deleted = deleted;
+ public KvDeleteOut success(Boolean success) {
+        this.success = success;
         return this;
     }
 
     /**
-    * Get deleted
+    * Whether the operation succeeded or was a noop due to pre-conditions.
     *
-     * @return deleted
+     * @return success
      */
     @javax.annotation.Nonnull
-     public Boolean getDeleted() {
-        return deleted;
+     public Boolean getSuccess() {
+        return success;
     }
 
-     public void setDeleted(Boolean deleted) {
-        this.deleted = deleted;
+     public void setSuccess(Boolean success) {
+        this.success = success;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/KvSetOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvSetOut.java
@@ -28,9 +28,29 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class KvSetOut {
+@JsonProperty private Boolean success;
 public KvSetOut () {}
 
-/**
+ public KvSetOut success(Boolean success) {
+        this.success = success;
+        return this;
+    }
+
+    /**
+    * Whether the operation succeeded or was a noop due to pre-conditions.
+    *
+     * @return success
+     */
+    @javax.annotation.Nonnull
+     public Boolean getSuccess() {
+        return success;
+    }
+
+     public void setSuccess(Boolean success) {
+        this.success = success;
+    }
+
+    /**
      * Create an instance of KvSetOut given an JSON string
      *
      * @param jsonString JSON string

--- a/clients/javascript/src/models/cacheDeleteOut.ts
+++ b/clients/javascript/src/models/cacheDeleteOut.ts
@@ -1,21 +1,21 @@
 // this file is @generated
 
 export interface CacheDeleteOut {
-    deleted: boolean;
+    success: boolean;
 }
 
 export const CacheDeleteOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject(object: any): CacheDeleteOut {
         return {
-            deleted: object['deleted'],
+            success: object['success'],
         };
     },
 
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _toJsonObject(self: CacheDeleteOut): any {
         return {
-            'deleted': self.deleted,
+            'success': self.success,
         };
     }
 }

--- a/clients/javascript/src/models/kvDeleteOut.ts
+++ b/clients/javascript/src/models/kvDeleteOut.ts
@@ -1,21 +1,22 @@
 // this file is @generated
 
 export interface KvDeleteOut {
-    deleted: boolean;
+    /** Whether the operation succeeded or was a noop due to pre-conditions. */
+    success: boolean;
 }
 
 export const KvDeleteOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject(object: any): KvDeleteOut {
         return {
-            deleted: object['deleted'],
+            success: object['success'],
         };
     },
 
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _toJsonObject(self: KvDeleteOut): any {
         return {
-            'deleted': self.deleted,
+            'success': self.success,
         };
     }
 }

--- a/clients/javascript/src/models/kvSetOut.ts
+++ b/clients/javascript/src/models/kvSetOut.ts
@@ -1,19 +1,22 @@
 // this file is @generated
-// biome-ignore-all lint/suspicious/noEmptyInterface: forwards compat
 
 export interface KvSetOut {
+    /** Whether the operation succeeded or was a noop due to pre-conditions. */
+    success: boolean;
 }
 
 export const KvSetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
-    _fromJsonObject(_object: any): KvSetOut {
+    _fromJsonObject(object: any): KvSetOut {
         return {
+            success: object['success'],
         };
     },
 
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
-    _toJsonObject(_self: KvSetOut): any {
+    _toJsonObject(self: KvSetOut): any {
         return {
+            'success': self.success,
         };
     }
 }

--- a/clients/python/coyote/models/cache_delete_out.py
+++ b/clients/python/coyote/models/cache_delete_out.py
@@ -4,4 +4,4 @@ from ..internal.base_model import BaseModel
 
 
 class CacheDeleteOut(BaseModel):
-    deleted: bool
+    success: bool

--- a/clients/python/coyote/models/kv_delete_out.py
+++ b/clients/python/coyote/models/kv_delete_out.py
@@ -4,4 +4,5 @@ from ..internal.base_model import BaseModel
 
 
 class KvDeleteOut(BaseModel):
-    deleted: bool
+    success: bool
+    """Whether the operation succeeded or was a noop due to pre-conditions."""

--- a/clients/python/coyote/models/kv_set_out.py
+++ b/clients/python/coyote/models/kv_set_out.py
@@ -4,4 +4,5 @@ from ..internal.base_model import BaseModel
 
 
 class KvSetOut(BaseModel):
-    pass
+    success: bool
+    """Whether the operation succeeded or was a noop due to pre-conditions."""

--- a/clients/rust/src/models/cache_delete_out.rs
+++ b/clients/rust/src/models/cache_delete_out.rs
@@ -3,11 +3,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CacheDeleteOut {
-    pub deleted: bool,
+    pub success: bool,
 }
 
 impl CacheDeleteOut {
-    pub fn new(deleted: bool) -> Self {
-        Self { deleted }
+    pub fn new(success: bool) -> Self {
+        Self { success }
     }
 }

--- a/clients/rust/src/models/kv_delete_out.rs
+++ b/clients/rust/src/models/kv_delete_out.rs
@@ -3,11 +3,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KvDeleteOut {
-    pub deleted: bool,
+    /// Whether the operation succeeded or was a noop due to pre-conditions.
+    pub success: bool,
 }
 
 impl KvDeleteOut {
-    pub fn new(deleted: bool) -> Self {
-        Self { deleted }
+    pub fn new(success: bool) -> Self {
+        Self { success }
     }
 }

--- a/clients/rust/src/models/kv_set_out.rs
+++ b/clients/rust/src/models/kv_set_out.rs
@@ -2,10 +2,13 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct KvSetOut {}
+pub struct KvSetOut {
+    /// Whether the operation succeeded or was a noop due to pre-conditions.
+    pub success: bool,
+}
 
 impl KvSetOut {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(success: bool) -> Self {
+        Self { success }
     }
 }

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -113,7 +113,7 @@ impl KvController {
         expiry: Option<Timestamp>,
         behavior: OperationBehavior,
         now: Timestamp,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         match behavior {
             OperationBehavior::Upsert => {
                 self.insert_with_expiration(namespace_id, key, value, expiry)?;
@@ -124,7 +124,7 @@ impl KvController {
                 if !exists {
                     self.insert_with_expiration(namespace_id, key, value, expiry)?;
                 } else {
-                    // FIXME(@svix-lucho): Do nothing?
+                    return Ok(false);
                 }
             }
             OperationBehavior::Update => {
@@ -132,12 +132,12 @@ impl KvController {
                 if exists {
                     self.insert_with_expiration(namespace_id, key, value, expiry)?;
                 } else {
-                    // FIXME(@svix-lucho): Do nothing?
+                    return Ok(false);
                 }
             }
         }
 
-        Ok(())
+        Ok(true)
     }
 
     #[tracing::instrument(skip(self))]
@@ -304,6 +304,7 @@ mod tests {
         let setup = SetupFixture::new();
         let controller = setup.controller;
 
+        // Update on non-existent key returns false
         let res = controller.set(
             ns(),
             "key1",
@@ -312,7 +313,7 @@ mod tests {
             OperationBehavior::Update,
             Timestamp::now(),
         );
-        assert!(res.is_ok());
+        assert!(!res.unwrap());
         assert!(!key_exists(&controller, "key1"));
 
         let res = controller.set(
@@ -323,11 +324,12 @@ mod tests {
             OperationBehavior::Insert,
             Timestamp::now(),
         );
-        assert!(res.is_ok());
+        assert!(res.unwrap());
         assert!(key_exists(&controller, "key1"));
         let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
         assert!(result.is_some());
 
+        // Insert on existing key returns false
         let res = controller.set(
             ns(),
             "key1",
@@ -336,7 +338,7 @@ mod tests {
             OperationBehavior::Insert,
             Timestamp::now(),
         );
-        assert!(res.is_ok());
+        assert!(!res.unwrap());
         assert!(key_exists(&controller, "key1"));
         let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
         assert!(result.is_some());
@@ -351,7 +353,7 @@ mod tests {
             OperationBehavior::Upsert,
             Timestamp::now(),
         );
-        assert!(res.is_ok());
+        assert!(res.unwrap());
         assert!(key_exists(&controller, "key1"));
         let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
         assert!(result.is_some());

--- a/crates/kv/src/operations/mod.rs
+++ b/crates/kv/src/operations/mod.rs
@@ -10,7 +10,7 @@ mod set;
 pub use clear_expired::ClearExpiredOperation;
 pub use create_namespace::{CreateKvOperation, CreateKvResponseData};
 pub use delete::DeleteOperation;
-pub use set::SetOperation;
+pub use set::{SetOperation, SetResponseData};
 
 use coyote_operations::raft_module_operations;
 
@@ -22,7 +22,7 @@ pub struct KvRaftState<'a> {
 raft_module_operations!(
     KvRequest,
     KvOperation {
-        Set(SetOperation) -> (),
+        Set(SetOperation) -> SetResponseData,
         Delete(DeleteOperation) -> (),
         CreateKv(CreateKvOperation) -> CreateKvResponseData,
         ClearExpired(ClearExpiredOperation) -> (),

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -12,6 +12,11 @@ use serde::{Deserialize, Serialize};
 use tap::TapOptional;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetResponseData {
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetOperation {
     namespace_id: NamespaceId,
     storage_type: StorageType,
@@ -44,8 +49,8 @@ impl SetOperation {
 }
 
 impl SetOperation {
-    fn apply_real(self, state: &State, now: Timestamp) -> Result<()> {
-        state.controller(self.storage_type).set(
+    fn apply_real(self, state: &State, now: Timestamp) -> Result<SetResponseData> {
+        let success = state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
             self.value,
@@ -53,7 +58,7 @@ impl SetOperation {
             self.behavior,
             now,
         )?;
-        Ok(())
+        Ok(SetResponseData { success })
     }
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -1311,12 +1311,12 @@
       "CacheDeleteOut": {
         "type": "object",
         "properties": {
-          "deleted": {
+          "success": {
             "type": "boolean"
           }
         },
         "required": [
-          "deleted"
+          "success"
         ]
       },
       "CacheGetIn": {
@@ -1766,12 +1766,13 @@
       "KvDeleteOut": {
         "type": "object",
         "properties": {
-          "deleted": {
+          "success": {
+            "description": "Whether the operation succeeded or was a noop due to pre-conditions.",
             "type": "boolean"
           }
         },
         "required": [
-          "deleted"
+          "success"
         ]
       },
       "KvGetIn": {
@@ -1897,7 +1898,16 @@
         ]
       },
       "KvSetOut": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "success": {
+            "description": "Whether the operation succeeded or was a noop due to pre-conditions.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ]
       },
       "MsgIn": {
         "type": "object",

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -88,7 +88,7 @@ pub struct CacheDeleteIn {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct CacheDeleteOut {
-    pub deleted: bool,
+    pub success: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -186,7 +186,7 @@ async fn cache_del(
 
     let operation = DeleteOperation::new(namespace, data.key.to_string());
     repl.client_write(operation).await.or_internal_error()?.0?;
-    Ok(MsgPackOrJson(CacheDeleteOut { deleted: true }))
+    Ok(MsgPackOrJson(CacheDeleteOut { success: true }))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -39,7 +39,10 @@ pub struct KvSetIn {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
-pub struct KvSetOut {}
+pub struct KvSetOut {
+    /// Whether the operation succeeded or was a noop due to pre-conditions.
+    pub success: bool,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 #[schemars(extend("x-positional" = ["key"]))]
@@ -76,7 +79,8 @@ pub struct KvDeleteIn {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct KvDeleteOut {
-    pub deleted: bool,
+    /// Whether the operation succeeded or was a noop due to pre-conditions.
+    pub success: bool,
 }
 
 /// KV Set
@@ -92,9 +96,11 @@ async fn kv_set(
         .ok_or_not_found()?;
 
     let operation = SetOperation::new(namespace, data.key, data.value, data.ttl, data.behavior);
-    repl.client_write(operation).await.or_internal_error()?.0?;
+    let resp = repl.client_write(operation).await.or_internal_error()?.0?;
 
-    let ret = KvSetOut {};
+    let ret = KvSetOut {
+        success: resp.success,
+    };
     Ok(MsgPackOrJson(ret))
 }
 
@@ -146,7 +152,7 @@ async fn kv_del(
     let operation = DeleteOperation::new(namespace, key);
     repl.client_write(operation).await.or_internal_error()?.0?;
 
-    let ret = KvDeleteOut { deleted: true };
+    let ret = KvDeleteOut { success: true };
     Ok(MsgPackOrJson(ret))
 }
 

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -82,7 +82,7 @@ async fn test_cache_set_get_and_delete() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    assert_eq!(delete_response["deleted"], true);
+    assert_eq!(delete_response["success"], true);
 
     let response = client
         .post("cache/get")

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -14,7 +14,7 @@ async fn kv_set(
     value: &str,
     behavior: &str,
 ) -> TestResult<()> {
-    client
+    let response = client
         .post("kv/set")
         .json(json!({
             "key": key,
@@ -23,7 +23,31 @@ async fn kv_set(
             "behavior": behavior
         }))
         .await?
-        .ensure(StatusCode::OK)?;
+        .ensure(StatusCode::OK)?
+        .json();
+    assert!(response["success"].as_bool().unwrap());
+    Ok(())
+}
+
+async fn kv_set_unsuccessful(
+    client: &TestClient,
+    key: &str,
+    expire_in: Option<u64>,
+    value: &str,
+    behavior: &str,
+) -> TestResult<()> {
+    let response = client
+        .post("kv/set")
+        .json(json!({
+            "key": key,
+            "ttl": expire_in,
+            "value": value.as_bytes(),
+            "behavior": behavior
+        }))
+        .await?
+        .ensure(StatusCode::OK)?
+        .json();
+    assert!(!response["success"].as_bool().unwrap());
     Ok(())
 }
 
@@ -112,13 +136,13 @@ async fn test_kv_set_with_insert_and_delete() -> TestResult {
         ..
     } = start_server().await;
 
-    kv_set(&client, "kv-key-2", None, "value-ignored", "update").await?;
+    kv_set_unsuccessful(&client, "kv-key-2", None, "value-ignored", "update").await?;
     kv_not_found(&client, "kv-key-2").await?;
 
     kv_set(&client, "kv-key-2", None, "permanent-value", "insert").await?;
 
     // This insert gets ignored
-    kv_set(&client, "kv-key-2", None, "value-ignored-2", "insert").await?;
+    kv_set_unsuccessful(&client, "kv-key-2", None, "value-ignored-2", "insert").await?;
 
     let response = kv_get(&client, "kv-key-2").await?;
     assert_eq!(response["value"], json!("permanent-value".as_bytes()));
@@ -133,7 +157,7 @@ async fn test_kv_set_with_insert_and_delete() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    assert_eq!(delete_response["deleted"], true);
+    assert_eq!(delete_response["success"], true);
 
     kv_not_found(&client, "kv-key-2").await?;
 
@@ -187,7 +211,7 @@ async fn test_kv_update_expiration() -> TestResult {
 
     // Test updating expired key
     kv_set(&client, "kv6", Some(1000), "v6", "upsert").await?;
-    kv_set(&client, "kv6", Some(500), "v6", "insert").await?;
+    kv_set_unsuccessful(&client, "kv6", Some(500), "v6", "insert").await?;
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let response = kv_get(&client, "kv6").await?;
@@ -195,7 +219,7 @@ async fn test_kv_update_expiration() -> TestResult {
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    kv_set(&client, "kv6", Some(500), "v6", "update").await?;
+    kv_set_unsuccessful(&client, "kv6", Some(500), "v6", "update").await?;
     kv_not_found(&client, "kv6").await?;
 
     Ok(())
@@ -305,7 +329,7 @@ async fn test_kv_delete() -> TestResult {
     //     .json();
 
     // FIXME(@svix-lucho): Behavior not implemented yet
-    // assert_eq!(response["deleted"], false);
+    // assert_eq!(response["success"], false);
 
     kv_set(&client, "kv-key-5", None, "value-5", "upsert").await?;
 
@@ -317,7 +341,7 @@ async fn test_kv_delete() -> TestResult {
         .await?
         .expect(StatusCode::OK)
         .json();
-    assert_eq!(response["deleted"], true);
+    assert_eq!(response["success"], true);
 
     kv_not_found(&client, "kv-key-5").await?;
 


### PR DESCRIPTION
We should return an indication when we fail to insert/update because keys already exist/don't exist. We definitely shouldn't fail silently.

Also changed the `deleted` in kv/cache responses to say `success` to match these.

Discussion on Slack: https://svixhq.slack.com/archives/C0A72988962/p1773457868083409