### PR TITLE
Add idempotency routes to codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "openapi-codegen"
 version = "0.1.0"
-source = "git+https://github.com/svix/openapi-codegen?rev=29098b6b02c86fbe79091f0d4da697ca486c2875#29098b6b02c86fbe79091f0d4da697ca486c2875"
+source = "git+https://github.com/svix/openapi-codegen?rev=f464ae88b65c76fd6a39b6547003611e24680825#f464ae88b65c76fd6a39b6547003611e24680825"
 dependencies = [
  "aide 0.14.2",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ itertools = "0.14"
 jiff = { version = "0.2.18", features = ["serde"] }
 mimalloc = "0.1.48"
 mime = "0.3"
-openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "29098b6b02c86fbe79091f0d4da697ca486c2875" }
+openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "f464ae88b65c76fd6a39b6547003611e24680825" }
 openraft = { version = "0.9.21", features = ["tracing-log", "anyhow", "serde", "storage-v2"] }
 opentelemetry = { version = "0.31.0", features = ["metrics"] }
 opentelemetry-http = "0.31.0"

--- a/clients/cli/src/cmds/api/idempotency.rs
+++ b/clients/cli/src/cmds/api/idempotency.rs
@@ -14,6 +14,16 @@ pub struct IdempotencyArgs {
 #[derive(Subcommand)]
 pub enum IdempotencyCommands {
     Namespace(IdempotencyNamespaceArgs),
+    /// Start an idempotent request
+    Start {
+        key: String,
+        idempotency_start_in: crate::json::JsonOf<coyote_client::models::IdempotencyStartIn>,
+    },
+    /// Complete an idempotent request with a response
+    Complete {
+        key: String,
+        idempotency_complete_in: crate::json::JsonOf<coyote_client::models::IdempotencyCompleteIn>,
+    },
     /// Abandon an idempotent request (remove lock without saving response)
     Abort {
         key: String,
@@ -30,6 +40,26 @@ impl IdempotencyCommands {
         match self {
             Self::Namespace(args) => {
                 args.command.exec(client, color_mode).await?;
+            }
+            Self::Start {
+                key,
+                idempotency_start_in,
+            } => {
+                let resp = client
+                    .idempotency()
+                    .start(key, idempotency_start_in.into_inner())
+                    .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Complete {
+                key,
+                idempotency_complete_in,
+            } => {
+                let resp = client
+                    .idempotency()
+                    .complete(key, idempotency_complete_in.into_inner())
+                    .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
             }
             Self::Abort {
                 key,

--- a/clients/go/internal/apis/idempotency.go
+++ b/clients/go/internal/apis/idempotency.go
@@ -18,6 +18,38 @@ func NewIdempotency(client *coyote_proto.HttpClient) Idempotency {
 	return Idempotency{client}
 }
 
+// Start an idempotent request
+func (idempotency Idempotency) Start(
+	ctx context.Context,
+	idempotencyStartIn coyote_models.IdempotencyStartIn,
+) (*coyote_models.IdempotencyStartOut, error) {
+	return coyote_proto.ExecuteRequest[coyote_models.IdempotencyStartIn, coyote_models.IdempotencyStartOut](
+		ctx,
+		idempotency.client,
+		"POST",
+		"/api/v1/idempotency/start",
+		nil,
+		nil,
+		&idempotencyStartIn,
+	)
+}
+
+// Complete an idempotent request with a response
+func (idempotency Idempotency) Complete(
+	ctx context.Context,
+	idempotencyCompleteIn coyote_models.IdempotencyCompleteIn,
+) (*coyote_models.IdempotencyCompleteOut, error) {
+	return coyote_proto.ExecuteRequest[coyote_models.IdempotencyCompleteIn, coyote_models.IdempotencyCompleteOut](
+		ctx,
+		idempotency.client,
+		"POST",
+		"/api/v1/idempotency/complete",
+		nil,
+		nil,
+		&idempotencyCompleteIn,
+	)
+}
+
 // Abandon an idempotent request (remove lock without saving response)
 func (idempotency Idempotency) Abort(
 	ctx context.Context,

--- a/clients/go/internal/models/idempotency_complete_in.go
+++ b/clients/go/internal/models/idempotency_complete_in.go
@@ -1,0 +1,9 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type IdempotencyCompleteIn struct {
+	Key      string  `json:"key"`
+	Response []uint8 `json:"response"` // The response to cache
+	Ttl      uint64  `json:"ttl"`      // TTL in seconds for the cached response
+}

--- a/clients/go/internal/models/idempotency_complete_out.go
+++ b/clients/go/internal/models/idempotency_complete_out.go
@@ -1,0 +1,6 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type IdempotencyCompleteOut struct {
+}

--- a/clients/go/internal/models/idempotency_completed.go
+++ b/clients/go/internal/models/idempotency_completed.go
@@ -1,0 +1,7 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type IdempotencyCompleted struct {
+	Response []uint8 `json:"response"`
+}

--- a/clients/go/internal/models/idempotency_start_in.go
+++ b/clients/go/internal/models/idempotency_start_in.go
@@ -1,0 +1,8 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type IdempotencyStartIn struct {
+	Key string `json:"key"`
+	Ttl uint64 `json:"ttl"` // TTL in seconds for the lock/response
+}

--- a/clients/go/internal/models/idempotency_start_out.go
+++ b/clients/go/internal/models/idempotency_start_out.go
@@ -1,0 +1,75 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// When creating an IdempotencyStartOut, use the appropriate data structure based on the Type:
+//   - "started","locked": No data needed (nil or just ignore the data field)
+//   - "completed": Use IdempotencyCompleted
+type IdempotencyStartOut struct {
+	Status IdempotencyStartOutStatus `json:"status"`
+	Data   IdempotencyStartOutData   `json:"data"`
+}
+
+type IdempotencyStartOutStatus string
+
+const (
+	IdempotencyStartOutStatusStarted   IdempotencyStartOutStatus = "started"
+	IdempotencyStartOutStatusLocked    IdempotencyStartOutStatus = "locked"
+	IdempotencyStartOutStatusCompleted IdempotencyStartOutStatus = "completed"
+)
+
+type IdempotencyStartOutData interface {
+	isIdempotencyStartOutData()
+}
+
+func (emptyMap) isIdempotencyStartOutData()             {}
+func (IdempotencyCompleted) isIdempotencyStartOutData() {}
+
+func (i *IdempotencyStartOut) UnmarshalJSON(data []byte) error {
+	type Alias IdempotencyStartOut
+	aux := struct {
+		*Alias
+		Data json.RawMessage `json:"data"`
+	}{Alias: (*Alias)(i)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	var err error
+	switch i.Status {
+	case "started", "locked":
+	case "completed":
+		var c IdempotencyCompleted
+		err = json.Unmarshal(aux.Data, &c)
+		i.Data = c
+	default:
+		// should be unreachable
+		return fmt.Errorf("unexpected type %s", i.Status)
+	}
+	return err
+}
+
+var IdempotencyStartOutStatusWithNoData = map[string]bool{
+	"started": true,
+	"locked":  true,
+}
+
+func (i IdempotencyStartOut) MarshalJSON() ([]byte, error) {
+	type Alias IdempotencyStartOut
+	if _, found := IdempotencyStartOutStatusWithNoData[string(i.Status)]; found {
+		i.Data = emptyMap{}
+	}
+	return json.Marshal(&struct{ Alias }{Alias: (Alias)(i)})
+}
+
+var IdempotencyStartOutStatusFromString = map[string]IdempotencyStartOutStatus{
+	"started":   IdempotencyStartOutStatusStarted,
+	"locked":    IdempotencyStartOutStatusLocked,
+	"completed": IdempotencyStartOutStatusCompleted,
+}

--- a/clients/go/models.go
+++ b/clients/go/models.go
@@ -19,10 +19,15 @@ type (
 	EvictionPolicy                = coyote_models.EvictionPolicy
 	IdempotencyAbortIn            = coyote_models.IdempotencyAbortIn
 	IdempotencyAbortOut           = coyote_models.IdempotencyAbortOut
+	IdempotencyCompleteIn         = coyote_models.IdempotencyCompleteIn
+	IdempotencyCompleteOut        = coyote_models.IdempotencyCompleteOut
+	IdempotencyCompleted          = coyote_models.IdempotencyCompleted
 	IdempotencyCreateNamespaceIn  = coyote_models.IdempotencyCreateNamespaceIn
 	IdempotencyCreateNamespaceOut = coyote_models.IdempotencyCreateNamespaceOut
 	IdempotencyGetNamespaceIn     = coyote_models.IdempotencyGetNamespaceIn
 	IdempotencyGetNamespaceOut    = coyote_models.IdempotencyGetNamespaceOut
+	IdempotencyStartIn            = coyote_models.IdempotencyStartIn
+	IdempotencyStartOut           = coyote_models.IdempotencyStartOut
 	KvCreateNamespaceIn           = coyote_models.KvCreateNamespaceIn
 	KvCreateNamespaceOut          = coyote_models.KvCreateNamespaceOut
 	KvDeleteIn                    = coyote_models.KvDeleteIn

--- a/clients/java/src/main/java/com/svix/coyote/apis/Idempotency.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/Idempotency.java
@@ -16,12 +16,44 @@ import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import com.svix.coyote.models.IdempotencyAbortIn;
 import com.svix.coyote.models.IdempotencyAbortOut;
+import com.svix.coyote.models.IdempotencyCompleteIn;
+import com.svix.coyote.models.IdempotencyCompleteOut;
+import com.svix.coyote.models.IdempotencyStartIn;
+import com.svix.coyote.models.IdempotencyStartOut;
 
 public class Idempotency {
     private final HttpClient client;
 
     public Idempotency(HttpClient client) {
         this.client = client;
+    }
+
+    /** Start an idempotent request */
+    public IdempotencyStartOut start(
+        final IdempotencyStartIn idempotencyStartIn
+    ) throws IOException, ApiException {
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/idempotency/start");
+        return this.client.executeRequest(
+            "POST",
+            url.build(),
+            null,
+            idempotencyStartIn,
+            IdempotencyStartOut.class
+            );
+    }
+
+    /** Complete an idempotent request with a response */
+    public IdempotencyCompleteOut complete(
+        final IdempotencyCompleteIn idempotencyCompleteIn
+    ) throws IOException, ApiException {
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/idempotency/complete");
+        return this.client.executeRequest(
+            "POST",
+            url.build(),
+            null,
+            idempotencyCompleteIn,
+            IdempotencyCompleteOut.class
+            );
     }
 
     /** Abandon an idempotent request (remove lock without saving response) */

--- a/clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteIn.java
@@ -1,0 +1,119 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
+public class IdempotencyCompleteIn {
+@JsonProperty private String key;
+@JsonProperty private List<Byte> response;
+@JsonProperty private Long ttl;
+public IdempotencyCompleteIn () {}
+
+ public IdempotencyCompleteIn key(String key) {
+        this.key = key;
+        return this;
+    }
+
+    /**
+    * Get key
+    *
+     * @return key
+     */
+    @javax.annotation.Nonnull
+     public String getKey() {
+        return key;
+    }
+
+     public void setKey(String key) {
+        this.key = key;
+    }
+
+     public IdempotencyCompleteIn response(List<Byte> response) {
+        this.response = response;
+        return this;
+    }
+
+     public IdempotencyCompleteIn addResponseItem(Byte responseItem) {
+        if (this.response == null) {
+            this.response = new ArrayList<>();
+        }
+        this.response.add(responseItem);
+        return this;
+    }
+    /**
+    * The response to cache
+    *
+     * @return response
+     */
+    @javax.annotation.Nonnull
+     public List<Byte> getResponse() {
+        return response;
+    }
+
+     public void setResponse(List<Byte> response) {
+        this.response = response;
+    }
+
+     public IdempotencyCompleteIn ttl(Long ttl) {
+        this.ttl = ttl;
+        return this;
+    }
+
+    /**
+    * TTL in seconds for the cached response
+    *
+     * @return ttl
+     */
+    @javax.annotation.Nonnull
+     public Long getTtl() {
+        return ttl;
+    }
+
+     public void setTtl(Long ttl) {
+        this.ttl = ttl;
+    }
+
+    /**
+     * Create an instance of IdempotencyCompleteIn given an JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of IdempotencyCompleteIn
+     * @throws JsonProcessingException if the JSON string is invalid with respect to IdempotencyCompleteIn
+     */
+    public static IdempotencyCompleteIn fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, IdempotencyCompleteIn.class);
+    }
+
+    /**
+     * Convert an instance of IdempotencyCompleteIn to an JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteOut.java
@@ -1,0 +1,52 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
+public class IdempotencyCompleteOut {
+public IdempotencyCompleteOut () {}
+
+/**
+     * Create an instance of IdempotencyCompleteOut given an JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of IdempotencyCompleteOut
+     * @throws JsonProcessingException if the JSON string is invalid with respect to IdempotencyCompleteOut
+     */
+    public static IdempotencyCompleteOut fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, IdempotencyCompleteOut.class);
+    }
+
+    /**
+     * Convert an instance of IdempotencyCompleteOut to an JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleted.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleted.java
@@ -1,0 +1,79 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
+public class IdempotencyCompleted {
+@JsonProperty private List<Byte> response;
+public IdempotencyCompleted () {}
+
+ public IdempotencyCompleted response(List<Byte> response) {
+        this.response = response;
+        return this;
+    }
+
+     public IdempotencyCompleted addResponseItem(Byte responseItem) {
+        if (this.response == null) {
+            this.response = new ArrayList<>();
+        }
+        this.response.add(responseItem);
+        return this;
+    }
+    /**
+    * Get response
+    *
+     * @return response
+     */
+    @javax.annotation.Nonnull
+     public List<Byte> getResponse() {
+        return response;
+    }
+
+     public void setResponse(List<Byte> response) {
+        this.response = response;
+    }
+
+    /**
+     * Create an instance of IdempotencyCompleted given an JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of IdempotencyCompleted
+     * @throws JsonProcessingException if the JSON string is invalid with respect to IdempotencyCompleted
+     */
+    public static IdempotencyCompleted fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, IdempotencyCompleted.class);
+    }
+
+    /**
+     * Convert an instance of IdempotencyCompleted to an JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartIn.java
@@ -1,0 +1,92 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE,setterVisibility = Visibility.NONE)
+public class IdempotencyStartIn {
+@JsonProperty private String key;
+@JsonProperty private Long ttl;
+public IdempotencyStartIn () {}
+
+ public IdempotencyStartIn key(String key) {
+        this.key = key;
+        return this;
+    }
+
+    /**
+    * Get key
+    *
+     * @return key
+     */
+    @javax.annotation.Nonnull
+     public String getKey() {
+        return key;
+    }
+
+     public void setKey(String key) {
+        this.key = key;
+    }
+
+     public IdempotencyStartIn ttl(Long ttl) {
+        this.ttl = ttl;
+        return this;
+    }
+
+    /**
+    * TTL in seconds for the lock/response
+    *
+     * @return ttl
+     */
+    @javax.annotation.Nonnull
+     public Long getTtl() {
+        return ttl;
+    }
+
+     public void setTtl(Long ttl) {
+        this.ttl = ttl;
+    }
+
+    /**
+     * Create an instance of IdempotencyStartIn given an JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of IdempotencyStartIn
+     * @throws JsonProcessingException if the JSON string is invalid with respect to IdempotencyStartIn
+     */
+    public static IdempotencyStartIn fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, IdempotencyStartIn.class);
+    }
+
+    /**
+     * Convert an instance of IdempotencyStartIn to an JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartOut.java
@@ -1,0 +1,112 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.svix.coyote.Utils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.EqualsAndHashCode;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.Objects;
+import java.net.URI;
+import java.time.OffsetDateTime;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@EqualsAndHashCode
+@AllArgsConstructor
+@JsonSerialize(using = IdempotencyStartOutSerializer.class)
+@JsonDeserialize(using = IdempotencyStartOutDeserializer.class)
+public class IdempotencyStartOut {
+    private IdempotencyStartOutConfig data;
+
+    public IdempotencyStartOut data(IdempotencyStartOutConfig data) {
+        this.data = data;
+        return this;
+    }
+
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+
+    public static IdempotencyStartOut fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, IdempotencyStartOut.class);
+    }
+}
+
+@Getter
+@NoArgsConstructor
+class IdempotencyStartOutSurrogate {
+    @JsonProperty("status") String status;
+    @JsonProperty("data") JsonNode data;
+
+    IdempotencyStartOutSurrogate(IdempotencyStartOut o, String status, JsonNode data ){
+        this.status = status;
+        this.data = data;
+    }
+}
+
+
+class IdempotencyStartOutSerializer extends StdSerializer<IdempotencyStartOut> {
+    public IdempotencyStartOutSerializer() {
+        this(null);
+    }
+
+    public IdempotencyStartOutSerializer(Class<IdempotencyStartOut> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(IdempotencyStartOut value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        IdempotencyStartOutSurrogate surrogate = new IdempotencyStartOutSurrogate(value,value.getData().getVariantName(),value.getData().toJsonNode());
+        gen.writeObject(surrogate);
+    }
+}
+
+
+class IdempotencyStartOutDeserializer extends StdDeserializer<IdempotencyStartOut> {
+    public IdempotencyStartOutDeserializer() {
+        this(null);
+    }
+
+    public IdempotencyStartOutDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public IdempotencyStartOut deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        IdempotencyStartOutSurrogate surrogate = p.getCodec().readValue(p, IdempotencyStartOutSurrogate.class);
+        String status = surrogate.getStatus();
+        JsonNode data = surrogate.getData();
+        IdempotencyStartOutConfig sourceType = IdempotencyStartOutConfig.fromTypeAndConfig(status, data);
+        return new IdempotencyStartOut(sourceType);
+    }
+}
+
+
+

--- a/clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartOutConfig.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartOutConfig.java
@@ -1,0 +1,73 @@
+// This file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.svix.coyote.Utils;
+import com.svix.coyote.VariantName;
+import lombok.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ToString
+@EqualsAndHashCode
+public abstract class IdempotencyStartOutConfig {
+    @JsonIgnore
+    public String getVariantName() {
+        VariantName annotation = this.getClass().getAnnotation(VariantName.class);
+        return annotation != null ? annotation.value() : null;
+    }
+
+    public abstract JsonNode toJsonNode();
+
+    @ToString
+    @EqualsAndHashCode(callSuper = false)
+    @VariantName("started")
+    public static class Started extends IdempotencyStartOutConfig {
+        @Override public JsonNode toJsonNode() {
+            return Utils.getObjectMapper().createObjectNode();
+            }
+    }
+    @ToString
+    @EqualsAndHashCode(callSuper = false)
+    @VariantName("locked")
+    public static class Locked extends IdempotencyStartOutConfig {
+        @Override public JsonNode toJsonNode() {
+            return Utils.getObjectMapper().createObjectNode();
+            }
+    }
+    @Getter
+        @Setter
+        @AllArgsConstructor
+        @ToString
+    @EqualsAndHashCode(callSuper = false)
+    @VariantName("completed")
+    public static class Completed extends IdempotencyStartOutConfig {
+        private final IdempotencyCompleted completed;
+        @Override public JsonNode toJsonNode() {
+            return Utils.getObjectMapper().valueToTree(completed);
+            }
+    }
+    @FunctionalInterface
+    private interface TypeFactory {
+        IdempotencyStartOutConfig create(JsonNode config);
+    }
+    private static final Map<String, TypeFactory> TY_M = new HashMap<>();
+    private static final ObjectMapper m = Utils.getObjectMapper();
+    static {
+        TY_M.put("started", c -> new Started());
+            TY_M.put("locked", c -> new Locked());
+            TY_M.put("completed", c -> new Completed(m.convertValue(c, IdempotencyCompleted.class)));
+            }
+
+    public static IdempotencyStartOutConfig fromTypeAndConfig(String type, JsonNode config) {
+        TypeFactory factory = TY_M.get(type);
+        if (factory == null) {
+            throw new IllegalArgumentException("Unknown type: " + type);
+        }
+        return factory.create(config);
+    }
+
+}

--- a/clients/javascript/src/apis/idempotency.ts
+++ b/clients/javascript/src/apis/idempotency.ts
@@ -8,6 +8,22 @@ import {
     type IdempotencyAbortOut,
     IdempotencyAbortOutSerializer,
 } from '../models/idempotencyAbortOut';
+import {
+    type IdempotencyCompleteIn,
+    IdempotencyCompleteInSerializer,
+} from '../models/idempotencyCompleteIn';
+import {
+    type IdempotencyCompleteOut,
+    IdempotencyCompleteOutSerializer,
+} from '../models/idempotencyCompleteOut';
+import {
+    type IdempotencyStartIn,
+    IdempotencyStartInSerializer,
+} from '../models/idempotencyStartIn';
+import {
+    type IdempotencyStartOut,
+    IdempotencyStartOutSerializer,
+} from '../models/idempotencyStartOut';
 import { IdempotencyNamespace } from './idempotencyNamespace';
 import { HttpMethod, CoyoteRequest, type CoyoteRequestContext } from "../request";
 
@@ -18,7 +34,37 @@ export class Idempotency {
         return new IdempotencyNamespace(this.requestCtx);
     }
 
-    /** Abandon an idempotent request (remove lock without saving response) */
+    /** Start an idempotent request */
+    public start(
+        idempotencyStartIn: IdempotencyStartIn,
+        ): Promise<IdempotencyStartOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/start");
+
+        request.setBody(
+            IdempotencyStartInSerializer._toJsonObject(
+                idempotencyStartIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            IdempotencyStartOutSerializer._fromJsonObject,
+        );
+    }/** Complete an idempotent request with a response */
+    public complete(
+        idempotencyCompleteIn: IdempotencyCompleteIn,
+        ): Promise<IdempotencyCompleteOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/complete");
+
+        request.setBody(
+            IdempotencyCompleteInSerializer._toJsonObject(
+                idempotencyCompleteIn,
+            )
+        );
+        return request.send(
+            this.requestCtx,
+            IdempotencyCompleteOutSerializer._fromJsonObject,
+        );
+    }/** Abandon an idempotent request (remove lock without saving response) */
     public abort(
         idempotencyAbortIn: IdempotencyAbortIn,
         ): Promise<IdempotencyAbortOut> {

--- a/clients/javascript/src/models/idempotencyCompleteIn.ts
+++ b/clients/javascript/src/models/idempotencyCompleteIn.ts
@@ -1,0 +1,29 @@
+// this file is @generated
+
+export interface IdempotencyCompleteIn {
+    key: string;
+    /** The response to cache */
+    response: number[];
+    /** TTL in seconds for the cached response */
+    ttl: number;
+}
+
+export const IdempotencyCompleteInSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(object: any): IdempotencyCompleteIn {
+        return {
+            key: object['key'],
+            response: object['response'],
+            ttl: object['ttl'],
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(self: IdempotencyCompleteIn): any {
+        return {
+            'key': self.key,
+            'response': self.response,
+            'ttl': self.ttl,
+        };
+    }
+}

--- a/clients/javascript/src/models/idempotencyCompleteOut.ts
+++ b/clients/javascript/src/models/idempotencyCompleteOut.ts
@@ -1,0 +1,19 @@
+// this file is @generated
+// biome-ignore-all lint/suspicious/noEmptyInterface: forwards compat
+
+export interface IdempotencyCompleteOut {
+}
+
+export const IdempotencyCompleteOutSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(_object: any): IdempotencyCompleteOut {
+        return {
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(_self: IdempotencyCompleteOut): any {
+        return {
+        };
+    }
+}

--- a/clients/javascript/src/models/idempotencyCompleted.ts
+++ b/clients/javascript/src/models/idempotencyCompleted.ts
@@ -1,0 +1,21 @@
+// this file is @generated
+
+export interface IdempotencyCompleted {
+    response: number[];
+}
+
+export const IdempotencyCompletedSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(object: any): IdempotencyCompleted {
+        return {
+            response: object['response'],
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(self: IdempotencyCompleted): any {
+        return {
+            'response': self.response,
+        };
+    }
+}

--- a/clients/javascript/src/models/idempotencyStartIn.ts
+++ b/clients/javascript/src/models/idempotencyStartIn.ts
@@ -1,0 +1,25 @@
+// this file is @generated
+
+export interface IdempotencyStartIn {
+    key: string;
+    /** TTL in seconds for the lock/response */
+    ttl: number;
+}
+
+export const IdempotencyStartInSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(object: any): IdempotencyStartIn {
+        return {
+            key: object['key'],
+            ttl: object['ttl'],
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(self: IdempotencyStartIn): any {
+        return {
+            'key': self.key,
+            'ttl': self.ttl,
+        };
+    }
+}

--- a/clients/javascript/src/models/idempotencyStartOut.ts
+++ b/clients/javascript/src/models/idempotencyStartOut.ts
@@ -1,0 +1,97 @@
+// this file is @generated
+import {
+    type IdempotencyCompleted,
+    IdempotencyCompletedSerializer,
+} from './idempotencyCompleted';
+interface _IdempotencyStartOutFields {}
+
+
+    
+// biome-ignore lint/suspicious/noEmptyInterface: backwards compat
+interface IdempotencyStartOutStartedData {}
+    
+
+    
+// biome-ignore lint/suspicious/noEmptyInterface: backwards compat
+interface IdempotencyStartOutLockedData {}
+    
+
+    
+
+
+
+interface IdempotencyStartOutStarted {
+    status: 'started';
+    data?: IdempotencyStartOutStartedData
+}
+
+interface IdempotencyStartOutLocked {
+    status: 'locked';
+    data?: IdempotencyStartOutLockedData
+}
+
+interface IdempotencyStartOutCompleted {
+    status: 'completed';
+    data: IdempotencyCompleted;
+    
+}
+
+
+
+export type IdempotencyStartOut = _IdempotencyStartOutFields & (| IdempotencyStartOutStarted
+    | IdempotencyStartOutLocked
+    | IdempotencyStartOutCompleted
+    );
+
+export const IdempotencyStartOutSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(object: any): IdempotencyStartOut {
+        const status = object['status'];
+
+        // biome-ignore lint/suspicious/noExplicitAny: intentional any
+        function getData(status: string): any {
+            switch (status) {
+                
+                case 'started':
+                    return {}
+                
+                case 'locked':
+                    return {}
+                case 'completed':
+                    return IdempotencyCompletedSerializer._fromJsonObject(
+                            object['data']
+                        );default:
+                    throw new Error(`Unexpected status: ${ status }`);
+            }
+        }
+
+        return {
+            status,
+            data:getData(status),
+            };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(self: IdempotencyStartOut): any {
+        // biome-ignore lint/suspicious/noImplicitAnyLet: the return type needs to be any
+        let data;
+        switch (self.status) {
+            case 'started':
+                data = {}
+                break;
+            case 'locked':
+                data = {}
+                break;
+            case 'completed':
+                data =
+                    IdempotencyCompletedSerializer._toJsonObject(
+                        self.data
+                    );
+                break;}
+
+        return {
+            'status': self.status,
+            'data': data,
+            };
+    }
+}

--- a/clients/python/coyote/apis/idempotency.py
+++ b/clients/python/coyote/apis/idempotency.py
@@ -4,12 +4,18 @@ from ..internal.api_common import ApiBase
 from ..models import (
     IdempotencyAbortIn,
     IdempotencyAbortOut,
+    IdempotencyCompleteIn,
+    IdempotencyCompleteOut,
+    IdempotencyStartIn,
+    IdempotencyStartOut,
 )
 from .idempotency_namespace import (
     IdempotencyNamespace,
     IdempotencyNamespaceAsync,
 )
 
+from ..models.idempotency_start_in import _IdempotencyStartIn
+from ..models.idempotency_complete_in import _IdempotencyCompleteIn
 from ..models.idempotency_abort_in import _IdempotencyAbortIn
 
 
@@ -17,6 +23,43 @@ class IdempotencyAsync(ApiBase):
     @property
     def namespace(self) -> IdempotencyNamespaceAsync:
         return IdempotencyNamespaceAsync(self._client)
+
+    async def start(
+        self,
+        key: str,
+        idempotency_start_in: IdempotencyStartIn,
+    ) -> IdempotencyStartOut:
+        """Start an idempotent request"""
+        body = _IdempotencyStartIn(
+            key=key,
+            ttl=idempotency_start_in.ttl,
+        ).model_dump(exclude_none=True)
+
+        return await self._request_asyncio(
+            method="post",
+            path="/api/v1/idempotency/start",
+            body=body,
+            response_type=IdempotencyStartOut,
+        )
+
+    async def complete(
+        self,
+        key: str,
+        idempotency_complete_in: IdempotencyCompleteIn,
+    ) -> IdempotencyCompleteOut:
+        """Complete an idempotent request with a response"""
+        body = _IdempotencyCompleteIn(
+            key=key,
+            response=idempotency_complete_in.response,
+            ttl=idempotency_complete_in.ttl,
+        ).model_dump(exclude_none=True)
+
+        return await self._request_asyncio(
+            method="post",
+            path="/api/v1/idempotency/complete",
+            body=body,
+            response_type=IdempotencyCompleteOut,
+        )
 
     async def abort(
         self,
@@ -40,6 +83,43 @@ class Idempotency(ApiBase):
     @property
     def namespace(self) -> IdempotencyNamespace:
         return IdempotencyNamespace(self._client)
+
+    def start(
+        self,
+        key: str,
+        idempotency_start_in: IdempotencyStartIn,
+    ) -> IdempotencyStartOut:
+        """Start an idempotent request"""
+        body = _IdempotencyStartIn(
+            key=key,
+            ttl=idempotency_start_in.ttl,
+        ).model_dump(exclude_none=True)
+
+        return self._request_sync(
+            method="post",
+            path="/api/v1/idempotency/start",
+            body=body,
+            response_type=IdempotencyStartOut,
+        )
+
+    def complete(
+        self,
+        key: str,
+        idempotency_complete_in: IdempotencyCompleteIn,
+    ) -> IdempotencyCompleteOut:
+        """Complete an idempotent request with a response"""
+        body = _IdempotencyCompleteIn(
+            key=key,
+            response=idempotency_complete_in.response,
+            ttl=idempotency_complete_in.ttl,
+        ).model_dump(exclude_none=True)
+
+        return self._request_sync(
+            method="post",
+            path="/api/v1/idempotency/complete",
+            body=body,
+            response_type=IdempotencyCompleteOut,
+        )
 
     def abort(
         self,

--- a/clients/python/coyote/models/__init__.py
+++ b/clients/python/coyote/models/__init__.py
@@ -13,10 +13,15 @@ from .consistency import Consistency
 from .eviction_policy import EvictionPolicy
 from .idempotency_abort_in import IdempotencyAbortIn
 from .idempotency_abort_out import IdempotencyAbortOut
+from .idempotency_complete_in import IdempotencyCompleteIn
+from .idempotency_complete_out import IdempotencyCompleteOut
+from .idempotency_completed import IdempotencyCompleted
 from .idempotency_create_namespace_in import IdempotencyCreateNamespaceIn
 from .idempotency_create_namespace_out import IdempotencyCreateNamespaceOut
 from .idempotency_get_namespace_in import IdempotencyGetNamespaceIn
 from .idempotency_get_namespace_out import IdempotencyGetNamespaceOut
+from .idempotency_start_in import IdempotencyStartIn
+from .idempotency_start_out import IdempotencyStartOut
 from .kv_create_namespace_in import KvCreateNamespaceIn
 from .kv_create_namespace_out import KvCreateNamespaceOut
 from .kv_delete_in import KvDeleteIn
@@ -87,10 +92,15 @@ __all__ = [
     "EvictionPolicy",
     "IdempotencyAbortIn",
     "IdempotencyAbortOut",
+    "IdempotencyCompleteIn",
+    "IdempotencyCompleteOut",
+    "IdempotencyCompleted",
     "IdempotencyCreateNamespaceIn",
     "IdempotencyCreateNamespaceOut",
     "IdempotencyGetNamespaceIn",
     "IdempotencyGetNamespaceOut",
+    "IdempotencyStartIn",
+    "IdempotencyStartOut",
     "KvCreateNamespaceIn",
     "KvCreateNamespaceOut",
     "KvDeleteIn",

--- a/clients/python/coyote/models/idempotency_complete_in.py
+++ b/clients/python/coyote/models/idempotency_complete_in.py
@@ -1,0 +1,21 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class IdempotencyCompleteIn(BaseModel):
+    response: bytes
+    """The response to cache"""
+
+    ttl: int
+    """TTL in seconds for the cached response"""
+
+
+class _IdempotencyCompleteIn(BaseModel):
+    key: str
+
+    response: bytes
+    """The response to cache"""
+
+    ttl: int
+    """TTL in seconds for the cached response"""

--- a/clients/python/coyote/models/idempotency_complete_out.py
+++ b/clients/python/coyote/models/idempotency_complete_out.py
@@ -1,0 +1,7 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class IdempotencyCompleteOut(BaseModel):
+    pass

--- a/clients/python/coyote/models/idempotency_completed.py
+++ b/clients/python/coyote/models/idempotency_completed.py
@@ -1,0 +1,7 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class IdempotencyCompleted(BaseModel):
+    response: bytes

--- a/clients/python/coyote/models/idempotency_start_in.py
+++ b/clients/python/coyote/models/idempotency_start_in.py
@@ -1,0 +1,15 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class IdempotencyStartIn(BaseModel):
+    ttl: int
+    """TTL in seconds for the lock/response"""
+
+
+class _IdempotencyStartIn(BaseModel):
+    key: str
+
+    ttl: int
+    """TTL in seconds for the lock/response"""

--- a/clients/python/coyote/models/idempotency_start_out.py
+++ b/clients/python/coyote/models/idempotency_start_out.py
@@ -1,0 +1,31 @@
+# this file is @generated
+import typing as t
+from typing_extensions import Self
+from pydantic import ModelWrapValidatorHandler, model_validator
+from ..internal.base_model import BaseModel
+
+
+from .idempotency_completed import IdempotencyCompleted
+
+
+class IdempotencyStartOut(BaseModel):
+    status: t.Union[t.Literal["started"], t.Literal["locked"], t.Literal["completed"]]
+    data: t.Union[t.Dict[str, t.Any], IdempotencyCompleted]
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def validate_model(
+        cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
+    ) -> Self:
+        if "data" not in data:
+            data["data"] = {}
+        output = handler(data)
+        if output.type == "started":
+            output.data = data.get("data", {})
+        elif output.type == "locked":
+            output.data = data.get("data", {})
+        elif output.type == "completed":
+            output.data = IdempotencyCompleted.model_validate(data.get("data", {}))
+        else:
+            raise ValueError(f"Unexpected type `{output.type}`")
+        return output

--- a/clients/rust/src/api/idempotency.rs
+++ b/clients/rust/src/api/idempotency.rs
@@ -15,6 +15,41 @@ impl<'a> Idempotency<'a> {
         IdempotencyNamespace::new(self.cfg)
     }
 
+    /// Start an idempotent request
+    pub async fn start(
+        &self,
+        key: String,
+        idempotency_start_in: IdempotencyStartIn,
+    ) -> Result<IdempotencyStartOut> {
+        let idempotency_start_in = IdempotencyStartIn_ {
+            key,
+            ttl: idempotency_start_in.ttl,
+        };
+
+        crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/start")
+            .with_body(idempotency_start_in)
+            .execute(self.cfg)
+            .await
+    }
+
+    /// Complete an idempotent request with a response
+    pub async fn complete(
+        &self,
+        key: String,
+        idempotency_complete_in: IdempotencyCompleteIn,
+    ) -> Result<IdempotencyCompleteOut> {
+        let idempotency_complete_in = IdempotencyCompleteIn_ {
+            key,
+            response: idempotency_complete_in.response,
+            ttl: idempotency_complete_in.ttl,
+        };
+
+        crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/complete")
+            .with_body(idempotency_complete_in)
+            .execute(self.cfg)
+            .await
+    }
+
     /// Abandon an idempotent request (remove lock without saving response)
     pub async fn abort(
         &self,

--- a/clients/rust/src/models/idempotency_complete_in.rs
+++ b/clients/rust/src/models/idempotency_complete_in.rs
@@ -1,0 +1,28 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct IdempotencyCompleteIn {
+    /// The response to cache
+    pub response: Vec<u8>,
+
+    /// TTL in seconds for the cached response
+    pub ttl: u64,
+}
+
+impl IdempotencyCompleteIn {
+    pub fn new(response: Vec<u8>, ttl: u64) -> Self {
+        Self { response, ttl }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct IdempotencyCompleteIn_ {
+    pub key: String,
+
+    /// The response to cache
+    pub response: Vec<u8>,
+
+    /// TTL in seconds for the cached response
+    pub ttl: u64,
+}

--- a/clients/rust/src/models/idempotency_complete_out.rs
+++ b/clients/rust/src/models/idempotency_complete_out.rs
@@ -1,0 +1,11 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IdempotencyCompleteOut {}
+
+impl IdempotencyCompleteOut {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/clients/rust/src/models/idempotency_completed.rs
+++ b/clients/rust/src/models/idempotency_completed.rs
@@ -1,0 +1,13 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IdempotencyCompleted {
+    pub response: Vec<u8>,
+}
+
+impl IdempotencyCompleted {
+    pub fn new(response: Vec<u8>) -> Self {
+        Self { response }
+    }
+}

--- a/clients/rust/src/models/idempotency_start_in.rs
+++ b/clients/rust/src/models/idempotency_start_in.rs
@@ -1,0 +1,22 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct IdempotencyStartIn {
+    /// TTL in seconds for the lock/response
+    pub ttl: u64,
+}
+
+impl IdempotencyStartIn {
+    pub fn new(ttl: u64) -> Self {
+        Self { ttl }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct IdempotencyStartIn_ {
+    pub key: String,
+
+    /// TTL in seconds for the lock/response
+    pub ttl: u64,
+}

--- a/clients/rust/src/models/idempotency_start_out.rs
+++ b/clients/rust/src/models/idempotency_start_out.rs
@@ -1,0 +1,16 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+use super::idempotency_completed::IdempotencyCompleted;
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "status", content = "data")]
+pub enum IdempotencyStartOut {
+    #[serde(rename = "started")]
+    Started,
+    #[serde(rename = "locked")]
+    Locked,
+    #[serde(rename = "completed")]
+    Completed(IdempotencyCompleted),
+}

--- a/clients/rust/src/models/mod.rs
+++ b/clients/rust/src/models/mod.rs
@@ -15,10 +15,15 @@ mod consistency;
 mod eviction_policy;
 mod idempotency_abort_in;
 mod idempotency_abort_out;
+mod idempotency_complete_in;
+mod idempotency_complete_out;
+mod idempotency_completed;
 mod idempotency_create_namespace_in;
 mod idempotency_create_namespace_out;
 mod idempotency_get_namespace_in;
 mod idempotency_get_namespace_out;
+mod idempotency_start_in;
+mod idempotency_start_out;
 mod kv_create_namespace_in;
 mod kv_create_namespace_out;
 mod kv_delete_in;
@@ -81,10 +86,13 @@ pub use self::{
     cache_get_out::CacheGetOut, cache_set_in::CacheSetIn, cache_set_out::CacheSetOut,
     consistency::Consistency, eviction_policy::EvictionPolicy,
     idempotency_abort_in::IdempotencyAbortIn, idempotency_abort_out::IdempotencyAbortOut,
+    idempotency_complete_in::IdempotencyCompleteIn,
+    idempotency_complete_out::IdempotencyCompleteOut, idempotency_completed::IdempotencyCompleted,
     idempotency_create_namespace_in::IdempotencyCreateNamespaceIn,
     idempotency_create_namespace_out::IdempotencyCreateNamespaceOut,
     idempotency_get_namespace_in::IdempotencyGetNamespaceIn,
     idempotency_get_namespace_out::IdempotencyGetNamespaceOut,
+    idempotency_start_in::IdempotencyStartIn, idempotency_start_out::IdempotencyStartOut,
     kv_create_namespace_in::KvCreateNamespaceIn, kv_create_namespace_out::KvCreateNamespaceOut,
     kv_delete_in::KvDeleteIn, kv_delete_out::KvDeleteOut, kv_get_in::KvGetIn,
     kv_get_namespace_in::KvGetNamespaceIn, kv_get_namespace_out::KvGetNamespaceOut,
@@ -117,7 +125,8 @@ pub use self::{
 
 pub(crate) use self::{
     cache_delete_in::CacheDeleteIn_, cache_get_in::CacheGetIn_, cache_set_in::CacheSetIn_,
-    idempotency_abort_in::IdempotencyAbortIn_, kv_delete_in::KvDeleteIn_, kv_get_in::KvGetIn_,
+    idempotency_abort_in::IdempotencyAbortIn_, idempotency_complete_in::IdempotencyCompleteIn_,
+    idempotency_start_in::IdempotencyStartIn_, kv_delete_in::KvDeleteIn_, kv_get_in::KvGetIn_,
     kv_set_in::KvSetIn_, msg_namespace_create_in::MsgNamespaceCreateIn_,
     msg_namespace_get_in::MsgNamespaceGetIn_, msg_publish_in::MsgPublishIn_,
     msg_queue_ack_in::MsgQueueAckIn_, msg_queue_configure_in::MsgQueueConfigureIn_,

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -56,11 +56,7 @@ fn main() -> anyhow::Result<ExitCode> {
         components,
         &webhooks,
         IncludeMode::PublicAndInternal,
-        &BTreeSet::from_iter([
-            "v1.idempotency.start".to_owned(),
-            "v1.idempotency.complete".to_owned(),
-            "v1.idempotency.abandon".to_owned(),
-        ]),
+        &BTreeSet::new(),
         &BTreeSet::new(),
     )?;
 

--- a/codegen/templates/python/types/struct.py.jinja
+++ b/codegen/templates/python/types/struct.py.jinja
@@ -48,5 +48,9 @@ class {{ type_name }}(BaseModel):
 {%- if has_positional_fields %}
 
 class _{{ type_name }}(BaseModel):
+{%- if type.fields | length == 0 %}
+    pass
+{%- else %}
 {% include "types/struct_fields.py.jinja" %}
+{%- endif %}
 {%- endif %}

--- a/codegen/templates/python/types/struct_enum.py.jinja
+++ b/codegen/templates/python/types/struct_enum.py.jinja
@@ -10,15 +10,15 @@ from . {{ c | to_snake_case }} import {{ c | to_upper_camel_case }}
 {%- endfor %}
 
 class {{ type_name }}(BaseModel):
-    {% include "types/struct_fields.py.jinja" %}
+    {%- include "types/struct_fields.py.jinja" %}
     {{ type.discriminator_field }}: t.Union[
-        {% for variant in type.variants -%}
-            t.Literal["{{ variant.name }}"] {% if not loop.last %},{% endif %}
-        {% endfor -%}
+    {%- for variant in type.variants %}
+        t.Literal["{{ variant.name }}"] {% if not loop.last %},{% endif %}
+    {%- endfor %}
     ]
     {{ type.content_field }}: t.Union[
-        {% set content_field_types = [] %}
-        {{ type.variants| map(attribute="schema_ref", default="t.Dict[str,t.Any]") | unique | join(",") }}
+        {%- set content_field_types = [] %}
+        {{ type.variants| map(attribute="schema_ref", default="t.Dict[str, t.Any]") | unique | join(",") }}
     ]
 
     @model_validator(mode="wrap")

--- a/codegen/templates/python/types/struct_fields.py.jinja
+++ b/codegen/templates/python/types/struct_fields.py.jinja
@@ -1,4 +1,3 @@
-{% if type.fields | length == 0 %}    pass{% endif -%}
 {% for field in type.fields %}
     {%- if field.required and not field.nullable %}
         {%- if field.name | to_lower_camel_case != field.name %}

--- a/openapi.json
+++ b/openapi.json
@@ -1517,6 +1517,23 @@
       "IdempotencyCompleteOut": {
         "type": "object"
       },
+      "IdempotencyCompleted": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0,
+              "maximum": 255
+            }
+          }
+        },
+        "required": [
+          "response"
+        ]
+      },
       "IdempotencyCreateNamespaceIn": {
         "type": "object",
         "properties": {
@@ -1671,25 +1688,19 @@
             "description": "Request was already completed, cached response returned",
             "type": "object",
             "properties": {
-              "response": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0,
-                  "maximum": 255
-                }
-              },
               "status": {
                 "type": "string",
                 "enum": [
                   "completed"
                 ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/IdempotencyCompleted"
               }
             },
             "required": [
               "status",
-              "response"
+              "data"
             ]
           }
         ]

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -44,14 +44,19 @@ pub struct IdempotencyStartIn {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "status", rename_all = "snake_case")]
+#[serde(tag = "status", content = "data", rename_all = "snake_case")]
 pub enum IdempotencyStartOut {
     /// Lock acquired, request should proceed
     Started,
     /// Request is already in progress (locked)
     Locked,
     /// Request was already completed, cached response returned
-    Completed { response: Vec<u8> },
+    Completed(IdempotencyCompleted),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct IdempotencyCompleted {
+    pub response: Vec<u8>,
 }
 
 impl From<IdempotencyStartResult> for IdempotencyStartOut {
@@ -60,7 +65,7 @@ impl From<IdempotencyStartResult> for IdempotencyStartOut {
             IdempotencyStartResult::Started => IdempotencyStartOut::Started,
             IdempotencyStartResult::Locked => IdempotencyStartOut::Locked,
             IdempotencyStartResult::Completed { response } => {
-                IdempotencyStartOut::Completed { response }
+                IdempotencyStartOut::Completed(IdempotencyCompleted { response })
             }
         }
     }

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -80,7 +80,7 @@ async fn test_idempotency_start_and_complete() -> TestResult {
 
     let response = start(&client, "k3", 60).await?;
     assert_eq!(response["status"], "completed");
-    assert_eq!(response["response"], json!("v2".as_bytes()));
+    assert_eq!(response["data"]["response"], json!("v2".as_bytes()));
 
     start(&client, "k4", 60).await?;
     abandon(&client, "k4").await?;
@@ -90,18 +90,18 @@ async fn test_idempotency_start_and_complete() -> TestResult {
     start(&client, "k5", 60).await?;
     complete(&client, "k5", "v2", 60).await?;
     let response = start(&client, "k5", 60).await?;
-    assert_eq!(response["response"], json!("v2".as_bytes()));
+    assert_eq!(response["data"]["response"], json!("v2".as_bytes()));
 
     complete(&client, "k5", "v3", 60).await?;
     let response = start(&client, "k5", 60).await?;
     assert_eq!(response["status"], "completed");
-    assert_eq!(response["response"], json!("v3".as_bytes()));
+    assert_eq!(response["data"]["response"], json!("v3".as_bytes()));
 
     start(&client, "k6", 60).await?;
     complete(&client, "k6", "v4", 60).await?;
 
     let response = start(&client, "k6", 60).await?;
-    assert_eq!(response["response"], json!("v4".as_bytes()));
+    assert_eq!(response["data"]["response"], json!("v4".as_bytes()));
 
     abandon(&client, "k6").await?;
 
@@ -178,7 +178,7 @@ async fn test_idempotency_expiration() -> TestResult {
     tokio::time::sleep(Duration::from_secs(1)).await;
     let response = start(&client, "k5", 1).await?;
     assert_eq!(response["status"], "completed");
-    assert_eq!(response["response"], json!("v1".as_bytes()));
+    assert_eq!(response["data"]["response"], json!("v1".as_bytes()));
 
     Ok(())
 }


### PR DESCRIPTION
Requires a small change to the response structure. We could probably change it back if we invest a little extra effort into openapi-codegen.

Closes https://github.com/svix/coyote-private/issues/238.