### PR TITLE
Allow more characters in entity keys

### DIFF
--- a/crates/coyote-core/src/types/mod.rs
+++ b/crates/coyote-core/src/types/mod.rs
@@ -184,7 +184,7 @@ string_wrapper!(
     StringSchema {
         string_validation: Some(json_schema!({
             "maxLength": 256,
-            "pattern": r"^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.]+$",
+            "pattern": r"^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.=+]+$",
         })),
         example: Some("some_key".to_string()),
     }
@@ -194,7 +194,7 @@ impl Validate for EntityKey {
     fn validate(&self) -> Result<(), ValidationErrors> {
         const MAX_LENGTH: usize = 256;
         static RE: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.]+$").unwrap());
+            LazyLock::new(|| Regex::new(r"^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.=+]+$").unwrap());
         let mut errors = ValidationErrors::new();
         if self.0.is_empty() {
             errors.add(
@@ -214,7 +214,7 @@ impl Validate for EntityKey {
                 ALL_ERROR,
                 validation_error(
                     Some("invalid_entity_key"),
-                    Some(r"Entity key must match the following pattern: ^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.]+$."),
+                    Some(r"Entity key must match the following pattern: ^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.=+]+$."),
                 ),
             );
         }

--- a/crates/coyote-core/src/types/mod.rs
+++ b/crates/coyote-core/src/types/mod.rs
@@ -280,6 +280,10 @@ mod tests {
         allowed("foo/bar/baz");
         allowed("foo:bar");
         allowed("foo:bar/baz");
+        allowed("foo/bar:baz");
+        allowed(":baz");
+        allowed("foo:");
+        allowed("foo:bar:baz");
         allowed("1");
         allowed("foo/+==");
     }

--- a/crates/coyote-core/src/types/mod.rs
+++ b/crates/coyote-core/src/types/mod.rs
@@ -184,7 +184,7 @@ string_wrapper!(
     StringSchema {
         string_validation: Some(json_schema!({
             "maxLength": 256,
-            "pattern": r"^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.=+]+$",
+            "pattern": r"^[a-zA-Z0-9\-/_.=+:]+$",
         })),
         example: Some("some_key".to_string()),
     }
@@ -194,7 +194,7 @@ impl Validate for EntityKey {
     fn validate(&self) -> Result<(), ValidationErrors> {
         const MAX_LENGTH: usize = 256;
         static RE: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.=+]+$").unwrap());
+            LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9\-/_.=+:]+$").unwrap());
         let mut errors = ValidationErrors::new();
         if self.0.is_empty() {
             errors.add(
@@ -214,7 +214,7 @@ impl Validate for EntityKey {
                 ALL_ERROR,
                 validation_error(
                     Some("invalid_entity_key"),
-                    Some(r"Entity key must match the following pattern: ^(?:[a-zA-Z0-9\-_.]+:)?[a-zA-Z0-9\-/_.=+]+$."),
+                    Some(r"Entity key must match the following pattern: ^[a-zA-Z0-9\-/_.=+:]+$."),
                 ),
             );
         }
@@ -280,15 +280,15 @@ mod tests {
         allowed("foo/bar/baz");
         allowed("foo:bar");
         allowed("foo:bar/baz");
+        allowed("1");
+        allowed("foo/+==");
     }
 
     #[test]
     fn test_rejected_entity_keys() {
         rejected("");
         rejected("foo bar");
-        rejected("foo/bar:baz");
-        rejected(":baz");
-        rejected("foo:");
-        rejected("foo:bar:baz");
+        rejected("foo&bar");
+        rejected("foo\\bar");
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1386,7 +1386,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           }
         },
@@ -1419,7 +1419,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "consistency": {
@@ -1512,7 +1512,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "value": {
@@ -1631,7 +1631,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           }
         },
@@ -1656,7 +1656,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "response": {
@@ -1810,7 +1810,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "ttl": {
@@ -1944,7 +1944,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           }
         },
@@ -1978,7 +1978,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "consistency": {
@@ -2076,7 +2076,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "value": {
@@ -2783,7 +2783,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "tokens": {
@@ -2934,7 +2934,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "config": {
@@ -2979,7 +2979,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
+            "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
           "config": {

--- a/openapi.json
+++ b/openapi.json
@@ -1386,7 +1386,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           }
         },
@@ -1419,7 +1419,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "consistency": {
@@ -1512,7 +1512,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "value": {
@@ -1631,7 +1631,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           }
         },
@@ -1656,7 +1656,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "response": {
@@ -1810,7 +1810,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "ttl": {
@@ -1944,7 +1944,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           }
         },
@@ -1978,7 +1978,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "consistency": {
@@ -2076,7 +2076,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "value": {
@@ -2783,7 +2783,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "tokens": {
@@ -2934,7 +2934,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "config": {
@@ -2979,7 +2979,7 @@
           "key": {
             "type": "string",
             "maxLength": 256,
-            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.]+$",
+            "pattern": "^(?:[a-zA-Z0-9\\-_.]+:)?[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_key"
           },
           "config": {


### PR DESCRIPTION
Allow '=' and '+' so the base64 standard alphabet can be used in keys