### PR TITLE
codegen: Refactor positional field handling

### DIFF
--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -68,10 +68,8 @@ impl {{ resource_type_name }}Commands {
                     {% if op.request_body_schema_name is defined -%}
                         {# positional body parameters -#}
                         {% set body_schema = api.types[op.request_body_schema_name] -%}
-                        {% for field in body_schema.fields -%}
-                        {% if field.positional -%}
+                        {% for field in body_schema.fields | selectattr("positional") -%}
                             {{ field.name | to_snake_case }},
-                        {% endif -%}
                         {% endfor -%}
 
                         {# body parameter struct -#}
@@ -94,10 +92,8 @@ impl {{ resource_type_name }}Commands {
                                 {# positional body parameters -#}
                                 {% set body_schema = api.types[op.request_body_schema_name] -%}
                                 {% set body_schema_all_optional = body_schema.fields | selectattr("required") | length == 0 %}
-                                {% for field in body_schema.fields -%}
-                                {% if field.positional -%}
+                                {% for field in body_schema.fields | selectattr("positional") -%}
                                     {{ field.name | to_snake_case }},
-                                {% endif -%}
                                 {% endfor -%}
 
                                 {# body parameter struct -#}

--- a/codegen/templates/go/api_resource.go.jinja
+++ b/codegen/templates/go/api_resource.go.jinja
@@ -63,11 +63,9 @@ func ({{ resource_self_name }} {{ resource_type_name }}) {{ op.name | to_upper_c
 	{%- if op.request_body_schema_name is defined %}
 		{# positional body parameters -#}
 		{% set body_schema = api.types[op.request_body_schema_name] -%}
-		{% set has_positional_fields = body_schema.fields | selectattr("positional") | length > 0 -%}
-		{% for field in body_schema.fields -%}
-			{% if field.positional -%}
+		{% set positional_fields = body_schema.fields | selectattr("positional") -%}
+		{% for field in positional_fields -%}
 			{{ field.name | to_lower_camel_case }} {{ field.type.to_go() }},
-			{% endif -%}
 		{% endfor -%}
 
 		{# body parameter interface -#}
@@ -76,7 +74,7 @@ func ({{ resource_self_name }} {{ resource_type_name }}) {{ op.name | to_upper_c
 ) {{ func_ret_type }} {
 	{# body parameter -#}
 	{% if op.request_body_schema_name is defined -%}
-		{% if has_positional_fields -%}
+		{% if positional_fields | length > 0 -%}
 	body := coyote_models.{{ op.request_body_schema_name }}_{
 		{%- for field in body_schema.fields %}
 			{{ field.name | to_upper_camel_case }}:
@@ -97,7 +95,7 @@ func ({{ resource_self_name }} {{ resource_type_name }}) {{ op.name | to_upper_c
 	{% if op.request_body_schema_name is defined -%}
 		{% set generics -%}
 			coyote_models.{{ op.request_body_schema_name }}
-			{%- if has_positional_fields %}_{% endif %}, {{ ret_type }}
+			{%- if positional_fields | length > 0 %}_{% endif %}, {{ ret_type }}
 		{%- endset -%}
 	{% else -%}
 		{% set generics -%}any, {{ ret_type }}{% endset -%}

--- a/codegen/templates/go/types/struct.go.jinja
+++ b/codegen/templates/go/types/struct.go.jinja
@@ -1,5 +1,5 @@
 {% set type_name = type.name | to_upper_camel_case -%}
-{% set has_positional_fields = type.fields | selectattr("positional") | length > 0 -%}
+{% set positional_fields = type.fields | selectattr("positional") -%}
 import (
 	"time"
 
@@ -10,29 +10,27 @@ import (
 {{ type.description | to_doc_comment(style="go")}}
 {% endif -%}
 type {{ type_name }} struct {
-	{%- for field in type.fields %}
-		{%- if not field.positional %}
-			{%- set f_name = field.name | to_upper_camel_case %}
-			{%- set f_type = field.type.to_go() %}
-			{%- set json_annotation = "" %}
-			{%- if (not field.required or field.nullable) %}
-				{%- set json_annotation = ",omitempty" %}
-				{%- if not field.type.is_set() and not field.type.is_list() %}
-					{%- set f_type %}*{{ f_type }}{% endset %}
-				{%- endif %}
+	{%- for field in type.fields | selectattr("positional", "false") %}
+		{%- set f_name = field.name | to_upper_camel_case %}
+		{%- set f_type = field.type.to_go() %}
+		{%- set json_annotation = "" %}
+		{%- if (not field.required or field.nullable) %}
+			{%- set json_annotation = ",omitempty" %}
+			{%- if not field.type.is_set() and not field.type.is_list() %}
+				{%- set f_type %}*{{ f_type }}{% endset %}
 			{%- endif %}
-			{%- if field.description is defined and "\n" in field.description %}
-	{{ field.description | to_doc_comment(style="go") | indent(4) }}
-			{%- endif %}
-	{{ f_name }} {{ f_type }} `json:"{{ field.name }}{{ json_annotation }}"`
-			{%- if field.description is defined and "\n" not in field.description -%}
-			{{ field.description | to_doc_comment(style="go") }}
-			{%- endif %}
+		{%- endif %}
+		{%- if field.description is defined and "\n" in field.description %}
+{{ field.description | to_doc_comment(style="go") | indent(4) }}
+		{%- endif %}
+{{ f_name }} {{ f_type }} `json:"{{ field.name }}{{ json_annotation }}"`
+		{%- if field.description is defined and "\n" not in field.description -%}
+		{{ field.description | to_doc_comment(style="go") }}
 		{%- endif %}
 	{%- endfor %}
 }
 
-{%- if has_positional_fields %}
+{%- if positional_fields | length > 0 %}
 
 type {{ type_name }}_ struct {
 	{% include "types/struct_fields.go.jinja" -%}

--- a/codegen/templates/java/api_resource.java.jinja
+++ b/codegen/templates/java/api_resource.java.jinja
@@ -52,8 +52,8 @@ public class {{ resource_type_name }} {
 
         {#- positional body parameters #}
         {%- set body_schema = api.types[op.request_body_schema_name] %}
-        {%- set has_positional_fields = body_schema.fields | selectattr("positional") | length > 0 %}
-        {%- for field in body_schema.fields | selectattr("positional") %}
+        {%- set positional_fields = body_schema.fields | selectattr("positional") %}
+        {%- for field in positional_fields %}
         {{ field.type.to_java() }} {{ field.name | to_lower_camel_case }},
         {%- endfor %}
 
@@ -69,7 +69,7 @@ public class {{ resource_type_name }} {
 
         {#- request body #}
         {%- if op.request_body_schema_name is defined %}
-            {%- if has_positional_fields %}
+            {%- if positional_fields | length > 0 %}
         {{ op.request_body_schema_name }}_ body = new {{ op.request_body_schema_name }}_(
         {%- set args %}
         {%- for field in body_schema.fields %}
@@ -106,9 +106,9 @@ public class {{ resource_type_name }} {
         );
     }
 
-    {%- if has_positional_fields and
+    {%- if positional_fields is defined and
         (body_schema.fields | selectattr("required") | length)
-            == (body_schema.fields | selectattr("positional") | length) %}
+            == (positional_fields | length) %}
     {#- if all required body parameters are positional, generate
         an extra overload without the body parameter interface #}
 
@@ -119,7 +119,7 @@ public class {{ resource_type_name }} {
     public {{ res_type }} {{ method_name }}(
         {%- set func_args %}
         {#- positional body parameters #}
-        {%- for field in body_schema.fields | selectattr("positional") %}
+        {%- for field in positional_fields %}
         {{ field.type.to_java() }} {{ field.name | to_lower_camel_case }},
         {%- endfor %}
         {% endset -%}
@@ -127,7 +127,7 @@ public class {{ resource_type_name }} {
     ) {{ throws }} {
         {% if res_type != "void" %}return {% endif -%}
         this.{{ method_name }}(
-            {%- for field in body_schema.fields | selectattr("positional") %}
+            {%- for field in positional_fields %}
             {{ field.name | to_lower_camel_case }},
             {%- endfor %}
             new {{ op.request_body_schema_name }}()

--- a/codegen/templates/java/types/struct.java.jinja
+++ b/codegen/templates/java/types/struct.java.jinja
@@ -1,5 +1,5 @@
 {% set class_name = type.name | to_upper_camel_case -%}
-{% set has_positional_fields = type.fields | selectattr("positional") | length > 0 -%}
+{% set positional_fields = type.fields | selectattr("positional") -%}
 {% macro fromJson_toJson(ty) -%}
     /**
      * Create an instance of {{ ty }} given a JSON string
@@ -152,13 +152,13 @@ public class {{ class_name }} {
     {%- endif %}
     {%- endif %}
 {%- endfor %}
-{%- if not has_positional_fields %}
+{%- if positional_fields | length == 0 %}
 
     {{ fromJson_toJson(class_name) }}
 {%- endif %}
 }
 
-{%- if has_positional_fields %}
+{%- if positional_fields | length > 0 %}
 {%- set extra_class_decl -%}
 // this file is @generated
 package com.svix.coyote.models;

--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -31,11 +31,9 @@ export class {{ resource_type_name }} {
     {%- if op.request_body_schema_name is defined %}
         {# positional body parameters -#}
         {% set body_schema = api.types[op.request_body_schema_name] -%}
-        {% set has_positional_fields = body_schema.fields | selectattr("positional") | length > 0 -%}
-        {% for field in body_schema.fields -%}
-        {% if field.positional -%}
+        {% set positional_fields = body_schema.fields | selectattr("positional") -%}
+        {% for field in positional_fields -%}
             {{ field.name | to_snake_case }}: {{ field.type.to_js() }},
-        {% endif -%}
         {% endfor -%}
 
         {# body parameter interface -#}
@@ -47,14 +45,12 @@ export class {{ resource_type_name }} {
 
         {# body parameter -#}
         {% if op.request_body_schema_name is defined -%}
-        {% if has_positional_fields -%}
+        {% if positional_fields | length > 0 -%}
         {% set body -%}
             {
                 ...{{ req_body_schema_name }},
-            {%- for field in body_schema.fields %}
-                {%- if field.positional %}
+            {%- for field in positional_fields %}
                 {{ field.name | to_snake_case }},
-                {%- endif %}
             {%- endfor %}
             }
         {%- endset -%}

--- a/codegen/templates/javascript/types/struct.ts.jinja
+++ b/codegen/templates/javascript/types/struct.ts.jinja
@@ -6,10 +6,9 @@ import {
 } from './{{ c | to_lower_camel_case }}';
 {% endfor -%}
 {% set type_name = type.name | to_upper_camel_case -%}
-{% set has_positional_fields = type.fields | selectattr("positional") | length > 0 -%}
-{% set has_non_positional_fields = type.fields | selectattr("positional", "false") | length > 0 -%}
+{% set positional_fields = type.fields | selectattr("positional") -%}
 
-{% if not has_non_positional_fields -%}
+{% if type.fields | selectattr("positional", "false") | length == 0 -%}
 // biome-ignore-all lint/suspicious/noEmptyInterface: forwards compat
 {% endif -%}
 
@@ -29,7 +28,7 @@ export interface {{ type_name }} {
 {%- endfor %}
 }
 
-{% if has_positional_fields -%}
+{% if positional_fields | length > 0 -%}
 export interface {{ type_name }}_ {
     {%- include "types/struct_fields.ts.jinja" %}
 }
@@ -37,7 +36,7 @@ export interface {{ type_name }}_ {
 {% endif -%}
 
 export const {{ type_name }}Serializer = {
-    {% if has_positional_fields %}{% set type_name = type_name ~ "_" %}{% endif -%}
+    {% if positional_fields | length > 0 %}{% set type_name = type_name ~ "_" %}{% endif -%}
     {% set underscore_prefix %}{% if type.fields | length == 0%}_{% endif %}{% endset -%}
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject({{ underscore_prefix }}object: any): {{ type_name }} {

--- a/codegen/templates/python/api_resource.py.jinja
+++ b/codegen/templates/python/api_resource.py.jinja
@@ -59,17 +59,15 @@ class {{ resource.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}
         {% set req_body_schema_snake = op.request_body_schema_name | to_snake_case -%}
         {# positional body parameters -#}
         {% set body_schema = api.types[op.request_body_schema_name] -%}
-        {% set has_positional_fields = body_schema.fields | selectattr("positional") | length > 0 -%}
-        {% for field in body_schema.fields -%}
-        {% if field.positional -%}
+        {% set positional_fields = body_schema.fields | selectattr("positional") -%}
+        {% for field in positional_fields -%}
         {{ field.name | to_snake_case }}: {{ field.type.to_python() }},
-        {% endif -%}
         {% endfor -%}
         {#- body parameter struct #}
         {{ req_body_schema_snake }}: {{ op.request_body_schema_name }}
         {%- if
             (body_schema.fields | selectattr("required") | length)
-                == (body_schema.fields | selectattr("positional") | length)
+                == (positional_fields | length)
         %} = {{ op.request_body_schema_name }}()
         {%- endif %},
         {%- endif %}
@@ -85,7 +83,7 @@ class {{ resource.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}
             {%- endif -%}
         {%- endset %}
         {%- if op.request_body_schema_name is defined %}
-        body = {% if has_positional_fields -%}
+        body = {% if positional_fields | length > 0 -%}
         _{{ op.request_body_schema_name }}(
         {%- for field in body_schema.fields %}
             {% set field_name = field.name | to_snake_case -%}

--- a/codegen/templates/python/types/struct.py.jinja
+++ b/codegen/templates/python/types/struct.py.jinja
@@ -1,6 +1,5 @@
 {% set type_name = type.name | to_upper_camel_case -%}
-{% set has_positional_fields = type.fields | selectattr("positional") | length > 0 -%}
-{% set has_non_positional_fields = type.fields | selectattr("positional", "false") | length > 0 -%}
+{% set positional_fields = type.fields | selectattr("positional") -%}
 import typing as t
 from pydantic import Field
 from datetime import datetime
@@ -15,7 +14,7 @@ class {{ type_name }}(BaseModel):
 {%- if type.description is defined %}
     {{ type.description | to_doc_comment(style="python") | indent(4) }}
 {%- endif %}
-{%- if not has_non_positional_fields %}
+{%- if type.fields | selectattr("positional", "false") | length == 0 %}
     pass
 {%- endif %}
 {%- for field in type.fields %}
@@ -45,7 +44,7 @@ class {{ type_name }}(BaseModel):
     {%- endif %}
 {% endfor %}
 
-{%- if has_positional_fields %}
+{%- if positional_fields | length > 0 %}
 
 class _{{ type_name }}(BaseModel):
 {%- if type.fields | length == 0 %}

--- a/codegen/templates/rust/api_resource.rs.jinja
+++ b/codegen/templates/rust/api_resource.rs.jinja
@@ -47,14 +47,12 @@ impl<'a> {{ resource_type_name }}<'a> {
         {% if op.request_body_schema_name is defined -%}
             {# positional body parameters -#}
             {% set body_schema = api.types[op.request_body_schema_name] -%}
-            {% set has_positional_fields = body_schema.fields | selectattr("positional") | length > 0 -%}
-            {% if has_positional_fields -%}
+            {% set positional_fields = body_schema.fields | selectattr("positional") -%}
+            {% if positional_fields | length > 0 -%}
                 {% set unused_body_param_struct = body_schema.fields | selectattr("positional", "false") | length == 0 -%}
             {% endif -%}
-            {% for field in body_schema.fields -%}
-            {% if field.positional -%}
+            {% for field in positional_fields -%}
                 {{ field.name | to_snake_case }}: {{ field.type.to_rust() }},
-            {% endif -%}
             {% endfor -%}
 
             {#- body parameter struct -#}
@@ -64,7 +62,7 @@ impl<'a> {{ resource_type_name }}<'a> {
         {%- if unused_body_param_struct %}
         let _unused = {{ req_body_schema_name }};
         {%- endif %}
-        {%- if has_positional_fields %}
+        {%- if positional_fields is defined and positional_fields | length > 0 %}
         let {{ req_body_schema_name }} = {{ op.request_body_schema_name }}_{
             {% for field in body_schema.fields -%}
                 {% set field_name = field.name | to_snake_case -%}

--- a/codegen/templates/rust/types/struct.rs.jinja
+++ b/codegen/templates/rust/types/struct.rs.jinja
@@ -1,6 +1,6 @@
 {% from "types/macros.rs.jinja" import ident -%}
 {% set type_name = type.name | to_upper_camel_case -%}
-{% set has_positional_fields = type.fields | selectattr("positional") | length > 0 -%}
+{% set positional_fields = type.fields | selectattr("positional") -%}
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -17,7 +17,7 @@ use super::{
     Default,
     {%- endif %}
     Deserialize,
-    {%- if not has_positional_fields %}
+    {%- if positional_fields | length == 0 %}
     Serialize,
     {%- endif %}
 )]
@@ -96,7 +96,7 @@ impl {{ type_name }} {
     {% endfor -%}
 }
 
-{%- if has_positional_fields %}
+{%- if positional_fields | length > 0 %}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct {{ type_name }}_ {


### PR DESCRIPTION
Should also change the `struct_fields.{foo}.jinja` templates to by macros rather than includes, and reduce the amount of template code in the main `struct.{foo}.jinja` files with that, where applicable. Not this month though.