### PR TITLE
devex: add vacuum-openapi to justfile; add missing docstrings

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,13 +2,43 @@ set quiet := true
 
 HERE := justfile_directory()
 
-lint:
+# run all lints
+[group('lint')]
+lint: clippy machete fmt sort vacuum-openapi
+
+# run clippy in --fix mode
+[group('lint')]
+clippy:
     # keep this beta to keep it in sync with CI
     cargo +beta clippy --workspace --fix --allow-dirty --all-features --all-targets
+
+# run cargo-machete in --fix mode
+[group('lint')]
+machete:
     cargo machete --fix
+
+# run cargo-fmt in --fix mode
+[group('lint')]
+fmt:
     # this has to be nightly to get import sorting working correctly
     cargo +nightly fmt
+
+# run cargo sort
+[group('lint')]
+sort:
     cargo sort --no-format --workspace -o package,lib,bin,features,dependencies,dev-dependencies,lints,workspace
+
+# run `vacuum` to check openapi
+[group('lint')]
+vacuum-openapi:
+    # keep this in sync with lint-openapi.yml
+    docker run --rm \
+            -v .:/work:ro \
+            dshanley/vacuum lint \
+            openapi.json \
+            --fail-severity error \
+            --ruleset .vacuum.yaml \
+            --min-score 0
 
 # Test the backend
 test *args='':
@@ -18,6 +48,7 @@ test *args='':
 test-sdks:
     cargo nextest run --package=coyote-client --package=coyote-cli
 
+# Invoke `docker-compose`
 [no-exit-message]
 test-dc *args='':
     docker compose -f {{ HERE / "testing-docker-compose.yml" }} {{ args }}
@@ -28,12 +59,14 @@ test-dc-rebuild service:
     docker compose -f {{ HERE / "testing-docker-compose.yml" }} rm -fs {{ service }}
     docker compose -f {{ HERE / "testing-docker-compose.yml" }} up --build -d {{ service }}
 
+# Generate all of the client libraries
 codegen:
     cargo codegen
 
 # Run all the test commands
 test-all: test test-sdks
 
+# Run benchmarks
 [working-directory('benchmarks')]
 bench:
     cargo bench


### PR DESCRIPTION
Changes:

 - breaks up lint into multiple rules so you can easily ru na single step
 - adds all the missing docstrings
 - adds vacuum-api command that matches CI

```
$ just -l
Available recipes:
    bench                   # Run benchmarks
    codegen                 # Generate all of the client libraries
    test *args=''           # Test the backend
    test-all                # Run all the test commands
    test-dc *args=''        # Invoke `docker-compose`
    test-dc-rebuild service # Rebuild a service in `docker compose`, leaving its volumes intact
    test-sdks               # Test the SDKs + CLI

    [lint]
    clippy                  # run clippy in --fix mode
    fmt                     # run cargo-fmt in --fix mode
    lint                    # run all lints
    machete                 # run cargo-machete in --fix mode
    sort                    # run cargo sort
    vacuum-openapi          # run `vacuum` to check openapi
```