### PR TITLE
cluster: run kv cleanups in the background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "fjall-utils",
  "itertools 0.14.0",
  "jiff",
+ "parking_lot",
  "schemars 1.2.1",
  "serde",
  "tap",
@@ -1227,13 +1228,16 @@ name = "coyote-operations"
 version = "0.0.1"
 dependencies = [
  "axum",
+ "coyote-core",
  "coyote-error",
+ "futures-util",
  "http",
  "http-serde",
  "jiff",
  "opentelemetry",
  "paste",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/coyote-operations/Cargo.toml
+++ b/crates/coyote-operations/Cargo.toml
@@ -7,13 +7,16 @@ rust-version.workspace = true
 
 [dependencies]
 axum.workspace = true
+coyote-core.workspace = true
 coyote-error.workspace = true
+futures-util.workspace = true
 http.workspace = true
 http-serde.workspace = true
 jiff.workspace = true
 opentelemetry.workspace = true
 paste.workspace = true
 serde.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -6,11 +6,13 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 mod context;
 pub use context::OpContext;
+pub mod workers;
 
 #[derive(Debug)]
 pub enum BackgroundError {
     NotLeader,
     InvalidResponse,
+    TooManyPanics,
     Other(coyote_error::Error),
 }
 
@@ -19,6 +21,10 @@ impl std::fmt::Display for BackgroundError {
         match self {
             Self::NotLeader => write!(f, "tried to write to a non-leader node"),
             Self::InvalidResponse => write!(f, "raft layer returned invalid response type"),
+            Self::TooManyPanics => write!(
+                f,
+                "a background worker experienced too many panics in a row"
+            ),
             Self::Other(e) => std::fmt::Display::fmt(&e, f),
         }
     }
@@ -32,7 +38,7 @@ impl std::error::Error for BackgroundError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self {
             Self::Other(e) => Some(e),
-            Self::InvalidResponse | Self::NotLeader => None,
+            Self::InvalidResponse | Self::NotLeader | Self::TooManyPanics => None,
         }
     }
 }

