### PR TITLE
server: add panic handling to the HTTP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5209,6 +5209,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "mime",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ tokio = { version = "1.24.2", features = ["rt", "signal", "fs"] }
 tokio-util = "0.7"
 toml = { version = "1.0.3", default-features = false, features = ["parse", "serde"] }
 tower = "0.5.1"
-tower-http = { version = "0.6.1", features = ["cors", "normalize-path", "request-id", "trace", "util"] }
+tower-http = { version = "0.6.1", features = ["cors", "normalize-path", "request-id", "trace", "util", "catch-panic"] }
 tower-service = "0.3.3"
 tracing = { version = "0.1.35", features = ["release_max_level_debug"] }
 tracing-opentelemetry = "0.32.1"

--- a/clients/cli/src/cmds/api/health.rs
+++ b/clients/cli/src/cmds/api/health.rs
@@ -13,6 +13,8 @@ pub struct HealthArgs {
 pub enum HealthCommands {
     /// Verify the server is up and running.
     Ping {},
+    /// Intentionally return an error
+    Error {},
 }
 
 impl HealthCommands {
@@ -25,6 +27,9 @@ impl HealthCommands {
             Self::Ping {} => {
                 let resp = client.health().ping().await?;
                 crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Error {} => {
+                client.health().error().await?;
             }
         }
 

--- a/clients/go/internal/apis/health.go
+++ b/clients/go/internal/apis/health.go
@@ -40,8 +40,6 @@ func (health Health) Error(
 		"POST",
 		"/api/v1/health/error",
 		nil,
-		nil,
-		nil,
 	)
 	return err
 }

--- a/clients/go/internal/apis/health.go
+++ b/clients/go/internal/apis/health.go
@@ -29,3 +29,19 @@ func (health Health) Ping(
 		nil,
 	)
 }
+
+// Intentionally return an error
+func (health Health) Error(
+	ctx context.Context,
+) error {
+	_, err := coyote_proto.ExecuteRequest[any, any](
+		ctx,
+		health.client,
+		"POST",
+		"/api/v1/health/error",
+		nil,
+		nil,
+		nil,
+	)
+	return err
+}

--- a/clients/java/src/main/java/com/svix/coyote/apis/Health.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/Health.java
@@ -35,4 +35,18 @@ public class Health {
             PingOut.class
             );
     }
+
+    /** Intentionally return an error */
+    public void error(
+        
+    ) throws IOException, ApiException {
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/health/error");
+        this.client.executeRequest(
+            "POST",
+            url.build(),
+            null,
+            null,
+            null
+            );
+    }
 }

--- a/clients/javascript/src/apis/health.ts
+++ b/clients/javascript/src/apis/health.ts
@@ -19,6 +19,13 @@ export class Health {
             this.requestCtx,
             PingOutSerializer._fromJsonObject,
         );
+    }/** Intentionally return an error */
+    public error(
+    ): Promise<void> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/health/error");
+
+        
+        return request.sendNoResponseBody(this.requestCtx);
     }
 }
 

--- a/clients/python/coyote/apis/health.py
+++ b/clients/python/coyote/apis/health.py
@@ -18,6 +18,16 @@ class HealthAsync(ApiBase):
             response_type=PingOut,
         )
 
+    async def error(
+        self,
+    ) -> None:
+        """Intentionally return an error"""
+
+        await self._request_asyncio(
+            method="post",
+            path="/api/v1/health/error",
+        )
+
 
 class Health(ApiBase):
     def ping(
@@ -29,4 +39,14 @@ class Health(ApiBase):
             method="get",
             path="/api/v1/health/ping",
             response_type=PingOut,
+        )
+
+    def error(
+        self,
+    ) -> None:
+        """Intentionally return an error"""
+
+        self._request_sync(
+            method="post",
+            path="/api/v1/health/error",
         )

--- a/clients/rust/src/api/health.rs
+++ b/clients/rust/src/api/health.rs
@@ -16,4 +16,12 @@ impl<'a> Health<'a> {
             .execute(self.cfg)
             .await
     }
+
+    /// Intentionally return an error
+    pub async fn error(&self) -> Result<()> {
+        crate::request::Request::new(http::Method::POST, "/api/v1/health/error")
+            .returns_nothing()
+            .execute(self.cfg)
+            .await
+    }
 }

--- a/clients/rust/src/request.rs
+++ b/clients/rust/src/request.rs
@@ -44,6 +44,11 @@ impl Request {
         }
     }
 
+    pub(crate) fn returns_nothing(mut self) -> Self {
+        self.no_return_type = true;
+        self
+    }
+
     pub(crate) fn with_body<T: serde::Serialize>(mut self, param: T) -> Self {
         self.serialized_body = Some(rmp_serde::to_vec_named(&param).unwrap());
         self

--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -110,7 +110,11 @@ impl IntoResponse for Error {
                     message,
                     "generic error",
                 );
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({}))).into_response()
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "internal error"})),
+                )
+                    .into_response()
             }
         }
     }

--- a/openapi.json
+++ b/openapi.json
@@ -37,6 +37,26 @@
         ]
       }
     },
