### PR TITLE
Update ErrorType::NotFound to return HTTP 400

### DIFF
--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -104,8 +104,8 @@ impl IntoResponse for Error {
                 (StatusCode::BAD_REQUEST, Json(body)).into_response()
             }
             ErrorType::NotFound(body) => {
-                tracing::debug!(error = %body, "not found");
-                (StatusCode::NOT_FOUND, Json(body)).into_response()
+                tracing::debug!(error = %body, "entity not found");
+                (StatusCode::BAD_REQUEST, Json(body)).into_response()
             }
             ErrorType::Validation(body) => {
                 tracing::debug!(error = %body, "validation error");

--- a/crates/test-utils/src/test_client.rs
+++ b/crates/test-utils/src/test_client.rs
@@ -198,6 +198,12 @@ impl TestResponse {
         Ok(self)
     }
 
+    pub fn ensure_not_found(self) -> anyhow::Result<()> {
+        let response = self.ensure(StatusCode::BAD_REQUEST)?.json();
+        anyhow::ensure!(response["code"] == "not_found");
+        Ok(())
+    }
+
     #[track_caller]
     pub fn expect(self, expected_status: StatusCode) -> Self {
         self.ensure(expected_status).unwrap()

--- a/tests/it/auth_token.rs
+++ b/tests/it/auth_token.rs
@@ -318,7 +318,7 @@ async fn test_auth_token_rotate_nonexistent() -> TestResult {
         .post("auth-token/rotate")
         .json(json!({ "id": "key_06egrha0d5x9x8wa4kfcy1prhr" }))
         .await?
-        .ensure(StatusCode::NOT_FOUND)?;
+        .ensure_not_found()?;
 
     Ok(())
 }
@@ -335,7 +335,7 @@ async fn test_auth_token_namespace_get_not_found() -> TestResult {
         .post("auth-token/namespace/get")
         .json(json!({ "name": "no-such-ns" }))
         .await?
-        .ensure(StatusCode::NOT_FOUND)?;
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -56,7 +56,7 @@ async fn test_cache_set_and_get() -> TestResult {
             "behavior": "upsert",
         }))
         .await?
-        .ensure(StatusCode::NOT_FOUND)?;
+        .ensure_not_found()?;
 
     Ok(())
 }
@@ -264,7 +264,7 @@ async fn get_namespace_not_found() -> TestResult {
             "name": "nonexistent-ns",
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -364,7 +364,7 @@ async fn get_namespace_not_found() -> TestResult {
             "name": "nonexistent-ns",
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -125,7 +125,7 @@ async fn test_kv_set_and_get() -> TestResult {
             "behavior": "upsert",
         }))
         .await?
-        .ensure(StatusCode::NOT_FOUND)?;
+        .ensure_not_found()?;
 
     Ok(())
 }
@@ -508,7 +508,7 @@ async fn get_namespace_not_found() -> TestResult {
             "name": "nonexistent-ns",
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/msgs/namespace.rs
+++ b/tests/it/msgs/namespace.rs
@@ -173,7 +173,7 @@ async fn get_namespace_not_found() -> TestResult {
             "name": "nonexistent-ns",
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/msgs/publish.rs
+++ b/tests/it/msgs/publish.rs
@@ -221,7 +221,7 @@ async fn publish_to_nonexistent_namespace() -> TestResult {
             "msgs": [{ "value": "x".as_bytes() }],
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/msgs/queue.rs
+++ b/tests/it/msgs/queue.rs
@@ -297,7 +297,7 @@ async fn queue_receive_nonexistent_namespace() -> TestResult {
             "consumer_group": "test-cg",
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }
@@ -772,7 +772,7 @@ async fn nack_nonexistent_namespace() -> TestResult {
             "msg_ids": ["0:0"],
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }
@@ -793,7 +793,7 @@ async fn redrive_dlq_nonexistent_namespace() -> TestResult {
             "consumer_group": "test-cg",
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -272,7 +272,7 @@ async fn stream_receive_nonexistent_namespace() -> TestResult {
             "consumer_group": "cg1",
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }
@@ -684,7 +684,7 @@ async fn commit_nonexistent_namespace() -> TestResult {
             "offset": 0,
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/msgs/stream_seek.rs
+++ b/tests/it/msgs/stream_seek.rs
@@ -420,7 +420,7 @@ async fn seek_nonexistent_namespace() -> TestResult {
             "position": "earliest",
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }

--- a/tests/it/msgs/topic_configure.rs
+++ b/tests/it/msgs/topic_configure.rs
@@ -249,7 +249,7 @@ async fn configure_nonexistent_namespace() -> TestResult {
             "partitions": 4,
         }))
         .await?
-        .expect(StatusCode::NOT_FOUND);
+        .ensure_not_found()?;
 
     Ok(())
 }


### PR DESCRIPTION
… to distinguish from route-not-found axum errors, as discussed previously.