### PR TITLE
KV: implement opportunistic concurrency control.

### DIFF
--- a/clients/go/internal/models/kv_get_out.go
+++ b/clients/go/internal/models/kv_get_out.go
@@ -9,4 +9,7 @@ import (
 type KvGetOut struct {
 	Expiry *time.Time `json:"expiry,omitempty"` // Time of expiry
 	Value  []uint8    `json:"value,omitempty"`
+	// Opaque version token for optimistic concurrency control.
+	// Pass as `version` in a subsequent `set` to perform a conditional write.
+	Version uint64 `json:"version"`
 }

--- a/clients/go/internal/models/kv_set_in.go
+++ b/clients/go/internal/models/kv_set_in.go
@@ -7,4 +7,7 @@ type KvSetIn struct {
 	Value    []uint8            `json:"value"`
 	Ttl      *uint64            `json:"ttl,omitempty"` // Time to live in milliseconds
 	Behavior *OperationBehavior `json:"behavior,omitempty"`
+	// If set, the write only succeeds when the stored version matches this value.
+	// Use the `version` field from a prior `get` response.
+	Version *uint64 `json:"version,omitempty"`
 }

--- a/clients/go/internal/models/kv_set_out.go
+++ b/clients/go/internal/models/kv_set_out.go
@@ -3,5 +3,6 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type KvSetOut struct {
-	Success bool `json:"success"` // Whether the operation succeeded or was a noop due to pre-conditions.
+	Success bool   `json:"success"` // Whether the operation succeeded or was a noop due to pre-conditions.
+	Version uint64 `json:"version"`
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/KvGetOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvGetOut.java
@@ -30,6 +30,7 @@ import lombok.ToString;
 public class KvGetOut {
 @JsonProperty private OffsetDateTime expiry;
 @JsonProperty private List<Byte> value;
+@JsonProperty private Long version;
 public KvGetOut () {}
 
  public KvGetOut expiry(OffsetDateTime expiry) {
@@ -75,6 +76,26 @@ public KvGetOut () {}
 
      public void setValue(List<Byte> value) {
         this.value = value;
+    }
+
+     public KvGetOut version(Long version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+    * Opaque version token for optimistic concurrency control.
+Pass as `version` in a subsequent `set` to perform a conditional write.
+    *
+     * @return version
+     */
+    @javax.annotation.Nonnull
+     public Long getVersion() {
+        return version;
+    }
+
+     public void setVersion(Long version) {
+        this.version = version;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/KvSetIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvSetIn.java
@@ -32,6 +32,7 @@ public class KvSetIn {
 @JsonProperty private List<Byte> value;
 @JsonProperty private Long ttl;
 @JsonProperty private OperationBehavior behavior;
+@JsonProperty private Long version;
 public KvSetIn () {}
 
  public KvSetIn key(String key) {
@@ -115,6 +116,26 @@ public KvSetIn () {}
 
      public void setBehavior(OperationBehavior behavior) {
         this.behavior = behavior;
+    }
+
+     public KvSetIn version(Long version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+    * If set, the write only succeeds when the stored version matches this value.
+Use the `version` field from a prior `get` response.
+    *
+     * @return version
+     */
+    @javax.annotation.Nullable
+     public Long getVersion() {
+        return version;
+    }
+
+     public void setVersion(Long version) {
+        this.version = version;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/KvSetOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/KvSetOut.java
@@ -29,6 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
 public class KvSetOut {
 @JsonProperty private Boolean success;
+@JsonProperty private Long version;
 public KvSetOut () {}
 
  public KvSetOut success(Boolean success) {
@@ -48,6 +49,25 @@ public KvSetOut () {}
 
      public void setSuccess(Boolean success) {
         this.success = success;
+    }
+
+     public KvSetOut version(Long version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+    * Get version
+    *
+     * @return version
+     */
+    @javax.annotation.Nonnull
+     public Long getVersion() {
+        return version;
+    }
+
+     public void setVersion(Long version) {
+        this.version = version;
     }
 
     /**

--- a/clients/javascript/src/models/kvGetOut.ts
+++ b/clients/javascript/src/models/kvGetOut.ts
@@ -4,6 +4,11 @@ export interface KvGetOut {
     /** Time of expiry */
     expiry?: Date | null;
     value?: number[] | null;
+    /**
+* Opaque version token for optimistic concurrency control.
+* Pass as `version` in a subsequent `set` to perform a conditional write.
+*/
+    version: number;
 }
 
 export const KvGetOutSerializer = {
@@ -12,6 +17,7 @@ export const KvGetOutSerializer = {
         return {
             expiry: object['expiry'] ? new Date(object['expiry']) : null,
             value: object['value'],
+            version: object['version'],
         };
     },
 
@@ -20,6 +26,7 @@ export const KvGetOutSerializer = {
         return {
             'expiry': self.expiry,
             'value': self.value,
+            'version': self.version,
         };
     }
 }

--- a/clients/javascript/src/models/kvSetIn.ts
+++ b/clients/javascript/src/models/kvSetIn.ts
@@ -10,6 +10,11 @@ export interface KvSetIn {
     /** Time to live in milliseconds */
     ttl?: number | null;
     behavior?: OperationBehavior;
+    /**
+* If set, the write only succeeds when the stored version matches this value.
+* Use the `version` field from a prior `get` response.
+*/
+    version?: number | null;
 }
 
 export const KvSetInSerializer = {
@@ -20,6 +25,7 @@ export const KvSetInSerializer = {
             value: object['value'],
             ttl: object['ttl'],
             behavior: object['behavior'] != null ? OperationBehaviorSerializer._fromJsonObject(object['behavior']): undefined,
+            version: object['version'],
         };
     },
 
@@ -30,6 +36,7 @@ export const KvSetInSerializer = {
             'value': self.value,
             'ttl': self.ttl,
             'behavior': self.behavior != null ? OperationBehaviorSerializer._toJsonObject(self.behavior) : undefined,
+            'version': self.version,
         };
     }
 }

--- a/clients/javascript/src/models/kvSetOut.ts
+++ b/clients/javascript/src/models/kvSetOut.ts
@@ -3,6 +3,7 @@
 export interface KvSetOut {
     /** Whether the operation succeeded or was a noop due to pre-conditions. */
     success: boolean;
+    version: number;
 }
 
 export const KvSetOutSerializer = {
@@ -10,6 +11,7 @@ export const KvSetOutSerializer = {
     _fromJsonObject(object: any): KvSetOut {
         return {
             success: object['success'],
+            version: object['version'],
         };
     },
 
@@ -17,6 +19,7 @@ export const KvSetOutSerializer = {
     _toJsonObject(self: KvSetOut): any {
         return {
             'success': self.success,
+            'version': self.version,
         };
     }
 }

--- a/clients/python/coyote/apis/kv.py
+++ b/clients/python/coyote/apis/kv.py
@@ -35,6 +35,7 @@ class KvAsync(ApiBase):
             value=kv_set_in.value,
             ttl=kv_set_in.ttl,
             behavior=kv_set_in.behavior,
+            version=kv_set_in.version,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -96,6 +97,7 @@ class Kv(ApiBase):
             value=kv_set_in.value,
             ttl=kv_set_in.ttl,
             behavior=kv_set_in.behavior,
+            version=kv_set_in.version,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/clients/python/coyote/models/kv_get_out.py
+++ b/clients/python/coyote/models/kv_get_out.py
@@ -10,3 +10,7 @@ class KvGetOut(BaseModel):
     """Time of expiry"""
 
     value: t.Optional[bytes] = None
+
+    version: int
+    """Opaque version token for optimistic concurrency control.
+    Pass as `version` in a subsequent `set` to perform a conditional write."""

--- a/clients/python/coyote/models/kv_set_in.py
+++ b/clients/python/coyote/models/kv_set_in.py
@@ -14,6 +14,10 @@ class KvSetIn(BaseModel):
 
     behavior: t.Optional[OperationBehavior] = None
 
+    version: t.Optional[int] = None
+    """If set, the write only succeeds when the stored version matches this value.
+    Use the `version` field from a prior `get` response."""
+
 
 class _KvSetIn(BaseModel):
     key: str
@@ -24,3 +28,7 @@ class _KvSetIn(BaseModel):
     """Time to live in milliseconds"""
 
     behavior: t.Optional[OperationBehavior] = None
+
+    version: t.Optional[int] = None
+    """If set, the write only succeeds when the stored version matches this value.
+    Use the `version` field from a prior `get` response."""

--- a/clients/python/coyote/models/kv_set_out.py
+++ b/clients/python/coyote/models/kv_set_out.py
@@ -6,3 +6,5 @@ from ..internal.base_model import BaseModel
 class KvSetOut(BaseModel):
     success: bool
     """Whether the operation succeeded or was a noop due to pre-conditions."""
+
+    version: int

--- a/clients/rust/src/api/kv.rs
+++ b/clients/rust/src/api/kv.rs
@@ -22,6 +22,7 @@ impl<'a> Kv<'a> {
             value: kv_set_in.value,
             ttl: kv_set_in.ttl,
             behavior: kv_set_in.behavior,
+            version: kv_set_in.version,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1/kv/set")

--- a/clients/rust/src/models/kv_get_out.rs
+++ b/clients/rust/src/models/kv_get_out.rs
@@ -9,13 +9,18 @@ pub struct KvGetOut {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<u8>>,
+
+    /// Opaque version token for optimistic concurrency control.
+    /// Pass as `version` in a subsequent `set` to perform a conditional write.
+    pub version: u64,
 }
 
 impl KvGetOut {
-    pub fn new() -> Self {
+    pub fn new(version: u64) -> Self {
         Self {
             expiry: None,
             value: None,
+            version,
         }
     }
 

--- a/clients/rust/src/models/kv_set_in.rs
+++ b/clients/rust/src/models/kv_set_in.rs
@@ -13,6 +13,11 @@ pub struct KvSetIn {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub behavior: Option<OperationBehavior>,
+
+    /// If set, the write only succeeds when the stored version matches this value.
+    /// Use the `version` field from a prior `get` response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
 }
 
 impl KvSetIn {
@@ -21,6 +26,7 @@ impl KvSetIn {
             value,
             ttl: None,
             behavior: None,
+            version: None,
         }
     }
 
@@ -31,6 +37,11 @@ impl KvSetIn {
 
     pub fn with_behavior(mut self, value: impl Into<Option<OperationBehavior>>) -> Self {
         self.behavior = value.into();
+        self
+    }
+
+    pub fn with_version(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.version = value.into();
         self
     }
 }
@@ -47,4 +58,9 @@ pub(crate) struct KvSetIn_ {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub behavior: Option<OperationBehavior>,
+
+    /// If set, the write only succeeds when the stored version matches this value.
+    /// Use the `version` field from a prior `get` response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
 }

--- a/clients/rust/src/models/kv_set_out.rs
+++ b/clients/rust/src/models/kv_set_out.rs
@@ -5,10 +5,12 @@ use serde::{Deserialize, Serialize};
 pub struct KvSetOut {
     /// Whether the operation succeeded or was a noop due to pre-conditions.
     pub success: bool,
+
+    pub version: u64,
 }
 
 impl KvSetOut {
-    pub fn new(success: bool) -> Self {
-        Self { success }
+    pub fn new(success: bool, version: u64) -> Self {
+        Self { success, version }
     }
 }

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -1,6 +1,6 @@
 use super::{CacheRaftState, CacheRequest, SetResponse};
 use crate::{CacheModel, CacheNamespace};
-use coyote_kv::kvcontroller::OperationBehavior;
+use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
 use coyote_namespace::entities::NamespaceId;
 use coyote_operations::{OpContext, Result};
 use fjall_utils::StorageType;
@@ -27,14 +27,18 @@ impl SetOperation {
 }
 
 impl SetOperation {
-    fn apply_real(self, state: &CacheRaftState<'_>, now: Timestamp) -> Result<()> {
+    fn apply_real(self, state: &CacheRaftState<'_>, now: Timestamp, log_index: u64) -> Result<()> {
         state.state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
-            self.model.value,
-            self.model.expiry,
+            KvModelIn {
+                value: self.model.value,
+                expiry: self.model.expiry,
+                version: None,
+            },
             OperationBehavior::Upsert,
             now,
+            log_index,
         )?;
         Ok(())
     }
@@ -42,6 +46,6 @@ impl SetOperation {
 
 impl CacheRequest for SetOperation {
     fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> SetResponse {
-        SetResponse(self.apply_real(&state, ctx.timestamp))
+        SetResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index))
     }
 }

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use super::{CompleteResponse, IdempotencyRaftState, IdempotencyRequest};
 use crate::{IdempotencyNamespace, IdempotencyState};
-use coyote_kv::kvcontroller::OperationBehavior;
+use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
 use coyote_namespace::entities::NamespaceId;
 use coyote_operations::Result;
 use fjall_utils::StorageType;
@@ -36,18 +36,27 @@ impl CompleteOperation {
 }
 
 impl CompleteOperation {
-    fn apply_real(self, state: &IdempotencyRaftState<'_>, now: Timestamp) -> Result<()> {
+    fn apply_real(
+        self,
+        state: &IdempotencyRaftState<'_>,
+        now: Timestamp,
+        log_index: u64,
+    ) -> Result<()> {
         let expiry = now + Duration::from_secs(self.ttl_seconds);
         state.state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
-            IdempotencyState::Completed {
-                response: self.response,
-            }
-            .into(),
-            Some(expiry),
+            KvModelIn {
+                value: IdempotencyState::Completed {
+                    response: self.response,
+                }
+                .into(),
+                expiry: Some(expiry),
+                version: None,
+            },
             OperationBehavior::Upsert,
             now,
+            log_index,
         )?;
 
         Ok(())
@@ -60,6 +69,6 @@ impl IdempotencyRequest for CompleteOperation {
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CompleteResponse {
-        CompleteResponse(self.apply_real(&state, ctx.timestamp))
+        CompleteResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index))
     }
 }

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use super::{IdempotencyRaftState, IdempotencyRequest, TryStartResponse};
 use crate::{IdempotencyNamespace, IdempotencyStartResult, IdempotencyState};
-use coyote_kv::kvcontroller::OperationBehavior;
+use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
 use coyote_namespace::entities::NamespaceId;
 use coyote_operations::Result;
 use fjall_utils::StorageType;
@@ -38,6 +38,7 @@ impl TryStartOperation {
         self,
         state: &IdempotencyRaftState<'_>,
         now: Timestamp,
+        log_index: u64,
     ) -> Result<TryStartResponseData> {
         let expiry = now + Duration::from_secs(self.ttl_seconds);
 
@@ -48,10 +49,14 @@ impl TryStartOperation {
                 controller.set(
                     self.namespace_id,
                     &self.key,
-                    IdempotencyState::InProgress.into(),
-                    Some(expiry),
+                    KvModelIn {
+                        value: IdempotencyState::InProgress.into(),
+                        expiry: Some(expiry),
+                        version: None,
+                    },
                     OperationBehavior::Insert,
                     now,
+                    log_index,
                 )?;
                 Ok(TryStartResponseData {
                     result: IdempotencyStartResult::Started,
@@ -77,6 +82,6 @@ impl IdempotencyRequest for TryStartOperation {
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> TryStartResponse {
-        TryStartResponse(self.apply_real(&state, ctx.timestamp))
+        TryStartResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index))
     }
 }

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -1,4 +1,4 @@
-use coyote_error::Result;
+use coyote_error::{Error, Result};
 use coyote_namespace::entities::NamespaceId;
 use fjall::{KeyspaceCreateOptions, KvSeparationOptions};
 use fjall_utils::{StorageType, TableRow, WriteBatchExt};
@@ -25,6 +25,23 @@ pub enum OperationBehavior {
 pub struct KvModel {
     pub expiry: Option<Timestamp>,
     pub value: Vec<u8>,
+    /// Opaque version token for optimistic concurrency control.
+    pub version: u64,
+}
+
+/// Input model for [`KvController::set`]. `version` is the expected current
+/// version for OCC — `None` skips the check.
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
+pub struct KvModelIn {
+    pub value: Vec<u8>,
+    pub expiry: Option<Timestamp>,
+    pub version: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvSetResult {
+    pub version: u64,
+    pub success: bool,
 }
 
 impl From<KvPairRow> for KvModel {
@@ -32,6 +49,7 @@ impl From<KvPairRow> for KvModel {
         Self {
             expiry: row.expiry,
             value: row.value,
+            version: row.version,
         }
     }
 }
@@ -81,16 +99,19 @@ impl KvController {
         &self,
         namespace_id: NamespaceId,
         key: &str,
-        value: Vec<u8>,
-        expiry: Option<Timestamp>,
+        model: KvModel,
     ) -> Result<()> {
         let mut batch = self.db.batch();
 
-        let row = KvPairRow { value, expiry };
+        let row = KvPairRow {
+            value: model.value,
+            expiry: model.expiry,
+            version: model.version,
+        };
 
         batch.insert_row(&self.keyspace, KvPairRow::key_for(namespace_id, key), &row)?;
 
-        if let Some(expiry) = expiry {
+        if let Some(expiry) = row.expiry {
             let expiration_row = ExpirationRow::new();
             batch.insert_row(
                 &self.keyspace,
@@ -104,40 +125,78 @@ impl KvController {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, value))]
+    #[tracing::instrument(skip(self, model))]
     pub fn set(
         &self,
         namespace_id: NamespaceId,
         key: &str,
-        value: Vec<u8>,
-        expiry: Option<Timestamp>,
+        model: KvModelIn,
         behavior: OperationBehavior,
         now: Timestamp,
-    ) -> Result<bool> {
-        match behavior {
-            OperationBehavior::Upsert => {
-                self.insert_with_expiration(namespace_id, key, value, expiry)?;
-            }
-            OperationBehavior::Insert => {
-                let exists = self.fetch(namespace_id, key, now)?.is_some();
-
-                if !exists {
-                    self.insert_with_expiration(namespace_id, key, value, expiry)?;
-                } else {
-                    return Ok(false);
-                }
-            }
-            OperationBehavior::Update => {
-                let exists = self.fetch(namespace_id, key, now)?.is_some();
-                if exists {
-                    self.insert_with_expiration(namespace_id, key, value, expiry)?;
-                } else {
-                    return Ok(false);
-                }
+        // This is a monotonically increasing global counter (e.g. raft offset)
+        global_counter: u64,
+    ) -> Result<KvSetResult> {
+        let mut current = None;
+        // OCC check: if the caller supplied an expected version, verify it.
+        if let Some(expected) = model.version {
+            current = self.fetch(namespace_id, key, now)?;
+            let current_version = current.as_ref().map(|m| m.version).unwrap_or(0);
+            if current_version != expected {
+                return Err(Error::bad_request("version_mismatch", "version mismatch"));
             }
         }
 
-        Ok(true)
+        let new_version = global_counter + 1;
+
+        let new_model = KvModel {
+            value: model.value,
+            expiry: model.expiry,
+            version: new_version,
+        };
+
+        match behavior {
+            OperationBehavior::Upsert => {
+                self.insert_with_expiration(namespace_id, key, new_model)?;
+            }
+            OperationBehavior::Insert => {
+                current = if current.is_some() {
+                    current
+                } else {
+                    self.fetch(namespace_id, key, now)?
+                };
+
+                if let Some(current) = current {
+                    return Ok(KvSetResult {
+                        version: current.version,
+                        success: false,
+                    });
+                } else {
+                    self.insert_with_expiration(namespace_id, key, new_model)?;
+                }
+            }
+            OperationBehavior::Update => {
+                current = if current.is_some() {
+                    current
+                } else {
+                    self.fetch(namespace_id, key, now)?
+                };
+                let exists = current.is_some();
+
+                if exists {
+                    self.insert_with_expiration(namespace_id, key, new_model)?;
+                } else {
+                    return Ok(KvSetResult {
+                        version: 0,
+                        success: false,
+                    });
+                }
+            }
+        };
+
+        Ok(KvSetResult {
+            version: new_version,
+            success: true,
+        })
     }
 
     #[tracing::instrument(skip(self))]
@@ -281,10 +340,14 @@ mod tests {
             .set(
                 ns(),
                 key,
-                b"hello world".to_vec(),
-                None,
+                KvModelIn {
+                    value: b"hello world".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
                 OperationBehavior::Upsert,
                 Timestamp::now(),
+                0,
             )
             .unwrap();
 
@@ -309,23 +372,31 @@ mod tests {
         let res = controller.set(
             ns(),
             "key1",
-            b"key1 updated".to_vec(),
-            None,
+            KvModelIn {
+                value: b"key1 updated".to_vec(),
+                expiry: None,
+                version: None,
+            },
             OperationBehavior::Update,
             Timestamp::now(),
+            0,
         );
-        assert!(!res.unwrap());
+        assert!(!res.unwrap().success);
         assert!(!key_exists(&controller, "key1"));
 
         let res = controller.set(
             ns(),
             "key1",
-            b"key1 inserted".to_vec(),
-            None,
+            KvModelIn {
+                value: b"key1 inserted".to_vec(),
+                expiry: None,
+                version: None,
+            },
             OperationBehavior::Insert,
             Timestamp::now(),
+            0,
         );
-        assert!(res.unwrap());
+        assert!(res.unwrap().success);
         assert!(key_exists(&controller, "key1"));
         let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
         assert!(result.is_some());
@@ -334,12 +405,16 @@ mod tests {
         let res = controller.set(
             ns(),
             "key1",
-            b"another value".to_vec(),
-            None,
+            KvModelIn {
+                value: b"another value".to_vec(),
+                expiry: None,
+                version: None,
+            },
             OperationBehavior::Insert,
             Timestamp::now(),
+            0,
         );
-        assert!(!res.unwrap());
+        assert!(!res.unwrap().success);
         assert!(key_exists(&controller, "key1"));
         let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
         assert!(result.is_some());
@@ -349,12 +424,16 @@ mod tests {
         let res = controller.set(
             ns(),
             "key1",
-            b"key1 upserted".to_vec(),
-            None,
+            KvModelIn {
+                value: b"key1 upserted".to_vec(),
+                expiry: None,
+                version: None,
+            },
             OperationBehavior::Upsert,
             Timestamp::now(),
+            0,
         );
-        assert!(res.unwrap());
+        assert!(res.unwrap().success);
         assert!(key_exists(&controller, "key1"));
         let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
         assert!(result.is_some());
@@ -371,20 +450,28 @@ mod tests {
             .set(
                 ns(),
                 key,
-                b"first value".to_vec(),
-                None,
+                KvModelIn {
+                    value: b"first value".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
                 OperationBehavior::Upsert,
                 Timestamp::now(),
+                0,
             )
             .unwrap();
         controller
             .set(
                 ns(),
                 key,
-                b"second value".to_vec(),
-                None,
+                KvModelIn {
+                    value: b"second value".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
                 OperationBehavior::Upsert,
                 Timestamp::now(),
+                0,
             )
             .unwrap();
 
@@ -407,10 +494,14 @@ mod tests {
             .set(
                 ns(),
                 "expired:key",
-                b"expired data".to_vec(),
-                Some(now.checked_sub(1.hour()).unwrap()),
+                KvModelIn {
+                    value: b"expired data".to_vec(),
+                    expiry: Some(now.checked_sub(1.hour()).unwrap()),
+                    version: None,
+                },
                 OperationBehavior::Upsert,
                 now,
+                0,
             )
             .unwrap();
 
@@ -437,10 +528,14 @@ mod tests {
                 .set(
                     ns(),
                     key,
-                    value.to_vec(),
-                    Some(*expiry),
+                    KvModelIn {
+                        value: value.to_vec(),
+                        expiry: Some(*expiry),
+                        version: None,
+                    },
                     OperationBehavior::Upsert,
                     now,
+                    0,
                 )
                 .unwrap();
         }
@@ -450,10 +545,14 @@ mod tests {
             .set(
                 ns(),
                 valid_key,
-                b"valid data".to_vec(),
-                Some(now.checked_add(1.hour()).unwrap()),
+                KvModelIn {
+                    value: b"valid data".to_vec(),
+                    expiry: Some(now.checked_add(1.hour()).unwrap()),
+                    version: None,
+                },
                 OperationBehavior::Upsert,
                 now,
+                0,
             )
             .unwrap();
 
@@ -462,10 +561,14 @@ mod tests {
             .set(
                 ns(),
                 permanent_key,
-                b"permanent data".to_vec(),
-                None,
+                KvModelIn {
+                    value: b"permanent data".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
                 OperationBehavior::Upsert,
                 now,
+                0,
             )
             .unwrap();
 

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -1,6 +1,10 @@
 use std::time::Duration;
 
-use crate::{KvNamespace, State, kvcontroller::OperationBehavior, operations::KvRaftState};
+use crate::{
+    KvNamespace, State,
+    kvcontroller::{KvModelIn, OperationBehavior},
+    operations::KvRaftState,
+};
 
 use super::{KvRequest, SetResponse};
 use coyote_core::types::EntityKey;
@@ -14,6 +18,7 @@ use tap::TapOptional;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetResponseData {
     pub success: bool,
+    pub version: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,8 +26,7 @@ pub struct SetOperation {
     namespace_id: NamespaceId,
     storage_type: StorageType,
     pub(crate) key: EntityKey,
-    expiry: Option<Timestamp>,
-    value: Vec<u8>,
+    model: KvModelIn,
     behavior: OperationBehavior,
 }
 
@@ -33,6 +37,7 @@ impl SetOperation {
         value: Vec<u8>,
         ttl: Option<u64>,
         behavior: OperationBehavior,
+        version: Option<u64>,
     ) -> Self {
         let expiry = ttl
             .map(|ttl| Timestamp::now() + Duration::from_millis(ttl))
@@ -41,29 +46,35 @@ impl SetOperation {
             namespace_id: namespace.id,
             storage_type: namespace.storage_type,
             key,
-            expiry,
-            value,
+            model: KvModelIn {
+                value,
+                expiry,
+                version,
+            },
             behavior,
         }
     }
 }
 
 impl SetOperation {
-    fn apply_real(self, state: &State, now: Timestamp) -> Result<SetResponseData> {
-        let success = state.controller(self.storage_type).set(
+    fn apply_real(self, state: &State, ctx: &OpContext) -> Result<SetResponseData> {
+        let result = state.controller(self.storage_type).set(
             self.namespace_id,
             &self.key,
-            self.value,
-            self.expiry,
+            self.model,
             self.behavior,
-            now,
+            ctx.timestamp,
+            ctx.log_index,
         )?;
-        Ok(SetResponseData { success })
+        Ok(SetResponseData {
+            success: result.success,
+            version: result.version,
+        })
     }
 }
 
 impl KvRequest for SetOperation {
     fn apply(self, state: KvRaftState<'_>, ctx: &OpContext) -> SetResponse {
-        SetResponse(self.apply_real(state.state, ctx.timestamp))
+        SetResponse(self.apply_real(state.state, ctx))
     }
 }

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -15,6 +15,8 @@ enum RowType {
 pub struct KvPairRow {
     pub value: Vec<u8>,
     pub expiry: Option<Timestamp>,
+    #[serde(default)]
+    pub version: u64,
 }
 
 impl TableRow for KvPairRow {

--- a/openapi.json
+++ b/openapi.json
@@ -1867,8 +1867,17 @@
               "maximum": 255
             },
             "nullable": true
+          },
+          "version": {
+            "description": "Opaque version token for optimistic concurrency control.\nPass as `version` in a subsequent `set` to perform a conditional write.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           }
-        }
+        },
+        "required": [
+          "version"
+        ]
       },
       "KvSetIn": {
         "type": "object",
@@ -1898,6 +1907,13 @@
           "behavior": {
             "default": "upsert",
             "$ref": "#/components/schemas/OperationBehavior"
+          },
+          "version": {
+            "description": "If set, the write only succeeds when the stored version matches this value.\nUse the `version` field from a prior `get` response.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "nullable": true
           }
         },
         "required": [
@@ -1914,10 +1930,16 @@
           "success": {
             "description": "Whether the operation succeeded or was a noop due to pre-conditions.",
             "type": "boolean"
+          },
+          "version": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           }
         },
         "required": [
-          "success"
+          "success",
+          "version"
         ]
       },
       "MsgIn": {

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -11,7 +11,7 @@ use coyote_error::{OptionExt, ResultExt};
 use coyote_kv::{
     KvNamespace,
     kvcontroller::{KvModel, OperationBehavior},
-    operations::{CreateKvOperation, DeleteOperation, SetOperation},
+    operations::{CreateKvOperation, DeleteOperation, SetOperation, SetResponseData},
 };
 use coyote_namespace::entities::StorageType;
 use coyote_proto::MsgPackOrJson;
@@ -36,12 +36,17 @@ pub struct KvSetIn {
 
     #[serde(default)]
     pub behavior: OperationBehavior,
+
+    /// If set, the write only succeeds when the stored version matches this value.
+    /// Use the `version` field from a prior `get` response.
+    pub version: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct KvSetOut {
     /// Whether the operation succeeded or was a noop due to pre-conditions.
     pub success: bool,
+    pub version: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -59,6 +64,10 @@ pub struct KvGetOut {
     pub expiry: Option<Timestamp>,
 
     pub value: Option<Vec<u8>>,
+
+    /// Opaque version token for optimistic concurrency control.
+    /// Pass as `version` in a subsequent `set` to perform a conditional write.
+    pub version: u64,
 }
 
 impl KvGetOut {
@@ -66,6 +75,7 @@ impl KvGetOut {
         Self {
             expiry: model.expiry,
             value: Some(model.value),
+            version: model.version,
         }
     }
 }
@@ -95,12 +105,18 @@ async fn kv_set(
         .fetch_namespace(data.key.namespace())?
         .ok_or_not_found()?;
 
-    let operation = SetOperation::new(namespace, data.key, data.value, data.ttl, data.behavior);
-    let resp = repl.client_write(operation).await.or_internal_error()?.0?;
+    let operation = SetOperation::new(
+        namespace,
+        data.key,
+        data.value,
+        data.ttl,
+        data.behavior,
+        data.version,
+    );
+    let SetResponseData { version, success } =
+        repl.client_write(operation).await.or_internal_error()?.0?;
 
-    let ret = KvSetOut {
-        success: resp.success,
-    };
+    let ret = KvSetOut { version, success };
     Ok(MsgPackOrJson(ret))
 }
 
@@ -131,6 +147,7 @@ async fn kv_get(
         None => KvGetOut {
             expiry: None,
             value: None,
+            version: 0,
         },
     };
     Ok(MsgPackOrJson(ret))


### PR DESCRIPTION
We allow passing a `version` field which is evaluated against the known version we have on disk. If they match it goes through, otherwise it aborts the request.

At the moment it throws an error on version mismatch, which I think makes sense, but let's see how this discussion evolves: https://svixhq.slack.com/archives/C0A72988962/p1773457868083409

It's currently only implemented for kv. I need to think whether it makes sense to implement it for `cache` as well. We do it in svix webhooks private to ensure we cache the right value in highly contended environments (CMA). Though I wonder whether there are more elegant things we can do.