### PR TITLE
Update openapi-codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,7 +3285,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "openapi-codegen"
 version = "0.1.0"
-source = "git+https://github.com/svix/openapi-codegen?rev=f464ae88b65c76fd6a39b6547003611e24680825#f464ae88b65c76fd6a39b6547003611e24680825"
+source = "git+https://github.com/svix/openapi-codegen?rev=73153ca9ff9450231eb4018d4cdb2ef070331c62#73153ca9ff9450231eb4018d4cdb2ef070331c62"
 dependencies = [
  "aide 0.14.2",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ kube = { version = "3.0.1", features = ["runtime", "derive", "client"] }
 maplit = "1"
 mimalloc = "0.1.48"
 mime = "0.3"
-openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "f464ae88b65c76fd6a39b6547003611e24680825" }
+openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "73153ca9ff9450231eb4018d4cdb2ef070331c62" }
 openraft = { version = "0.9.21", features = ["tracing-log", "anyhow", "serde", "storage-v2"] }
 opentelemetry = { version = "0.31.0", features = ["metrics"] }
 opentelemetry-http = "0.31.0"

--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -35,19 +35,18 @@ pub enum {{ resource_type_name }}Commands {
             {% if op.request_body_schema_name is defined -%}
                 {# positional body parameters -#}
                 {% set body_schema = api.types[op.request_body_schema_name] -%}
-                {% for field in body_schema.fields -%}
-                {% if field.positional -%}
+                {% set body_schema_all_optional = body_schema.fields | selectattr("required") | length == 0 %}
+                {% for field in body_schema.fields | selectattr("positional") -%}
                     {% if field.description is defined -%}
                         {{ field.description | to_doc_comment(style="rust") }}
                     {% endif -%}
                     {{ field.name | to_snake_case }}: {{ field.type.to_rust() }},
-                {% endif -%}
                 {% endfor -%}
 
                 {# body parameter struct -#}
                 {% set ty = "crate::json::JsonOf<coyote_client::models::" ~ op.request_body_schema_name ~ ">" -%}
                 {{ op.request_body_schema_name | to_snake_case }}:
-                {% if op.request_body_all_optional %}Option<{{ ty }}>{% else %}{{ ty }}{% endif %},
+                {% if body_schema_all_optional %}Option<{{ ty }}>{% else %}{{ ty }}{% endif %},
             {% endif -%}
         },
     {% endfor %}
@@ -94,6 +93,7 @@ impl {{ resource_type_name }}Commands {
                             {% if op.request_body_schema_name is defined -%}
                                 {# positional body parameters -#}
                                 {% set body_schema = api.types[op.request_body_schema_name] -%}
+                                {% set body_schema_all_optional = body_schema.fields | selectattr("required") | length == 0 %}
                                 {% for field in body_schema.fields -%}
                                 {% if field.positional -%}
                                     {{ field.name | to_snake_case }},
@@ -102,7 +102,7 @@ impl {{ resource_type_name }}Commands {
 
                                 {# body parameter struct -#}
                                 {{ op.request_body_schema_name | to_snake_case }}
-                                {% if op.request_body_all_optional -%}
+                                {% if body_schema_all_optional -%}
                                     .unwrap_or_default()
                                 {% endif -%}
                                     .into_inner(),


### PR DESCRIPTION
The `request_body_all_optional` logic is choking on some types from Tom's auth branch. We don't really need it given it's super easy to do the same check in template code (see update to CLI template code), so I removed it on the coyote branch of openapi-codegen.