### PR TITLE
Allow deploying coyote onto specific nodes

### DIFF
--- a/infra/helm-coyote/values.yaml
+++ b/infra/helm-coyote/values.yaml
@@ -69,3 +69,10 @@ cluster:
         value: grpc://datadog-agent.datadog.svc.cluster.local:4317
       - name: COYOTE_ADMIN_TOKEN
         value: "admin_abcdefghijlmnopqrstuvwxyz12345"
+    nodeSelector:
+      db-name: coyote
+    tolerations:
+      - key: db-name
+        operator: Equal
+        value: coyote
+        effect: NoSchedule

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use k8s_openapi::api::core::v1::TopologySpreadConstraint;
+use k8s_openapi::api::core::v1::{Affinity, Toleration, TopologySpreadConstraint};
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -88,6 +88,20 @@ pub(crate) struct CoyoteClusterSpec {
     #[serde(default)]
     #[schemars(schema_with = "topology_spread_constraints_schema")]
     pub topology_spread_constraints: Vec<TopologySpreadConstraint>,
+
+    /// Node selector for scheduling pods onto nodes with matching labels.
+    #[serde(default)]
+    pub node_selector: Option<BTreeMap<String, String>>,
+
+    /// Tolerations to allow pods to be scheduled onto nodes with matching taints.
+    #[serde(default)]
+    #[schemars(schema_with = "tolerations_schema")]
+    pub tolerations: Option<Vec<Toleration>>,
+
+    /// Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity).
+    #[serde(default)]
+    #[schemars(schema_with = "affinity_schema")]
+    pub affinity: Option<Affinity>,
 }
 
 /// Storage configuration for a Coyote cluster.
@@ -244,4 +258,15 @@ fn topology_spread_constraints_schema(_gen: &mut schemars::SchemaGenerator) -> s
         "type": "array",
         "items": { "type": "object" }
     })
+}
+
+fn tolerations_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "array",
+        "items": { "type": "object" }
+    })
+}
+
+fn affinity_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({ "type": "object" })
 }

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -4,10 +4,10 @@ use k8s_openapi::{
     api::{
         apps::v1::{StatefulSet, StatefulSetSpec},
         core::v1::{
-            Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction, ObjectFieldSelector,
-            PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSecurityContext, PodSpec,
-            PodTemplateSpec, Probe, ResourceRequirements, TopologySpreadConstraint, VolumeMount,
-            VolumeResourceRequirements,
+            Affinity, Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction,
+            ObjectFieldSelector, PersistentVolumeClaim, PersistentVolumeClaimSpec,
+            PodSecurityContext, PodSpec, PodTemplateSpec, Probe, ResourceRequirements, Toleration,
+            TopologySpreadConstraint, VolumeMount, VolumeResourceRequirements,
         },
     },
     apimachinery::pkg::{
@@ -52,6 +52,10 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<StatefulSet> {
     let topology_spread_constraints: Vec<TopologySpreadConstraint> =
         spec.topology_spread_constraints.clone();
 
+    let node_selector: Option<BTreeMap<String, String>> = spec.node_selector.clone();
+    let tolerations: Option<Vec<Toleration>> = spec.tolerations.clone();
+    let affinity: Option<Affinity> = spec.affinity.clone();
+
     let pod_spec = PodSpec {
         containers: vec![container],
         volumes: None,
@@ -66,6 +70,9 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<StatefulSet> {
         } else {
             Some(topology_spread_constraints)
         },
+        node_selector,
+        tolerations,
+        affinity,
         ..Default::default()
     };
 


### PR DESCRIPTION
Allow specifying node selection and taint toleration so we can control which nodes the operator/cluster gets scheduled on.

We are not quite ready to actually use these yet, but let's get support for it ready.