--- a/crates/coyote-operations/src/workers.rs
+++ b/crates/coyote-operations/src/workers.rs
@@ -1,0 +1,53 @@
+use futures_util::future::FutureExt;
+use std::{panic::AssertUnwindSafe, time::Duration};
+
+const MAX_PANICS_PER_JOB: usize = 10;
+
+pub trait BackgroundWorker: Clone + Send {
+    const NAME: &str;
+
+    fn run(self) -> impl Future<Output = crate::BackgroundResult<()>> + Send;
+
+    fn run_while_handling_panics(self) -> impl Future<Output = crate::BackgroundResult<()>> + Send {
+        async move {
+            let shutting_down = coyote_core::shutdown::shutting_down_token();
+            let mut backoff = coyote_core::backoff::ExponentialBackoffWithJitter::new(
+                Duration::from_millis(10),
+                Duration::from_secs(5),
+            );
+            let mut failures = 0;
+            let job_name = Self::NAME;
+
+            loop {
+                let job = self.clone();
+                match AssertUnwindSafe(job.run()).catch_unwind().await {
+                    Ok(v) => v?,
+                    Err(err) => {
+                        failures += 1;
+                        if failures > MAX_PANICS_PER_JOB {
+                            tracing::error!(
+                                ?err,
+                                job_name,
+                                "a panic occurred during a background job; shutting down the server"
+                            );
+                            return Err(crate::BackgroundError::TooManyPanics);
+                        } else {
+                            tracing::error!(
+                                ?err,
+                                job_name,
+                                "a panic occurred during a background job; restarting"
+                            );
+                        }
+                    }
+                }
+                if shutting_down
+                    .run_until_cancelled(backoff.backoff())
+                    .await
+                    .is_none()
+                {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}

--- a/crates/kv/Cargo.toml
+++ b/crates/kv/Cargo.toml
@@ -6,7 +6,7 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-coyote-core = { version = "0.0.1", path = "../coyote-core" }
+coyote-core.workspace = true
 coyote-error.workspace = true
 coyote-namespace.workspace = true
 coyote-operations.workspace = true
@@ -14,6 +14,7 @@ fjall.workspace = true
 fjall-utils.workspace = true
 itertools.workspace = true
 jiff.workspace = true
+parking_lot.workspace = true
 schemars.workspace = true
 serde.workspace = true
 tap.workspace = true

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -1,15 +1,22 @@
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
 use coyote_error::{Error, Result};
 use coyote_namespace::entities::NamespaceId;
 use fjall::{KeyspaceCreateOptions, KvSeparationOptions};
 use fjall_utils::{StorageType, TableRow, WriteBatchExt};
 use itertools::Itertools;
 use jiff::Timestamp;
+use parking_lot::{Mutex, MutexGuard};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::tables::{ExpirationRow, KvPairRow};
 
 const EXPIRATION_BATCH_SIZE: usize = 1_000;
+const WARN_LONG_LOCK_DURATION: Duration = Duration::from_millis(100);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -56,7 +63,7 @@ impl From<KvPairRow> for KvModel {
 
 #[derive(Clone)]
 pub struct KvController {
-    db: fjall::Database,
+    db: Arc<Mutex<fjall::Database>>,
     keyspace: fjall::Keyspace,
     keyspace_name: &'static str,
 }
@@ -70,7 +77,7 @@ impl KvController {
         };
 
         Self {
-            db,
+            db: Arc::new(Mutex::new(db)),
             keyspace: tables,
             keyspace_name,
         }
@@ -97,11 +104,12 @@ impl KvController {
 
     fn insert_with_expiration(
         &self,
+        db: MutexGuard<'_, fjall::Database>,
         namespace_id: NamespaceId,
         key: &str,
         model: KvModel,
     ) -> Result<()> {
-        let mut batch = self.db.batch();
+        let mut batch = db.batch();
 
         let row = KvPairRow {
             value: model.value,
@@ -113,11 +121,8 @@ impl KvController {
 
         if let Some(expiry) = row.expiry {
             let expiration_row = ExpirationRow::new();
-            batch.insert_row(
-                &self.keyspace,
-                ExpirationRow::key_for(namespace_id, expiry, key),
-                &expiration_row,
-            )?;
+            let key = ExpirationRow::key_for(namespace_id, expiry, key);
+            batch.insert_row(&self.keyspace, key, &expiration_row)?;
         }
 
         batch.commit()?;
@@ -154,9 +159,11 @@ impl KvController {
             version: new_version,
         };
 
+        let db = self.db.lock();
+
         match behavior {
             OperationBehavior::Upsert => {
-                self.insert_with_expiration(namespace_id, key, new_model)?;
+                self.insert_with_expiration(db, namespace_id, key, new_model)?;
             }
             OperationBehavior::Insert => {
                 current = if current.is_some() {
@@ -171,7 +178,7 @@ impl KvController {
                         success: false,
                     });
                 } else {
-                    self.insert_with_expiration(namespace_id, key, new_model)?;
+                    self.insert_with_expiration(db, namespace_id, key, new_model)?;
                 }
             }
             OperationBehavior::Update => {
@@ -183,7 +190,7 @@ impl KvController {
                 let exists = current.is_some();
 
                 if exists {
-                    self.insert_with_expiration(namespace_id, key, new_model)?;
+                    self.insert_with_expiration(db, namespace_id, key, new_model)?;
                 } else {
                     return Ok(KvSetResult {
                         version: 0,
@@ -201,9 +208,11 @@ impl KvController {
 
     #[tracing::instrument(skip(self))]
     pub fn delete(&self, namespace_id: NamespaceId, key: &str) -> Result<bool> {
+        let db = self.db.lock();
+
         if let Some(data) = KvPairRow::fetch(&self.keyspace, KvPairRow::key_for(namespace_id, key))?
         {
-            let mut batch = self.db.batch();
+            let mut batch = db.batch();
 
             // Delete from the expiration keyspace
             if let Some(expiry) = data.expiry {
@@ -239,7 +248,10 @@ impl KvController {
             .unwrap_or(false)
     }
 
-    #[tracing::instrument(skip(self), fields(keyspace_id, storage_type, cleared))]
+    #[tracing::instrument(skip(self), fields(
+        keyspace_name = self.keyspace_name,
+        cleared,
+    ))]
     pub fn clear_expired(
         &self,
         now: Timestamp,
@@ -251,11 +263,7 @@ impl KvController {
         let end = ExpirationRow::key_for(NamespaceId::max(), now, "").into_fjall_key();
 
         let mut cleared = 0;
-        let start_time = std::time::Instant::now();
-
-        tracing::Span::current()
-            .record("keyspace_name", self.keyspace_name)
-            .record("storage_type", tracing::field::debug(storage_type));
+        let start_time = Instant::now();
 
         for chunk in &self
             .keyspace
@@ -263,7 +271,8 @@ impl KvController {
             .take(max_expirations)
             .chunks(EXPIRATION_BATCH_SIZE)
         {
-            let mut batch = self.db.batch();
+            let db = self.db.lock();
+            let mut batch = db.batch();
             for item in chunk {
                 cleared += 1;
                 let k = item.key()?;
@@ -278,6 +287,83 @@ impl KvController {
         if cleared == max_expirations {
             tracing::warn!(cleared, elapsed=?start_time.elapsed(), "expiration loop is not keeping up");
         } else if cleared > 0 {
+            tracing::debug!(cleared, "cleared some keys");
+        } else {
+            tracing::trace!("no expired keys");
+        }
+        tracing::Span::current().record("cleared", cleared);
+
+        Ok(cleared)
+    }
+
+    #[tracing::instrument(skip(self), fields(
+        keyspace_name = self.keyspace_name,
+        cleared
+    ))]
+    pub fn clear_expired_in_background(
+        &self,
+        now: Timestamp,
+        storage_type: StorageType,
+    ) -> Result<usize> {
+        let grace_period = now - jiff::SignedDuration::from_secs(10);
+        let start =
+            ExpirationRow::key_for(NamespaceId::nil(), Timestamp::UNIX_EPOCH, "").into_fjall_key();
+        let end = ExpirationRow::key_for(NamespaceId::max(), grace_period, "").into_fjall_key();
+
+        let mut cleared = 0;
+
+        loop {
+            let mut keys = self
+                .keyspace
+                .range(start.clone()..=end.clone())
+                .take(EXPIRATION_BATCH_SIZE)
+                .map(|item| item.key());
+            let Some(Ok(first)) = keys.next() else {
+                tracing::trace!("nothing to clean up");
+                break;
+            };
+            let Some(Ok(last)) = keys.last() else {
+                break;
+            };
+
+            tracing::trace!(first_key=?first, last_key=?last, "about to prune some expired keys");
+
+            let start_batch = Instant::now();
+            let num_this_batch = tracing::debug_span!("clear_expired_in_background:remove_chunk")
+                .in_scope(|| {
+                let db = self.db.lock();
+                let start_lock = Instant::now();
+                let mut batch = db.batch();
+                let mut num_this_batch = 0;
+
+                for item in self.keyspace.range(first..=last) {
+                    cleared += 1;
+                    num_this_batch += 1;
+                    let k = item.key()?;
+                    let (namespace_id, main_key) = ExpirationRow::extract_key_from_fjall_key(&k)?;
+                    batch.remove_row(&self.keyspace, KvPairRow::key_for(namespace_id, main_key))?;
+
+                    batch.remove(&self.keyspace, k);
+                }
+                batch.commit()?;
+                drop(db);
+                let duration = start_lock.elapsed();
+                if duration > WARN_LONG_LOCK_DURATION {
+                    tracing::warn!(
+                        lock_us = duration.as_micros(),
+                        "clear_expired_in_background locked kvcontroller for a long time"
+                    );
+                }
+                Ok::<_, Error>(num_this_batch)
+            })?;
+            tracing::trace!(num_this_batch, elapsed=?start_batch.elapsed(), "cleared a batch of items");
+
+            if num_this_batch < EXPIRATION_BATCH_SIZE {
+                break;
+            }
+        }
+
+        if cleared > 0 {
             tracing::debug!(cleared, "cleared some keys");
         } else {
             tracing::trace!("no expired keys");
@@ -594,6 +680,144 @@ mod tests {
             // now it should really and truly be gone
             assert!(!key_exists(&controller, key));
             assert!(!key_exists_as_of(&controller, key, then));
+        }
+        assert!(!key_exists(&controller, "expired:key"));
+        assert!(!key_exists_as_of(&controller, "expired:key", then));
+
+        assert!(key_exists(&controller, valid_key));
+        let valid = controller.fetch(ns(), valid_key, Timestamp::now()).unwrap();
+        assert!(valid.is_some());
+        assert_eq!(valid.unwrap().value, b"valid data");
+
+        assert!(key_exists(&controller, permanent_key));
+        let permanent = controller
+            .fetch(ns(), permanent_key, Timestamp::now())
+            .unwrap();
+        assert!(permanent.is_some());
+        assert_eq!(permanent.unwrap().value, b"permanent data");
+    }
+
+    #[test]
+    fn test_clear_expired_in_background_removes_expired_entries() {
+        let setup = SetupFixture::new();
+        let controller = setup.controller;
+
+        let now = Timestamp::now();
+
+        controller
+            .set(
+                ns(),
+                "expired:key",
+                KvModelIn {
+                    value: b"expired data".to_vec(),
+                    expiry: Some(now.checked_sub(1.hour()).unwrap()),
+                    version: None,
+                },
+                OperationBehavior::Upsert,
+                now,
+                0,
+            )
+            .unwrap();
+
+        let expired_models = [
+            (
+                "expired:key:1",
+                now.checked_sub(3.hour()).unwrap(),
+                b"expired data 1".as_slice(),
+            ),
+            (
+                "expired:key:2",
+                now.checked_sub(2.hour()).unwrap(),
+                b"expired data 2".as_slice(),
+            ),
+            (
+                "expired:key:3",
+                now.checked_sub(11.second()).unwrap(),
+                b"expired data 3".as_slice(),
+            ),
+            (
+                "expired:key:4",
+                now.checked_sub(1.second()).unwrap(),
+                b"expired data that is in the grace period".as_slice(),
+            ),
+        ];
+
+        for (key, expiry, value) in &expired_models {
+            controller
+                .set(
+                    ns(),
+                    key,
+                    KvModelIn {
+                        value: value.to_vec(),
+                        expiry: Some(*expiry),
+                        version: None,
+                    },
+                    OperationBehavior::Upsert,
+                    now,
+                    0,
+                )
+                .unwrap();
+        }
+
+        let valid_key = "valid:key";
+        controller
+            .set(
+                ns(),
+                valid_key,
+                KvModelIn {
+                    value: b"valid data".to_vec(),
+                    expiry: Some(now.checked_add(1.hour()).unwrap()),
+                    version: None,
+                },
+                OperationBehavior::Upsert,
+                now,
+                0,
+            )
+            .unwrap();
+
+        let permanent_key = "permanent:key";
+        controller
+            .set(
+                ns(),
+                permanent_key,
+                KvModelIn {
+                    value: b"permanent data".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
+                OperationBehavior::Upsert,
+                now,
+                0,
+            )
+            .unwrap();
+
+        assert_eq!(controller.iter().unwrap().count(), 7);
+
+        // the key should have expired by now, so key_exists should already be false
+        assert!(!key_exists(&controller, "expired:key"));
+        let then = Timestamp::now().checked_sub(6.hours()).unwrap();
+        // but if we time travel to the past, it should still be there
+        assert!(key_exists_as_of(&controller, "expired:key", then));
+        for (key, _, _) in &expired_models {
+            assert!(key_exists_as_of(&controller, key, then));
+        }
+
+        assert_eq!(
+            controller
+                .clear_expired_in_background(Timestamp::now(), StorageType::Persistent)
+                .unwrap(),
+            4
+        );
+
+        for (key, _, _) in &expired_models {
+            // now it should really and truly be gone
+            assert!(!key_exists(&controller, key));
+            if *key == "expired:key:4" {
+                // this one is in the grace period
+                assert!(key_exists_as_of(&controller, key, then));
+            } else {
+                assert!(!key_exists_as_of(&controller, key, then));
+            }
         }
         assert!(!key_exists(&controller, "expired:key"));
         assert!(!key_exists_as_of(&controller, "expired:key", then));

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -1,7 +1,7 @@
 use coyote_core::Monotime;
 use coyote_error::Result;
 use coyote_namespace::{Namespace, entities::KeyValueConfig};
-use coyote_operations::OperationWriter;
+use coyote_operations::{BackgroundError, BackgroundResult, OperationWriter};
 use fjall_utils::{Databases, StorageType};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -47,55 +47,74 @@ pub enum OperationBehavior {
     Update,
 }
 
-/// This is the worker function for this module, it does background cleanup and accounting.
+#[derive(Clone)]
+pub struct AllNodesWorker {
+    state: State,
+    time: Monotime,
+}
+
+impl coyote_operations::workers::BackgroundWorker for AllNodesWorker {
+    const NAME: &'static str = "bg-worker:kv";
+
+    /// This is a worker function which runs on every node
+    ///
+    /// It should not mutate the database in any way that could possibly be customer- or
+    /// replication-visible; all  mutations should be written through the writer function
+    async fn run(self) -> BackgroundResult<()> {
+        let mut timer = tokio::time::interval(std::time::Duration::from_secs(1));
+
+        let shutting_down = coyote_core::shutdown::shutting_down_token();
+
+        while shutting_down
+            .run_until_cancelled(timer.tick())
+            .await
+            .is_some()
+        {
+            self.worker_loop(self.time.last()).await?;
+        }
+
+        Ok(())
+    }
+}
+
+impl AllNodesWorker {
+    pub fn new(state: State, time: Monotime) -> Self {
+        Self { state, time }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn worker_loop(&self, now: jiff::Timestamp) -> BackgroundResult<()> {
+        let mut tasks = tokio::task::JoinSet::new();
+        let state = self.state.clone();
+        tasks.spawn_blocking(move || {
+            state
+                .persistent_controller
+                .clear_expired_in_background(now, StorageType::Persistent)
+        });
+        let state = self.state.clone();
+        tasks.spawn_blocking(move || {
+            state
+                .ephemeral_controller
+                .clear_expired_in_background(now, StorageType::Ephemeral)
+        });
+        for result in tasks.join_all().await {
+            result.map_err(BackgroundError::Other)?;
+        }
+        Ok(())
+    }
+}
+
+/// This is a worker function for this module which runs only on the leader
 ///
 /// It should not mutate the database in any way that could possibly be customer- or
 /// replication-visible; all  mutations should be written through the writer function
-pub async fn worker<F>(
-    state: State,
-    writer: F,
-    time: Monotime,
-) -> coyote_operations::BackgroundResult<()>
+pub async fn leader_worker<F>(_state: State, _writer: F, _time: Monotime) -> BackgroundResult<()>
 where
     F: OperationWriter<operations::KvOperation>,
 {
-    let mut timer = tokio::time::interval(std::time::Duration::from_secs(1));
-
     let shutting_down = coyote_core::shutdown::shutting_down_token();
 
-    while shutting_down
-        .run_until_cancelled(timer.tick())
-        .await
-        .is_some()
-    {
-        worker_loop(&state, &writer, time.last()).await?;
-    }
+    shutting_down.cancelled().await;
 
-    Ok(())
-}
-
-#[tracing::instrument(skip_all)]
-pub async fn worker_loop<F>(
-    state: &State,
-    writer: &F,
-    now: jiff::Timestamp,
-) -> coyote_operations::BackgroundResult<()>
-where
-    F: OperationWriter<operations::KvOperation>,
-{
-    if state.persistent_controller.has_expired(now).await {
-        writer
-            .write_request(operations::ClearExpiredOperation::new(
-                StorageType::Persistent,
-            ))
-            .await?;
-    }
-    if state.ephemeral_controller.has_expired(now).await {
-        writer
-            .write_request(operations::ClearExpiredOperation::new(
-                StorageType::Ephemeral,
-            ))
-            .await?;
-    }
     Ok(())
 }

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -102,7 +102,7 @@ impl BackgroundJob for KvBackground {
     async fn run_on_leader(self) -> BackgroundResult<()> {
         let store = self.handle.state_machine.kv_store().await;
         let time = self.handle.state_machine.time.clone();
-        coyote_kv::worker(store, self.handle, time).await
+        coyote_kv::leader_worker(store, self.handle, time).await
     }
 }
 

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -703,7 +703,7 @@ impl StoreHandle {
         self.time.now()
     }
 
-    pub(super) async fn kv_store(&self) -> coyote_kv::State {
+    pub(crate) async fn kv_store(&self) -> coyote_kv::State {
         self.inner.read().await.stores.read().kv_state.clone()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use crate::{
         metrics::{ConnectionMetrics, ConnectionType, RequestMetrics},
         otel_spans::{AxumOtelOnFailure, AxumOtelOnResponse, AxumOtelSpanCreator},
     },
+    workers::Workers,
 };
 use coyote_core::shutdown::{shutting_down_token, start_shut_down};
 
@@ -43,6 +44,7 @@ pub use coyote_error as error;
 pub mod openapi;
 mod serde;
 pub mod v1;
+mod workers;
 
 async fn graceful_shutdown_handler() {
     let ctrl_c = async {
@@ -284,7 +286,7 @@ pub async fn run_with_listeners(
     };
     tracing::debug!("API: Listening on {}", listener.local_addr().unwrap());
 
-    bootstrap::run(cfg, raft_state)
+    bootstrap::run(cfg, raft_state.clone())
         .await
         .expect("bootstrapping failed");
 
@@ -297,6 +299,9 @@ pub async fn run_with_listeners(
             .accepted(node_id, ConnectionType::External);
     });
 
+    let mut workers = Workers::new();
+    workers.spawn_all(raft_state).await;
+
     axum::serve(listener, make_svc)
         .with_graceful_shutdown(shutting_down_token().cancelled_owned())
         .await
@@ -305,6 +310,7 @@ pub async fn run_with_listeners(
     // Wait for workers to finish cleanup
     tracing::debug!("done serving; waiting for background tasks to finish");
     let _ = interserver.await;
+    let _ = workers.shutdown().await;
     tracing::debug!("we're outta here!");
 }
 

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -1,0 +1,57 @@
+use crate::core::cluster::RaftState;
+use coyote_operations::{BackgroundError, BackgroundResult, workers::BackgroundWorker};
+use tokio::task::JoinSet;
+
+pub(crate) struct Workers {
+    join_set: JoinSet<BackgroundResult<()>>,
+}
+
+impl Workers {
+    pub(crate) fn new() -> Self {
+        Self {
+            join_set: JoinSet::new(),
+        }
+    }
+
+    pub(crate) async fn spawn_all(&mut self, state: RaftState) {
+        tracing::debug!("spawning background workers");
+        let time = state.state_machine.time.clone();
+        {
+            tracing::debug!("spawning KV module worker");
+            let state = state.state_machine.kv_store().await;
+            self.spawn(coyote_kv::AllNodesWorker::new(state, time));
+        }
+    }
+
+    pub(crate) async fn shutdown(mut self) {
+        tracing::debug!("shutting down all background workers");
+        self.join_set.abort_all();
+        for item in self.join_set.join_all().await {
+            if let Err(err) = item {
+                tracing::warn!(?err, "error from background job at shutdown");
+            }
+        }
+    }
+
+    fn spawn<W>(&mut self, job: W)
+    where
+        W: BackgroundWorker + 'static,
+    {
+        self.join_set.spawn(async move {
+            match job.run_while_handling_panics().await {
+                Err(BackgroundError::TooManyPanics) => {
+                    tracing::error!(
+                        job_name = W::NAME,
+                        "background worker had too many panics, shutting down server"
+                    );
+                    crate::start_shut_down();
+                    Ok(())
+                }
+                other => {
+                    tracing::debug!(job_name = W::NAME, res=?other, "background worker has finished");
+                    other
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This is an alternative to #451 which skips the fancy locking in favor of just a big mutex around the whole controller.

I've only done this for `kv` but if it looks okay I can make the same change to the other crates that use `kvcontroller` (cache and idempotency) pretty easily.

Part of #492