### PR TITLE
Add extra ordering test for custom base32 scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ version = "0.0.1"
 dependencies = [
  "data-encoding",
  "data-encoding-macro",
+ "itertools 0.14.0",
  "jiff",
  "rmp-serde",
  "schemars 1.2.1",

--- a/crates/coyote-id/Cargo.toml
+++ b/crates/coyote-id/Cargo.toml
@@ -14,6 +14,7 @@ serde.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+itertools.workspace = true
 rmp-serde.workspace = true
 
 [lints]

--- a/crates/coyote-id/src/public.rs
+++ b/crates/coyote-id/src/public.rs
@@ -109,7 +109,8 @@ fn decode_base32(prefix: &'static str, input: &str) -> Result<Uuid, String> {
 mod tests {
     use std::iter::zip;
 
-    use uuid::uuid;
+    use itertools::Itertools;
+    use uuid::{Uuid, uuid};
 
     use super::{decode_base32, encode_base32};
 
@@ -141,6 +142,24 @@ mod tests {
         for (e, d) in zip(encoded, decoded) {
             assert_eq!(e, encode_base32("prefix_", &d));
             assert_eq!(decode_base32("prefix_", e).unwrap(), d);
+        }
+    }
+
+    #[test]
+    fn test_big_range_ordering() {
+        let start = (u128::MAX - u16::MAX as u128) / 2;
+        let end = start + u16::MAX as u128;
+
+        for (a, b) in (start..end).tuple_windows() {
+            let uuid_a = Uuid::from_u128(a);
+            let uuid_b = Uuid::from_u128(b);
+
+            assert!(uuid_a < uuid_b);
+
+            let encoded_a = encode_base32("", &uuid_a);
+            let encoded_b = encode_base32("", &uuid_b);
+
+            assert!(encoded_a < encoded_b);
         }
     }
 }


### PR DESCRIPTION
I expected 65k base32 encodes to be fast enough to run the test a couple times manually but not fast enough to include in the test suite. Actually it just takes 0.11s on my machine, so no problem to have it as part of the test suite.