### PR TITLE
rename monotime functions

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -72,7 +72,7 @@ where
         .await
         .is_some()
     {
-        worker_loop(&state, &writer, time.last()).await?;
+        worker_loop(&state, &writer, time.now()).await?;
     }
 
     Ok(())

--- a/crates/coyote-core/src/monotime.rs
+++ b/crates/coyote-core/src/monotime.rs
@@ -10,7 +10,7 @@ use std::sync::{
 /// wall clock goes backwards, this will stall until the clock catches up.
 ///
 /// This structure is cheaply cloneable and clones all point at the same underlying data
-/// (internally, this is an Arc).
+/// (internally, this is an Arc). Time is stored with millisecond granularity.
 #[derive(Debug, Clone)]
 pub struct Monotime {
     time: Arc<AtomicI64>,
@@ -23,31 +23,37 @@ impl Monotime {
         }
     }
 
-    /// Get the last time that the leader set
-    pub fn last(&self) -> Timestamp {
+    /// Get the last time that the leader set.
+    ///
+    /// This time only advances when we receive a message through replication (which the Ticker
+    /// guarantees will be every several hundred milliseconds).
+    pub fn now(&self) -> Timestamp {
         Timestamp::from_millisecond(self.as_i64())
             .expect("time was wildly outside of acceptable ranges, I must crash")
     }
 
     /// Get a monotonic version of the current time, updating our internal knowledge about time.
-    pub fn now(&self) -> Timestamp {
-        Timestamp::from_millisecond(self.now_raw())
+    ///
+    /// This should only be called on the leader when generating a log message.
+    pub fn update_now(&self) -> Timestamp {
+        Timestamp::from_millisecond(self.update_now_raw())
             .expect("time was wildly outside of acceptable ranges, I must crash")
     }
 
-    /// Get a monotonic version of the current time as the number of millis since epoch, updating our internal knowledge about time.
-    fn now_raw(&self) -> i64 {
+    fn update_now_raw(&self) -> i64 {
         let now = Timestamp::now().as_millisecond();
         self.bump_raw(now)
     }
 
-    /// Ingest another timestamp
-    pub fn bump(&self, other: Timestamp) {
-        self.bump_raw(other.as_millisecond());
-    }
-
     fn bump_raw(&self, other: i64) -> i64 {
         self.time.fetch_max(other, Ordering::AcqRel).max(other)
+    }
+
+    /// Ingest another timestamp
+    ///
+    /// This should be applied when reading logs or joining a cluster.
+    pub fn update_from_other(&self, other: Timestamp) {
+        self.bump_raw(other.as_millisecond());
     }
 
     fn as_i64(&self) -> i64 {
@@ -64,7 +70,7 @@ impl Monotime {
         let millis: i64 = by.as_millis().try_into().expect("duration out of bounds");
         tracing::trace!(millis, "fast-forwarding time");
         self.time.fetch_add(millis, Ordering::AcqRel);
-        self.last()
+        self.now()
     }
 }
 
@@ -85,30 +91,30 @@ mod tests {
     fn test_basic_behavior() {
         let mt = Monotime::initial();
         // initially, it's empty
-        assert_eq!(mt.last(), Timestamp::UNIX_EPOCH);
+        assert_eq!(mt.now(), Timestamp::UNIX_EPOCH);
         // calling .now returns the current time and bumps `last`
         let now = Timestamp::now();
+        assert_approximately_equal(now, mt.update_now());
         assert_approximately_equal(now, mt.now());
-        assert_approximately_equal(now, mt.last());
         let future = now + Duration::from_mins(10);
         // bumping into the future prevents now from rewinding
-        mt.bump(future);
-        assert_approximately_equal(mt.last(), future);
+        mt.update_from_other(future);
         assert_approximately_equal(mt.now(), future);
+        assert_approximately_equal(mt.update_now(), future);
     }
 
     #[test]
     fn test_mockable_time() {
         let mt = Monotime::initial();
-        assert_eq!(mt.last(), Timestamp::UNIX_EPOCH);
+        assert_eq!(mt.now(), Timestamp::UNIX_EPOCH);
         mt.fast_forward(Duration::from_hours(1));
-        assert_eq!(mt.last().as_second(), 3600);
+        assert_eq!(mt.now().as_second(), 3600);
         // we can still keep moving forward, e.g., with now()
-        assert_approximately_equal(Timestamp::now(), mt.now());
+        assert_approximately_equal(Timestamp::now(), mt.update_now());
         mt.fast_forward(Duration::from_hours(1));
+        assert_approximately_equal(Timestamp::now() + Duration::from_hours(1), mt.update_now());
         assert_approximately_equal(Timestamp::now() + Duration::from_hours(1), mt.now());
-        assert_approximately_equal(Timestamp::now() + Duration::from_hours(1), mt.last());
         // running .now won't rewind us, monotonicity stands
-        assert!(mt.now() > Timestamp::now());
+        assert!(mt.update_now() > Timestamp::now());
     }
 }

--- a/crates/idempotency/src/lib.rs
+++ b/crates/idempotency/src/lib.rs
@@ -95,7 +95,7 @@ where
         .await
         .is_some()
     {
-        worker_loop(&state, &writer, time.last()).await?;
+        worker_loop(&state, &writer, time.now()).await?;
     }
 
     Ok(())

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -70,7 +70,7 @@ impl coyote_operations::workers::BackgroundWorker for AllNodesWorker {
             .await
             .is_some()
         {
-            self.worker_loop(self.time.last()).await?;
+            self.worker_loop(self.time.now()).await?;
         }
 
         Ok(())

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -111,7 +111,7 @@ impl TestServerBuilder {
         let base_uri = format!("http://{addr}/api/v1");
 
         let time = Monotime::initial();
-        time.now();
+        time.update_now();
 
         let server_handle = tokio::spawn({
             let cfg = cfg.clone();

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -319,7 +319,7 @@ async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {
     let cluster_id = state.state_machine.cluster_id().await;
     #[allow(clippy::disallowed_methods)]
     let wall_time = jiff::Timestamp::now();
-    let monotonic_time = state.state_machine.time.last();
+    let monotonic_time = state.state_machine.time.now();
     state
         .raft
         .with_raft_state(move |s| {

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -34,7 +34,7 @@ pub(super) async fn apply_request(
         child_span.set_attribute("hashed_key", Value::String(hash.into()));
     }
 
-    state_machine.time.bump(request.timestamp);
+    state_machine.time.update_from_other(request.timestamp);
 
     let context = coyote_operations::OpContext {
         timestamp: request.timestamp,

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -325,7 +325,7 @@ impl RaftState {
             > + Into<O::RequestParent>,
     {
         let inner: Request = op.into().into();
-        let now = self.time.now();
+        let now = self.time.update_now();
         let request =
             RequestWithContext::new(inner, now, Some(opentelemetry::Context::current().into()));
         let response = match self.raft.client_write(request.clone()).await {

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -204,7 +204,7 @@ mod tests {
             let edb = Database::builder(e_data_path).open()?;
 
             let time = coyote_core::Monotime::initial();
-            let _ = time.now();
+            let _ = time.update_now();
 
             let app_state: AppState = AppState::new(cfg, time.clone());
 

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -180,7 +180,7 @@ impl Store {
 
         if let Some(timestamp) = logs.get_last_timestamp().await? {
             // if we've ever committed anything, make sure we don't rewind time on restarting
-            time.bump(timestamp);
+            time.update_from_other(timestamp);
         }
 
         anyhow::ensure!(
@@ -702,7 +702,7 @@ impl StoreHandle {
     }
 
     pub fn now(&self) -> jiff::Timestamp {
-        self.time.now()
+        self.time.update_now()
     }
 
     pub(crate) async fn kv_store(&self) -> coyote_kv::State {

--- a/src/v1/endpoints/admin/cluster.rs
+++ b/src/v1/endpoints/admin/cluster.rs
@@ -135,7 +135,7 @@ async fn cluster_status(
         .then(|| app_state.cfg.cluster.name.to_owned());
     let this_node_id = repl.node_id;
 
-    let this_node_last_committed_timestamp = repl.time.last();
+    let this_node_last_committed_timestamp = repl.time.now();
 
     let nodes = futures_util::stream::iter(pnodes)
         .map(|peer| {

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -114,12 +114,12 @@ async fn auth_token_create(
         namespace,
         data.name,
         token.hash(),
-        data.expiry_millis.map(|ms| repl.time.last() + ms),
+        data.expiry_millis.map(|ms| repl.time.now() + ms),
         data.metadata,
         data.owner_id,
         data.scopes,
         data.enabled,
-        repl.time.last(),
+        repl.time.now(),
     );
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
 
@@ -155,7 +155,7 @@ async fn auth_token_expire(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let expiry = data.expiry_millis.map(|ms| repl.time.last() + ms);
+    let expiry = data.expiry_millis.map(|ms| repl.time.now() + ms);
     let operation = ExpireAuthTokenOperation::new(namespace, data.id.into_inner(), expiry);
     let _ = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(AuthTokenExpireOut {}))
@@ -226,7 +226,7 @@ async fn auth_token_verify(
     let auth_token_state = coyote_auth_token::State::init(state.do_not_use_dbs.clone())?;
     let token = auth_token_state
         .controller
-        .fetch_non_expired(namespace.id, &token_hashed, repl.time.last())
+        .fetch_non_expired(namespace.id, &token_hashed, repl.time.now())
         .await?;
 
     // FIXME: actually do something if expired, failed for other reasons, etc.
@@ -304,7 +304,7 @@ async fn auth_token_update(
         namespace,
         data.id.into_inner(),
         data.name,
-        data.expiry_millis.map(|ms| repl.time.last() + ms),
+        data.expiry_millis.map(|ms| repl.time.now() + ms),
         data.metadata,
         data.scopes,
         data.enabled,

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -155,7 +155,7 @@ async fn cache_set(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let now = repl.time.last();
+    let now = repl.time.now();
 
     let operation = SetOperation::new(namespace, data.key.to_string(), data.into_model(now));
     repl.client_write(operation).await.or_internal_error()?.0?;
@@ -183,7 +183,7 @@ async fn cache_get(
     let controller = cache_state.controller(namespace.storage_type);
 
     let model = controller
-        .fetch(namespace.id, data.key, repl.time.last())
+        .fetch(namespace.id, data.key, repl.time.now())
         .await?;
 
     let ret = match model {

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -121,7 +121,7 @@ async fn kv_set(
         data.ttl,
         data.behavior,
         data.version,
-        repl.time.last(),
+        repl.time.now(),
     );
     let SetResponseData { version, success } =
         repl.client_write(operation).await.or_internal_error()?.0?;
@@ -151,7 +151,7 @@ async fn kv_get(
     let controller = kv_state.controller(namespace.storage_type);
 
     let model = controller
-        .fetch(namespace.id, data.key, repl.time.last())
+        .fetch(namespace.id, data.key, repl.time.now())
         .await?;
 
     let ret = match model {

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -152,7 +152,7 @@ async fn rate_limit_get_remaining(
 
     repl.wait_linearizable().await.or_internal_error()?;
 
-    let now = repl.time.last();
+    let now = repl.time.now();
     // FIXME: this state should be passed, not created every time.
     let rate_limit_state = coyote_rate_limit::State::init(state.do_not_use_dbs.clone())?;
     let controller = rate_limit_state.controller(namespace.storage_type);

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -94,7 +94,7 @@ async fn test_kv_set_and_get() -> TestResult {
     assert!(response["expiry"].is_null());
 
     let expires_in = 1000;
-    let now = time.last();
+    let now = time.now();
     kv_set(
         &client,
         "kv-key-1",


### PR DESCRIPTION
@tasn asked for this this morning

This renames the methods on Monotime, as well as making their docstrings much clearer.

Essentially, `Monotime::last` -> `Monotime::now`, and `Monotime::now` -> `Monotime::update_now`