### PR TITLE
Add ability to configure stream consumer group to start at beginning of the stream

### DIFF
--- a/clients/go/internal/apis/msgs_stream.go
+++ b/clients/go/internal/apis/msgs_stream.go
@@ -28,11 +28,12 @@ func (msgsStream MsgsStream) Receive(
 	msgStreamReceiveIn coyote_models.MsgStreamReceiveIn,
 ) (*coyote_models.MsgStreamReceiveOut, error) {
 	body := coyote_models.MsgStreamReceiveIn_{
-		Namespace:           msgStreamReceiveIn.Namespace,
-		Topic:               topic,
-		ConsumerGroup:       consumerGroup,
-		BatchSize:           msgStreamReceiveIn.BatchSize,
-		LeaseDurationMillis: msgStreamReceiveIn.LeaseDurationMillis,
+		Namespace:               msgStreamReceiveIn.Namespace,
+		Topic:                   topic,
+		ConsumerGroup:           consumerGroup,
+		BatchSize:               msgStreamReceiveIn.BatchSize,
+		LeaseDurationMillis:     msgStreamReceiveIn.LeaseDurationMillis,
+		DefaultStartingPosition: msgStreamReceiveIn.DefaultStartingPosition,
 	}
 
 	return coyote_proto.ExecuteRequest[coyote_models.MsgStreamReceiveIn_, coyote_models.MsgStreamReceiveOut](

--- a/clients/go/internal/models/msg_stream_receive_in.go
+++ b/clients/go/internal/models/msg_stream_receive_in.go
@@ -3,15 +3,17 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type MsgStreamReceiveIn struct {
-	Namespace           *string `msgpack:"namespace,omitempty"`
-	BatchSize           *uint16 `msgpack:"batch_size,omitempty"`
-	LeaseDurationMillis *uint64 `msgpack:"lease_duration_millis,omitempty"`
+	Namespace               *string `msgpack:"namespace,omitempty"`
+	BatchSize               *uint16 `msgpack:"batch_size,omitempty"`
+	LeaseDurationMillis     *uint64 `msgpack:"lease_duration_millis,omitempty"`
+	DefaultStartingPosition *string `msgpack:"default_starting_position,omitempty"`
 }
 
 type MsgStreamReceiveIn_ struct {
-	Namespace           *string `msgpack:"namespace,omitempty"`
-	Topic               string  `msgpack:"topic"`
-	ConsumerGroup       string  `msgpack:"consumer_group"`
-	BatchSize           *uint16 `msgpack:"batch_size,omitempty"`
-	LeaseDurationMillis *uint64 `msgpack:"lease_duration_millis,omitempty"`
+	Namespace               *string `msgpack:"namespace,omitempty"`
+	Topic                   string  `msgpack:"topic"`
+	ConsumerGroup           string  `msgpack:"consumer_group"`
+	BatchSize               *uint16 `msgpack:"batch_size,omitempty"`
+	LeaseDurationMillis     *uint64 `msgpack:"lease_duration_millis,omitempty"`
+	DefaultStartingPosition *string `msgpack:"default_starting_position,omitempty"`
 }

--- a/clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
@@ -47,7 +47,8 @@ public class MsgsStream {
             topic,
             consumerGroup,
             msgStreamReceiveIn.getBatchSize(),
-            msgStreamReceiveIn.getLeaseDurationMillis()
+            msgStreamReceiveIn.getLeaseDurationMillis(),
+            msgStreamReceiveIn.getDefaultStartingPosition()
         );
 
         return this.client.executeRequest(

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn.java
@@ -33,6 +33,7 @@ public class MsgStreamReceiveIn {
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty("batch_size") private Short batchSize;
     @JsonProperty("lease_duration_millis") private Long leaseDurationMillis;
+    @JsonProperty("default_starting_position") private String defaultStartingPosition;
     public MsgStreamReceiveIn() {}
 
     public MsgStreamReceiveIn namespace(String namespace) {
@@ -90,5 +91,24 @@ public class MsgStreamReceiveIn {
 
     public void setLeaseDurationMillis(Long leaseDurationMillis) {
         this.leaseDurationMillis = leaseDurationMillis;
+    }
+
+    public MsgStreamReceiveIn defaultStartingPosition(String defaultStartingPosition) {
+        this.defaultStartingPosition = defaultStartingPosition;
+        return this;
+    }
+
+    /**
+    * Get defaultStartingPosition
+    *
+     * @return defaultStartingPosition
+     */
+    @javax.annotation.Nullable
+    public String getDefaultStartingPosition() {
+        return defaultStartingPosition;
+    }
+
+    public void setDefaultStartingPosition(String defaultStartingPosition) {
+        this.defaultStartingPosition = defaultStartingPosition;
     }
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn_.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn_.java
@@ -28,19 +28,22 @@ public class MsgStreamReceiveIn_ {
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty("batch_size") private Short batchSize;
     @JsonProperty("lease_duration_millis") private Long leaseDurationMillis;
+    @JsonProperty("default_starting_position") private String defaultStartingPosition;
 
     public MsgStreamReceiveIn_(
         String namespace,
         String topic,
         String consumerGroup,
         Short batchSize,
-        Long leaseDurationMillis
+        Long leaseDurationMillis,
+        String defaultStartingPosition
     ) {
         this.namespace = namespace;
         this.topic = topic;
         this.consumerGroup = consumerGroup;
         this.batchSize = batchSize;
         this.leaseDurationMillis = leaseDurationMillis;
+        this.defaultStartingPosition = defaultStartingPosition;
     }
 
     /**

--- a/clients/javascript/src/models/msgStreamReceiveIn.ts
+++ b/clients/javascript/src/models/msgStreamReceiveIn.ts
@@ -4,6 +4,7 @@ export interface MsgStreamReceiveIn {
     namespace?: string | null;
     batchSize?: number;
     leaseDurationMillis?: number;
+    defaultStartingPosition?: string;
 }
 
 export interface MsgStreamReceiveIn_ {
@@ -12,6 +13,7 @@ export interface MsgStreamReceiveIn_ {
     consumerGroup: string;
     batchSize?: number;
     leaseDurationMillis?: number;
+    defaultStartingPosition?: string;
 }
 
 export const MsgStreamReceiveInSerializer = {
@@ -23,6 +25,7 @@ export const MsgStreamReceiveInSerializer = {
             consumerGroup: object['consumer_group'],
             batchSize: object['batch_size'],
             leaseDurationMillis: object['lease_duration_millis'],
+            defaultStartingPosition: object['default_starting_position'],
         };
     },
 
@@ -34,6 +37,7 @@ export const MsgStreamReceiveInSerializer = {
             'consumer_group': self.consumerGroup,
             'batch_size': self.batchSize,
             'lease_duration_millis': self.leaseDurationMillis,
+            'default_starting_position': self.defaultStartingPosition,
         };
     }
 }

--- a/clients/python/coyote/apis/msgs_stream.py
+++ b/clients/python/coyote/apis/msgs_stream.py
@@ -32,6 +32,7 @@ class MsgsStreamAsync(ApiBase):
             consumer_group=consumer_group,
             batch_size=msg_stream_receive_in.batch_size,
             lease_duration_millis=msg_stream_receive_in.lease_duration_millis,
+            default_starting_position=msg_stream_receive_in.default_starting_position,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -109,6 +110,7 @@ class MsgsStream(ApiBase):
             consumer_group=consumer_group,
             batch_size=msg_stream_receive_in.batch_size,
             lease_duration_millis=msg_stream_receive_in.lease_duration_millis,
+            default_starting_position=msg_stream_receive_in.default_starting_position,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/clients/python/coyote/models/msg_stream_receive_in.py
+++ b/clients/python/coyote/models/msg_stream_receive_in.py
@@ -14,6 +14,10 @@ class MsgStreamReceiveIn(BaseModel):
         default=None, alias="lease_duration_millis"
     )
 
+    default_starting_position: t.Optional[str] = Field(
+        default=None, alias="default_starting_position"
+    )
+
 
 class _MsgStreamReceiveIn(BaseModel):
     namespace: t.Optional[str] = None
@@ -26,4 +30,8 @@ class _MsgStreamReceiveIn(BaseModel):
 
     lease_duration_millis: t.Optional[int] = Field(
         default=None, alias="lease_duration_millis"
+    )
+
+    default_starting_position: t.Optional[str] = Field(
+        default=None, alias="default_starting_position"
     )

--- a/clients/rust/src/api/msgs_stream.rs
+++ b/clients/rust/src/api/msgs_stream.rs
@@ -26,6 +26,7 @@ impl<'a> MsgsStream<'a> {
             consumer_group,
             batch_size: msg_stream_receive_in.batch_size,
             lease_duration_millis: msg_stream_receive_in.lease_duration_millis,
+            default_starting_position: msg_stream_receive_in.default_starting_position,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1/msgs/stream/receive")

--- a/clients/rust/src/models/msg_stream_receive_in.rs
+++ b/clients/rust/src/models/msg_stream_receive_in.rs
@@ -11,6 +11,9 @@ pub struct MsgStreamReceiveIn {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lease_duration_millis: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_starting_position: Option<String>,
 }
 
 impl MsgStreamReceiveIn {
@@ -19,6 +22,7 @@ impl MsgStreamReceiveIn {
             namespace: None,
             batch_size: None,
             lease_duration_millis: None,
+            default_starting_position: None,
         }
     }
 
@@ -34,6 +38,11 @@ impl MsgStreamReceiveIn {
 
     pub fn with_lease_duration_millis(mut self, value: impl Into<Option<u64>>) -> Self {
         self.lease_duration_millis = value.into();
+        self
+    }
+
+    pub fn with_default_starting_position(mut self, value: impl Into<Option<String>>) -> Self {
+        self.default_starting_position = value.into();
         self
     }
 }
@@ -52,4 +61,7 @@ pub(crate) struct MsgStreamReceiveIn_ {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lease_duration_millis: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_starting_position: Option<String>,
 }

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -361,10 +361,11 @@ pub struct QueueMsgOut {
     pub timestamp: Timestamp,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SeekPosition {
     Earliest,
+    #[default]
     Latest,
 }
 

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -10,7 +10,9 @@ use tracing::Span;
 
 use crate::{
     State,
-    entities::{ConsumerGroup, Offset, Partition, TopicIn, TopicName, TopicPartition},
+    entities::{
+        ConsumerGroup, Offset, Partition, SeekPosition, TopicIn, TopicName, TopicPartition,
+    },
     tables::{MsgRow, StreamLeaseRow, TopicRow},
 };
 
@@ -24,6 +26,7 @@ pub struct StreamReceiveOperation {
     consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
     lease_duration_millis: DurationMs,
+    default_starting_position: SeekPosition,
 }
 
 impl StreamReceiveOperation {
@@ -33,6 +36,7 @@ impl StreamReceiveOperation {
         consumer_group: ConsumerGroup,
         batch_size: NonZeroU16,
         lease_duration_millis: DurationMs,
+        default_starting_position: SeekPosition,
     ) -> coyote_error::Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
@@ -45,6 +49,7 @@ impl StreamReceiveOperation {
             consumer_group,
             batch_size,
             lease_duration_millis,
+            default_starting_position,
         })
     }
 
@@ -88,8 +93,14 @@ impl StreamReceiveOperation {
                     Some(lease) => (lease, false),
                     None => {
                         let mut lease = StreamLeaseRow::new()?;
-                        lease.offset =
-                            MsgRow::next_offset(&state.msg_table, topic_row.id, topic.partition)?;
+                        lease.offset = match self.default_starting_position {
+                            SeekPosition::Earliest => 0,
+                            SeekPosition::Latest => MsgRow::next_offset(
+                                &state.msg_table,
+                                topic_row.id,
+                                topic.partition,
+                            )?,
+                        };
                         (lease, true)
                     }
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -3353,6 +3353,10 @@
             "type": "integer",
             "format": "uint64",
             "default": 300000
+          },
+          "default_starting_position": {
+            "type": "string",
+            "default": "latest"
           }
         },
         "required": [

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -188,6 +188,8 @@ struct MsgStreamReceiveIn {
     pub batch_size: NonZeroU16,
     #[serde(default = "default_lease_duration_millis")]
     pub lease_duration_millis: DurationMs,
+    #[serde(default)]
+    pub default_starting_position: SeekPosition,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -216,6 +218,7 @@ async fn stream_receive(
         data.consumer_group,
         data.batch_size,
         data.lease_duration_millis,
+        data.default_starting_position,
     )?;
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -1027,3 +1027,52 @@ async fn default_namespace_receive_and_commit() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn default_starting_position_earliest_gets_preexisting() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("msgs/namespace/create")
+        .json(json!({ "name": "ns-dsp" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish 5 messages before any consumer group exists
+    client
+        .post("msgs/publish")
+        .json(json!({
+            "topic": "ns-dsp:t1",
+            "msgs": (0..5)
+                .map(|i| json!({ "value": format!("msg-{i}").as_bytes(), "key": "k1" }))
+                .collect::<Vec<_>>(),
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive with default_starting_position=earliest — should get all 5 messages
+    let r1 = client
+        .post("msgs/stream/receive")
+        .json(json!({
+            "topic": "ns-dsp:t1",
+            "consumer_group": "cg1",
+            "default_starting_position": "earliest",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r1["msgs"].assert_array();
+    assert_eq!(
+        msgs.len(),
+        5,
+        "earliest starting position should return all pre-existing messages"
+    );
+    assert_eq!(msgs[0]["offset"].assert_u64(), 0);
+
+    Ok(())
+}


### PR DESCRIPTION
Stream consumer groups, by default, start at the end of the stream when they're first created. Similar to Kafka's default.

Kafka has the ability to tell a consumer group to start at the beginning (if the consumer group hasn't already committed offsets) - which is a feature we USE in svix-webhooks-private. (Specifically, when a server may write messages to a topic before workers with relevant consumer groups have been spun up).

To make this work, I added a `msgs.stream.configure` endpoint, analogous to the already extant `msgs.queue.configure` for configuring queue consumer groups. This lets the client configure the default starting position for the consumer group.