### PR TITLE
ci: Only run lint-openapi on PRs

### DIFF
--- a/.github/workflows/lint-openapi.yml
+++ b/.github/workflows/lint-openapi.yml
@@ -1,13 +1,7 @@
 name: Lint OpenAPI
 
 on:
-  workflow_dispatch:
   workflow_call:
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/lint-openapi.yml'
-      - 'openapi.json'
 
 jobs:
   lint-openapi:


### PR DESCRIPTION
I got an error notification about it not being able to do its thing regarding PR comments. I think this workflow is only meant to be used for PRs, and enabling it for main wasn't a concious decision anyways.