### PR TITLE
make kv-related modules' appliers async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,7 @@ version = "0.0.1"
 dependencies = [
  "coyote-proto",
  "jiff",
+ "parking_lot",
  "rand 0.9.2",
  "regex",
  "schemars 1.2.1",
@@ -1123,6 +1124,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-test",
  "uuid",
  "validator",
 ]
@@ -1196,7 +1198,6 @@ dependencies = [
  "fjall-utils",
  "itertools 0.14.0",
  "jiff",
- "parking_lot",
  "schemars 1.2.1",
  "serde",
  "tap",
@@ -1236,6 +1237,7 @@ dependencies = [
  "jiff",
  "schemars 1.2.1",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -5379,6 +5381,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ opentelemetry-http = "0.31.0"
 opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["internal-logs", "metrics", "grpc-tonic", "http-proto", "reqwest-client"] }
 opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["metrics", "rt-tokio", "rt-tokio-current-thread", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }
-parking_lot = { version = "0.12", features = ["arc_lock"] }
+parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 paste = "1.0.15"
 pnet = "0.35"
 proc-macro2 = "1.0.78"
@@ -211,6 +211,7 @@ tower-service = "0.3.3"
 tracing = { version = "0.1.35", features = ["release_max_level_debug"] }
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "local-time", "fmt", "registry", "std"] }
+tracing-test = "0.2"
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.19.0", features = ["v7", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }

--- a/crates/cache/src/operations/clear_expired.rs
+++ b/crates/cache/src/operations/clear_expired.rs
@@ -20,18 +20,17 @@ impl ClearExpiredOperation {
 }
 
 impl ClearExpiredOperation {
-    fn apply_real(self, state: &State, timestamp: jiff::Timestamp) -> Result<()> {
-        state.controller(self.storage_type).clear_expired(
-            timestamp,
-            self.max_expirations,
-            self.storage_type,
-        )?;
+    async fn apply_real(self, state: &State, timestamp: jiff::Timestamp) -> Result<()> {
+        state
+            .controller(self.storage_type)
+            .clear_expired(timestamp, self.max_expirations, self.storage_type)
+            .await?;
         Ok(())
     }
 }
 
 impl CacheRequest for ClearExpiredOperation {
-    fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp))
+    async fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> ClearExpiredResponse {
+        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp).await)
     }
 }

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -45,13 +45,13 @@ impl CreateCacheOperation {
         }
     }
 
-    fn apply_real(
+    async fn apply_real(
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
     ) -> coyote_operations::Result<CreateCacheResponseData> {
         let op: CreateNamespace<CacheConfig> = self.into();
-        let out = op.apply_operation(namespace_state, now)?;
+        let out = op.async_apply_operation(namespace_state, now).await?;
         Ok(out.into())
     }
 }