+    "/api/v1/health/error": {
+      "post": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Error",
+        "description": "Intentionally return an error",
+        "operationId": "v1.health.error",
+        "responses": {
+          "204": {
+            "description": "no content"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/cache/set": {
       "post": {
         "tags": [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,19 +7,23 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{sync::Arc, time::Duration};
 
+use ::serde::Serialize;
 use aide::axum::ApiRouter;
-use axum::{Extension, extract::DefaultBodyLimit, middleware, serve::ListenerExt as _};
+use axum::{
+    Extension, extract::DefaultBodyLimit, middleware, response::IntoResponse as _,
+    serve::ListenerExt as _,
+};
 use coyote_core::Monotime;
 use coyote_error::Error;
 use fjall_utils::{Databases, ReadonlyDatabases};
 use opentelemetry::metrics::Meter;
 use tokio::{net::TcpListener, sync::Barrier};
-use tower_http::trace::TraceLayer;
-
 use tower_http::{
     ServiceExt,
+    catch_panic::CatchPanicLayer,
     cors::{AllowHeaders, Any, CorsLayer},
     normalize_path::NormalizePath,
+    trace::TraceLayer,
 };
 
 use crate::{
@@ -89,6 +93,21 @@ pub struct AppState {
     pub(crate) time: Monotime,
 }
 
+fn handle_panic(_err: Box<dyn std::any::Any + Send + 'static>) -> axum::response::Response {
+    #[derive(Debug, Serialize)]
+    struct MinimalError {
+        message: &'static str,
+    }
+    tracing::error!("Unhandled panic");
+    (
+        http::StatusCode::INTERNAL_SERVER_ERROR,
+        coyote_proto::MsgPackOrJson(MinimalError {
+            message: "unhandled internal panic",
+        }),
+    )
+        .into_response()
+}
+
 async fn run_interserver(
     cfg: Configuration,
     state: AppState,
@@ -118,6 +137,7 @@ async fn run_interserver(
         .layer(Extension(raft.clone()))
         .layer(DefaultBodyLimit::disable())
         .layer(middleware::from_fn(coyote_proto::capture_accept_hdr))
+        .layer(CatchPanicLayer::custom(handle_panic))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(AxumOtelSpanCreator)
@@ -243,6 +263,7 @@ pub async fn run_with_listeners(
                 .allow_headers(AllowHeaders::mirror_request())
                 .max_age(Duration::from_secs(600)),
             middleware::from_fn(coyote_proto::capture_accept_hdr),
+            CatchPanicLayer::custom(handle_panic),
         ))
         // It is important that this service wraps the router instead of being
         // applied via `Router::layer`, as it would run after routing then.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,12 +93,18 @@ pub struct AppState {
     pub(crate) time: Monotime,
 }
 
-fn handle_panic(_err: Box<dyn std::any::Any + Send + 'static>) -> axum::response::Response {
+fn handle_panic(err: Box<dyn std::any::Any + Send + 'static>) -> axum::response::Response {
     #[derive(Debug, Serialize)]
     struct MinimalError {
         message: &'static str,
     }
-    tracing::error!("Unhandled panic");
+    if let Some(err) = err.downcast_ref::<String>() {
+        tracing::error!(?err, "Unhandled panic");
+    } else if let Some(err) = err.downcast_ref::<&'static str>() {
+        tracing::error!(?err, "Unhandled panic");
+    } else {
+        tracing::error!("Unhandled non-string panic");
+    }
     (
         http::StatusCode::INTERNAL_SERVER_ERROR,
         coyote_proto::MsgPackOrJson(MinimalError {

--- a/src/v1/endpoints/health.rs
+++ b/src/v1/endpoints/health.rs
@@ -45,9 +45,8 @@ pub fn router() -> ApiRouter<AppState> {
         .api_route_with("/health/ping", get_with(ping, ping_operation), &tag)
         .api_route_with("/health/error", post_with(error, error_operation), &tag);
 
-    if cfg!(debug_assertions) {
-        router.route("/health/panic", post(panic))
-    } else {
-        router
-    }
+    #[cfg(debug_assertions)]
+    let router = router.route("/health/panic", post(panic));
+
+    router
 }

--- a/src/v1/endpoints/health.rs
+++ b/src/v1/endpoints/health.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use aide::axum::{ApiRouter, routing::get_with};
+use aide::axum::{
+    ApiRouter,
+    routing::{get_with, post, post_with},
+};
 use coyote_derive::aide_annotate;
 use coyote_proto::MsgPackOrJson;
 use schemars::JsonSchema;
@@ -20,8 +23,31 @@ async fn ping() -> Result<MsgPackOrJson<PingOut>> {
     Ok(MsgPackOrJson(PingOut { ok: true }))
 }
 
+/// Intentionally return an error
+#[aide_annotate(op_id = "v1.health.error")]
+async fn error() -> Result<()> {
+    Err(coyote_error::Error::internal(
+        "despite appearances, I am not an error",
+    ))
+}
+
+/// Intentionally panic a thread
+#[aide_annotate(op_id = "v1.health.panic")]
+#[cfg(debug_assertions)]
+async fn panic() -> Result<()> {
+    panic!("oh dear")
+}
+
 pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Health");
 
-    ApiRouter::new().api_route_with("/health/ping", get_with(ping, ping_operation), &tag)
+    let router = ApiRouter::new()
+        .api_route_with("/health/ping", get_with(ping, ping_operation), &tag)
+        .api_route_with("/health/error", post_with(error, error_operation), &tag);
+
+    if cfg!(debug_assertions) {
+        router.route("/health/panic", post(panic))
+    } else {
+        router
+    }
 }


### PR DESCRIPTION
Apparently, this isn't "free" in axum so you need to use Tower.

This does a few things:

 1. Adds a panic handler that returns msgpack or JSON (based on the tokio task-local storage property) with a basic body
 2. Changes the `coyote_error::Error::internal` body to have an `error` field instead of just being empty JSON
 3. Adds new `/api/v1/health/error` and `/api/v1/health/panic` endpoints to force a request to error or panic. The panic endpoint is undocumented and only built in debug mode.

related to #134