### PR TITLE
go: Remove support for path, header params

### DIFF
--- a/clients/go/internal/apis/cache.go
+++ b/clients/go/internal/apis/cache.go
@@ -38,8 +38,6 @@ func (cache Cache) Set(
 		cache.client,
 		"POST",
 		"/api/v1/cache/set",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -60,8 +58,6 @@ func (cache Cache) Get(
 		cache.client,
 		"POST",
 		"/api/v1/cache/get",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -81,8 +77,6 @@ func (cache Cache) Delete(
 		cache.client,
 		"POST",
 		"/api/v1/cache/delete",
-		nil,
-		nil,
 		&body,
 	)
 }

--- a/clients/go/internal/apis/cache_namespace.go
+++ b/clients/go/internal/apis/cache_namespace.go
@@ -27,8 +27,6 @@ func (cacheNamespace CacheNamespace) Create(
 		cacheNamespace.client,
 		"POST",
 		"/api/v1/cache/namespace/create",
-		nil,
-		nil,
 		&cacheCreateNamespaceIn,
 	)
 }
@@ -43,8 +41,6 @@ func (cacheNamespace CacheNamespace) Get(
 		cacheNamespace.client,
 		"POST",
 		"/api/v1/cache/namespace/get",
-		nil,
-		nil,
 		&cacheGetNamespaceIn,
 	)
 }

--- a/clients/go/internal/apis/health.go
+++ b/clients/go/internal/apis/health.go
@@ -27,7 +27,5 @@ func (health Health) Ping(
 		"GET",
 		"/api/v1/health/ping",
 		nil,
-		nil,
-		nil,
 	)
 }

--- a/clients/go/internal/apis/idempotency.go
+++ b/clients/go/internal/apis/idempotency.go
@@ -37,8 +37,6 @@ func (idempotency Idempotency) Start(
 		idempotency.client,
 		"POST",
 		"/api/v1/idempotency/start",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -60,8 +58,6 @@ func (idempotency Idempotency) Complete(
 		idempotency.client,
 		"POST",
 		"/api/v1/idempotency/complete",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -81,8 +77,6 @@ func (idempotency Idempotency) Abort(
 		idempotency.client,
 		"POST",
 		"/api/v1/idempotency/abort",
-		nil,
-		nil,
 		&body,
 	)
 }

--- a/clients/go/internal/apis/idempotency_namespace.go
+++ b/clients/go/internal/apis/idempotency_namespace.go
@@ -27,8 +27,6 @@ func (idempotencyNamespace IdempotencyNamespace) Create(
 		idempotencyNamespace.client,
 		"POST",
 		"/api/v1/idempotency/namespace/create",
-		nil,
-		nil,
 		&idempotencyCreateNamespaceIn,
 	)
 }
@@ -43,8 +41,6 @@ func (idempotencyNamespace IdempotencyNamespace) Get(
 		idempotencyNamespace.client,
 		"POST",
 		"/api/v1/idempotency/namespace/get",
-		nil,
-		nil,
 		&idempotencyGetNamespaceIn,
 	)
 }

--- a/clients/go/internal/apis/kv.go
+++ b/clients/go/internal/apis/kv.go
@@ -40,8 +40,6 @@ func (kv Kv) Set(
 		kv.client,
 		"POST",
 		"/api/v1/kv/set",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -62,8 +60,6 @@ func (kv Kv) Get(
 		kv.client,
 		"POST",
 		"/api/v1/kv/get",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -83,8 +79,6 @@ func (kv Kv) Delete(
 		kv.client,
 		"POST",
 		"/api/v1/kv/delete",
-		nil,
-		nil,
 		&body,
 	)
 }

--- a/clients/go/internal/apis/kv_namespace.go
+++ b/clients/go/internal/apis/kv_namespace.go
@@ -27,8 +27,6 @@ func (kvNamespace KvNamespace) Create(
 		kvNamespace.client,
 		"POST",
 		"/api/v1/kv/namespace/create",
-		nil,
-		nil,
 		&kvCreateNamespaceIn,
 	)
 }
@@ -43,8 +41,6 @@ func (kvNamespace KvNamespace) Get(
 		kvNamespace.client,
 		"POST",
 		"/api/v1/kv/namespace/get",
-		nil,
-		nil,
 		&kvGetNamespaceIn,
 	)
 }

--- a/clients/go/internal/apis/msgs.go
+++ b/clients/go/internal/apis/msgs.go
@@ -46,8 +46,6 @@ func (msgs Msgs) Publish(
 		msgs.client,
 		"POST",
 		"/api/v1/msgs/publish",
-		nil,
-		nil,
 		&body,
 	)
 }

