### PR TITLE
Rate limit: add expiry to rate-limit keys.

### DIFF
--- a/crates/rate-limit/src/algorithms.rs
+++ b/crates/rate-limit/src/algorithms.rs
@@ -42,9 +42,17 @@ impl TokenBucket {
         (capacity, new_last_refill)
     }
 
-    pub(crate) fn calculate_retry_after(&self, current: u64, wanted: u64) -> Duration {
+    fn calculate_refill_duration(&self, current: u64, wanted: u64) -> Duration {
         let wanted = wanted.saturating_sub(current);
         let intervals = wanted.div_ceil(self.refill_rate);
         Duration::from_millis(intervals * self.refill_interval.as_millis())
+    }
+
+    pub(crate) fn calculate_retry_after(&self, current: u64, wanted: u64) -> Duration {
+        self.calculate_refill_duration(current, wanted)
+    }
+
+    pub(crate) fn calculate_when_full(&self, current: u64) -> Duration {
+        self.calculate_refill_duration(current, self.bucket_size)
     }
 }

--- a/crates/rate-limit/src/controller.rs
+++ b/crates/rate-limit/src/controller.rs
@@ -2,14 +2,16 @@ use std::time::Duration;
 
 use coyote_error::Result;
 use coyote_id::NamespaceId;
-use fjall_utils::TableRow;
+use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 
-use crate::{algorithms::TokenBucket, tables::TokenBucketRow};
+use crate::{
+    algorithms::TokenBucket,
+    tables::{ExpirationRow, TokenBucketRow},
+};
 
 #[derive(Clone)]
 pub struct RateLimitController {
-    #[allow(dead_code)]
     db: fjall::Database,
     tables: fjall::Keyspace,
 }
@@ -33,6 +35,7 @@ impl RateLimitController {
         .unwrap_or(TokenBucketRow {
             tokens: config.bucket_size,
             last_refill: now,
+            expiry: now,
         });
         Ok(config.get_new_capacity(bucket.tokens, now, bucket.last_refill))
     }
@@ -55,15 +58,26 @@ impl RateLimitController {
         }
 
         let remaining = capacity - wanted;
+        let expiry = now + config.calculate_when_full(capacity);
 
-        TokenBucketRow::insert(
+        let mut batch = self.db.batch();
+
+        batch.insert_row(
             &self.tables,
             TokenBucketRow::key_for(namespace_id, identifier),
             &TokenBucketRow {
                 tokens: remaining,
                 last_refill: new_last_refill,
+                expiry,
             },
         )?;
+        batch.insert_row(
+            &self.tables,
+            ExpirationRow::key_for(namespace_id, expiry, identifier),
+            &ExpirationRow {},
+        )?;
+
+        batch.commit()?;
 
         Ok((true, remaining, None))
     }
@@ -86,10 +100,28 @@ impl RateLimitController {
     }
 
     pub fn reset(&self, namespace_id: NamespaceId, identifier: &str) -> Result<()> {
-        TokenBucketRow::remove(
+        let row = TokenBucketRow::fetch(
             &self.tables,
             TokenBucketRow::key_for(namespace_id, identifier),
         )?;
+
+        if let Some(row) = row {
+            let mut batch = self.db.batch();
+
+            batch.remove_row(
+                &self.tables,
+                TokenBucketRow::key_for(namespace_id, identifier),
+            )?;
+            batch.remove_row(
+                &self.tables,
+                ExpirationRow::key_for(namespace_id, row.expiry, identifier),
+            )?;
+
+            batch.commit()?;
+        } else {
+            // FIXME: Should we error if not found?
+        }
+
         Ok(())
     }
 }

--- a/crates/rate-limit/src/tables.rs
+++ b/crates/rate-limit/src/tables.rs
@@ -1,3 +1,4 @@
+use coyote_error::{Result, ResultExt};
 use coyote_id::NamespaceId;
 use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
@@ -7,12 +8,14 @@ use serde::{Deserialize, Serialize};
 #[repr(u8)]
 enum RowType {
     TokenBucket = 0,
+    Expiration = 1,
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TokenBucketRow {
     pub tokens: u64,
     pub last_refill: Timestamp,
+    pub expiry: Timestamp,
 }
 
 impl TableRow for TokenBucketRow {
@@ -22,5 +25,47 @@ impl TableRow for TokenBucketRow {
 impl TokenBucketRow {
     pub(crate) fn key_for(namespace_id: NamespaceId, key: &str) -> TableKey<Self> {
         TableKey::init_key(Self::ROW_TYPE, &[namespace_id.as_bytes()], &[key])
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ExpirationRow {}
+
+impl ExpirationRow {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    pub(crate) fn key_for(
+        namespace_id: NamespaceId,
+        expiration_time: Timestamp,
+        key: &str,
+    ) -> TableKey<Self> {
+        let ts_ms = expiration_time.as_millisecond();
+        let ts_bytes = ts_ms.to_be_bytes();
+
+        TableKey::init_key(
+            Self::ROW_TYPE,
+            &[&ts_bytes, namespace_id.as_bytes()],
+            &[key],
+        )
+    }
+
+    pub(crate) fn extract_key_from_fjall_key(key: &fjall::UserKey) -> Result<(NamespaceId, &str)> {
+        let namespace_offset = 1 /* row_type */ + size_of::<i64>() /* timestamp */;
+        let fixed_sizes = namespace_offset + size_of::<NamespaceId>() /* namespace */;
+        let namespace_id =
+            NamespaceId::from_slice(&key[namespace_offset..fixed_sizes]).or_internal_error()?;
+        let main_key = str::from_utf8(&key[fixed_sizes..]).or_internal_error()?;
+        Ok((namespace_id, main_key))
+    }
+}
+
+impl TableRow for ExpirationRow {
+    const ROW_TYPE: u8 = RowType::Expiration as u8;
+
+    // We only store data in the keys
+    fn to_fjall_value(&self) -> Result<fjall::UserValue> {
+        Ok(b"".into())
     }
 }


### PR DESCRIPTION
Keys expire when they would have been completely full if we kept accounting of that. So essentially we calculate when they would be full, and set the expiry to that.