### PR TITLE
CI: Fix artifact name clash

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
       artifact_prefix: ${{ steps.prefix.outputs.artifact_prefix }}
     steps:
       - name: Compute artifact prefix
-        id: prefix 
+        id: prefix
         run: |
           image="${{ inputs.image_name }}"
           echo "artifact_prefix=digests-${image//\//-}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,19 @@ env:
   IMAGE_NAME: ${{ inputs.image_name }}
 
 jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    outputs:
+      artifact_prefix: ${{ steps.prefix.outputs.artifact_prefix }}
+    steps:
+      - name: Compute artifact prefix
+        id: prefix 
+        run: |
+          image="${{ inputs.image_name }}"
+          echo "artifact_prefix=digests-${image//\//-}" >> "$GITHUB_OUTPUT"
+
   build-and-push-image:
+    needs: prepare
     permissions:
       actions: read
       packages: write
@@ -146,7 +158,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v6
         with:
-          name: digests-nonfips-${{ inputs.target }}-${{ env.PLATFORM_PAIR }}
+          name: ${{ needs.prepare.outputs.artifact_prefix }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -157,13 +169,14 @@ jobs:
     permissions:
       packages: write
     needs:
+      - prepare
       - build-and-push-image
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-nonfips-${{ inputs.target }}-*
+          pattern: ${{ needs.prepare.outputs.artifact_prefix }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Ensure artifact names don't clash with
various jobs reusing the publish step.