--- a/clients/go/internal/apis/msgs_namespace.go
+++ b/clients/go/internal/apis/msgs_namespace.go
@@ -34,8 +34,6 @@ func (msgsNamespace MsgsNamespace) Create(
 		msgsNamespace.client,
 		"POST",
 		"/api/v1/msgs/namespace/create",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -55,8 +53,6 @@ func (msgsNamespace MsgsNamespace) Get(
 		msgsNamespace.client,
 		"POST",
 		"/api/v1/msgs/namespace/get",
-		nil,
-		nil,
 		&body,
 	)
 }

--- a/clients/go/internal/apis/msgs_queue.go
+++ b/clients/go/internal/apis/msgs_queue.go
@@ -40,8 +40,6 @@ func (msgsQueue MsgsQueue) Receive(
 		msgsQueue.client,
 		"POST",
 		"/api/v1/msgs/queue/receive",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -66,8 +64,6 @@ func (msgsQueue MsgsQueue) Ack(
 		msgsQueue.client,
 		"POST",
 		"/api/v1/msgs/queue/ack",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -94,8 +90,6 @@ func (msgsQueue MsgsQueue) Configure(
 		msgsQueue.client,
 		"POST",
 		"/api/v1/msgs/queue/configure",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -121,8 +115,6 @@ func (msgsQueue MsgsQueue) Nack(
 		msgsQueue.client,
 		"POST",
 		"/api/v1/msgs/queue/nack",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -144,8 +136,6 @@ func (msgsQueue MsgsQueue) RedriveDlq(
 		msgsQueue.client,
 		"POST",
 		"/api/v1/msgs/queue/redrive-dlq",
-		nil,
-		nil,
 		&body,
 	)
 }

--- a/clients/go/internal/apis/msgs_stream.go
+++ b/clients/go/internal/apis/msgs_stream.go
@@ -39,8 +39,6 @@ func (msgsStream MsgsStream) Receive(
 		msgsStream.client,
 		"POST",
 		"/api/v1/msgs/stream/receive",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -66,8 +64,6 @@ func (msgsStream MsgsStream) Commit(
 		msgsStream.client,
 		"POST",
 		"/api/v1/msgs/stream/commit",
-		nil,
-		nil,
 		&body,
 	)
 }
@@ -95,8 +91,6 @@ func (msgsStream MsgsStream) Seek(
 		msgsStream.client,
 		"POST",
 		"/api/v1/msgs/stream/seek",
-		nil,
-		nil,
 		&body,
 	)
 }

--- a/clients/go/internal/apis/msgs_topic.go
+++ b/clients/go/internal/apis/msgs_topic.go
@@ -35,8 +35,6 @@ func (msgsTopic MsgsTopic) Configure(
 		msgsTopic.client,
 		"POST",
 		"/api/v1/msgs/topic/configure",
-		nil,
-		nil,
 		&body,
 	)
 }

--- a/clients/go/internal/apis/rate_limit.go
+++ b/clients/go/internal/apis/rate_limit.go
@@ -31,8 +31,6 @@ func (rateLimit RateLimit) Limit(
 		rateLimit.client,
 		"POST",
 		"/api/v1/rate-limit/limit",
-		nil,
-		nil,
 		&rateLimitCheckIn,
 	)
 }
@@ -47,8 +45,6 @@ func (rateLimit RateLimit) GetRemaining(
 		rateLimit.client,
 		"POST",
 		"/api/v1/rate-limit/get-remaining",
-		nil,
-		nil,
 		&rateLimitGetRemainingIn,
 	)
 }
@@ -63,8 +59,6 @@ func (rateLimit RateLimit) Reset(
 		rateLimit.client,
 		"POST",
 		"/api/v1/rate-limit/reset",
-		nil,
-		nil,
 		&rateLimitResetIn,
 	)
 }

--- a/clients/go/internal/apis/rate_limit_namespace.go
+++ b/clients/go/internal/apis/rate_limit_namespace.go
@@ -27,8 +27,6 @@ func (rateLimitNamespace RateLimitNamespace) Create(
 		rateLimitNamespace.client,
 		"POST",
 		"/api/v1/rate-limit/namespace/create",
-		nil,
-		nil,
 		&rateLimitCreateNamespaceIn,
 	)
 }
@@ -43,8 +41,6 @@ func (rateLimitNamespace RateLimitNamespace) Get(
 		rateLimitNamespace.client,
 		"POST",
 		"/api/v1/rate-limit/namespace/get",
-		nil,
-		nil,
 		&rateLimitGetNamespaceIn,
 	)
 }

