### PR TITLE
Build cli docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,10 +2,17 @@ name: Coyote Docker Build
 
 on:
   workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: svix/coyote-server
+  IMAGE_NAME: ${{ inputs.image_name }}
 
 jobs:
   build-and-push-image:
@@ -63,6 +70,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          target: ${{ inputs.target }}
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -108,7 +116,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          target: prod
+          target: ${{ inputs.target }}
           push: true
           provenance: false
           cache-from: type=gha
@@ -130,7 +138,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v6
         with:
-          name: digests-nonfips-${{ env.PLATFORM_PAIR }}
+          name: digests-nonfips-${{ inputs.target }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -147,7 +155,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-nonfips-*
+          pattern: digests-nonfips-${{ inputs.target }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -11,10 +11,25 @@ jobs:
     #  benchmark:
     #    uses: ./.github/workflows/benchmark.yml
     #    secrets: inherit
-  docker_publish:
+  docker_publish_server:
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
     needs: ci
+    with:
+      image_name: svix/coyote-server
+      target: prod
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+      security-events: write
+  docker_publish_cli:
+    uses: ./.github/workflows/docker-publish.yml
+    secrets: inherit
+    needs: ci
+    with:
+      image_name: svix/coyote-cli
+      target: cli-prod
     permissions:
       actions: read
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer
 RUN cargo chef cook --release --package coyote-server --features coyote/openapi --recipe-path recipe.json
+RUN cargo chef cook --release --package coyote-cli --recipe-path recipe.json
 
 # Build the server
 COPY . .
@@ -49,6 +50,7 @@ ARG CARGO_LOG
 ARG GITHUB_SHA
 ARG RELEASE_VERSION
 RUN cargo build --release --package coyote-server --bin coyote-server --features coyote/openapi --frozen
+RUN cargo build --release --package coyote-cli --bin coyote --frozen
 
 # Production
 FROM docker.io/debian:trixie-slim AS prod
@@ -90,3 +92,33 @@ EXPOSE 8050
 COPY --chown=root:root --chmod=755 --from=build /app/target/release/coyote-server /usr/local/bin/coyote-server
 
 CMD ["/usr/local/bin/coyote-server"]
+
+# CLI Production
+FROM docker.io/debian:trixie-slim AS cli-prod
+
+RUN <<EOF
+    #!/bin/bash
+    set -euxo pipefail
+    useradd appuser
+    mkdir -p /home/appuser
+    chown -R appuser: /home/appuser
+EOF
+
+ENV __BUST_DOCKER_BUILD_CACHE=2026-01-30
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
+    #!/bin/bash
+    set -euxo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -q
+    apt-get install -y \
+        ca-certificates=20250419 \
+        --no-install-recommends
+    update-ca-certificates
+EOF
+
+USER appuser
+WORKDIR /home/appuser
+
+COPY --chown=root:root --chmod=755 --from=build /app/target/release/coyote /usr/local/bin/coyote
+
+ENTRYPOINT ["/usr/local/bin/coyote"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ WORKDIR /home/appuser
 EXPOSE 8050
 
 COPY --chown=root:root --chmod=755 --from=build /app/target/release/coyote-server /usr/local/bin/coyote-server
+COPY --chown=root:root --chmod=755 --from=build /app/target/release/coyote /usr/local/bin/coyote
 
 CMD ["/usr/local/bin/coyote-server"]
 


### PR DESCRIPTION
This tries to reuse the server Dockerfile as much as possible, adding a separate target for cli that will be invoked separately in github.