### PR TITLE
rust: Derive Default for structs with no required fields

### DIFF
--- a/clients/rust/src/models/cache_get_out.rs
+++ b/clients/rust/src/models/cache_get_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CacheGetOut {
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/clients/rust/src/models/cache_set_out.rs
+++ b/clients/rust/src/models/cache_set_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CacheSetOut {}
 
 impl CacheSetOut {

--- a/clients/rust/src/models/idempotency_abort_out.rs
+++ b/clients/rust/src/models/idempotency_abort_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct IdempotencyAbortOut {}
 
 impl IdempotencyAbortOut {

--- a/clients/rust/src/models/idempotency_complete_out.rs
+++ b/clients/rust/src/models/idempotency_complete_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct IdempotencyCompleteOut {}
 
 impl IdempotencyCompleteOut {

--- a/clients/rust/src/models/msg_queue_ack_out.rs
+++ b/clients/rust/src/models/msg_queue_ack_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MsgQueueAckOut {}
 
 impl MsgQueueAckOut {

--- a/clients/rust/src/models/msg_queue_nack_out.rs
+++ b/clients/rust/src/models/msg_queue_nack_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MsgQueueNackOut {}
 
 impl MsgQueueNackOut {

--- a/clients/rust/src/models/msg_queue_redrive_dlq_out.rs
+++ b/clients/rust/src/models/msg_queue_redrive_dlq_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MsgQueueRedriveDlqOut {}
 
 impl MsgQueueRedriveDlqOut {

--- a/clients/rust/src/models/msg_stream_commit_out.rs
+++ b/clients/rust/src/models/msg_stream_commit_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MsgStreamCommitOut {}
 
 impl MsgStreamCommitOut {

--- a/clients/rust/src/models/msg_stream_seek_out.rs
+++ b/clients/rust/src/models/msg_stream_seek_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MsgStreamSeekOut {}
 
 impl MsgStreamSeekOut {

--- a/clients/rust/src/models/rate_limit_reset_out.rs
+++ b/clients/rust/src/models/rate_limit_reset_out.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct RateLimitResetOut {}
 
 impl RateLimitResetOut {

--- a/clients/rust/src/models/retention.rs
+++ b/clients/rust/src/models/retention.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Retention {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub millis: Option<u64>,

--- a/codegen/templates/rust/types/struct.rs.jinja
+++ b/codegen/templates/rust/types/struct.rs.jinja
@@ -13,6 +13,9 @@ use super::{
 #[derive(
     Clone,
     Debug,
+    {%- if type.fields | selectattr("required") | length == 0 %}
+    Default,
+    {%- endif %}
     Deserialize,
     {%- if not has_positional_fields %}
     Serialize,


### PR DESCRIPTION
Fixes yet another compile error on Tom's auth branch.