### PR TITLE
clippy: disallow jiff::Timestamp::now by default

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -2,3 +2,7 @@ disallowed-types = [
     { path = "axum::Json", replacement = "coyote_proto::MsgPackOrJson" },
     { path = "serde_json::Value", reason = "not compatible with msgpack" },
 ]
+
+disallowed-methods = [
+    { path = "jiff::Timestamp::now", reason = "generally, should be reading cluster Monotime" }
+]

--- a/clients/cli/src/cmds/cluster.rs
+++ b/clients/cli/src/cmds/cluster.rs
@@ -87,6 +87,7 @@ async fn print_status(
             Cell::new("Last Committed Timestamp").add_attribute(Attribute::Bold),
             Cell::new({
                 let ts = raw_status.this_node_last_committed_timestamp;
+                #[allow(clippy::disallowed_methods)]
                 let now = jiff::Timestamp::now();
                 if now > ts {
                     let ago = now - ts;

--- a/crates/coyote-core/src/monotime.rs
+++ b/crates/coyote-core/src/monotime.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 use jiff::Timestamp;
 use std::sync::{
     Arc,

--- a/crates/coyote-id/src/lib.rs
+++ b/crates/coyote-id/src/lib.rs
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn private_id_serde() {
-        let id = PrivateId::new(jiff::Timestamp::now());
+        let id = PrivateId::new(jiff::Timestamp::UNIX_EPOCH);
 
         assert_eq!(size_of_val(&id), 16); // 16 bytes, i.e. just a UUID
 
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn public_id_serde() {
-        let id = PublicId::new(jiff::Timestamp::now());
+        let id = PublicId::new(jiff::Timestamp::UNIX_EPOCH);
 
         assert_eq!(size_of_val(&id), 16); // 16 bytes, also just a UUID
 

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -374,6 +374,7 @@ impl KvController {
     }
 }
 
+#[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 mod tests {
     use coyote_id::NamespaceId;

--- a/crates/rate-limit/src/controller.rs
+++ b/crates/rate-limit/src/controller.rs
@@ -94,6 +94,7 @@ impl RateLimitController {
     }
 }
 
+#[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -317,6 +317,7 @@ async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {
     let leader = state.raft.current_leader().await;
     let me = state.node_id;
     let cluster_id = state.state_machine.cluster_id().await;
+    #[allow(clippy::disallowed_methods)]
     let wall_time = jiff::Timestamp::now();
     let monotonic_time = state.state_machine.time.last();
     state

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -353,6 +353,7 @@ pub(super) async fn run_background_jobs_on_all_nodes(
 
             let offset_to_purge = match purge_by {
                 PurgeBy::Time(duration) => {
+                    #[allow(clippy::disallowed_methods)]
                     let then = jiff::Timestamp::now() - duration;
                     handle
                         .state_machine

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -744,6 +744,7 @@ mod tests {
     #[tokio::test]
     async fn test_log_timestamps() -> TestResult {
         let context = TestContext::new();
+        #[allow(clippy::disallowed_methods)]
         let now = Timestamp::now();
         context
             .logs

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -55,6 +55,7 @@ pub(super) async fn initialize_cluster(
         .await?;
     let new_id = ClusterId::generate();
     tracing::info!(cluster_id=%new_id, "cluster initialized, setting cluster_id");
+    #[allow(clippy::disallowed_methods)]
     raft.client_write(RequestWithContext::new(
         Request::ClusterInternal(SetClusterUuidOperation(new_id).into()),
         jiff::Timestamp::now(),


### PR DESCRIPTION
follow-up to #528