--- a/clients/go/internal/proto/http_client.go
+++ b/clients/go/internal/proto/http_client.go
@@ -48,11 +48,9 @@ func ExecuteRequest[ReqBody any, ResBody any](
 	client *HttpClient,
 	method string,
 	path string,
-	pathParams map[string]string,
-	headerParams map[string]string,
 	jsonBody *ReqBody,
 ) (*ResBody, error) {
-	urlStr := client.BaseURL + replacePathKeys(path, pathParams)
+	urlStr := client.BaseURL + path
 
 	var req *http.Request
 	var err error
@@ -75,9 +73,6 @@ func ExecuteRequest[ReqBody any, ResBody any](
 
 	req.Header.Set("svix-req-id", strconv.FormatUint(rand.Uint64(), 10))
 	for hKey, hVal := range client.DefaultHeaders {
-		req.Header.Add(hKey, hVal)
-	}
-	for hKey, hVal := range headerParams {
 		req.Header.Add(hKey, hVal)
 	}
 
@@ -164,14 +159,6 @@ func executeRequestWithRetries(client *HttpClient, request *http.Request) (*http
 		}
 	}
 	return resp, err
-}
-
-func replacePathKeys(path string, pathParams map[string]string) string {
-	for key, value := range pathParams {
-		placeholder := "{" + key + "}"
-		path = strings.ReplaceAll(path, placeholder, value)
-	}
-	return path
 }
 
 func SerializeParamToMap(key string, val interface{}, d map[string]string, err *error) {

--- a/codegen/templates/go/api_resource.go.jinja
+++ b/codegen/templates/go/api_resource.go.jinja
@@ -60,12 +60,7 @@ func ({{ resource_self_name }} {{ resource_type_name }}) {{ name | to_upper_came
 func ({{ resource_self_name }} {{ resource_type_name }}) {{ op.name | to_upper_camel_case }}(
 	ctx context.Context,
 
-	{#- path parameters #}
-	{% for p in op.path_params -%}
-		{{ p | to_lower_camel_case }} string,
-	{% endfor -%}
-
-	{% if op.request_body_schema_name is defined -%}
+	{%- if op.request_body_schema_name is defined %}
 		{# positional body parameters -#}
 		{% set body_schema = api.types[op.request_body_schema_name] -%}
 		{% set has_positional_fields = body_schema.fields | selectattr("positional") | length > 0 -%}
@@ -77,21 +72,8 @@ func ({{ resource_self_name }} {{ resource_type_name }}) {{ op.name | to_upper_c
 
 		{# body parameter interface -#}
 		{{ request_body_param }} coyote_models.{{ op.request_body_schema_name }},
-	{% endif -%}
+	{%- endif %}
 ) {{ func_ret_type }} {
-	{# path params -#}
-	{% if op.path_params | length > 0 -%}
-	pathMap := map[string]string{
-		{% for p in op.path_params -%}
-		"{{ p }}" : {{ p | to_lower_camel_case }},
-		{% endfor -%}
-	}
-	{% endif -%}
-
-	{% if op.header_params | length > 0 -%}
-	headerMap := map[string]string{}
-	{% endif -%}
-
 	{# body parameter -#}
 	{% if op.request_body_schema_name is defined -%}
 		{% if has_positional_fields -%}
@@ -112,7 +94,6 @@ func ({{ resource_self_name }} {{ resource_type_name }}) {{ op.name | to_upper_c
 		{% set body = "nil" -%}
 	{% endif -%}
 
-	{# make template ugly, but generated code nice -#}
 	{% if op.request_body_schema_name is defined -%}
 		{% set generics -%}
 			coyote_models.{{ op.request_body_schema_name }}
@@ -126,20 +107,6 @@ func ({{ resource_self_name }} {{ resource_type_name }}) {{ op.name | to_upper_c
 		{{ resource_self_name }}.client,
 		"{{ op.method | upper }}",
 		"{{ op.path }}",
-		{# path params -#}
-		{% if op.path_params | length > 0 -%}
-		pathMap,
-		{% else -%}
-		nil,
-		{% endif -%}
-
-		{#- header params -#}
-		{% if op.header_params | length >0 -%}
-		headerMap,
-		{% else -%}
-		nil,
-		{% endif -%}
-
 		{{ body }},
 	)
 	{% if not has_return -%}

--- a/codegen/templates/rust/api_resource.rs.jinja
+++ b/codegen/templates/rust/api_resource.rs.jinja
@@ -75,10 +75,6 @@ impl<'a> {{ resource_type_name }}<'a> {
         {# make the request -#}
         crate::request::Request::new(http::Method::{{ op.method | upper }}, "{{ op.path }}")
 
-        {% for p in op.path_params -%}
-            .with_path_param("{{ p }}", {{ p }})
-        {% endfor -%}
-
         {% for p in op.header_params -%}
             .with_optional_header_param("{{ p.name }}", {{ p.name | to_snake_case }})
         {% endfor -%}


### PR DESCRIPTION
… plus a little bit of Rust template cleanup.

Follow-up to https://github.com/svix/coyote-private/pull/488.