### PR TITLE
Get rid of some of the boilerplate around OperationError

### DIFF
--- a/crates/auth-token/src/operations/create.rs
+++ b/crates/auth-token/src/operations/create.rs
@@ -8,8 +8,9 @@ use crate::{
     operations::{AuthTokenRaftState, AuthTokenRequest, CreateResponse},
 };
 use coyote_core::types::Metadata;
+use coyote_error::Result;
 use coyote_id::{AuthTokenId, NamespaceId};
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,6 +86,6 @@ impl CreateAuthTokenOperation {
 
 impl AuthTokenRequest for CreateAuthTokenOperation {
     async fn apply(self, state: AuthTokenRaftState<'_>, ctx: &OpContext) -> CreateResponse {
-        CreateResponse(self.apply_real(state.state, ctx).await)
+        CreateResponse::new(self.apply_real(state.state, ctx).await)
     }
 }

--- a/crates/auth-token/src/operations/create_namespace.rs
+++ b/crates/auth-token/src/operations/create_namespace.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU64;
 
+use coyote_error::Result;
 use coyote_namespace::{
     entities::{AuthTokenConfig, StorageType},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -44,7 +45,7 @@ impl CreateAuthTokenNamespaceOperation {
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
-    ) -> coyote_operations::Result<CreateAuthTokenNamespaceResponseData> {
+    ) -> Result<CreateAuthTokenNamespaceResponseData> {
         let op: CreateNamespace<AuthTokenConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;
         Ok(out.into())
@@ -78,6 +79,6 @@ impl AuthTokenRequest for CreateAuthTokenNamespaceOperation {
         state: AuthTokenRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CreateNamespaceResponse {
-        CreateNamespaceResponse(self.apply_real(state.namespace, ctx.timestamp).await)
+        CreateNamespaceResponse::new(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/auth-token/src/operations/delete.rs
+++ b/crates/auth-token/src/operations/delete.rs
@@ -4,8 +4,9 @@ use crate::{
     AuthTokenNamespace, State,
     operations::{AuthTokenRaftState, AuthTokenRequest, DeleteResponse},
 };
+use coyote_error::Result;
 use coyote_id::{AuthTokenId, NamespaceId};
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,6 +38,6 @@ impl DeleteAuthTokenOperation {
 
 impl AuthTokenRequest for DeleteAuthTokenOperation {
     async fn apply(self, state: AuthTokenRaftState<'_>, _ctx: &OpContext) -> DeleteResponse {
-        DeleteResponse(self.apply_real(state.state).await)
+        DeleteResponse::new(self.apply_real(state.state).await)
     }
 }

--- a/crates/auth-token/src/operations/expire.rs
+++ b/crates/auth-token/src/operations/expire.rs
@@ -6,8 +6,9 @@ use crate::{
     controller::AuthTokenModel,
     operations::{AuthTokenRaftState, AuthTokenRequest, ExpireResponse},
 };
+use coyote_error::Result;
 use coyote_id::{AuthTokenId, NamespaceId};
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,6 +48,6 @@ impl ExpireAuthTokenOperation {
 
 impl AuthTokenRequest for ExpireAuthTokenOperation {
     async fn apply(self, state: AuthTokenRaftState<'_>, ctx: &OpContext) -> ExpireResponse {
-        ExpireResponse(self.apply_real(state.state, ctx).await)
+        ExpireResponse::new(self.apply_real(state.state, ctx).await)
     }
 }

--- a/crates/auth-token/src/operations/rotate.rs
+++ b/crates/auth-token/src/operations/rotate.rs
@@ -7,8 +7,9 @@ use crate::{
     entities::TokenHashed,
     operations::{AuthTokenRaftState, AuthTokenRequest, RotateResponse},
 };
+use coyote_error::Result;
 use coyote_id::{AuthTokenId, NamespaceId};
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -68,6 +69,6 @@ impl RotateAuthTokenOperation {
 
 impl AuthTokenRequest for RotateAuthTokenOperation {
     async fn apply(self, state: AuthTokenRaftState<'_>, ctx: &OpContext) -> RotateResponse {
-        RotateResponse(self.apply_real(state.state, ctx).await)
+        RotateResponse::new(self.apply_real(state.state, ctx).await)
     }
 }

--- a/crates/auth-token/src/operations/update.rs
+++ b/crates/auth-token/src/operations/update.rs
@@ -7,8 +7,9 @@ use crate::{
     operations::{AuthTokenRaftState, AuthTokenRequest, UpdateResponse},
 };
 use coyote_core::types::Metadata;
+use coyote_error::Result;
 use coyote_id::{AuthTokenId, NamespaceId};
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,6 +74,6 @@ impl UpdateAuthTokenOperation {
 
 impl AuthTokenRequest for UpdateAuthTokenOperation {
     async fn apply(self, state: AuthTokenRaftState<'_>, ctx: &OpContext) -> UpdateResponse {
-        UpdateResponse(self.apply_real(state.state, ctx).await)
+        UpdateResponse::new(self.apply_real(state.state, ctx).await)
     }
 }

--- a/crates/cache/src/operations/clear_expired.rs
+++ b/crates/cache/src/operations/clear_expired.rs
@@ -1,8 +1,10 @@
-use super::{CacheRequest, ClearExpiredResponse};
-use crate::{State, operations::CacheRaftState};
-use coyote_operations::{OpContext, Result};
+use coyote_error::Result;
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
+
+use super::{CacheRequest, ClearExpiredResponse};
+use crate::{State, operations::CacheRaftState};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClearExpiredOperation {
@@ -31,6 +33,6 @@ impl ClearExpiredOperation {
 
 impl CacheRequest for ClearExpiredOperation {
     async fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp).await)
+        ClearExpiredResponse::new(self.apply_real(state.state, ctx.timestamp).await)
     }
 }

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU64;
 
+use coyote_error::Result;
 use coyote_namespace::{
     entities::{CacheConfig, EvictionPolicy, StorageType},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -49,7 +50,7 @@ impl CreateCacheOperation {
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
-    ) -> coyote_operations::Result<CreateCacheResponseData> {
+    ) -> Result<CreateCacheResponseData> {
         let op: CreateNamespace<CacheConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;
         Ok(out.into())
@@ -85,6 +86,6 @@ impl CacheRequest for CreateCacheOperation {
         state: CacheRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CreateCacheResponse {
-        CreateCacheResponse(self.apply_real(state.namespace, ctx.timestamp).await)
+        CreateCacheResponse::new(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/cache/src/operations/delete.rs
+++ b/crates/cache/src/operations/delete.rs
@@ -1,7 +1,8 @@
 use super::{CacheRaftState, CacheRequest, DeleteResponse};
 use crate::CacheNamespace;
+use coyote_error::Result;
 use coyote_id::NamespaceId;
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
 
@@ -40,6 +41,6 @@ impl DeleteOperation {
 
 impl CacheRequest for DeleteOperation {
     async fn apply(self, state: CacheRaftState<'_>, _ctx: &OpContext) -> DeleteResponse {
-        DeleteResponse(self.apply_real(&state).await)
+        DeleteResponse::new(self.apply_real(&state).await)
     }
 }

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -1,8 +1,9 @@
 use super::{CacheRaftState, CacheRequest, SetResponse};
 use crate::{CacheModel, CacheNamespace};
+use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -55,6 +56,6 @@ impl SetOperation {
 
 impl CacheRequest for SetOperation {
     async fn apply(self, state: CacheRaftState<'_>, ctx: &OpContext) -> SetResponse {
-        SetResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
+        SetResponse::new(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
     }
 }

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -44,7 +44,7 @@ impl std::error::Error for BackgroundError {
     }
 }
 
-pub type BackgroundResult<T> = std::result::Result<T, BackgroundError>;
+pub type BackgroundResult<T> = Result<T, BackgroundError>;
 
 // Not part of the trait below so do_write_request only has to be codegen'ed once
 pub trait OperationWriterBase {
@@ -77,9 +77,7 @@ pub trait OperationWriter<M: ModuleRequest>:
         let module_request: O::RequestParent = op.into();
         let top_level_request: Self::Request = module_request.into();
         let top_level_response = self.do_write_request(top_level_request).await?;
-        let Ok(module_response): std::result::Result<M::Response, _> =
-            top_level_response.try_into()
-        else {
+        let Ok(module_response): Result<M::Response, _> = top_level_response.try_into() else {
             return Err(BackgroundError::InvalidResponse);
         };
         module_response
@@ -96,6 +94,7 @@ impl<T, M: ModuleRequest> OperationWriter<M> for T where
 /// Macro support module
 #[doc(hidden)]
 pub mod __reexports {
+    pub use coyote_error;
     pub use pastey;
     pub use serde;
 }
@@ -174,5 +173,3 @@ impl From<JoinError> for OperationError {
         }
     }
 }
-
-pub type Result<T> = std::result::Result<T, OperationError>;

--- a/crates/coyote-operations/src/macros.rs
+++ b/crates/coyote-operations/src/macros.rs
@@ -164,13 +164,19 @@ macro_rules! async_raft_module_operations {
 
             $(
                 #[derive(
-                Debug,
-                Clone,
-                $crate::__reexports::serde::Serialize,
-                $crate::__reexports::serde::Deserialize,
-            )]
-            #[serde(crate = "coyote_operations::__reexports::serde")]
-                pub struct [<$variant Response>](pub $crate::Result<$response_data_type>);
+                    Debug,
+                    Clone,
+                    $crate::__reexports::serde::Serialize,
+                    $crate::__reexports::serde::Deserialize,
+                )]
+                #[serde(crate = "coyote_operations::__reexports::serde")]
+                pub struct [<$variant Response>](pub Result<$response_data_type, $crate::OperationError>);
+
+                impl [<$variant Response>] {
+                    pub fn new(inner: $crate::__reexports::coyote_error::Result<$response_data_type>) -> Self {
+                        Self(inner.map_err(Into::into))
+                    }
+                }
             )*
 
             #[derive(

--- a/crates/idempotency/src/operations/abort.rs
+++ b/crates/idempotency/src/operations/abort.rs
@@ -1,7 +1,7 @@
 use super::{AbortResponse, IdempotencyRaftState, IdempotencyRequest};
 use crate::IdempotencyNamespace;
+use coyote_error::Result;
 use coyote_id::NamespaceId;
-use coyote_operations::Result;
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
 
@@ -40,6 +40,6 @@ impl IdempotencyRequest for AbortOperation {
         state: IdempotencyRaftState<'_>,
         _ctx: &coyote_operations::OpContext,
     ) -> AbortResponse {
-        AbortResponse(self.apply_real(&state).await)
+        AbortResponse::new(self.apply_real(&state).await)
     }
 }

--- a/crates/idempotency/src/operations/clear_expired.rs
+++ b/crates/idempotency/src/operations/clear_expired.rs
@@ -1,6 +1,6 @@
 use super::{ClearExpiredResponse, IdempotencyRequest};
 use crate::{State, operations::IdempotencyRaftState};
-use coyote_operations::Result;
+use coyote_error::Result;
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +35,6 @@ impl IdempotencyRequest for ClearExpiredOperation {
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp).await)
+        ClearExpiredResponse::new(self.apply_real(state.state, ctx.timestamp).await)
     }
 }

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -1,9 +1,9 @@
 use super::{CompleteResponse, IdempotencyRaftState, IdempotencyRequest};
 use crate::{IdempotencyNamespace, IdempotencyState};
 use coyote_core::types::DurationS;
+use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
-use coyote_operations::Result;
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -72,6 +72,6 @@ impl IdempotencyRequest for CompleteOperation {
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CompleteResponse {
-        CompleteResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
+        CompleteResponse::new(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
     }
 }

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU64;
 
+use coyote_error::Result;
 use coyote_namespace::{
     entities::{IdempotencyConfig, StorageType},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -44,7 +45,7 @@ impl CreateIdempotencyOperation {
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
-    ) -> coyote_operations::Result<CreateIdempotencyResponseData> {
+    ) -> Result<CreateIdempotencyResponseData> {
         let op: CreateNamespace<IdempotencyConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;
         Ok(out.into())
@@ -78,6 +79,6 @@ impl IdempotencyRequest for CreateIdempotencyOperation {
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CreateIdempotencyResponse {
-        CreateIdempotencyResponse(self.apply_real(state.namespace, ctx.timestamp).await)
+        CreateIdempotencyResponse::new(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -1,9 +1,9 @@
 use super::{IdempotencyRaftState, IdempotencyRequest, TryStartResponse};
 use crate::{IdempotencyNamespace, IdempotencyStartResult, IdempotencyState};
 use coyote_core::types::DurationS;
+use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
-use coyote_operations::Result;
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -86,6 +86,6 @@ impl IdempotencyRequest for TryStartOperation {
         state: IdempotencyRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> TryStartResponse {
-        TryStartResponse(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
+        TryStartResponse::new(self.apply_real(&state, ctx.timestamp, ctx.log_index).await)
     }
 }

--- a/crates/kv/src/operations/clear_expired.rs
+++ b/crates/kv/src/operations/clear_expired.rs
@@ -1,6 +1,6 @@
 use super::{ClearExpiredResponse, KvRequest};
 use crate::{State, operations::KvRaftState};
-use coyote_operations::Result;
+use coyote_error::Result;
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +35,6 @@ impl KvRequest for ClearExpiredOperation {
         state: KvRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> ClearExpiredResponse {
-        ClearExpiredResponse(self.apply_real(state.state, ctx.timestamp).await)
+        ClearExpiredResponse::new(self.apply_real(state.state, ctx.timestamp).await)
     }
 }

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU64;
 
+use coyote_error::Result;
 use coyote_namespace::{
     entities::{KeyValueConfig, StorageType},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -44,7 +45,7 @@ impl CreateKvOperation {
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
-    ) -> coyote_operations::Result<CreateKvResponseData> {
+    ) -> Result<CreateKvResponseData> {
         let op: CreateNamespace<KeyValueConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;
         Ok(out.into())
@@ -78,6 +79,6 @@ impl KvRequest for CreateKvOperation {
         state: KvRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CreateKvResponse {
-        CreateKvResponse(self.apply_real(state.namespace, ctx.timestamp).await)
+        CreateKvResponse::new(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -1,8 +1,8 @@
 use super::{DeleteResponse, KvRequest};
 use crate::{KvNamespace, State, operations::KvRaftState};
 use coyote_core::types::EntityKey;
+use coyote_error::Result;
 use coyote_id::NamespaceId;
-use coyote_operations::Result;
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
 
@@ -44,6 +44,6 @@ impl KvRequest for DeleteOperation {
         state: KvRaftState<'_>,
         _ctx: &coyote_operations::OpContext,
     ) -> DeleteResponse {
-        DeleteResponse(self.apply_real(state.state).await)
+        DeleteResponse::new(self.apply_real(state.state).await)
     }
 }

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -6,8 +6,9 @@ use crate::{
 
 use super::{KvRequest, SetResponse};
 use coyote_core::types::{DurationMs, EntityKey};
+use coyote_error::Result;
 use coyote_id::NamespaceId;
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -77,6 +78,6 @@ impl SetOperation {
 
 impl KvRequest for SetOperation {
     async fn apply(self, state: KvRaftState<'_>, ctx: &OpContext) -> SetResponse {
-        SetResponse(self.apply_real(state.state, ctx).await)
+        SetResponse::new(self.apply_real(state.state, ctx).await)
     }
 }

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -1,15 +1,15 @@
 use std::time::Duration;
 
+use coyote_error::Result;
 use coyote_namespace::{
     entities::{NamespaceName, StorageType, StreamConfig},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
-
-use crate::entities::{Retention, default_retention_bytes, default_retention_millis};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use super::{CreateNamespaceResponse, MsgsRaftState, MsgsRequest};
+use crate::entities::{Retention, default_retention_bytes, default_retention_millis};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateNamespaceOperation {
@@ -31,7 +31,7 @@ impl CreateNamespaceOperation {
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
-    ) -> coyote_operations::Result<CreateNamespaceResponseData> {
+    ) -> Result<CreateNamespaceResponseData> {
         let op = CreateNamespace::new(
             self.name,
             StreamConfig {
@@ -80,6 +80,6 @@ impl MsgsRequest for CreateNamespaceOperation {
         state: MsgsRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CreateNamespaceResponse {
-        CreateNamespaceResponse(self.apply_real(state.namespace, ctx.timestamp).await)
+        CreateNamespaceResponse::new(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -1,12 +1,7 @@
 use std::collections::BTreeMap;
 
-use crate::{
-    State,
-    entities::{MsgIn, Offset, Partition, TopicIn, TopicName, TopicPartition, partition_for_key},
-    tables::{MsgRow, TopicRow},
-};
 use coyote_core::task::spawn_blocking_in_current_span;
-use coyote_error::Error;
+use coyote_error::{Error, Result};
 use coyote_id::{NamespaceId, TopicId};
 use fjall::OwnedWriteBatch;
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -15,6 +10,11 @@ use serde::{Deserialize, Serialize};
 use tracing::Span;
 
 use super::{MsgsRaftState, MsgsRequest, PublishResponse};
+use crate::{
+    State,
+    entities::{MsgIn, Offset, Partition, TopicIn, TopicName, TopicPartition, partition_for_key},
+    tables::{MsgRow, TopicRow},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublishOperation {
@@ -25,11 +25,7 @@ pub struct PublishOperation {
 }
 
 impl PublishOperation {
-    pub fn new(
-        namespace_id: NamespaceId,
-        topic: TopicIn,
-        msgs: Vec<MsgIn>,
-    ) -> coyote_error::Result<Self> {
+    pub fn new(namespace_id: NamespaceId, topic: TopicIn, msgs: Vec<MsgIn>) -> Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => {
                 if msgs.iter().any(|m| m.key.is_some()) {
@@ -51,11 +47,7 @@ impl PublishOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(msg_count = self.msgs.len()))]
-    async fn apply_real(
-        self,
-        state: &State,
-        now: Timestamp,
-    ) -> coyote_operations::Result<PublishResponseData> {
+    async fn apply_real(self, state: &State, now: Timestamp) -> Result<PublishResponseData> {
         let state = state.clone();
 
         let results = spawn_blocking_in_current_span(move || {
@@ -130,7 +122,7 @@ impl MsgsRequest for PublishOperation {
         state: MsgsRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> PublishResponse {
-        PublishResponse(self.apply_real(state.msgs, ctx.timestamp).await)
+        PublishResponse::new(self.apply_real(state.msgs, ctx.timestamp).await)
     }
 }
 
@@ -157,7 +149,7 @@ fn write_msg_batch(
     topic_id: TopicId,
     msgs_by_partition: BTreeMap<Partition, Vec<MsgIn>>,
     now: Timestamp,
-) -> coyote_operations::Result<Vec<PublishedTopic>> {
+) -> Result<Vec<PublishedTopic>> {
     let mut results: Vec<PublishedTopic> = Vec::with_capacity(msgs_by_partition.len());
 
     for (partition, msgs) in msgs_by_partition {

--- a/crates/msgs/src/operations/queue/ack.rs
+++ b/crates/msgs/src/operations/queue/ack.rs
@@ -1,5 +1,5 @@
 use coyote_core::task::spawn_blocking_in_current_span;
-use coyote_error::Error;
+use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
 use serde::{Deserialize, Serialize};
@@ -39,7 +39,7 @@ impl QueueAckOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug")]
-    async fn apply_real(self, state: &State) -> coyote_operations::Result<QueueAckResponseData> {
+    async fn apply_real(self, state: &State) -> Result<QueueAckResponseData> {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
@@ -108,6 +108,6 @@ impl MsgsRequest for QueueAckOperation {
         state: MsgsRaftState<'_>,
         _ctx: &coyote_operations::OpContext,
     ) -> QueueAckResponse {
-        QueueAckResponse(self.apply_real(state.msgs).await)
+        QueueAckResponse::new(self.apply_real(state.msgs).await)
     }
 }

--- a/crates/msgs/src/operations/queue/configure.rs
+++ b/crates/msgs/src/operations/queue/configure.rs
@@ -1,5 +1,5 @@
 use coyote_core::task::spawn_blocking_in_current_span;
-use coyote_error::Error;
+use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
 use fjall_utils::WriteBatchExt;
 use jiff::Timestamp;
@@ -40,11 +40,7 @@ impl QueueConfigureOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug")]
-    async fn apply_real(
-        self,
-        state: &State,
-        now: Timestamp,
-    ) -> coyote_operations::Result<QueueConfigureResponseData> {
+    async fn apply_real(self, state: &State, now: Timestamp) -> Result<QueueConfigureResponseData> {
         let state = state.clone();
         spawn_blocking_in_current_span(move || {
             let mut batch = state.db.batch();
@@ -90,6 +86,6 @@ impl MsgsRequest for QueueConfigureOperation {
         state: MsgsRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> QueueConfigureResponse {
-        QueueConfigureResponse(self.apply_real(state.msgs, ctx.timestamp).await)
+        QueueConfigureResponse::new(self.apply_real(state.msgs, ctx.timestamp).await)
     }
 }

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use coyote_core::task::spawn_blocking_in_current_span;
-use coyote_error::Error;
+use coyote_error::{Error, Result};
 use coyote_id::{NamespaceId, TopicId};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
@@ -39,11 +39,7 @@ impl QueueNackOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug")]
-    async fn apply_real(
-        self,
-        state: &State,
-        now: Timestamp,
-    ) -> coyote_operations::Result<QueueNackResponseData> {
+    async fn apply_real(self, state: &State, now: Timestamp) -> Result<QueueNackResponseData> {
         let state = state.clone();
         spawn_blocking_in_current_span(move || {
             let topic_row = TopicRow::fetch(
@@ -124,7 +120,7 @@ fn forward_to_dlq(
     dlq_topic: &TopicName,
     consumer_group: &ConsumerGroup,
     now: Timestamp,
-) -> coyote_error::Result<()> {
+) -> Result<()> {
     let original = MsgRow::fetch(
         &state.msg_table,
         MsgRow::key_for(source_topic_id, msg_id.partition, msg_id.offset),
@@ -169,6 +165,6 @@ impl MsgsRequest for QueueNackOperation {
         state: MsgsRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> QueueNackResponse {
-        QueueNackResponse(self.apply_real(state.msgs, ctx.timestamp).await)
+        QueueNackResponse::new(self.apply_real(state.msgs, ctx.timestamp).await)
     }
 }

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, num::NonZeroU16};
 
 use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
-use coyote_error::Error;
+use coyote_error::{Error, Result};
 use coyote_id::{NamespaceId, TopicId};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
@@ -33,7 +33,7 @@ impl QueueReceiveOperation {
         consumer_group: ConsumerGroup,
         batch_size: NonZeroU16,
         lease_duration_millis: DurationMs,
-    ) -> coyote_error::Result<Self> {
+    ) -> Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
             TopicIn::TopicName(tn) => (tn, None),
@@ -49,11 +49,7 @@ impl QueueReceiveOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size = self.batch_size))]
-    async fn apply_real(
-        self,
-        state: &State,
-        now: Timestamp,
-    ) -> coyote_operations::Result<QueueReceiveResponseData> {
+    async fn apply_real(self, state: &State, now: Timestamp) -> Result<QueueReceiveResponseData> {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
@@ -175,7 +171,7 @@ fn lease_available_msgs(
     consumer_group: &ConsumerGroup,
     now: Timestamp,
     expiry: Timestamp,
-) -> coyote_error::Result<u16> {
+) -> Result<u16> {
     let mut count = 0;
 
     for (i, msg) in msgs.into_iter().enumerate() {
@@ -229,7 +225,7 @@ pub(crate) fn compact_cursor(
     topic_id: TopicId,
     partition: Partition,
     consumer_group: &ConsumerGroup,
-) -> coyote_error::Result<()> {
+) -> Result<()> {
     loop {
         let check_id = MsgId::new(partition, cursor.offset);
         match QueueLeaseRow::fetch(
@@ -272,6 +268,6 @@ impl MsgsRequest for QueueReceiveOperation {
         state: MsgsRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> QueueReceiveResponse {
-        QueueReceiveResponse(self.apply_real(state.msgs, ctx.timestamp).await)
+        QueueReceiveResponse::new(self.apply_real(state.msgs, ctx.timestamp).await)
     }
 }

--- a/crates/msgs/src/operations/queue/redrive_dlq.rs
+++ b/crates/msgs/src/operations/queue/redrive_dlq.rs
@@ -1,5 +1,5 @@
 use coyote_core::task::spawn_blocking_in_current_span;
-use coyote_error::Error;
+use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
 use serde::{Deserialize, Serialize};
@@ -29,10 +29,7 @@ impl QueueRedriveDlqOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug")]
-    async fn apply_real(
-        self,
-        state: &State,
-    ) -> coyote_operations::Result<QueueRedriveDlqResponseData> {
+    async fn apply_real(self, state: &State) -> Result<QueueRedriveDlqResponseData> {
         let state = state.clone();
         spawn_blocking_in_current_span(move || {
             let topic_row = TopicRow::fetch(
@@ -102,6 +99,6 @@ impl MsgsRequest for QueueRedriveDlqOperation {
         state: MsgsRaftState<'_>,
         _ctx: &coyote_operations::OpContext,
     ) -> QueueRedriveDlqResponse {
-        QueueRedriveDlqResponse(self.apply_real(state.msgs).await)
+        QueueRedriveDlqResponse::new(self.apply_real(state.msgs).await)
     }
 }

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -1,9 +1,8 @@
 use coyote_core::task::spawn_blocking_in_current_span;
+use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
 use serde::{Deserialize, Serialize};
-
-use coyote_error::Error;
 
 use crate::{
     State,
@@ -37,10 +36,7 @@ impl StreamCommitOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug")]
-    async fn apply_real(
-        self,
-        state: &State,
-    ) -> coyote_operations::Result<StreamCommitResponseData> {
+    async fn apply_real(self, state: &State) -> Result<StreamCommitResponseData> {
         let state = state.clone();
         spawn_blocking_in_current_span(move || {
             let mut batch = state.db.batch();
@@ -86,6 +82,6 @@ impl MsgsRequest for StreamCommitOperation {
         state: MsgsRaftState<'_>,
         _ctx: &coyote_operations::OpContext,
     ) -> StreamCommitResponse {
-        StreamCommitResponse(self.apply_real(state.msgs).await)
+        StreamCommitResponse::new(self.apply_real(state.msgs).await)
     }
 }

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU16;
 
 use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
-use coyote_error::Error;
+use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
@@ -37,7 +37,7 @@ impl StreamReceiveOperation {
         batch_size: NonZeroU16,
         lease_duration_millis: DurationMs,
         default_starting_position: SeekPosition,
-    ) -> coyote_error::Result<Self> {
+    ) -> Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
             TopicIn::TopicName(tn) => (tn, None),
@@ -54,11 +54,7 @@ impl StreamReceiveOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size = self.batch_size))]
-    async fn apply_real(
-        self,
-        state: &State,
-        now: Timestamp,
-    ) -> coyote_operations::Result<StreamReceiveResponseData> {
+    async fn apply_real(self, state: &State, now: Timestamp) -> Result<StreamReceiveResponseData> {
         let state = state.clone();
         spawn_blocking_in_current_span(move || {
             let mut remaining = self.batch_size.get();
@@ -164,7 +160,7 @@ impl StreamReceiveOperation {
             }
 
             if no_lease_available {
-                return Err(Error::invalid_user_input("no available leases").into());
+                return Err(Error::invalid_user_input("no available leases"));
             }
 
             batch.commit().map_err(Error::from)?;
@@ -197,6 +193,6 @@ impl MsgsRequest for StreamReceiveOperation {
         state: MsgsRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> StreamReceiveResponse {
-        StreamReceiveResponse(self.apply_real(state.msgs, ctx.timestamp).await)
+        StreamReceiveResponse::new(self.apply_real(state.msgs, ctx.timestamp).await)
     }
 }

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -1,5 +1,5 @@
 use coyote_core::task::spawn_blocking_in_current_span;
-use coyote_error::Error;
+use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
@@ -34,7 +34,7 @@ impl StreamSeekOperation {
         topic: TopicIn,
         consumer_group: ConsumerGroup,
         target: SeekTarget,
-    ) -> coyote_error::Result<Self> {
+    ) -> Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
             TopicIn::TopicName(tn) => (tn, None),
@@ -56,7 +56,7 @@ impl StreamSeekOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug")]
-    async fn apply_real(self, state: &State) -> coyote_operations::Result<StreamSeekResponseData> {
+    async fn apply_real(self, state: &State) -> Result<StreamSeekResponseData> {
         let state = state.clone();
         spawn_blocking_in_current_span(move || {
             let mut batch = state.db.batch();
@@ -113,6 +113,6 @@ impl MsgsRequest for StreamSeekOperation {
         state: MsgsRaftState<'_>,
         _ctx: &coyote_operations::OpContext,
     ) -> StreamSeekResponse {
-        StreamSeekResponse(self.apply_real(state.msgs).await)
+        StreamSeekResponse::new(self.apply_real(state.msgs).await)
     }
 }

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -1,10 +1,9 @@
+use coyote_core::task::spawn_blocking_in_current_span;
+use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
-
-use coyote_core::task::spawn_blocking_in_current_span;
-use coyote_error::Error;
 
 use crate::{
     State,
@@ -22,11 +21,7 @@ pub struct TopicConfigureOperation {
 }
 
 impl TopicConfigureOperation {
-    pub fn new(
-        namespace_id: NamespaceId,
-        topic: TopicName,
-        partitions: u16,
-    ) -> Result<Self, Error> {
+    pub fn new(namespace_id: NamespaceId, topic: TopicName, partitions: u16) -> Result<Self> {
         if partitions == 0 || partitions > MAX_PARTITION_COUNT {
             return Err(Error::invalid_user_input(format!(
                 "Partition count must be between 1 and {MAX_PARTITION_COUNT}."
@@ -39,11 +34,7 @@ impl TopicConfigureOperation {
         })
     }
 
-    async fn apply_real(
-        self,
-        state: &State,
-        now: Timestamp,
-    ) -> coyote_operations::Result<TopicConfigureResponseData> {
+    async fn apply_real(self, state: &State, now: Timestamp) -> Result<TopicConfigureResponseData> {
         let state = state.clone();
         spawn_blocking_in_current_span(move || {
             let mut topic_row = match TopicRow::fetch(
@@ -57,8 +48,7 @@ impl TopicConfigureOperation {
             if self.partitions < topic_row.partitions {
                 return Err(Error::invalid_user_input(
                     "Cannot decrease partition count. Only increases are allowed.",
-                )
-                .into());
+                ));
             }
 
             topic_row.partitions = self.partitions;
@@ -90,6 +80,6 @@ impl MsgsRequest for TopicConfigureOperation {
         state: MsgsRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> TopicConfigureResponse {
-        TopicConfigureResponse(self.apply_real(state.msgs, ctx.timestamp).await)
+        TopicConfigureResponse::new(self.apply_real(state.msgs, ctx.timestamp).await)
     }
 }

--- a/crates/rate-limit/src/operations/create_namespace.rs
+++ b/crates/rate-limit/src/operations/create_namespace.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU64;
 
+use coyote_error::Result;
 use coyote_namespace::{
     entities::{RateLimitConfig, StorageType},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -44,7 +45,7 @@ impl CreateRateLimitOperation {
         self,
         namespace_state: &coyote_namespace::State,
         now: Timestamp,
-    ) -> coyote_operations::Result<CreateRateLimitResponseData> {
+    ) -> Result<CreateRateLimitResponseData> {
         let op: CreateNamespace<RateLimitConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;
         Ok(out.into())
@@ -78,6 +79,6 @@ impl RateLimitRequest for CreateRateLimitOperation {
         state: RateLimitRaftState<'_>,
         ctx: &coyote_operations::OpContext,
     ) -> CreateRateLimitResponse {
-        CreateRateLimitResponse(self.apply_real(state.namespace, ctx.timestamp).await)
+        CreateRateLimitResponse::new(self.apply_real(state.namespace, ctx.timestamp).await)
     }
 }

--- a/crates/rate-limit/src/operations/limit.rs
+++ b/crates/rate-limit/src/operations/limit.rs
@@ -2,8 +2,9 @@ use std::time::Duration;
 
 use super::{LimitResponse, RateLimitRaftState, RateLimitRequest};
 use crate::{RateLimitNamespace, TokenBucket};
+use coyote_error::Result;
 use coyote_id::NamespaceId;
-use coyote_operations::{OpContext, Result};
+use coyote_operations::OpContext;
 use fjall_utils::StorageType;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -62,6 +63,6 @@ impl LimitOperation {
 
 impl RateLimitRequest for LimitOperation {
     async fn apply(self, state: RateLimitRaftState<'_>, ctx: &OpContext) -> LimitResponse {
-        LimitResponse(self.apply_real(&state, ctx.timestamp).await)
+        LimitResponse::new(self.apply_real(&state, ctx.timestamp).await)
     }
 }

--- a/crates/rate-limit/src/operations/reset.rs
+++ b/crates/rate-limit/src/operations/reset.rs
@@ -1,7 +1,7 @@
 use super::{RateLimitRaftState, RateLimitRequest, ResetResponse};
 use crate::{RateLimitNamespace, TokenBucket};
+use coyote_error::Result;
 use coyote_id::NamespaceId;
-use coyote_operations::Result;
 use fjall_utils::StorageType;
 use serde::{Deserialize, Serialize};
 
@@ -41,6 +41,6 @@ impl RateLimitRequest for ResetOperation {
         state: RateLimitRaftState<'_>,
         _ctx: &coyote_operations::OpContext,
     ) -> ResetResponse {
-        ResetResponse(self.apply_real(&state).await)
+        ResetResponse::new(self.apply_real(&state).await)
     }
 }


### PR DESCRIPTION
I've been hearing repeatedly that dealing with this error type is annoying. Hopefully this helps.