### PR TITLE
codegen: Use tab indentation for Go consistently

### DIFF
--- a/codegen/templates/go/types/struct_fields.go.jinja
+++ b/codegen/templates/go/types/struct_fields.go.jinja
@@ -1,18 +1,18 @@
 {% for field in type.fields -%}
-    {% set f_name = field.name | to_upper_camel_case -%}
-    {% set f_type = field.type.to_go() -%}
-    {% set json_annotation = "" -%}
-    {% if (not field.required or field.nullable) -%}
-        {% set json_annotation = ",omitempty" -%}
-        {% if not field.type.is_set() and not field.type.is_list() -%}
-            {% set f_type %}*{{ f_type }}{% endset -%}
-        {% endif -%}
-    {% endif -%}
-    {% if field.description is defined and "\n" in field.description -%}
+	{% set f_name = field.name | to_upper_camel_case -%}
+	{% set f_type = field.type.to_go() -%}
+	{% set json_annotation = "" -%}
+	{% if (not field.required or field.nullable) -%}
+		{% set json_annotation = ",omitempty" -%}
+		{% if not field.type.is_set() and not field.type.is_list() -%}
+			{% set f_type %}*{{ f_type }}{% endset -%}
+		{% endif -%}
+	{% endif -%}
+	{% if field.description is defined and "\n" in field.description -%}
 {{ field.description | to_doc_comment(style="go") | indent(4) }}
-    {% endif -%}
+	{% endif -%}
 {{ f_name }} {{ f_type }} `json:"{{ field.name }}{{ json_annotation }}"`
-    {%- if field.description is defined and "\n" not in field.description -%}
-    {{ field.description | to_doc_comment(style="go") }}
-    {%- endif %}
+	{%- if field.description is defined and "\n" not in field.description -%}
+	{{ field.description | to_doc_comment(style="go") }}
+	{%- endif %}
 {% endfor -%}


### PR DESCRIPTION
This was the only Go file with spaces as indentation.