### PR TITLE
Namespace: rename created_at/updated_at to remove the suffix

### DIFF
--- a/crates/auth-token/src/operations/create_namespace.rs
+++ b/crates/auth-token/src/operations/create_namespace.rs
@@ -66,8 +66,8 @@ impl From<CreateNamespaceOutput<AuthTokenConfig>> for CreateAuthTokenNamespaceRe
             name: value.name,
             max_storage_bytes: value.max_storage_bytes,
             storage_type: value.storage_type,
-            created: value.created_at,
-            updated: value.updated_at,
+            created: value.created,
+            updated: value.updated,
         }
     }
 }

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -73,8 +73,8 @@ impl From<CreateNamespaceOutput<CacheConfig>> for CreateCacheResponseData {
             max_storage_bytes: value.max_storage_bytes,
             storage_type: value.storage_type,
             eviction_policy: value.config.eviction_policy,
-            created: value.created_at,
-            updated: value.updated_at,
+            created: value.created,
+            updated: value.updated,
         }
     }
 }

--- a/crates/coyote-namespace/src/operations/create_namespace.rs
+++ b/crates/coyote-namespace/src/operations/create_namespace.rs
@@ -30,8 +30,8 @@ pub struct CreateNamespaceOutput<C: ModuleConfig> {
     pub storage_type: StorageType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_storage_bytes: Option<NonZeroU64>,
-    pub created_at: Timestamp,
-    pub updated_at: Timestamp,
+    pub created: Timestamp,
+    pub updated: Timestamp,
 }
 
 impl<C: ModuleConfig + 'static> CreateNamespace<C> {
@@ -79,7 +79,7 @@ impl<C: ModuleConfig + 'static> CreateNamespace<C> {
         let namespace = match Namespace::<C>::fetch(keyspace, &self.name)? {
             Some(mut namespace) => {
                 namespace.storage_type = self.storage_type;
-                namespace.updated_at = timestamp;
+                namespace.updated = timestamp;
                 namespace.max_storage_bytes = self.max_storage_bytes;
                 namespace.config = self.config;
                 namespace
@@ -91,8 +91,8 @@ impl<C: ModuleConfig + 'static> CreateNamespace<C> {
                     name: self.name,
                     storage_type: self.storage_type,
                     max_storage_bytes: self.max_storage_bytes,
-                    created_at: timestamp,
-                    updated_at: timestamp,
+                    created: timestamp,
+                    updated: timestamp,
                     config: self.config,
                 }
             }
@@ -110,8 +110,8 @@ impl<C: ModuleConfig + 'static> CreateNamespace<C> {
             storage_type: namespace.storage_type,
             max_storage_bytes: namespace.max_storage_bytes,
             config: namespace.config,
-            created_at: namespace.created_at,
-            updated_at: namespace.updated_at,
+            created: namespace.created,
+            updated: namespace.updated,
         })
     }
 }

--- a/crates/coyote-namespace/src/tables.rs
+++ b/crates/coyote-namespace/src/tables.rs
@@ -24,8 +24,8 @@ pub struct Namespace<C: ModuleConfig> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_storage_bytes: Option<NonZeroU64>,
 
-    pub created_at: Timestamp,
-    pub updated_at: Timestamp,
+    pub created: Timestamp,
+    pub updated: Timestamp,
 
     // Module-specific
     pub config: C,

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -66,8 +66,8 @@ impl From<CreateNamespaceOutput<IdempotencyConfig>> for CreateIdempotencyRespons
             name: value.name,
             max_storage_bytes: value.max_storage_bytes,
             storage_type: value.storage_type,
-            created: value.created_at,
-            updated: value.updated_at,
+            created: value.created,
+            updated: value.updated,
         }
     }
 }

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -66,8 +66,8 @@ impl From<CreateNamespaceOutput<KeyValueConfig>> for CreateKvResponseData {
             name: value.name,
             max_storage_bytes: value.max_storage_bytes,
             storage_type: value.storage_type,
-            created: value.created_at,
-            updated: value.updated_at,
+            created: value.created,
+            updated: value.updated,
         }
     }
 }

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -68,8 +68,8 @@ impl From<CreateNamespaceOutput<StreamConfig>> for CreateNamespaceResponseData {
             name: value.name,
             retention: Retention { millis, bytes },
             storage_type: value.storage_type,
-            created: value.created_at,
-            updated: value.updated_at,
+            created: value.created,
+            updated: value.updated,
         }
     }
 }

--- a/crates/rate-limit/src/operations/create_namespace.rs
+++ b/crates/rate-limit/src/operations/create_namespace.rs
@@ -66,8 +66,8 @@ impl From<CreateNamespaceOutput<RateLimitConfig>> for CreateRateLimitResponseDat
             name: value.name,
             max_storage_bytes: value.max_storage_bytes,
             storage_type: value.storage_type,
-            created: value.created_at,
-            updated: value.updated_at,
+            created: value.created,
+            updated: value.updated,
         }
     }
 }

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -391,8 +391,8 @@ async fn auth_token_get_namespace(
         name: namespace.name,
         max_storage_bytes: namespace.max_storage_bytes,
         storage_type: namespace.storage_type,
-        created: namespace.created_at,
-        updated: namespace.updated_at,
+        created: namespace.created,
+        updated: namespace.updated,
     }))
 }
 

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -258,8 +258,8 @@ async fn cache_get_namespace(
         max_storage_bytes: namespace.max_storage_bytes,
         storage_type: namespace.storage_type,
         eviction_policy: namespace.config.eviction_policy,
-        created: namespace.created_at,
-        updated: namespace.updated_at,
+        created: namespace.created,
+        updated: namespace.updated,
     }))
 }
 

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -241,8 +241,8 @@ async fn idempotency_get_namespace(
         name: namespace.name,
         max_storage_bytes: namespace.max_storage_bytes,
         storage_type: namespace.storage_type,
-        created: namespace.created_at,
-        updated: namespace.updated_at,
+        created: namespace.created,
+        updated: namespace.updated,
     }))
 }
 

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -262,8 +262,8 @@ async fn kv_get_namespace(
         name: namespace.name,
         max_storage_bytes: namespace.max_storage_bytes,
         storage_type: namespace.storage_type,
-        created: namespace.created_at,
-        updated: namespace.updated_at,
+        created: namespace.created,
+        updated: namespace.updated,
     }))
 }
 

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -111,8 +111,8 @@ async fn get_namespace(
         name: namespace.name,
         retention: Retention { millis, bytes },
         storage_type: namespace.storage_type,
-        created: namespace.created_at,
-        updated: namespace.updated_at,
+        created: namespace.created,
+        updated: namespace.updated,
     }))
 }
 

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -277,8 +277,8 @@ async fn rate_limit_get_namespace(
         name: namespace.name,
         max_storage_bytes: namespace.max_storage_bytes,
         storage_type: namespace.storage_type,
-        created: namespace.created_at,
-        updated: namespace.updated_at,
+        created: namespace.created,
+        updated: namespace.updated,
     }))
 }
 


### PR DESCRIPTION
This was discussed in some rfc/discussion somewhere. We don't need the superfluous _at. Other modules similarly don't have it.