### PR TITLE
Auth: add a basic auth middleware and admin tokens.

### DIFF
--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -59,6 +59,18 @@ impl Error {
         Self::bad_request("invalid_input", detail)
     }
 
+    pub fn authentication(code: &'static str, detail: impl fmt::Display) -> Self {
+        Self::new(ErrorType::Authentication(StandardErrorBody::new(
+            code, detail,
+        )))
+    }
+
+    pub fn authorization(code: &'static str, detail: impl fmt::Display) -> Self {
+        Self::new(ErrorType::Authorization(StandardErrorBody::new(
+            code, detail,
+        )))
+    }
+
     pub fn validation(detail: Vec<ValidationErrorItem>) -> Self {
         Self::new(ErrorType::Validation(ValidationErrorBody::new(detail)))
     }
@@ -98,6 +110,14 @@ impl IntoResponse for Error {
             ErrorType::Validation(body) => {
                 tracing::debug!(error = %body, "validation error");
                 (StatusCode::UNPROCESSABLE_ENTITY, Json(body)).into_response()
+            }
+            ErrorType::Authentication(body) => {
+                tracing::debug!(error = %body, "authentication");
+                (StatusCode::UNAUTHORIZED, Json(body)).into_response()
+            }
+            ErrorType::Authorization(body) => {
+                tracing::debug!(error = %body, "authorization");
+                (StatusCode::FORBIDDEN, Json(body)).into_response()
             }
             ErrorType::Operation {
                 code,
@@ -154,6 +174,12 @@ pub enum ErrorType {
     /// Entity not found
     NotFound(StandardErrorBody),
 
+    /// Authentication error
+    Authentication(StandardErrorBody),
+
+    /// Authorization error
+    Authorization(StandardErrorBody),
+
     /// An error from validating a request
     Validation(ValidationErrorBody),
 
@@ -170,6 +196,8 @@ impl fmt::Display for ErrorType {
             Self::Internal { message, .. } => message.fmt(f),
             Self::BadRequest(s) => write!(f, "bad_request {s}"),
             Self::NotFound(s) => write!(f, "not_found {s}"),
+            Self::Authentication(s) => write!(f, "authn {s}"),
+            Self::Authorization(s) => write!(f, "authz {s}"),
             Self::Validation(s) => s.fmt(f),
             Self::Operation { detail, code } => {
                 if let Some(detail) = detail {

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -82,11 +82,7 @@ impl TestServerBuilder {
     }
 
     pub async fn build(self) -> TestContext {
-        let token = if let Some(token) = self.token {
-            token
-        } else {
-            "Stubbed token. Should probably be legit when we add auth.".to_string()
-        };
+        let token = self.token.unwrap_or_else(|| TEST_ADMIN_TOKEN.to_string());
 
         let listener = if let Some(listener) = self.listener {
             listener
@@ -246,6 +242,8 @@ pub struct ServerlessTestContext {
     _workdir: TempDir,
 }
 
+pub const TEST_ADMIN_TOKEN: &str = "admin_abcdefghijlmnopqrstuvwxyz";
+
 pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
     let db_dir = workdir.join("db");
     let log_path = workdir.join("logs");
@@ -300,6 +298,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         },
         bootstrap_cfg: None,
         bootstrap_cfg_path: None,
+        admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
     }
 }
 

--- a/development.env
+++ b/development.env
@@ -1,3 +1,3 @@
 # Example .env file for development
-COYOTE_JWT_SECRET=x
+COYOTE_ADMIN_TOKEN=admin_abcdefghijlmnopqrstuvwxyz
 COYOTE_LOG_LEVEL=trace

--- a/openapi.json
+++ b/openapi.json
@@ -74,53 +74,6 @@
         ]
       }
     },
-    "/api/v1/health/ping": {
-      "get": {
-        "tags": [
-          "Health"
-        ],
-        "summary": "Ping",
-        "description": "Verify the server is up and running.",
-        "operationId": "v1.health.ping",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PingOut"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/api/v1/health/error": {
-      "post": {
-        "tags": [
-          "Health"
-        ],
-        "summary": "Error",
-        "description": "Intentionally return an error",
-        "operationId": "v1.health.error",
-        "responses": {
-          "204": {
-            "description": "no content"
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
     "/api/v1/cache/set": {
       "post": {
         "tags": [
@@ -1296,6 +1249,53 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/health/ping": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Ping",
+        "description": "Verify the server is up and running.",
+        "operationId": "v1.health.ping",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PingOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/health/error": {
+      "post": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Error",
+        "description": "Intentionally return an error",
+        "operationId": "v1.health.error",
+        "responses": {
+          "204": {
+            "description": "no content"
           }
         },
         "security": [

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -467,6 +467,16 @@ pub struct ConfigurationInner {
     /// YAML bootstrap data. Takes precedence over `bootstrap_cfg_path`
     #[serde(default)]
     pub bootstrap_cfg: Option<String>,
+
+    /// A pre-set admin token to use instead of having coyote generate one automatically.
+    ///
+    /// Under normal circumstances you should not set this, and instead let coyote generate the
+    /// admin token on first boot and use that to create any additional tokens you need. Setting
+    /// this directly is useful in CI pipelines and other automated environments where you need a
+    /// stable, well-known token for testing or scripted setup.
+    #[validate(custom(function = "validators::validate_admin_token"))]
+    #[serde(default)]
+    pub admin_token: Option<String>,
 }
 
 impl Default for ConfigurationInner {
@@ -610,6 +620,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         environment,
         bootstrap_cfg_path,
         bootstrap_cfg,
+        admin_token,
         cluster:
             ClusterConfiguration {
                 advertised_address: cluster_advertised_address,
@@ -662,6 +673,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         opentelemetry_sample_ratio: "COYOTE_OPENTELEMETRY_SAMPLE_RATIO",
         bootstrap_cfg_path: "COYOTE_BOOTSTRAP_CFG_PATH",
         bootstrap_cfg: "COYOTE_BOOTSTRAP_CFG",
+        admin_token: "COYOTE_ADMIN_TOKEN",
         cluster_listen_address: "COYOTE_CLUSTER_LISTEN_ADDRESS",
         cluster_advertised_address: "COYOTE_CLUSTER_ADVERTISED_ADDRESS",
         cluster_snapshot_path: "COYOTE_CLUSTER_SNAPSHOT_PATH",

--- a/src/cfg/validators.rs
+++ b/src/cfg/validators.rs
@@ -4,6 +4,15 @@ use validator::ValidationError;
 
 use crate::cfg::ClusterConfiguration;
 
+pub(super) fn validate_admin_token(token: &str) -> Result<(), ValidationError> {
+    if token.len() < 32 {
+        return Err(ValidationError::new(
+            "admin_token must be at least 32 characters long",
+        ));
+    }
+    Ok(())
+}
+
 pub(super) fn validate_log_sync_interval_duration(d: &Duration) -> Result<(), ValidationError> {
     if d.is_zero() {
         return Err(ValidationError::new(

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -1,0 +1,95 @@
+use axum::{
+    RequestExt,
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+};
+use axum_extra::{
+    TypedHeader,
+    headers::{Authorization, authorization::Bearer},
+};
+use tracing::Span;
+
+use crate::AppState;
+use coyote_error::Error;
+
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+
+    if a.len() != b.len() {
+        return false;
+    }
+
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+/// The `Permissions` for a request
+#[derive(Clone)]
+pub struct Permissions {
+    // pub scopes: ScopePermissions,
+    /// The role of the requester
+    /// FIXME: probably want to use the right type.
+    pub role: String,
+    /// The auth token id, if we used auth token
+    /// FIXME: probably want to use the right type.
+    pub auth_token_id: Option<String>,
+}
+
+pub async fn authorization(
+    state: State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> axum::response::Result<Response> {
+    // FIXME - get this explicitly from `AxumOtelSpanCreator`, instead of relying on
+    // this middleware being invoked with that span active
+    let span = Span::current();
+    let perms = authorization_inner(state, &mut request, span).await?;
+    // This is run outside of the `tracing::instrument` function, so that the
+    // route handler execution time isn't included in the span
+    let mut response = next.run(request).await;
+    response.extensions_mut().insert(perms);
+    Ok(response)
+}
+
+/// Adds [`PermissionsAndAuditData`] to the Request, making it available in handlers via the `Extension`
+/// extractor.
+///
+/// <https://docs.rs/axum/latest/axum/middleware/index.html#passing-state-from-middleware-to-handlers>
+#[tracing::instrument(name = "authorization", skip_all, level = "trace")]
+async fn authorization_inner(
+    State(state): State<AppState>,
+    request: &mut Request,
+    http_request_span: Span,
+) -> axum::response::Result<Permissions> {
+    let TypedHeader(Authorization(bearer)) = request
+        .extract_parts::<TypedHeader<Authorization<Bearer>>>()
+        .await
+        .map_err(|_| Error::authentication("auth_required", "`Authorization` header required"))?;
+
+    let token = bearer.token();
+
+    let perms = if let Some(admin_token) = state.cfg.admin_token.as_ref() {
+        if !constant_time_eq(admin_token, token) {
+            return Err(Error::authentication("invalid_token", "Invalid token.").into());
+        }
+
+        Permissions {
+            role: "admin".to_string(),
+            auth_token_id: Some("admin".to_string()),
+        }
+    } else {
+        // FIXME: support non-admin tokens too.
+        return Err(Error::authentication("invalid_token", "Invalid token.").into());
+    };
+
+    http_request_span.record("role", perms.role.as_str());
+    if let Some(role) = perms.auth_token_id.as_ref() {
+        http_request_span.record("role", role);
+    }
+
+    Ok(perms)
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+pub mod auth;
 pub mod cluster;
 pub mod metrics;
 pub mod otel_spans;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,10 @@ pub async fn run_with_listeners(
     let router = api_router.merge(docs_router);
     let svc = router
         .layer((
+            TraceLayer::new_for_http()
+                .make_span_with(AxumOtelSpanCreator)
+                .on_response(AxumOtelOnResponse)
+                .on_failure(AxumOtelOnFailure),
             CorsLayer::new()
                 .allow_origin(Any)
                 .allow_methods(Any)

--- a/src/v1/endpoints/mod.rs
+++ b/src/v1/endpoints/mod.rs
@@ -1,8 +1,5 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
-use aide::axum::ApiRouter;
-
-use crate::AppState;
 
 pub mod admin;
 pub mod cache;
@@ -12,15 +9,3 @@ pub mod kv;
 pub mod msgs;
 pub mod queue;
 pub mod rate_limit;
-
-pub fn router() -> ApiRouter<AppState> {
-    ApiRouter::new()
-        .merge(admin::router())
-        .merge(health::router())
-        .merge(cache::router())
-        .merge(kv::router())
-        .merge(rate_limit::router())
-        .merge(idempotency::router())
-        .merge(queue::router())
-        .merge(msgs::router())
-}

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -2,40 +2,52 @@
 // SPDX-License-Identifier: MIT
 
 use aide::axum::ApiRouter;
-use tower_http::trace::TraceLayer;
 
 use crate::{
     AppState,
-    core::otel_spans::{
-        AxumOtelOnFailure, AxumOtelOnResponse, AxumOtelSpanCreator, request_metrics_middleware,
-    },
+    core::{auth::authorization, otel_spans::request_metrics_middleware},
 };
 
 pub mod endpoints;
 pub mod utils;
 
 pub fn router(state: Option<AppState>) -> ApiRouter<AppState> {
-    let mut ret: ApiRouter<AppState> = ApiRouter::new().merge(endpoints::router());
+    let mut ret: ApiRouter<AppState> = ApiRouter::new();
 
-    if let Some(state) = state {
+    if let Some(state) = &state {
         ret = ret.layer(axum::middleware::from_fn_with_state(
-            state,
+            state.clone(),
             request_metrics_middleware,
         ));
     }
 
-    let ret = ret.layer(
-        TraceLayer::new_for_http()
-            .make_span_with(AxumOtelSpanCreator)
-            .on_response(AxumOtelOnResponse)
-            .on_failure(AxumOtelOnFailure),
-    );
+    let unauthenticated_router: ApiRouter<AppState> =
+        ApiRouter::new().merge(endpoints::health::router());
+
+    let mut authenticated_router: ApiRouter<AppState> = ApiRouter::new()
+        .merge(endpoints::admin::router())
+        .merge(endpoints::cache::router())
+        .merge(endpoints::kv::router())
+        .merge(endpoints::rate_limit::router())
+        .merge(endpoints::idempotency::router())
+        .merge(endpoints::queue::router())
+        .merge(endpoints::msgs::router());
+
+    if let Some(state) = state {
+        authenticated_router =
+            authenticated_router.layer(axum::middleware::from_fn_with_state(state, authorization));
+    }
+
+    ret = ret
+        .merge(authenticated_router)
+        .merge(unauthenticated_router);
 
     #[cfg(debug_assertions)]
     if cfg!(debug_assertions) {
         let dev_router: ApiRouter<AppState> = development::router().into();
         return ret.merge(dev_router);
     }
+
     ret
 }
 


### PR DESCRIPTION
Admin tokens are essentially just hardcoded tokens people can set in configs or environment variables.
They are mostly useful in CI and shouldn't be used under normal operations.
At the moment they can also be used to bootstrap a server, but we'll add better mechanisms in the future.

This also adds a basic auth middleware that validates the admin token and injects `Permissions` into the axum handler.