### PR TITLE
set up cargo-deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,10 @@ jobs:
           else
             echo 'all good.'
           fi
+  security-audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry_sdk",
  "parking_lot",
- "paste",
+ "pastey",
  "pnet",
  "rand 0.9.2",
  "regex",
@@ -1251,7 +1251,7 @@ dependencies = [
  "http-serde",
  "jiff",
  "opentelemetry",
- "paste",
+ "pastey",
  "serde",
  "tracing",
 ]
@@ -1612,7 +1612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1716,7 +1716,8 @@ dependencies = [
 [[package]]
 name = "dotenvy"
 version = "0.15.7"
-source = "git+https://github.com/svix-jbrown/dotenvy.git?rev=ffa0aa149e2c6da57113859001257f0d99b43431#ffa0aa149e2c6da57113859001257f0d99b43431"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtor"
@@ -3525,10 +3526,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ opentelemetry.workspace = true
 opentelemetry-http.workspace = true
 opentelemetry_sdk.workspace = true
 parking_lot.workspace = true
-paste.workspace = true
+pastey.workspace = true
 pnet.workspace = true
 rand.workspace = true
 regex.workspace = true
@@ -181,7 +181,7 @@ opentelemetry-otlp = { version = "0.31.0", default-features = false, features = 
 opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["metrics", "rt-tokio", "rt-tokio-current-thread", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
-paste = "1.0.15"
+pastey = "0.2"
 pnet = "0.35"
 proc-macro2 = "1.0.78"
 quote = "1.0.15"
@@ -274,6 +274,3 @@ strip = true
 coyote-client.opt-level = 2
 hyper.opt-level = 2
 tokio.opt-level = 2
-
-[patch.crates-io]
-dotenvy = { git = "https://github.com/svix-jbrown/dotenvy.git", rev = "ffa0aa149e2c6da57113859001257f0d99b43431" }

--- a/crates/coyote-operations/Cargo.toml
+++ b/crates/coyote-operations/Cargo.toml
@@ -14,7 +14,7 @@ http.workspace = true
 http-serde.workspace = true
 jiff.workspace = true
 opentelemetry.workspace = true
-paste.workspace = true
+pastey.workspace = true
 serde.workspace = true
 tracing.workspace = true
 

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -95,7 +95,7 @@ impl<T, M: ModuleRequest> OperationWriter<M> for T where
 /// Macro support module
 #[doc(hidden)]
 pub mod __reexports {
-    pub use paste;
+    pub use pastey;
     pub use serde;
 }
 

--- a/crates/coyote-operations/src/macros.rs
+++ b/crates/coyote-operations/src/macros.rs
@@ -29,7 +29,7 @@ macro_rules! raft_module_operations {
         state = $state_type:ty,
         response = $response_name:ident $(,)?
     ) => {
-        $crate::__reexports::paste::paste! {
+        $crate::__reexports::pastey::paste! {
             trait $trait_name: Into<$module_op_name> + $crate::OperationRequest
             where
                 Self: 'static,
@@ -154,7 +154,7 @@ macro_rules! async_raft_module_operations {
         state = $state_type:ty,
         response = $response_name:ident $(,)?
     ) => {
-        $crate::__reexports::paste::paste! {
+        $crate::__reexports::pastey::paste! {
             trait $trait_name: Into<$module_op_name> + $crate::OperationRequest
             where
                 Self: 'static,

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,50 @@
+[graph]
+targets = [
+    { triple = "x86_64-pc-windows-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" },
+]
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = []
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "bzip2-1.0.6",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0", # MIT No Attribution
+    "MPL-2.0",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+confidence-threshold = 0.8
+exceptions = []
+private.ignore = true
+unused-allowed-license = "allow"
+
+[bans]
+multiple-versions = "allow"
+wildcards = "allow"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ HERE := justfile_directory()
 
 # run all lints
 [group('lint')]
-lint: clippy machete fmt sort vacuum-openapi
+lint: clippy machete fmt sort vacuum-openapi audit
 
 # run clippy in --fix mode
 [group('lint')]
@@ -39,6 +39,11 @@ vacuum-openapi:
             --fail-severity error \
             --ruleset .vacuum.yaml \
             --min-score 0
+
+# run security lints
+[group('lint')]
+audit:
+    cargo deny check -c {{ HERE / "deny.toml" }}
 
 # Test the backend
 test *args='':

--- a/src/core/cluster/errors.rs
+++ b/src/core/cluster/errors.rs
@@ -2,7 +2,7 @@ use openraft::{AnyError, NodeId as RaftNodeId, StorageError, StorageIOError};
 
 macro_rules! build_openraft_storageio_error_helper {
     ($name:ident) => {
-        paste::paste! {
+        pastey::paste! {
             pub(crate) fn [< $name _err >]<N: RaftNodeId>(e: impl Into<AnyError>) -> StorageError<N> {
                 StorageError::IO {
                     source: StorageIOError::$name(e.into())


### PR DESCRIPTION
sets up `cargo-deny` and fixes the things it complains about (namely, removing my now-unneeded patch for dotenvy, and replacing paste with pastey).

branched off of #569