### PR TITLE
Tokio: bring back multithreaded runtime.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,7 @@ sysinfo = "0.38.2"
 tap = "1"
 tempfile = "3.24.0"
 test-utils.path = "crates/test-utils"
-tokio = { version = "1.24.2", features = ["rt", "signal", "fs"] }
+tokio = { version = "1.24.2", features = ["rt", "rt-multi-thread", "signal", "fs"] }
 tokio-util = "0.7"
 toml = { version = "1.0.3", default-features = false, features = ["parse", "serde"] }
 tower = "0.5.1"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -39,7 +39,7 @@ enum Commands {
     Server,
 }
 
-#[tokio::main(flavor = "local")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     _ = dotenv();
 


### PR DESCRIPTION
We changed it to the single threaded one at some point because we thought we may go down a certain architecture path. Though we haven't gone down that path, so it's no longer needed to do the single threaded.

If we ever want to do that architecture change or we think this can potentially improve performance somehow, we can change it. Though at the moment it feels unnecessary and limiting (e.g. no concurrent kv.get).

Fixes #495 