### PR TITLE
Allow dots in consumer group names

### DIFF
--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -404,7 +404,7 @@ impl JsonSchema for SeekPosition {
 
 /// A validated consumer group identifier.
 ///
-/// Must be at most 64 bytes and only contain ASCII alphanumeric characters, `_`, or `-`.
+/// Must be at most 64 bytes and only contain ASCII alphanumeric characters, `_`, `-`, or `.`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 #[serde(transparent)]
 pub struct ConsumerGroup(pub(crate) String);
@@ -418,10 +418,10 @@ impl ConsumerGroup {
         }
         if !s
             .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-' || b == b'.')
         {
             return Err(
-                "consumer group name must only contain alphanumeric characters, '_', and '-'",
+                "consumer group name must only contain alphanumeric characters, '_', and '-' and '.'",
             );
         }
         Ok(())


### PR DESCRIPTION
We use dots in consumer groups in svix-webhooks-private. I see no reason to exclude them.

Noticed while debugging test failures when integrating coyote w/webhooks-private