### PR TITLE
Idempotency: change fjall serialization to vec_named.

### DIFF
--- a/crates/idempotency/src/lib.rs
+++ b/crates/idempotency/src/lib.rs
@@ -42,7 +42,7 @@ pub enum IdempotencyStartResult {
 
 impl From<IdempotencyState> for Vec<u8> {
     fn from(state: IdempotencyState) -> Self {
-        rmp_serde::to_vec(&state).expect("Failed to serialize IdempotencyState")
+        rmp_serde::to_vec_named(&state).expect("Failed to serialize IdempotencyState")
     }
 }
 


### PR DESCRIPTION
The current version uses `to_vec` which is less future-proof and not
what we do everywhere else anyway.