### PR TITLE
Also publish a 'latest' image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,6 +84,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,format=long
+            type=raw,value=latest
 
       - name: Build ${{ matrix.os.arch }} Docker image
         uses: docker/build-push-action@v6
@@ -189,6 +190,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,format=long
+            type=raw,value=latest
 
       - name: Login to the GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
Not sure if there's any issues/objections here.

I want to be able to reference the "latest" successful build for coyote in webhooks-private.

Maybe there's a better solution?