@@ -80,11 +80,11 @@ impl From<CreateNamespaceOutput<CacheConfig>> for CreateCacheResponseData {
 }
 
 impl CacheRequest for CreateCacheOperation {
-    fn apply(
+    async fn apply(
         self,
         state: CacheRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CreateCacheResponse {
-        CreateCacheResponse(self.apply_real(state.namespace, ctx.timestamp))
+        CreateCacheResponse(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/cache/src/operations/delete.rs
+++ b/crates/cache/src/operations/delete.rs
@@ -28,17 +28,18 @@ impl DeleteOperation {
 }
 
 impl DeleteOperation {
-    fn apply_real(self, state: &CacheRaftState<'_>) -> Result<DeleteResponseData> {
+    async fn apply_real(self, state: &CacheRaftState<'_>) -> Result<DeleteResponseData> {
         let success = state
             .state
             .controller(self.storage_type)
-            .delete(self.namespace_id, &self.key)?;
+            .delete(self.namespace_id, self.key)
+            .await?;
         Ok(DeleteResponseData { success })
     }
 }
 
 impl CacheRequest for DeleteOperation {
-    fn apply(self, state: CacheRaftState<'_>, _ctx: &OpContext) -> DeleteResponse {
-        DeleteResponse(self.apply_real(&state))
+    async fn apply(self, state: CacheRaftState<'_>, _ctx: &OpContext) -> DeleteResponse {
+        DeleteResponse(self.apply_real(&state).await)
     }
 }

--- a/crates/cache/src/operations/mod.rs
+++ b/crates/cache/src/operations/mod.rs
@@ -10,14 +10,14 @@ pub use create_namespace::{CreateCacheOperation, CreateCacheResponseData};
 pub use delete::{DeleteOperation, DeleteResponseData};
 pub use set::SetOperation;
 
-use coyote_operations::raft_module_operations;
+use coyote_operations::async_raft_module_operations;
 
 pub struct CacheRaftState<'a> {
     pub state: &'a State,
     pub namespace: &'a coyote_namespace::State,
 }
 
-raft_module_operations!(
+async_raft_module_operations!(
     CacheRequest,
     CacheOperation {
         Set(SetOperation) -> (),

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -27,25 +27,34 @@ impl SetOperation {
 }
 
 impl SetOperation {
-    fn apply_real(self, state: &CacheRaftState<'_>, now: Timestamp, log_index: u64) -> Result<()> {
-        state.state.controller(self.storage_type).set(
-            self.namespace_id,
-            &self.key,
-            KvModelIn {
-                value: self.model.value,
-                expiry: self.model.expiry,
-                version: None,
-            },
-            OperationBehavior::Upsert,
-            now,
-            log_index,
-        )?;
+    async fn apply_real(
+        self,
+        state: &CacheRaftState<'_>,
+        now: Timestamp,
+        log_index: u64,
+    ) -> Result<()> {
+        state
+            .state
+            .controller(self.storage_type)
+            .set(
+                self.namespace_id,
+                self.key,
+                KvModelIn {
+                    value: self.model.value,
+                    expiry: self.model.expiry,
+                    version: None,
+                },
+                OperationBehavior::Upsert,
+                now,
+                log_index,
+            )
+            .await?;
         Ok(())
     }
 }
 
 impl CacheRequest for SetOperation {
-    fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> SetResponse {
-        SetResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index))
+    async fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> SetResponse {
+        SetResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
     }
 }

--- a/crates/coyote-core/Cargo.toml
+++ b/crates/coyote-core/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 [dependencies]
 coyote-proto.workspace = true
 jiff.workspace = true
+parking_lot.workspace = true
 rand.workspace = true
 regex.workspace = true
 schemars.workspace = true
@@ -19,6 +20,9 @@ tokio-util.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 validator.workspace = true
+
+[dev-dependencies]
+tracing-test.workspace = true
 
 [lints]
 workspace = true

--- a/crates/coyote-core/src/instrumented_mutex.rs
+++ b/crates/coyote-core/src/instrumented_mutex.rs
@@ -1,0 +1,164 @@
+use parking_lot::Mutex;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+#[derive(Clone)]
+pub struct InstrumentedMutex<T> {
+    id: u64,
+    inner: Arc<Mutex<T>>,
+}
+
+static ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
+
+impl<T> InstrumentedMutex<T> {
+    const WARN_LOCK_TIME: Duration = Duration::from_millis(10);
+
+    pub fn new(t: T) -> Self {
+        let id = ID_GENERATOR.fetch_add(1, Ordering::Relaxed);
+        Self {
+            id,
+            inner: Arc::new(Mutex::new(t)),
+        }
+    }
+
+    pub fn lock(&self, caller: &'static str) -> InstrumentedMutexGuard<'_, T> {
+        let start_acquire = Instant::now();
+        let guard = self.inner.lock();
+        let acquire_time = Instant::now();
+        let duration = acquire_time
+            .checked_duration_since(start_acquire)
+            .unwrap_or_default();
+        if duration > Self::WARN_LOCK_TIME {
+            tracing::warn!(
+                caller,
+                lock_id = self.id,
+                ?duration,
+                "slow lock acquisition!"
+            )
+        }
+        InstrumentedMutexGuard {
+            caller,
+            lock_id: self.id,
+            acquire_time,
+            guard,
+        }
+    }
+
+    /// Return the enclosed data if and only if there is exactly one strong reference
+    pub fn try_into_inner(self) -> Option<T> {
+        Arc::into_inner(self.inner).map(|m| m.into_inner())
+    }
+}
+
+pub struct InstrumentedMutexGuard<'a, T> {
+    caller: &'static str,
+    lock_id: u64,
+    acquire_time: Instant,
+    guard: parking_lot::MutexGuard<'a, T>,
+}
+
+impl<'a, T: 'a> std::ops::Deref for InstrumentedMutexGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.deref()
+    }
+}
+
+impl<'a, T: 'a> std::ops::DerefMut for InstrumentedMutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.guard.deref_mut()
+    }
+}
+
+impl<'a, T> InstrumentedMutexGuard<'a, T> {}
+
+impl<'a, T> Drop for InstrumentedMutexGuard<'a, T> {
+    fn drop(&mut self) {
+        let duration = self.acquire_time.elapsed();
+        if duration > InstrumentedMutex::<T>::WARN_LOCK_TIME {
+            tracing::warn!(
+                caller = self.caller,
+                lock_id = self.lock_id,
+                ?duration,
+                "lock held for a long time"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InstrumentedMutex;
+    use std::{
+        sync::{Arc, Barrier},
+        time::Duration,
+    };
+    use tracing_test::traced_test;
+
+    #[test]
+    fn test_deref_impls() {
+        let mutex = InstrumentedMutex::new(0);
+        let mut guard = mutex.lock("caller");
+        assert_eq!(*guard, 0);
+        *guard = 1;
+        assert_eq!(*guard, 1);
+        drop(guard);
+        assert_eq!(mutex.try_into_inner(), Some(1));
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_does_not_log_when_held_briefly() {
+        let mutex = InstrumentedMutex::new("foo");
+        let guard = mutex.lock("key");
+        assert_eq!(*guard, "foo");
+        drop(guard);
+        assert!(!logs_contain("lock held for a long time"));
+        assert!(!logs_contain("slow lock acquisition"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_does_log_when_held_for_a_long_time() {
+        let mutex = InstrumentedMutex::new("foo");
+        let guard = mutex.lock("key");
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(*guard, "foo");
+        drop(guard);
+        assert!(logs_contain("lock held for a long time"));
+        assert!(!logs_contain("slow lock acquisition"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_does_log_when_waiting_for_a_long_time() {
+        let mutex1 = InstrumentedMutex::new("foo");
+        let span = tracing::Span::current();
+        std::thread::scope(|s| {
+            let barrier = Arc::new(Barrier::new(2));
+            let barrier2 = Arc::clone(&barrier);
+            let mutex2 = mutex1.clone();
+            let span2 = span.clone();
+            s.spawn(move || {
+                // need to propagate the tracing span for traced_test to work
+                let _g = span.entered();
+                let _guard = mutex1.lock("thread 1");
+                barrier.wait();
+                std::thread::sleep(Duration::from_millis(100));
+            });
+            s.spawn(move || {
+                // need to propagate the tracing span for traced_test to work
+                let _g = span2.entered();
+                barrier2.wait();
+                let _guard = mutex2.lock("thread 2");
+            });
+        });
+        assert!(logs_contain("slow lock acquisition"));
+    }
+}

--- a/crates/coyote-core/src/lib.rs
+++ b/crates/coyote-core/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 pub mod backoff;
+pub mod instrumented_mutex;
 mod monotime;
 pub mod shutdown;
 pub mod types;

--- a/crates/coyote-core/src/types/mod.rs
+++ b/crates/coyote-core/src/types/mod.rs
@@ -100,6 +100,12 @@ macro_rules! string_wrapper_impl {
             }
         }
 
+        impl AsRef<str> for $name_id {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
         impl std::fmt::Display for $name_id {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 self.0.fmt(f)

--- a/crates/coyote-namespace/Cargo.toml
+++ b/crates/coyote-namespace/Cargo.toml
@@ -13,6 +13,7 @@ fjall-utils.workspace = true
 jiff.workspace = true
 schemars.workspace = true
 serde.workspace = true
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/coyote-namespace/src/entities.rs
+++ b/crates/coyote-namespace/src/entities.rs
@@ -41,7 +41,9 @@ pub enum EvictionPolicy {
     LeastRecentlyUsed,
 }
 
-pub trait ModuleConfig: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned {
+pub trait ModuleConfig:
+    Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync
+{
     fn module() -> Module;
 
     fn eviction_policy(&self) -> EvictionPolicy {

--- a/crates/coyote-namespace/src/operations/create_namespace.rs
+++ b/crates/coyote-namespace/src/operations/create_namespace.rs
@@ -34,7 +34,7 @@ pub struct CreateNamespaceOutput<C: ModuleConfig> {
     pub updated_at: Timestamp,
 }
 
-impl<C: ModuleConfig> CreateNamespace<C> {
+impl<C: ModuleConfig + 'static> CreateNamespace<C> {
     pub fn new(
         name: String,
         config: C,
@@ -49,6 +49,17 @@ impl<C: ModuleConfig> CreateNamespace<C> {
         }
     }
 
+    pub async fn async_apply_operation(
+        self,
+        state: &State,
+        timestamp: Timestamp,
+    ) -> Result<CreateNamespaceOutput<C>> {
+        let db = state.db().clone();
+        let keyspace = state.keyspace().clone();
+        tokio::task::spawn_blocking(move || self.apply_operation_inner(&db, &keyspace, timestamp))
+            .await?
+    }
+
     pub fn apply_operation(
         self,
         state: &State,
@@ -56,6 +67,15 @@ impl<C: ModuleConfig> CreateNamespace<C> {
     ) -> Result<CreateNamespaceOutput<C>> {
         let db = state.db();
         let keyspace = state.keyspace();
+        self.apply_operation_inner(db, keyspace, timestamp)
+    }
+
+    fn apply_operation_inner(
+        self,
+        db: &fjall::Database,
+        keyspace: &fjall::Keyspace,
+        timestamp: Timestamp,
+    ) -> Result<CreateNamespaceOutput<C>> {
         let namespace = match Namespace::<C>::fetch(keyspace, &self.name)? {
             Some(mut namespace) => {
                 namespace.storage_type = self.storage_type;

--- a/crates/idempotency/src/operations/abort.rs
+++ b/crates/idempotency/src/operations/abort.rs
@@ -23,22 +23,23 @@ impl AbortOperation {
 }
 
 impl AbortOperation {
-    fn apply_real(self, state: &IdempotencyRaftState<'_>) -> Result<()> {
+    async fn apply_real(self, state: &IdempotencyRaftState<'_>) -> Result<()> {
         state
             .state
             .controller(self.storage_type)
-            .delete(self.namespace_id, &self.key)?;
+            .delete(self.namespace_id, self.key)
+            .await?;
 
         Ok(())
     }
 }
 
 impl IdempotencyRequest for AbortOperation {
-    fn apply(
+    async fn apply(
         self,
         state: IdempotencyRaftState<'_>,
         _ctx: &coyote_operations::OpContext,
     ) -> AbortResponse {
-        AbortResponse(self.apply_real(&state))
+        AbortResponse(self.apply_real(&state).await)
     }
 }

--- a/crates/idempotency/src/operations/clear_expired.rs
+++ b/crates/idempotency/src/operations/clear_expired.rs
@@ -20,22 +20,21 @@ impl ClearExpiredOperation {
 }
 
 impl ClearExpiredOperation {
-    fn apply_real(self, state: &State, timestamp: jiff::Timestamp) -> Result<()> {
-        state.controller(self.storage_type).clear_expired(
-            timestamp,
-            self.max_expirations,
-            self.storage_type,
-        )?;
+    async fn apply_real(self, state: &State, timestamp: jiff::Timestamp) -> Result<()> {
+        state
+            .controller(self.storage_type)
+            .clear_expired(timestamp, self.max_expirations, self.storage_type)
+            .await?;
         Ok(())
     }
 }
 
 impl IdempotencyRequest for ClearExpiredOperation {
-    fn apply(
+    async fn apply(
         self,
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp))
+        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp).await)
     }
 }

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -35,39 +35,43 @@ impl CompleteOperation {
 }
 
 impl CompleteOperation {
-    fn apply_real(
+    async fn apply_real(
         self,
         state: &IdempotencyRaftState<'_>,
         now: Timestamp,
         log_index: u64,
     ) -> Result<()> {
         let expiry = now + self.ttl_seconds;
-        state.state.controller(self.storage_type).set(
-            self.namespace_id,
-            &self.key,
-            KvModelIn {
-                value: IdempotencyState::Completed {
-                    response: self.response,
-                }
-                .into(),
-                expiry: Some(expiry),
-                version: None,
-            },
-            OperationBehavior::Upsert,
-            now,
-            log_index,
-        )?;
+        state
+            .state
+            .controller(self.storage_type)
+            .set(
+                self.namespace_id,
+                self.key,
+                KvModelIn {
+                    value: IdempotencyState::Completed {
+                        response: self.response,
+                    }
+                    .into(),
+                    expiry: Some(expiry),
+                    version: None,
+                },
+                OperationBehavior::Upsert,
+                now,
+                log_index,
+            )
+            .await?;
 
         Ok(())
     }
 }
 
 impl IdempotencyRequest for CompleteOperation {
-    fn apply(
+    async fn apply(
         self,
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CompleteResponse {
-        CompleteResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index))
+        CompleteResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
     }
 }

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -40,13 +40,13 @@ impl CreateIdempotencyOperation {
         }
     }
 
-    fn apply_real(
+    async fn apply_real(
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
     ) -> coyote_operations::Result<CreateIdempotencyResponseData> {
         let op: CreateNamespace<IdempotencyConfig> = self.into();
-        let out = op.apply_operation(namespace_state, now)?;
+        let out = op.async_apply_operation(namespace_state, now).await?;
         Ok(out.into())
     }
 }
@@ -73,11 +73,11 @@ impl From<CreateNamespaceOutput<IdempotencyConfig>> for CreateIdempotencyRespons
 }
 
 impl IdempotencyRequest for CreateIdempotencyOperation {
-    fn apply(
+    async fn apply(
         self,
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CreateIdempotencyResponse {
-        CreateIdempotencyResponse(self.apply_real(state.namespace, ctx.timestamp))
+        CreateIdempotencyResponse(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/idempotency/src/operations/mod.rs
+++ b/crates/idempotency/src/operations/mod.rs
@@ -13,14 +13,14 @@ pub use try_start::{TryStartOperation, TryStartResponseData};
 
 pub use create_namespace::{CreateIdempotencyOperation, CreateIdempotencyResponseData};
 
-use coyote_operations::raft_module_operations;
+use coyote_operations::async_raft_module_operations;
 
 pub struct IdempotencyRaftState<'a> {
     pub state: &'a State,
     pub namespace: &'a coyote_namespace::State,
 }
 
-raft_module_operations!(
+async_raft_module_operations!(
     IdempotencyRequest,
     IdempotencyOperation {
         TryStart(TryStartOperation) -> TryStartResponseData,

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -33,7 +33,7 @@ pub struct TryStartResponseData {
 }
 
 impl TryStartOperation {
-    fn apply_real(
+    async fn apply_real(
         self,
         state: &IdempotencyRaftState<'_>,
         now: Timestamp,
@@ -43,20 +43,25 @@ impl TryStartOperation {
 
         let controller = state.state.controller(self.storage_type);
 
-        match controller.fetch(self.namespace_id, &self.key, now)? {
+        match controller
+            .fetch(self.namespace_id, self.key.clone(), now)
+            .await?
+        {
             None => {
-                controller.set(
-                    self.namespace_id,
-                    &self.key,
-                    KvModelIn {
-                        value: IdempotencyState::InProgress.into(),
-                        expiry: Some(expiry),
-                        version: None,
-                    },
-                    OperationBehavior::Insert,
-                    now,
-                    log_index,
-                )?;
+                controller
+                    .set(
+                        self.namespace_id,
+                        self.key,
+                        KvModelIn {
+                            value: IdempotencyState::InProgress.into(),
+                            expiry: Some(expiry),
+                            version: None,
+                        },
+                        OperationBehavior::Insert,
+                        now,
+                        log_index,
+                    )
+                    .await?;
                 Ok(TryStartResponseData {
                     result: IdempotencyStartResult::Started,
                 })
@@ -76,11 +81,11 @@ impl TryStartOperation {
 }
 
 impl IdempotencyRequest for TryStartOperation {
-    fn apply(
+    async fn apply(
         self,
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> TryStartResponse {
-        TryStartResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index))
+        TryStartResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
     }
 }

--- a/crates/kv/Cargo.toml
+++ b/crates/kv/Cargo.toml
@@ -15,7 +15,6 @@ fjall.workspace = true
 fjall-utils.workspace = true
 itertools.workspace = true
 jiff.workspace = true
-parking_lot.workspace = true
 schemars.workspace = true
 serde.workspace = true
 tap.workspace = true

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -1,15 +1,12 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
+use coyote_core::instrumented_mutex::{InstrumentedMutex, InstrumentedMutexGuard};
 use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
-use fjall::{KeyspaceCreateOptions, KvSeparationOptions};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, KvSeparationOptions};
 use fjall_utils::{StorageType, TableRow, WriteBatchExt};
 use itertools::Itertools;
 use jiff::Timestamp;
-use parking_lot::{Mutex, MutexGuard};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -63,13 +60,13 @@ impl From<KvPairRow> for KvModel {
 
 #[derive(Clone)]
 pub struct KvController {
-    db: Arc<Mutex<fjall::Database>>,
-    keyspace: fjall::Keyspace,
+    db: InstrumentedMutex<Database>,
+    keyspace: Keyspace,
     keyspace_name: &'static str,
 }
 
 impl KvController {
-    pub fn new(db: fjall::Database, keyspace_name: &'static str) -> Self {
+    pub fn new(db: Database, keyspace_name: &'static str) -> Self {
         let tables = {
             let opts = KeyspaceCreateOptions::default()
                 .with_kv_separation(Some(KvSeparationOptions::default()));
@@ -77,21 +74,20 @@ impl KvController {
         };
 
         Self {
-            db: Arc::new(Mutex::new(db)),
+            db: InstrumentedMutex::new(db),
             keyspace: tables,
             keyspace_name,
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn fetch(
-        &self,
+    #[tracing::instrument(skip(keyspace))]
+    fn fetch_inner(
+        keyspace: &Keyspace,
         namespace_id: NamespaceId,
         key: &str,
         now: Timestamp,
     ) -> Result<Option<KvModel>> {
-        let Some(data) = KvPairRow::fetch(&self.keyspace, KvPairRow::key_for(namespace_id, key))?
-        else {
+        let Some(data) = KvPairRow::fetch(keyspace, KvPairRow::key_for(namespace_id, key))? else {
             return Ok(None);
         };
 
@@ -102,9 +98,23 @@ impl KvController {
         Ok(Some(data.into()))
     }
 
-    fn insert_with_expiration(
+    #[tracing::instrument(skip(self))]
+    pub async fn fetch<K: AsRef<str> + std::fmt::Debug + 'static + Send>(
         &self,
-        db: MutexGuard<'_, fjall::Database>,
+        namespace_id: NamespaceId,
+        key: K,
+        now: Timestamp,
+    ) -> Result<Option<KvModel>> {
+        let keyspace = self.keyspace.clone();
+        tokio::task::spawn_blocking(move || {
+            Self::fetch_inner(&keyspace, namespace_id, key.as_ref(), now)
+        })
+        .await?
+    }
+
+    fn insert_with_expiration(
+        db: InstrumentedMutexGuard<'_, Database>,
+        keyspace: &Keyspace,
         namespace_id: NamespaceId,
         key: &str,
         model: KvModel,
@@ -117,12 +127,12 @@ impl KvController {
             version: model.version,
         };
 
-        batch.insert_row(&self.keyspace, KvPairRow::key_for(namespace_id, key), &row)?;
+        batch.insert_row(keyspace, KvPairRow::key_for(namespace_id, key), &row)?;
 
         if let Some(expiry) = row.expiry {
             let expiration_row = ExpirationRow::new();
             let key = ExpirationRow::key_for(namespace_id, expiry, key);
-            batch.insert_row(&self.keyspace, key, &expiration_row)?;
+            batch.insert_row(keyspace, key, &expiration_row)?;
         }
 
         batch.commit()?;
@@ -131,103 +141,119 @@ impl KvController {
     }
 
     #[tracing::instrument(skip(self, model))]
-    pub fn set(
+    pub async fn set<K: AsRef<str> + std::fmt::Debug + 'static + Send>(
         &self,
         namespace_id: NamespaceId,
-        key: &str,
+        key: K,
         model: KvModelIn,
         behavior: OperationBehavior,
         now: Timestamp,
         // This is a monotonically increasing global counter (e.g. raft offset)
         global_counter: u64,
     ) -> Result<KvSetResult> {
-        let mut current = None;
-        // OCC check: if the caller supplied an expected version, verify it.
-        if let Some(expected) = model.version {
-            current = self.fetch(namespace_id, key, now)?;
-            let current_version = current.as_ref().map(|m| m.version).unwrap_or(0);
-            if current_version != expected {
-                return Err(Error::bad_request("version_mismatch", "version mismatch"));
-            }
-        }
+        let db = self.db.clone();
+        let keyspace = self.keyspace.clone();
 
-        let new_version = global_counter + 1;
-
-        let new_model = KvModel {
-            value: model.value,
-            expiry: model.expiry,
-            version: new_version,
-        };
-
-        let db = self.db.lock();
-
-        match behavior {
-            OperationBehavior::Upsert => {
-                self.insert_with_expiration(db, namespace_id, key, new_model)?;
-            }
-            OperationBehavior::Insert => {
-                current = if current.is_some() {
-                    current
-                } else {
-                    self.fetch(namespace_id, key, now)?
-                };
-
-                if let Some(current) = current {
-                    return Ok(KvSetResult {
-                        version: current.version,
-                        success: false,
-                    });
-                } else {
-                    self.insert_with_expiration(db, namespace_id, key, new_model)?;
+        tokio::task::spawn_blocking(move || {
+            let key = key.as_ref();
+            let mut current = None;
+            // OCC check: if the caller supplied an expected version, verify it.
+            if let Some(expected) = model.version {
+                current = Self::fetch_inner(&keyspace, namespace_id, key, now)?;
+                let current_version = current.as_ref().map(|m| m.version).unwrap_or(0);
+                if current_version != expected {
+                    return Err(Error::bad_request("version_mismatch", "version mismatch"));
                 }
             }
-            OperationBehavior::Update => {
-                current = if current.is_some() {
-                    current
-                } else {
-                    self.fetch(namespace_id, key, now)?
-                };
-                let exists = current.is_some();
 
-                if exists {
-                    self.insert_with_expiration(db, namespace_id, key, new_model)?;
-                } else {
-                    return Ok(KvSetResult {
-                        version: 0,
-                        success: false,
-                    });
+            let new_version = global_counter + 1;
+
+            let new_model = KvModel {
+                value: model.value,
+                expiry: model.expiry,
+                version: new_version,
+            };
+
+            let db = db.lock("kvcontroller::set");
+
+            match behavior {
+                OperationBehavior::Upsert => {
+                    Self::insert_with_expiration(db, &keyspace, namespace_id, key, new_model)?;
                 }
-            }
-        };
+                OperationBehavior::Insert => {
+                    current = if current.is_some() {
+                        current
+                    } else {
+                        Self::fetch_inner(&keyspace, namespace_id, key, now)?
+                    };
 
-        Ok(KvSetResult {
-            version: new_version,
-            success: true,
+                    if let Some(current) = current {
+                        return Ok(KvSetResult {
+                            version: current.version,
+                            success: false,
+                        });
+                    } else {
+                        Self::insert_with_expiration(db, &keyspace, namespace_id, key, new_model)?;
+                    }
+                }
+                OperationBehavior::Update => {
+                    current = if current.is_some() {
+                        current
+                    } else {
+                        Self::fetch_inner(&keyspace, namespace_id, key, now)?
+                    };
+                    let exists = current.is_some();
+
+                    if exists {
+                        Self::insert_with_expiration(db, &keyspace, namespace_id, key, new_model)?;
+                    } else {
+                        return Ok(KvSetResult {
+                            version: 0,
+                            success: false,
+                        });
+                    }
+                }
+            };
+
+            Ok(KvSetResult {
+                version: new_version,
+                success: true,
+            })
         })
+        .await?
     }
 
     #[tracing::instrument(skip(self))]
-    pub fn delete(&self, namespace_id: NamespaceId, key: &str) -> Result<bool> {
-        let db = self.db.lock();
+    pub async fn delete<T: AsRef<str> + std::fmt::Debug + 'static + Send>(
+        &self,
+        namespace_id: NamespaceId,
+        key: T,
+    ) -> Result<bool> {
+        let db = self.db.clone();
+        let keyspace = self.keyspace.clone();
 
-        if let Some(data) = KvPairRow::fetch(&self.keyspace, KvPairRow::key_for(namespace_id, key))?
-        {
-            let mut batch = db.batch();
+        tokio::task::spawn_blocking(move || {
+            let db = db.lock("kvcontroller::delete");
+            let key = key.as_ref();
 
-            // Delete from the expiration keyspace
-            if let Some(expiry) = data.expiry {
-                batch.remove_row(
-                    &self.keyspace,
-                    ExpirationRow::key_for(namespace_id, expiry, key),
-                )?;
+            if let Some(data) = KvPairRow::fetch(&keyspace, KvPairRow::key_for(namespace_id, key))?
+            {
+                let mut batch = db.batch();
+
+                // Delete from the expiration keyspace
+                if let Some(expiry) = data.expiry {
+                    batch
+                        .remove_row(&keyspace, ExpirationRow::key_for(namespace_id, expiry, key))?;
+                }
+                batch.remove_row(&keyspace, KvPairRow::key_for(namespace_id, key))?;
+
+                batch.commit()?;
+                Ok(true)
+            } else {
+                Ok(false)
             }
-            batch.remove_row(&self.keyspace, KvPairRow::key_for(namespace_id, key))?;
-
-            batch.commit()?;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        })
+        .await?
     }
 
     pub fn iter(&self) -> Result<impl Iterator<Item = KvPairRow>> {
@@ -252,7 +278,7 @@ impl KvController {
         keyspace_name = self.keyspace_name,
         cleared,
     ))]
-    pub fn clear_expired(
+    pub async fn clear_expired(
         &self,
         now: Timestamp,
         max_expirations: usize,
@@ -262,27 +288,35 @@ impl KvController {
             ExpirationRow::key_for(NamespaceId::nil(), Timestamp::UNIX_EPOCH, "").into_fjall_key();
         let end = ExpirationRow::key_for(NamespaceId::max(), now, "").into_fjall_key();
 
-        let mut cleared = 0;
         let start_time = Instant::now();
 
-        for chunk in &self
-            .keyspace
-            .range(start..=end)
-            .take(max_expirations)
-            .chunks(EXPIRATION_BATCH_SIZE)
-        {
-            let db = self.db.lock();
-            let mut batch = db.batch();
-            for item in chunk {
-                cleared += 1;
-                let k = item.key()?;
-                let (namespace_id, main_key) = ExpirationRow::extract_key_from_fjall_key(&k)?;
-                batch.remove_row(&self.keyspace, KvPairRow::key_for(namespace_id, main_key))?;
+        let keyspace = self.keyspace.clone();
+        let db = self.db.clone();
 
-                batch.remove(&self.keyspace, k);
+        let cleared = tokio::task::spawn_blocking(move || {
+            let mut cleared = 0;
+
+            for chunk in &keyspace
+                .range(start..=end)
+                .take(max_expirations)
+                .chunks(EXPIRATION_BATCH_SIZE)
+            {
+                let db = db.lock("kvcontroller::clear_expired");
+                let mut batch = db.batch();
+                for item in chunk {
+                    cleared += 1;
+                    let k = item.key()?;
+                    let (namespace_id, main_key) = ExpirationRow::extract_key_from_fjall_key(&k)?;
+                    batch.remove_row(&keyspace, KvPairRow::key_for(namespace_id, main_key))?;
+
+                    batch.remove(&keyspace, k);
+                }
+                batch.commit()?;
             }
-            batch.commit()?;
-        }
+
+            Ok::<_, Error>(cleared)
+        })
+        .await??;
 
         if cleared == max_expirations {
             tracing::warn!(cleared, elapsed=?start_time.elapsed(), "expiration loop is not keeping up");
@@ -331,7 +365,7 @@ impl KvController {
             let start_batch = Instant::now();
             let num_this_batch = tracing::debug_span!("clear_expired_in_background:remove_chunk")
                 .in_scope(|| {
-                let db = self.db.lock();
+                let db = self.db.lock("kv_controller::clear_expired_in_background");
                 let start_lock = Instant::now();
                 let mut batch = db.batch();
                 let mut num_this_batch = 0;
@@ -389,7 +423,7 @@ mod tests {
     impl SetupFixture {
         fn new() -> Self {
             let workdir = tempfile::tempdir().unwrap();
-            let db = fjall::Database::builder(workdir.as_ref())
+            let db = Database::builder(workdir.as_ref())
                 .temporary(true)
                 .open()
                 .unwrap();
@@ -405,19 +439,22 @@ mod tests {
         NamespaceId::nil()
     }
 
-    fn key_exists_as_of(controller: &KvController, key: &str, now: Timestamp) -> bool {
-        controller.fetch(ns(), key, now).unwrap().is_some()
+    async fn key_exists_as_of(controller: &KvController, key: &str, now: Timestamp) -> bool {
+        let key = key.to_string();
+        controller.fetch(ns(), key, now).await.unwrap().is_some()
     }
 
-    fn key_exists(controller: &KvController, key: &str) -> bool {
+    async fn key_exists(controller: &KvController, key: &str) -> bool {
+        let key = key.to_string();
         controller
             .fetch(ns(), key, Timestamp::now())
+            .await
             .unwrap()
             .is_some()
     }
 
-    #[test]
-    fn test_insert_and_get() {
+    #[tokio::test]
+    async fn test_insert_and_get() {
         let setup = SetupFixture::new();
         let controller = setup.controller;
 
@@ -435,99 +472,118 @@ mod tests {
                 Timestamp::now(),
                 0,
             )
+            .await
             .unwrap();
 
-        assert!(key_exists(&controller, "test:key1"));
+        assert!(key_exists(&controller, "test:key1").await);
         let retrieved = controller
             .fetch(ns(), "test:key1", Timestamp::now())
+            .await
             .unwrap();
         assert!(retrieved.is_some());
         let retrieved = retrieved.unwrap();
         assert_eq!(retrieved.value, b"hello world");
         assert_eq!(retrieved.expiry, None);
 
-        assert!(!key_exists(&controller, "nonexistent:key"));
+        assert!(!key_exists(&controller, "nonexistent:key").await);
     }
 
-    #[test]
-    fn test_insert_behaviors() {
+    #[tokio::test]
+    async fn test_insert_behaviors() {
         let setup = SetupFixture::new();
         let controller = setup.controller;
 
         // Update on non-existent key returns false
-        let res = controller.set(
-            ns(),
-            "key1",
-            KvModelIn {
-                value: b"key1 updated".to_vec(),
-                expiry: None,
-                version: None,
-            },
-            OperationBehavior::Update,
-            Timestamp::now(),
-            0,
-        );
+        let res = controller
+            .set(
+                ns(),
+                "key1",
+                KvModelIn {
+                    value: b"key1 updated".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
+                OperationBehavior::Update,
+                Timestamp::now(),
+                0,
+            )
+            .await;
         assert!(!res.unwrap().success);
-        assert!(!key_exists(&controller, "key1"));
+        assert!(!key_exists(&controller, "key1").await);
 
-        let res = controller.set(
-            ns(),
-            "key1",
-            KvModelIn {
-                value: b"key1 inserted".to_vec(),
-                expiry: None,
-                version: None,
-            },
-            OperationBehavior::Insert,
-            Timestamp::now(),
-            0,
-        );
+        let res = controller
+            .set(
+                ns(),
+                "key1",
+                KvModelIn {
+                    value: b"key1 inserted".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
+                OperationBehavior::Insert,
+                Timestamp::now(),
+                0,
+            )
+            .await;
         assert!(res.unwrap().success);
-        assert!(key_exists(&controller, "key1"));
-        let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
+        assert!(key_exists(&controller, "key1").await);
+        let result = controller
+            .fetch(ns(), "key1", Timestamp::now())
+            .await
+            .unwrap();
         assert!(result.is_some());
 
         // Insert on existing key returns false
-        let res = controller.set(
-            ns(),
-            "key1",
-            KvModelIn {
-                value: b"another value".to_vec(),
-                expiry: None,
-                version: None,
-            },
-            OperationBehavior::Insert,
-            Timestamp::now(),
-            0,
-        );
+        let res = controller
+            .set(
+                ns(),
+                "key1",
+                KvModelIn {
+                    value: b"another value".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
+                OperationBehavior::Insert,
+                Timestamp::now(),
+                0,
+            )
+            .await;
         assert!(!res.unwrap().success);
-        assert!(key_exists(&controller, "key1"));
-        let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
+        assert!(key_exists(&controller, "key1").await);
+        let result = controller
+            .fetch(ns(), "key1", Timestamp::now())
+            .await
+            .unwrap();
         assert!(result.is_some());
 
         assert_eq!(result.unwrap().value, b"key1 inserted");
 
-        let res = controller.set(
-            ns(),
-            "key1",
-            KvModelIn {
-                value: b"key1 upserted".to_vec(),
-                expiry: None,
-                version: None,
-            },
-            OperationBehavior::Upsert,
-            Timestamp::now(),
-            0,
-        );
+        let res = controller
+            .set(
+                ns(),
+                "key1",
+                KvModelIn {
+                    value: b"key1 upserted".to_vec(),
+                    expiry: None,
+                    version: None,
+                },
+                OperationBehavior::Upsert,
+                Timestamp::now(),
+                0,
+            )
+            .await;
         assert!(res.unwrap().success);
-        assert!(key_exists(&controller, "key1"));
-        let result = controller.fetch(ns(), "key1", Timestamp::now()).unwrap();
+        assert!(key_exists(&controller, "key1").await);
+        let result = controller
+            .fetch(ns(), "key1", Timestamp::now())
+            .await
+            .unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().value, b"key1 upserted");
     }
 
-    #[test]
-    fn test_overwrite() {
+    #[tokio::test]
+    async fn test_overwrite() {
         let setup = SetupFixture::new();
         let controller = setup.controller;
 
@@ -545,6 +601,7 @@ mod tests {
                 Timestamp::now(),
                 0,
             )
+            .await
             .unwrap();
         controller
             .set(
@@ -559,18 +616,20 @@ mod tests {
                 Timestamp::now(),
                 0,
             )
+            .await
             .unwrap();
 
-        assert!(key_exists(&controller, "overwrite:key"));
+        assert!(key_exists(&controller, "overwrite:key").await);
         let retrieved = controller
             .fetch(ns(), "overwrite:key", Timestamp::now())
+            .await
             .unwrap()
             .unwrap();
         assert_eq!(retrieved.value, b"second value");
     }
 
-    #[test]
-    fn test_clear_expired_removes_expired_entries() {
+    #[tokio::test]
+    async fn test_clear_expired_removes_expired_entries() {
         let setup = SetupFixture::new();
         let controller = setup.controller;
 
@@ -589,6 +648,7 @@ mod tests {
                 now,
                 0,
             )
+            .await
             .unwrap();
 
         let expired_models = [
@@ -613,7 +673,7 @@ mod tests {
             controller
                 .set(
                     ns(),
-                    key,
+                    key.to_string(),
                     KvModelIn {
                         value: value.to_vec(),
                         expiry: Some(*expiry),
@@ -623,6 +683,7 @@ mod tests {
                     now,
                     0,
                 )
+                .await
                 .unwrap();
         }
 
@@ -640,6 +701,7 @@ mod tests {
                 now,
                 0,
             )
+            .await
             .unwrap();
 
         let permanent_key = "permanent:key";
@@ -656,49 +718,55 @@ mod tests {
                 now,
                 0,
             )
+            .await
             .unwrap();
 
         assert_eq!(controller.iter().unwrap().count(), 6);
 
         // the key should have expired by now, so key_exists should already be false
-        assert!(!key_exists(&controller, "expired:key"));
+        assert!(!key_exists(&controller, "expired:key").await);
         let then = Timestamp::now().checked_sub(6.hours()).unwrap();
         // but if we time travel to the past, it should still be there
-        assert!(key_exists_as_of(&controller, "expired:key", then));
+        assert!(key_exists_as_of(&controller, "expired:key", then).await);
         for (key, _, _) in &expired_models {
-            assert!(key_exists_as_of(&controller, key, then));
+            assert!(key_exists_as_of(&controller, key, then).await);
         }
 
         assert_eq!(
             controller
                 .clear_expired(Timestamp::now(), 100, StorageType::Persistent)
+                .await
                 .unwrap(),
             4
         );
 
         for (key, _, _) in &expired_models {
             // now it should really and truly be gone
-            assert!(!key_exists(&controller, key));
-            assert!(!key_exists_as_of(&controller, key, then));
+            assert!(!key_exists(&controller, key).await);
+            assert!(!key_exists_as_of(&controller, key, then).await);
         }
-        assert!(!key_exists(&controller, "expired:key"));
-        assert!(!key_exists_as_of(&controller, "expired:key", then));
+        assert!(!key_exists(&controller, "expired:key").await);
+        assert!(!key_exists_as_of(&controller, "expired:key", then).await);
 
-        assert!(key_exists(&controller, valid_key));
-        let valid = controller.fetch(ns(), valid_key, Timestamp::now()).unwrap();
+        assert!(key_exists(&controller, valid_key).await);
+        let valid = controller
+            .fetch(ns(), valid_key, Timestamp::now())
+            .await
+            .unwrap();
         assert!(valid.is_some());
         assert_eq!(valid.unwrap().value, b"valid data");
 
-        assert!(key_exists(&controller, permanent_key));
+        assert!(key_exists(&controller, permanent_key).await);
         let permanent = controller
             .fetch(ns(), permanent_key, Timestamp::now())
+            .await
             .unwrap();
         assert!(permanent.is_some());
         assert_eq!(permanent.unwrap().value, b"permanent data");
     }
 
-    #[test]
-    fn test_clear_expired_in_background_removes_expired_entries() {
+    #[tokio::test]
+    async fn test_clear_expired_in_background_removes_expired_entries() {
         let setup = SetupFixture::new();
         let controller = setup.controller;
 
@@ -717,6 +785,7 @@ mod tests {
                 now,
                 0,
             )
+            .await
             .unwrap();
 
         let expired_models = [
@@ -746,7 +815,7 @@ mod tests {
             controller
                 .set(
                     ns(),
-                    key,
+                    key.to_string(),
                     KvModelIn {
                         value: value.to_vec(),
                         expiry: Some(*expiry),
@@ -756,6 +825,7 @@ mod tests {
                     now,
                     0,
                 )
+                .await
                 .unwrap();
         }
 
@@ -773,6 +843,7 @@ mod tests {
                 now,
                 0,
             )
+            .await
             .unwrap();
 
         let permanent_key = "permanent:key";
@@ -789,17 +860,18 @@ mod tests {
                 now,
                 0,
             )
+            .await
             .unwrap();
 
         assert_eq!(controller.iter().unwrap().count(), 7);
 
         // the key should have expired by now, so key_exists should already be false
-        assert!(!key_exists(&controller, "expired:key"));
+        assert!(!key_exists(&controller, "expired:key").await);
         let then = Timestamp::now().checked_sub(6.hours()).unwrap();
         // but if we time travel to the past, it should still be there
-        assert!(key_exists_as_of(&controller, "expired:key", then));
+        assert!(key_exists_as_of(&controller, "expired:key", then).await);
         for (key, _, _) in &expired_models {
-            assert!(key_exists_as_of(&controller, key, then));
+            assert!(key_exists_as_of(&controller, key, then).await);
         }
 
         assert_eq!(
@@ -811,25 +883,29 @@ mod tests {
 
         for (key, _, _) in &expired_models {
             // now it should really and truly be gone
-            assert!(!key_exists(&controller, key));
+            assert!(!key_exists(&controller, key).await);
             if *key == "expired:key:4" {
                 // this one is in the grace period
-                assert!(key_exists_as_of(&controller, key, then));
+                assert!(key_exists_as_of(&controller, key, then).await);
             } else {
-                assert!(!key_exists_as_of(&controller, key, then));
+                assert!(!key_exists_as_of(&controller, key, then).await);
             }
         }
-        assert!(!key_exists(&controller, "expired:key"));
-        assert!(!key_exists_as_of(&controller, "expired:key", then));
+        assert!(!key_exists(&controller, "expired:key").await);
+        assert!(!key_exists_as_of(&controller, "expired:key", then).await);
 
-        assert!(key_exists(&controller, valid_key));
-        let valid = controller.fetch(ns(), valid_key, Timestamp::now()).unwrap();
+        assert!(key_exists(&controller, valid_key).await);
+        let valid = controller
+            .fetch(ns(), valid_key, Timestamp::now())
+            .await
+            .unwrap();
         assert!(valid.is_some());
         assert_eq!(valid.unwrap().value, b"valid data");
 
-        assert!(key_exists(&controller, permanent_key));
+        assert!(key_exists(&controller, permanent_key).await);
         let permanent = controller
             .fetch(ns(), permanent_key, Timestamp::now())
+            .await
             .unwrap();
         assert!(permanent.is_some());
         assert_eq!(permanent.unwrap().value, b"permanent data");

--- a/crates/kv/src/operations/clear_expired.rs
+++ b/crates/kv/src/operations/clear_expired.rs
@@ -20,22 +20,21 @@ impl ClearExpiredOperation {
 }
 
 impl ClearExpiredOperation {
-    fn apply_real(self, state: &State, timestamp: jiff::Timestamp) -> Result<()> {
-        state.controller(self.storage_type).clear_expired(
-            timestamp,
-            self.max_expirations,
-            self.storage_type,
-        )?;
+    async fn apply_real(self, state: &State, timestamp: jiff::Timestamp) -> Result<()> {
+        state
+            .controller(self.storage_type)
+            .clear_expired(timestamp, self.max_expirations, self.storage_type)
+            .await?;
         Ok(())
     }
 }
 
 impl KvRequest for ClearExpiredOperation {
-    fn apply(
+    async fn apply(
         self,
         state: KvRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp))
+        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp).await)
     }
 }

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -40,13 +40,13 @@ impl CreateKvOperation {
         }
     }
 
-    fn apply_real(
+    async fn apply_real(
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
     ) -> coyote_operations::Result<CreateKvResponseData> {
         let op: CreateNamespace<KeyValueConfig> = self.into();
-        let out = op.apply_operation(namespace_state, now)?;
+        let out = op.async_apply_operation(namespace_state, now).await?;
         Ok(out.into())
     }
 }
@@ -73,7 +73,11 @@ impl From<CreateNamespaceOutput<KeyValueConfig>> for CreateKvResponseData {
 }
 
 impl KvRequest for CreateKvOperation {
-    fn apply(self, state: KvRaftState<'_>, ctx: &coyote_operations::OpContext) -> CreateKvResponse {
-        CreateKvResponse(self.apply_real(state.namespace, ctx.timestamp))
+    async fn apply(
+        self,
+        state: KvRaftState<'_>,
+        ctx: &coyote_operations::OpContext,
+    ) -> CreateKvResponse {
+        CreateKvResponse(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -29,16 +29,21 @@ impl DeleteOperation {
 }
 
 impl DeleteOperation {
-    fn apply_real(self, state: &State) -> Result<DeleteResponseData> {
+    async fn apply_real(self, state: &State) -> Result<DeleteResponseData> {
         let success = state
             .controller(self.storage_type)
-            .delete(self.namespace_id, &self.key)?;
+            .delete(self.namespace_id, self.key)
+            .await?;
         Ok(DeleteResponseData { success })
     }
 }
 
 impl KvRequest for DeleteOperation {
-    fn apply(self, state: KvRaftState<'_>, _ctx: &coyote_operations::OpContext) -> DeleteResponse {
-        DeleteResponse(self.apply_real(state.state))
+    async fn apply(
+        self,
+        state: KvRaftState<'_>,
+        _ctx: &coyote_operations::OpContext,
+    ) -> DeleteResponse {
+        DeleteResponse(self.apply_real(state.state).await)
     }
 }

--- a/crates/kv/src/operations/mod.rs
+++ b/crates/kv/src/operations/mod.rs
@@ -10,14 +10,14 @@ pub use create_namespace::{CreateKvOperation, CreateKvResponseData};
 pub use delete::{DeleteOperation, DeleteResponseData};
 pub use set::{SetOperation, SetResponseData};
 
-use coyote_operations::raft_module_operations;
+use coyote_operations::async_raft_module_operations;
 
 pub struct KvRaftState<'a> {
     pub state: &'a State,
     pub namespace: &'a coyote_namespace::State,
 }
 
-raft_module_operations!(
+async_raft_module_operations!(
     KvRequest,
     KvOperation {
         Set(SetOperation) -> SetResponseData,

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -56,15 +56,18 @@ impl SetOperation {
 }
 
 impl SetOperation {
-    fn apply_real(self, state: &State, ctx: &OpContext) -> Result<SetResponseData> {
-        let result = state.controller(self.storage_type).set(
-            self.namespace_id,
-            &self.key,
-            self.model,
-            self.behavior,
-            ctx.timestamp,
-            ctx.log_index,
-        )?;
+    async fn apply_real(self, state: &State, ctx: &OpContext) -> Result<SetResponseData> {
+        let result = state
+            .controller(self.storage_type)
+            .set(
+                self.namespace_id,
+                self.key,
+                self.model,
+                self.behavior,
+                ctx.timestamp,
+                ctx.log_index,
+            )
+            .await?;
         Ok(SetResponseData {
             success: result.success,
             version: result.version,
@@ -73,7 +76,7 @@ impl SetOperation {
 }
 
 impl KvRequest for SetOperation {
-    fn apply(self, state: KvRaftState<'_>, ctx: &OpContext) -> SetResponse {
-        SetResponse(self.apply_real(state.state, ctx))
+    async fn apply(self, state: KvRaftState<'_>, ctx: &OpContext) -> SetResponse {
+        SetResponse(self.apply_real(state.state, ctx).await)
     }
 }

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -59,7 +59,7 @@ async fn apply_request_with_context(
                 state: &stores.kv_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Kv(req.apply(state, &context))
+            Response::Kv(req.apply(state, &context).await)
         }
         Request::RateLimit(req) => {
             let stores = state_machine.db_handle();
@@ -75,7 +75,7 @@ async fn apply_request_with_context(
                 state: &stores.idempotency_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Idempotency(req.apply(state, &context))
+            Response::Idempotency(req.apply(state, &context).await)
         }
         Request::Cache(req) => {
             let stores = state_machine.db_handle();
@@ -83,7 +83,7 @@ async fn apply_request_with_context(
                 state: &stores.cache_state,
                 namespace: &state_machine.state.namespace_state,
             };
-            Response::Cache(req.apply(state, &context))
+            Response::Cache(req.apply(state, &context).await)
         }
         Request::Msgs(req) => {
             let stores = state_machine.db_handle();

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -208,7 +208,7 @@ impl Store {
         self.cluster_id.as_ref()
     }
 
-    pub fn db_handle(&self) -> impl std::ops::Deref<Target = Stores> {
+    pub fn db_handle(&self) -> impl std::ops::Deref<Target = Stores> + Send {
         self.stores.read_arc()
     }
 

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -171,7 +171,9 @@ async fn cache_get(
     let cache_state = coyote_cache::State::init(state.do_not_use_dbs.clone())?;
     let controller = cache_state.controller(namespace.storage_type);
 
-    let model = controller.fetch(namespace.id, &data.key, repl.time.last())?;
+    let model = controller
+        .fetch(namespace.id, data.key, repl.time.last())
+        .await?;
 
     let ret = match model {
         Some(m) => CacheGetOut::from_model(m),

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -150,7 +150,9 @@ async fn kv_get(
     let kv_state = coyote_kv::State::init(state.do_not_use_dbs.clone())?;
     let controller = kv_state.controller(namespace.storage_type);
 
-    let model = controller.fetch(namespace.id, &data.key, repl.time.last())?;
+    let model = controller
+        .fetch(namespace.id, data.key, repl.time.last())
+        .await?;
 
     let ret = match model {
         Some(m) => KvGetOut::from_model(m),


### PR DESCRIPTION
This makes kv, cache, and idempotency fully async, using `tokio::task::spwan_blocking` internally to hide the synchronous fjall operations.

I also added a mutex type that logs when it's held for too long so we can try to track down things blocking forward progress.

I haven't yet done rate-limiter or msgs.

Part of #491