### PR TITLE
feat(helm): add `aggregate-to-view` label to CRD clusterrole

### DIFF
--- a/.github/workflows/svix-cloud-operator.yml
+++ b/.github/workflows/svix-cloud-operator.yml
@@ -78,6 +78,7 @@ jobs:
             --set-string operator.image.tag=${{ inputs.image_tag }} \
             --set-string cluster.image.tag=${{ inputs.image_tag }} \
             --set operator.image.pullPolicy=Always \
+            --set operator.rbac.aggregateViewClusterRoles=true \
             --set crds.enabled=true \
             --atomic \
             --timeout=120s \

--- a/infra/helm-coyote/templates/clusterrole.yaml
+++ b/infra/helm-coyote/templates/clusterrole.yaml
@@ -38,4 +38,24 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "coyote-operator.fullname" . }}-view
+  labels:
+    {{- include "coyote-operator.labels" . | nindent 4 }}
+    {{- if .Values.operator.rbac.aggregateViewClusterRoles }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+    {{- end }}
+rules:
+  - apiGroups: ["coyote.svix.com"]
+    resources: ["coyoteclusters"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coyote.svix.com"]
+    resources: ["coyoteclusters/status"]
+    verbs: ["get"]
 {{- end }}


### PR DESCRIPTION
This labels gives ability to the user with default view clusterrole permission to view the associated CRD.

A la [cert-manager](https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/templates/rbac.yaml#L482-L483)
