### PR TITLE
server: send panics to tracing instead of stderr

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -14,6 +14,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 static GLOBAL: MiMalloc = MiMalloc;
 
 mod otel;
+mod tracing_panic_hook;
 
 #[derive(Parser)]
 #[clap(author, version, about = env!("CARGO_PKG_DESCRIPTION"), long_about = None)]
@@ -67,6 +68,8 @@ async fn main() -> anyhow::Result<()> {
     let (tracing_subscriber, otel_tracer_provider) =
         otel::setup_tracing(&cfg, /* for_test = */ false);
     tracing_subscriber.init();
+
+    tracing_panic_hook::setup_tracing_panic_handler();
 
     match args.command {
         Some(Commands::Healthcheck { .. }) => {

--- a/server/src/tracing_panic_hook.rs
+++ b/server/src/tracing_panic_hook.rs
@@ -1,0 +1,43 @@
+use std::{
+    backtrace::{Backtrace, BacktraceStatus},
+    panic::PanicHookInfo,
+};
+
+pub(crate) fn tracing_panic_hook(panic_info: &PanicHookInfo<'_>) {
+    let backtrace = Backtrace::capture();
+    let (backtrace, note) = match backtrace.status() {
+        BacktraceStatus::Disabled => (
+            None,
+            Some("run with `RUST_BACKTRACE=1` environment variable to display a backtrace"),
+        ),
+        BacktraceStatus::Unsupported => {
+            (None, Some("backtraces are not supported on this platform"))
+        }
+        BacktraceStatus::Captured => (Some(backtrace), None),
+        _ => (None, Some("error capturing backtrace")),
+    };
+
+    let payload = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+        s
+    } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        ""
+    };
+
+    tracing::error!(
+        thread.name = std::thread::current().name(),
+        thread.id = ?std::thread::current().id(),
+        process.id = std::process::id(),
+        panic.payload = payload,
+        panic.location = panic_info.location().map(tracing::field::display),
+        panic.backtrace = backtrace.map(tracing::field::display),
+        panic.note = note,
+        "{} panicked at",
+        env!("CARGO_PKG_NAME")
+    );
+}
+
+pub(crate) fn setup_tracing_panic_handler() {
+    std::panic::set_hook(Box::new(tracing_panic_hook))
+}


### PR DESCRIPTION
same as svix/svix-webhooks-private#4952

by default, panics go to stderr without any formatting; this sends them to `tracing` instead

example output:

```plain_text
2026-03-17T20:32:13.753874Z ERROR HTTP request{http.versions=HTTP/1.1 http.host="localhost:8050" http.method=POST http.route="/api/v1/health/panic" http.target="/health/panic" http.user_agent="curl/8.7.1" otel.kind="server" request_id="217c14ec-9f48-45fc-a02b-9093174d868b" op_id="v1.health.panic"}: coyote_server::tracing_panic_hook: coyote-server panicked at thread.name="main" thread.id=ThreadId(1) process.id=78273 panic.payload="oh dear" panic.location=src/v1/endpoints/health.rs:38:5 panic.note="run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
```

related to #134 