### PR TITLE
Use ms instead of millis in all APIs

### DIFF
--- a/benchmarks/benches/queue.rs
+++ b/benchmarks/benches/queue.rs
@@ -120,7 +120,7 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                                 "bench-cg".to_owned(),
                                 MsgQueueReceiveIn::new()
                                     .with_batch_size(100u16)
-                                    .with_lease_duration_millis(100u64),
+                                    .with_lease_duration_ms(100u64),
                             )
                             .await
                             .unwrap(),

--- a/clients/cli/src/cmds/benchmark.rs
+++ b/clients/cli/src/cmds/benchmark.rs
@@ -856,7 +856,7 @@ impl<'a> BenchShard for BenchMsgsQueueReceive<'a> {
                 self.consumer_group.to_owned(),
                 MsgQueueReceiveIn::new()
                     .with_batch_size(self.batch_size)
-                    .with_lease_duration_millis(300_000u64),
+                    .with_lease_duration_ms(300_000u64),
             )
             .await?;
         let rcv_bytes = out.msgs.iter().fold(0, |acc, e| acc + e.value.len()) as u64;

--- a/clients/go/internal/apis/msgs_queue.go
+++ b/clients/go/internal/apis/msgs_queue.go
@@ -29,11 +29,11 @@ func (msgsQueue MsgsQueue) Receive(
 	msgQueueReceiveIn coyote_models.MsgQueueReceiveIn,
 ) (*coyote_models.MsgQueueReceiveOut, error) {
 	body := coyote_models.MsgQueueReceiveIn_{
-		Namespace:           msgQueueReceiveIn.Namespace,
-		Topic:               topic,
-		ConsumerGroup:       consumerGroup,
-		BatchSize:           msgQueueReceiveIn.BatchSize,
-		LeaseDurationMillis: msgQueueReceiveIn.LeaseDurationMillis,
+		Namespace:       msgQueueReceiveIn.Namespace,
+		Topic:           topic,
+		ConsumerGroup:   consumerGroup,
+		BatchSize:       msgQueueReceiveIn.BatchSize,
+		LeaseDurationMs: msgQueueReceiveIn.LeaseDurationMs,
 	}
 
 	return coyote_proto.ExecuteRequest[coyote_models.MsgQueueReceiveIn_, coyote_models.MsgQueueReceiveOut](

--- a/clients/go/internal/apis/msgs_stream.go
+++ b/clients/go/internal/apis/msgs_stream.go
@@ -32,7 +32,7 @@ func (msgsStream MsgsStream) Receive(
 		Topic:                   topic,
 		ConsumerGroup:           consumerGroup,
 		BatchSize:               msgStreamReceiveIn.BatchSize,
-		LeaseDurationMillis:     msgStreamReceiveIn.LeaseDurationMillis,
+		LeaseDurationMs:         msgStreamReceiveIn.LeaseDurationMs,
 		DefaultStartingPosition: msgStreamReceiveIn.DefaultStartingPosition,
 	}
 

--- a/clients/go/internal/models/auth_token_create_in.go
+++ b/clients/go/internal/models/auth_token_create_in.go
@@ -3,13 +3,13 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type AuthTokenCreateIn struct {
-	Namespace    *string            `msgpack:"namespace,omitempty"`
-	Name         string             `msgpack:"name"`
-	Prefix       *string            `msgpack:"prefix,omitempty"`
-	Suffix       *string            `msgpack:"suffix,omitempty"`
-	ExpiryMillis *uint64            `msgpack:"expiry_millis,omitempty"` // Milliseconds from now until the token expires.
-	Metadata     *map[string]string `msgpack:"metadata,omitempty"`
-	OwnerId      string             `msgpack:"owner_id"`
-	Scopes       []string           `msgpack:"scopes,omitempty"`
-	Enabled      *bool              `msgpack:"enabled,omitempty"` // Whether the token is enabled. Defaults to `true`.
+	Namespace *string            `msgpack:"namespace,omitempty"`
+	Name      string             `msgpack:"name"`
+	Prefix    *string            `msgpack:"prefix,omitempty"`
+	Suffix    *string            `msgpack:"suffix,omitempty"`
+	ExpiryMs  *uint64            `msgpack:"expiry_ms,omitempty"` // Milliseconds from now until the token expires.
+	Metadata  *map[string]string `msgpack:"metadata,omitempty"`
+	OwnerId   string             `msgpack:"owner_id"`
+	Scopes    []string           `msgpack:"scopes,omitempty"`
+	Enabled   *bool              `msgpack:"enabled,omitempty"` // Whether the token is enabled. Defaults to `true`.
 }

--- a/clients/go/internal/models/auth_token_expire_in.go
+++ b/clients/go/internal/models/auth_token_expire_in.go
@@ -3,7 +3,7 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type AuthTokenExpireIn struct {
-	Namespace    *string `msgpack:"namespace,omitempty"`
-	Id           string  `msgpack:"id"`
-	ExpiryMillis *uint64 `msgpack:"expiry_millis,omitempty"` // Milliseconds from now until the token expires. `None` means expire immediately.
+	Namespace *string `msgpack:"namespace,omitempty"`
+	Id        string  `msgpack:"id"`
+	ExpiryMs  *uint64 `msgpack:"expiry_ms,omitempty"` // Milliseconds from now until the token expires. `None` means expire immediately.
 }

--- a/clients/go/internal/models/auth_token_rotate_in.go
+++ b/clients/go/internal/models/auth_token_rotate_in.go
@@ -3,9 +3,9 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type AuthTokenRotateIn struct {
-	Namespace    *string `msgpack:"namespace,omitempty"`
-	Id           string  `msgpack:"id"`
-	Prefix       *string `msgpack:"prefix,omitempty"`
-	Suffix       *string `msgpack:"suffix,omitempty"`
-	ExpiryMillis *uint64 `msgpack:"expiry_millis,omitempty"` // Milliseconds from now until the old token expires. `None` means expire immediately.
+	Namespace *string `msgpack:"namespace,omitempty"`
+	Id        string  `msgpack:"id"`
+	Prefix    *string `msgpack:"prefix,omitempty"`
+	Suffix    *string `msgpack:"suffix,omitempty"`
+	ExpiryMs  *uint64 `msgpack:"expiry_ms,omitempty"` // Milliseconds from now until the old token expires. `None` means expire immediately.
 }

--- a/clients/go/internal/models/auth_token_update_in.go
+++ b/clients/go/internal/models/auth_token_update_in.go
@@ -3,11 +3,11 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type AuthTokenUpdateIn struct {
-	Namespace    *string            `msgpack:"namespace,omitempty"`
-	Id           string             `msgpack:"id"`
-	Name         *string            `msgpack:"name,omitempty"`
-	ExpiryMillis *uint64            `msgpack:"expiry_millis,omitempty"`
-	Metadata     *map[string]string `msgpack:"metadata,omitempty"`
-	Scopes       []string           `msgpack:"scopes,omitempty"`
-	Enabled      *bool              `msgpack:"enabled,omitempty"`
+	Namespace *string            `msgpack:"namespace,omitempty"`
+	Id        string             `msgpack:"id"`
+	Name      *string            `msgpack:"name,omitempty"`
+	ExpiryMs  *uint64            `msgpack:"expiry_ms,omitempty"`
+	Metadata  *map[string]string `msgpack:"metadata,omitempty"`
+	Scopes    []string           `msgpack:"scopes,omitempty"`
+	Enabled   *bool              `msgpack:"enabled,omitempty"`
 }

--- a/clients/go/internal/models/msg_queue_receive_in.go
+++ b/clients/go/internal/models/msg_queue_receive_in.go
@@ -3,15 +3,15 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type MsgQueueReceiveIn struct {
-	Namespace           *string `msgpack:"namespace,omitempty"`
-	BatchSize           *uint16 `msgpack:"batch_size,omitempty"`
-	LeaseDurationMillis *uint64 `msgpack:"lease_duration_millis,omitempty"`
+	Namespace       *string `msgpack:"namespace,omitempty"`
+	BatchSize       *uint16 `msgpack:"batch_size,omitempty"`
+	LeaseDurationMs *uint64 `msgpack:"lease_duration_ms,omitempty"`
 }
 
 type MsgQueueReceiveIn_ struct {
-	Namespace           *string `msgpack:"namespace,omitempty"`
-	Topic               string  `msgpack:"topic"`
-	ConsumerGroup       string  `msgpack:"consumer_group"`
-	BatchSize           *uint16 `msgpack:"batch_size,omitempty"`
-	LeaseDurationMillis *uint64 `msgpack:"lease_duration_millis,omitempty"`
+	Namespace       *string `msgpack:"namespace,omitempty"`
+	Topic           string  `msgpack:"topic"`
+	ConsumerGroup   string  `msgpack:"consumer_group"`
+	BatchSize       *uint16 `msgpack:"batch_size,omitempty"`
+	LeaseDurationMs *uint64 `msgpack:"lease_duration_ms,omitempty"`
 }

--- a/clients/go/internal/models/msg_stream_receive_in.go
+++ b/clients/go/internal/models/msg_stream_receive_in.go
@@ -5,7 +5,7 @@ package coyote_models
 type MsgStreamReceiveIn struct {
 	Namespace               *string `msgpack:"namespace,omitempty"`
 	BatchSize               *uint16 `msgpack:"batch_size,omitempty"`
-	LeaseDurationMillis     *uint64 `msgpack:"lease_duration_millis,omitempty"`
+	LeaseDurationMs         *uint64 `msgpack:"lease_duration_ms,omitempty"`
 	DefaultStartingPosition *string `msgpack:"default_starting_position,omitempty"`
 }
 
@@ -14,6 +14,6 @@ type MsgStreamReceiveIn_ struct {
 	Topic                   string  `msgpack:"topic"`
 	ConsumerGroup           string  `msgpack:"consumer_group"`
 	BatchSize               *uint16 `msgpack:"batch_size,omitempty"`
-	LeaseDurationMillis     *uint64 `msgpack:"lease_duration_millis,omitempty"`
+	LeaseDurationMs         *uint64 `msgpack:"lease_duration_ms,omitempty"`
 	DefaultStartingPosition *string `msgpack:"default_starting_position,omitempty"`
 }

--- a/clients/go/internal/models/rate_limit_check_out.go
+++ b/clients/go/internal/models/rate_limit_check_out.go
@@ -3,7 +3,7 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type RateLimitCheckOut struct {
-	Allowed          bool    `msgpack:"allowed"`                      // Whether the request is allowed
-	Remaining        uint64  `msgpack:"remaining"`                    // Number of tokens remaining
-	RetryAfterMillis *uint64 `msgpack:"retry_after_millis,omitempty"` // Milliseconds until enough tokens are available (only present when allowed is false)
+	Allowed      bool    `msgpack:"allowed"`                  // Whether the request is allowed
+	Remaining    uint64  `msgpack:"remaining"`                // Number of tokens remaining
+	RetryAfterMs *uint64 `msgpack:"retry_after_ms,omitempty"` // Milliseconds until enough tokens are available (only present when allowed is false)
 }

--- a/clients/go/internal/models/rate_limit_get_remaining_out.go
+++ b/clients/go/internal/models/rate_limit_get_remaining_out.go
@@ -3,6 +3,6 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type RateLimitGetRemainingOut struct {
-	Remaining        uint64  `msgpack:"remaining"`                    // Number of tokens remaining
-	RetryAfterMillis *uint64 `msgpack:"retry_after_millis,omitempty"` // Milliseconds until at least one token is available (only present when remaining is 0)
+	Remaining    uint64  `msgpack:"remaining"`                // Number of tokens remaining
+	RetryAfterMs *uint64 `msgpack:"retry_after_ms,omitempty"` // Milliseconds until at least one token is available (only present when remaining is 0)
 }

--- a/clients/go/internal/models/rate_limit_token_bucket_config.go
+++ b/clients/go/internal/models/rate_limit_token_bucket_config.go
@@ -3,7 +3,7 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type RateLimitTokenBucketConfig struct {
-	Capacity             uint64  `msgpack:"capacity"`                         // Maximum capacity of the bucket
-	RefillAmount         uint64  `msgpack:"refill_amount"`                    // Number of tokens to add per refill interval
-	RefillIntervalMillis *uint64 `msgpack:"refill_interval_millis,omitempty"` // Interval in milliseconds between refills (minimum 1 millisecond)
+	Capacity         uint64  `msgpack:"capacity"`                     // Maximum capacity of the bucket
+	RefillAmount     uint64  `msgpack:"refill_amount"`                // Number of tokens to add per refill interval
+	RefillIntervalMs *uint64 `msgpack:"refill_interval_ms,omitempty"` // Interval in milliseconds between refills (minimum 1 millisecond)
 }

--- a/clients/go/internal/models/retention.go
+++ b/clients/go/internal/models/retention.go
@@ -3,6 +3,6 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type Retention struct {
-	Millis *uint64 `msgpack:"millis,omitempty"`
-	Bytes  *uint64 `msgpack:"bytes,omitempty"`
+	Ms    *uint64 `msgpack:"ms,omitempty"`
+	Bytes *uint64 `msgpack:"bytes,omitempty"`
 }

--- a/clients/java/src/main/java/com/svix/coyote/apis/MsgsQueue.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/MsgsQueue.java
@@ -54,7 +54,7 @@ public class MsgsQueue {
             topic,
             consumerGroup,
             msgQueueReceiveIn.getBatchSize(),
-            msgQueueReceiveIn.getLeaseDurationMillis()
+            msgQueueReceiveIn.getLeaseDurationMs()
         );
 
         return this.client.executeRequest(

--- a/clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
+++ b/clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
@@ -47,7 +47,7 @@ public class MsgsStream {
             topic,
             consumerGroup,
             msgStreamReceiveIn.getBatchSize(),
-            msgStreamReceiveIn.getLeaseDurationMillis(),
+            msgStreamReceiveIn.getLeaseDurationMs(),
             msgStreamReceiveIn.getDefaultStartingPosition()
         );
 

--- a/clients/java/src/main/java/com/svix/coyote/models/AuthTokenCreateIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/AuthTokenCreateIn.java
@@ -32,7 +32,7 @@ public class AuthTokenCreateIn {
     @JsonProperty private String name;
     @JsonProperty private String prefix;
     @JsonProperty private String suffix;
-    @JsonProperty("expiry_millis") private Long expiryMillis;
+    @JsonProperty("expiry_ms") private Long expiryMs;
     @JsonProperty private Map<String,String> metadata;
     @JsonProperty("owner_id") private String ownerId;
     @JsonProperty private List<String> scopes;
@@ -115,23 +115,23 @@ public class AuthTokenCreateIn {
         this.suffix = suffix;
     }
 
-    public AuthTokenCreateIn expiryMillis(Long expiryMillis) {
-        this.expiryMillis = expiryMillis;
+    public AuthTokenCreateIn expiryMs(Long expiryMs) {
+        this.expiryMs = expiryMs;
         return this;
     }
 
     /**
     * Milliseconds from now until the token expires.
     *
-     * @return expiryMillis
+     * @return expiryMs
      */
     @javax.annotation.Nullable
-    public Long getExpiryMillis() {
-        return expiryMillis;
+    public Long getExpiryMs() {
+        return expiryMs;
     }
 
-    public void setExpiryMillis(Long expiryMillis) {
-        this.expiryMillis = expiryMillis;
+    public void setExpiryMs(Long expiryMs) {
+        this.expiryMs = expiryMs;
     }
 
     public AuthTokenCreateIn metadata(Map<String,String> metadata) {

--- a/clients/java/src/main/java/com/svix/coyote/models/AuthTokenExpireIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/AuthTokenExpireIn.java
@@ -30,7 +30,7 @@ import lombok.ToString;
 public class AuthTokenExpireIn {
     @JsonProperty private String namespace;
     @JsonProperty private String id;
-    @JsonProperty("expiry_millis") private Long expiryMillis;
+    @JsonProperty("expiry_ms") private Long expiryMs;
     public AuthTokenExpireIn() {}
 
     public AuthTokenExpireIn namespace(String namespace) {
@@ -71,23 +71,23 @@ public class AuthTokenExpireIn {
         this.id = id;
     }
 
-    public AuthTokenExpireIn expiryMillis(Long expiryMillis) {
-        this.expiryMillis = expiryMillis;
+    public AuthTokenExpireIn expiryMs(Long expiryMs) {
+        this.expiryMs = expiryMs;
         return this;
     }
 
     /**
     * Milliseconds from now until the token expires. `None` means expire immediately.
     *
-     * @return expiryMillis
+     * @return expiryMs
      */
     @javax.annotation.Nullable
-    public Long getExpiryMillis() {
-        return expiryMillis;
+    public Long getExpiryMs() {
+        return expiryMs;
     }
 
-    public void setExpiryMillis(Long expiryMillis) {
-        this.expiryMillis = expiryMillis;
+    public void setExpiryMs(Long expiryMs) {
+        this.expiryMs = expiryMs;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/AuthTokenRotateIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/AuthTokenRotateIn.java
@@ -32,7 +32,7 @@ public class AuthTokenRotateIn {
     @JsonProperty private String id;
     @JsonProperty private String prefix;
     @JsonProperty private String suffix;
-    @JsonProperty("expiry_millis") private Long expiryMillis;
+    @JsonProperty("expiry_ms") private Long expiryMs;
     public AuthTokenRotateIn() {}
 
     public AuthTokenRotateIn namespace(String namespace) {
@@ -111,23 +111,23 @@ public class AuthTokenRotateIn {
         this.suffix = suffix;
     }
 
-    public AuthTokenRotateIn expiryMillis(Long expiryMillis) {
-        this.expiryMillis = expiryMillis;
+    public AuthTokenRotateIn expiryMs(Long expiryMs) {
+        this.expiryMs = expiryMs;
         return this;
     }
 
     /**
     * Milliseconds from now until the old token expires. `None` means expire immediately.
     *
-     * @return expiryMillis
+     * @return expiryMs
      */
     @javax.annotation.Nullable
-    public Long getExpiryMillis() {
-        return expiryMillis;
+    public Long getExpiryMs() {
+        return expiryMs;
     }
 
-    public void setExpiryMillis(Long expiryMillis) {
-        this.expiryMillis = expiryMillis;
+    public void setExpiryMs(Long expiryMs) {
+        this.expiryMs = expiryMs;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/AuthTokenUpdateIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/AuthTokenUpdateIn.java
@@ -31,7 +31,7 @@ public class AuthTokenUpdateIn {
     @JsonProperty private String namespace;
     @JsonProperty private String id;
     @JsonProperty private String name;
-    @JsonProperty("expiry_millis") private Long expiryMillis;
+    @JsonProperty("expiry_ms") private Long expiryMs;
     @JsonProperty private Map<String,String> metadata;
     @JsonProperty private List<String> scopes;
     @JsonProperty private Boolean enabled;
@@ -94,23 +94,23 @@ public class AuthTokenUpdateIn {
         this.name = name;
     }
 
-    public AuthTokenUpdateIn expiryMillis(Long expiryMillis) {
-        this.expiryMillis = expiryMillis;
+    public AuthTokenUpdateIn expiryMs(Long expiryMs) {
+        this.expiryMs = expiryMs;
         return this;
     }
 
     /**
-    * Get expiryMillis
+    * Get expiryMs
     *
-     * @return expiryMillis
+     * @return expiryMs
      */
     @javax.annotation.Nullable
-    public Long getExpiryMillis() {
-        return expiryMillis;
+    public Long getExpiryMs() {
+        return expiryMs;
     }
 
-    public void setExpiryMillis(Long expiryMillis) {
-        this.expiryMillis = expiryMillis;
+    public void setExpiryMs(Long expiryMs) {
+        this.expiryMs = expiryMs;
     }
 
     public AuthTokenUpdateIn metadata(Map<String,String> metadata) {

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn.java
@@ -32,7 +32,7 @@ public class MsgQueueReceiveIn {
     @JsonProperty private String topic;
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty("batch_size") private Short batchSize;
-    @JsonProperty("lease_duration_millis") private Long leaseDurationMillis;
+    @JsonProperty("lease_duration_ms") private Long leaseDurationMs;
     public MsgQueueReceiveIn() {}
 
     public MsgQueueReceiveIn namespace(String namespace) {
@@ -73,22 +73,22 @@ public class MsgQueueReceiveIn {
         this.batchSize = batchSize;
     }
 
-    public MsgQueueReceiveIn leaseDurationMillis(Long leaseDurationMillis) {
-        this.leaseDurationMillis = leaseDurationMillis;
+    public MsgQueueReceiveIn leaseDurationMs(Long leaseDurationMs) {
+        this.leaseDurationMs = leaseDurationMs;
         return this;
     }
 
     /**
-    * Get leaseDurationMillis
+    * Get leaseDurationMs
     *
-     * @return leaseDurationMillis
+     * @return leaseDurationMs
      */
     @javax.annotation.Nullable
-    public Long getLeaseDurationMillis() {
-        return leaseDurationMillis;
+    public Long getLeaseDurationMs() {
+        return leaseDurationMs;
     }
 
-    public void setLeaseDurationMillis(Long leaseDurationMillis) {
-        this.leaseDurationMillis = leaseDurationMillis;
+    public void setLeaseDurationMs(Long leaseDurationMs) {
+        this.leaseDurationMs = leaseDurationMs;
     }
 }

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn_.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn_.java
@@ -27,20 +27,20 @@ public class MsgQueueReceiveIn_ {
     @JsonProperty private String topic;
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty("batch_size") private Short batchSize;
-    @JsonProperty("lease_duration_millis") private Long leaseDurationMillis;
+    @JsonProperty("lease_duration_ms") private Long leaseDurationMs;
 
     public MsgQueueReceiveIn_(
         String namespace,
         String topic,
         String consumerGroup,
         Short batchSize,
-        Long leaseDurationMillis
+        Long leaseDurationMs
     ) {
         this.namespace = namespace;
         this.topic = topic;
         this.consumerGroup = consumerGroup;
         this.batchSize = batchSize;
-        this.leaseDurationMillis = leaseDurationMillis;
+        this.leaseDurationMs = leaseDurationMs;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn.java
@@ -32,7 +32,7 @@ public class MsgStreamReceiveIn {
     @JsonProperty private String topic;
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty("batch_size") private Short batchSize;
-    @JsonProperty("lease_duration_millis") private Long leaseDurationMillis;
+    @JsonProperty("lease_duration_ms") private Long leaseDurationMs;
     @JsonProperty("default_starting_position") private String defaultStartingPosition;
     public MsgStreamReceiveIn() {}
 
@@ -74,23 +74,23 @@ public class MsgStreamReceiveIn {
         this.batchSize = batchSize;
     }
 
-    public MsgStreamReceiveIn leaseDurationMillis(Long leaseDurationMillis) {
-        this.leaseDurationMillis = leaseDurationMillis;
+    public MsgStreamReceiveIn leaseDurationMs(Long leaseDurationMs) {
+        this.leaseDurationMs = leaseDurationMs;
         return this;
     }
 
     /**
-    * Get leaseDurationMillis
+    * Get leaseDurationMs
     *
-     * @return leaseDurationMillis
+     * @return leaseDurationMs
      */
     @javax.annotation.Nullable
-    public Long getLeaseDurationMillis() {
-        return leaseDurationMillis;
+    public Long getLeaseDurationMs() {
+        return leaseDurationMs;
     }
 
-    public void setLeaseDurationMillis(Long leaseDurationMillis) {
-        this.leaseDurationMillis = leaseDurationMillis;
+    public void setLeaseDurationMs(Long leaseDurationMs) {
+        this.leaseDurationMs = leaseDurationMs;
     }
 
     public MsgStreamReceiveIn defaultStartingPosition(String defaultStartingPosition) {

--- a/clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn_.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn_.java
@@ -27,7 +27,7 @@ public class MsgStreamReceiveIn_ {
     @JsonProperty private String topic;
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty("batch_size") private Short batchSize;
-    @JsonProperty("lease_duration_millis") private Long leaseDurationMillis;
+    @JsonProperty("lease_duration_ms") private Long leaseDurationMs;
     @JsonProperty("default_starting_position") private String defaultStartingPosition;
 
     public MsgStreamReceiveIn_(
@@ -35,14 +35,14 @@ public class MsgStreamReceiveIn_ {
         String topic,
         String consumerGroup,
         Short batchSize,
-        Long leaseDurationMillis,
+        Long leaseDurationMs,
         String defaultStartingPosition
     ) {
         this.namespace = namespace;
         this.topic = topic;
         this.consumerGroup = consumerGroup;
         this.batchSize = batchSize;
-        this.leaseDurationMillis = leaseDurationMillis;
+        this.leaseDurationMs = leaseDurationMs;
         this.defaultStartingPosition = defaultStartingPosition;
     }
 

--- a/clients/java/src/main/java/com/svix/coyote/models/RateLimitCheckOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/RateLimitCheckOut.java
@@ -30,7 +30,7 @@ import lombok.ToString;
 public class RateLimitCheckOut {
     @JsonProperty private Boolean allowed;
     @JsonProperty private Long remaining;
-    @JsonProperty("retry_after_millis") private Long retryAfterMillis;
+    @JsonProperty("retry_after_ms") private Long retryAfterMs;
     public RateLimitCheckOut() {}
 
     public RateLimitCheckOut allowed(Boolean allowed) {
@@ -71,23 +71,23 @@ public class RateLimitCheckOut {
         this.remaining = remaining;
     }
 
-    public RateLimitCheckOut retryAfterMillis(Long retryAfterMillis) {
-        this.retryAfterMillis = retryAfterMillis;
+    public RateLimitCheckOut retryAfterMs(Long retryAfterMs) {
+        this.retryAfterMs = retryAfterMs;
         return this;
     }
 
     /**
     * Milliseconds until enough tokens are available (only present when allowed is false)
     *
-     * @return retryAfterMillis
+     * @return retryAfterMs
      */
     @javax.annotation.Nullable
-    public Long getRetryAfterMillis() {
-        return retryAfterMillis;
+    public Long getRetryAfterMs() {
+        return retryAfterMs;
     }
 
-    public void setRetryAfterMillis(Long retryAfterMillis) {
-        this.retryAfterMillis = retryAfterMillis;
+    public void setRetryAfterMs(Long retryAfterMs) {
+        this.retryAfterMs = retryAfterMs;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/RateLimitGetRemainingOut.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/RateLimitGetRemainingOut.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class RateLimitGetRemainingOut {
     @JsonProperty private Long remaining;
-    @JsonProperty("retry_after_millis") private Long retryAfterMillis;
+    @JsonProperty("retry_after_ms") private Long retryAfterMs;
     public RateLimitGetRemainingOut() {}
 
     public RateLimitGetRemainingOut remaining(Long remaining) {
@@ -51,23 +51,23 @@ public class RateLimitGetRemainingOut {
         this.remaining = remaining;
     }
 
-    public RateLimitGetRemainingOut retryAfterMillis(Long retryAfterMillis) {
-        this.retryAfterMillis = retryAfterMillis;
+    public RateLimitGetRemainingOut retryAfterMs(Long retryAfterMs) {
+        this.retryAfterMs = retryAfterMs;
         return this;
     }
 
     /**
     * Milliseconds until at least one token is available (only present when remaining is 0)
     *
-     * @return retryAfterMillis
+     * @return retryAfterMs
      */
     @javax.annotation.Nullable
-    public Long getRetryAfterMillis() {
-        return retryAfterMillis;
+    public Long getRetryAfterMs() {
+        return retryAfterMs;
     }
 
-    public void setRetryAfterMillis(Long retryAfterMillis) {
-        this.retryAfterMillis = retryAfterMillis;
+    public void setRetryAfterMs(Long retryAfterMs) {
+        this.retryAfterMs = retryAfterMs;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/RateLimitTokenBucketConfig.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/RateLimitTokenBucketConfig.java
@@ -30,7 +30,7 @@ import lombok.ToString;
 public class RateLimitTokenBucketConfig {
     @JsonProperty private Long capacity;
     @JsonProperty("refill_amount") private Long refillAmount;
-    @JsonProperty("refill_interval_millis") private Long refillIntervalMillis;
+    @JsonProperty("refill_interval_ms") private Long refillIntervalMs;
     public RateLimitTokenBucketConfig() {}
 
     public RateLimitTokenBucketConfig capacity(Long capacity) {
@@ -71,23 +71,23 @@ public class RateLimitTokenBucketConfig {
         this.refillAmount = refillAmount;
     }
 
-    public RateLimitTokenBucketConfig refillIntervalMillis(Long refillIntervalMillis) {
-        this.refillIntervalMillis = refillIntervalMillis;
+    public RateLimitTokenBucketConfig refillIntervalMs(Long refillIntervalMs) {
+        this.refillIntervalMs = refillIntervalMs;
         return this;
     }
 
     /**
     * Interval in milliseconds between refills (minimum 1 millisecond)
     *
-     * @return refillIntervalMillis
+     * @return refillIntervalMs
      */
     @javax.annotation.Nullable
-    public Long getRefillIntervalMillis() {
-        return refillIntervalMillis;
+    public Long getRefillIntervalMs() {
+        return refillIntervalMs;
     }
 
-    public void setRefillIntervalMillis(Long refillIntervalMillis) {
-        this.refillIntervalMillis = refillIntervalMillis;
+    public void setRefillIntervalMs(Long refillIntervalMs) {
+        this.refillIntervalMs = refillIntervalMs;
     }
 
     /**

--- a/clients/java/src/main/java/com/svix/coyote/models/Retention.java
+++ b/clients/java/src/main/java/com/svix/coyote/models/Retention.java
@@ -28,27 +28,27 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class Retention {
-    @JsonProperty private Long millis;
+    @JsonProperty private Long ms;
     @JsonProperty private Long bytes;
     public Retention() {}
 
-    public Retention millis(Long millis) {
-        this.millis = millis;
+    public Retention ms(Long ms) {
+        this.ms = ms;
         return this;
     }
 
     /**
-    * Get millis
+    * Get ms
     *
-     * @return millis
+     * @return ms
      */
     @javax.annotation.Nullable
-    public Long getMillis() {
-        return millis;
+    public Long getMs() {
+        return ms;
     }
 
-    public void setMillis(Long millis) {
-        this.millis = millis;
+    public void setMs(Long ms) {
+        this.ms = ms;
     }
 
     public Retention bytes(Long bytes) {

--- a/clients/javascript/src/models/authTokenCreateIn.ts
+++ b/clients/javascript/src/models/authTokenCreateIn.ts
@@ -6,7 +6,7 @@ export interface AuthTokenCreateIn {
     prefix?: string;
     suffix?: string | null;
     /** Milliseconds from now until the token expires. */
-    expiryMillis?: number | null;
+    expiryMs?: number | null;
     metadata?: { [key: string]: string };
     ownerId: string;
     scopes?: string[];
@@ -22,7 +22,7 @@ export const AuthTokenCreateInSerializer = {
             name: object['name'],
             prefix: object['prefix'],
             suffix: object['suffix'],
-            expiryMillis: object['expiry_millis'],
+            expiryMs: object['expiry_ms'],
             metadata: object['metadata'],
             ownerId: object['owner_id'],
             scopes: object['scopes'],
@@ -37,7 +37,7 @@ export const AuthTokenCreateInSerializer = {
             'name': self.name,
             'prefix': self.prefix,
             'suffix': self.suffix,
-            'expiry_millis': self.expiryMillis,
+            'expiry_ms': self.expiryMs,
             'metadata': self.metadata,
             'owner_id': self.ownerId,
             'scopes': self.scopes,

--- a/clients/javascript/src/models/authTokenExpireIn.ts
+++ b/clients/javascript/src/models/authTokenExpireIn.ts
@@ -4,7 +4,7 @@ export interface AuthTokenExpireIn {
     namespace?: string | null;
     id: string;
     /** Milliseconds from now until the token expires. `None` means expire immediately. */
-    expiryMillis?: number | null;
+    expiryMs?: number | null;
 }
 
 export const AuthTokenExpireInSerializer = {
@@ -13,7 +13,7 @@ export const AuthTokenExpireInSerializer = {
         return {
             namespace: object['namespace'],
             id: object['id'],
-            expiryMillis: object['expiry_millis'],
+            expiryMs: object['expiry_ms'],
         };
     },
 
@@ -22,7 +22,7 @@ export const AuthTokenExpireInSerializer = {
         return {
             'namespace': self.namespace,
             'id': self.id,
-            'expiry_millis': self.expiryMillis,
+            'expiry_ms': self.expiryMs,
         };
     }
 }

--- a/clients/javascript/src/models/authTokenRotateIn.ts
+++ b/clients/javascript/src/models/authTokenRotateIn.ts
@@ -6,7 +6,7 @@ export interface AuthTokenRotateIn {
     prefix?: string;
     suffix?: string | null;
     /** Milliseconds from now until the old token expires. `None` means expire immediately. */
-    expiryMillis?: number | null;
+    expiryMs?: number | null;
 }
 
 export const AuthTokenRotateInSerializer = {
@@ -17,7 +17,7 @@ export const AuthTokenRotateInSerializer = {
             id: object['id'],
             prefix: object['prefix'],
             suffix: object['suffix'],
-            expiryMillis: object['expiry_millis'],
+            expiryMs: object['expiry_ms'],
         };
     },
 
@@ -28,7 +28,7 @@ export const AuthTokenRotateInSerializer = {
             'id': self.id,
             'prefix': self.prefix,
             'suffix': self.suffix,
-            'expiry_millis': self.expiryMillis,
+            'expiry_ms': self.expiryMs,
         };
     }
 }

--- a/clients/javascript/src/models/authTokenUpdateIn.ts
+++ b/clients/javascript/src/models/authTokenUpdateIn.ts
@@ -4,7 +4,7 @@ export interface AuthTokenUpdateIn {
     namespace?: string | null;
     id: string;
     name?: string | null;
-    expiryMillis?: number | null;
+    expiryMs?: number | null;
     metadata?: { [key: string]: string } | null;
     scopes?: string[] | null;
     enabled?: boolean | null;
@@ -17,7 +17,7 @@ export const AuthTokenUpdateInSerializer = {
             namespace: object['namespace'],
             id: object['id'],
             name: object['name'],
-            expiryMillis: object['expiry_millis'],
+            expiryMs: object['expiry_ms'],
             metadata: object['metadata'],
             scopes: object['scopes'],
             enabled: object['enabled'],
@@ -30,7 +30,7 @@ export const AuthTokenUpdateInSerializer = {
             'namespace': self.namespace,
             'id': self.id,
             'name': self.name,
-            'expiry_millis': self.expiryMillis,
+            'expiry_ms': self.expiryMs,
             'metadata': self.metadata,
             'scopes': self.scopes,
             'enabled': self.enabled,

--- a/clients/javascript/src/models/msgQueueReceiveIn.ts
+++ b/clients/javascript/src/models/msgQueueReceiveIn.ts
@@ -3,7 +3,7 @@
 export interface MsgQueueReceiveIn {
     namespace?: string | null;
     batchSize?: number;
-    leaseDurationMillis?: number;
+    leaseDurationMs?: number;
 }
 
 export interface MsgQueueReceiveIn_ {
@@ -11,7 +11,7 @@ export interface MsgQueueReceiveIn_ {
     topic: string;
     consumerGroup: string;
     batchSize?: number;
-    leaseDurationMillis?: number;
+    leaseDurationMs?: number;
 }
 
 export const MsgQueueReceiveInSerializer = {
@@ -22,7 +22,7 @@ export const MsgQueueReceiveInSerializer = {
             topic: object['topic'],
             consumerGroup: object['consumer_group'],
             batchSize: object['batch_size'],
-            leaseDurationMillis: object['lease_duration_millis'],
+            leaseDurationMs: object['lease_duration_ms'],
         };
     },
 
@@ -33,7 +33,7 @@ export const MsgQueueReceiveInSerializer = {
             'topic': self.topic,
             'consumer_group': self.consumerGroup,
             'batch_size': self.batchSize,
-            'lease_duration_millis': self.leaseDurationMillis,
+            'lease_duration_ms': self.leaseDurationMs,
         };
     }
 }

--- a/clients/javascript/src/models/msgStreamReceiveIn.ts
+++ b/clients/javascript/src/models/msgStreamReceiveIn.ts
@@ -3,7 +3,7 @@
 export interface MsgStreamReceiveIn {
     namespace?: string | null;
     batchSize?: number;
-    leaseDurationMillis?: number;
+    leaseDurationMs?: number;
     defaultStartingPosition?: string;
 }
 
@@ -12,7 +12,7 @@ export interface MsgStreamReceiveIn_ {
     topic: string;
     consumerGroup: string;
     batchSize?: number;
-    leaseDurationMillis?: number;
+    leaseDurationMs?: number;
     defaultStartingPosition?: string;
 }
 
@@ -24,7 +24,7 @@ export const MsgStreamReceiveInSerializer = {
             topic: object['topic'],
             consumerGroup: object['consumer_group'],
             batchSize: object['batch_size'],
-            leaseDurationMillis: object['lease_duration_millis'],
+            leaseDurationMs: object['lease_duration_ms'],
             defaultStartingPosition: object['default_starting_position'],
         };
     },
@@ -36,7 +36,7 @@ export const MsgStreamReceiveInSerializer = {
             'topic': self.topic,
             'consumer_group': self.consumerGroup,
             'batch_size': self.batchSize,
-            'lease_duration_millis': self.leaseDurationMillis,
+            'lease_duration_ms': self.leaseDurationMs,
             'default_starting_position': self.defaultStartingPosition,
         };
     }

--- a/clients/javascript/src/models/rateLimitCheckOut.ts
+++ b/clients/javascript/src/models/rateLimitCheckOut.ts
@@ -6,7 +6,7 @@ export interface RateLimitCheckOut {
     /** Number of tokens remaining */
     remaining: number;
     /** Milliseconds until enough tokens are available (only present when allowed is false) */
-    retryAfterMillis?: number | null;
+    retryAfterMs?: number | null;
 }
 
 export const RateLimitCheckOutSerializer = {
@@ -15,7 +15,7 @@ export const RateLimitCheckOutSerializer = {
         return {
             allowed: object['allowed'],
             remaining: object['remaining'],
-            retryAfterMillis: object['retry_after_millis'],
+            retryAfterMs: object['retry_after_ms'],
         };
     },
 
@@ -24,7 +24,7 @@ export const RateLimitCheckOutSerializer = {
         return {
             'allowed': self.allowed,
             'remaining': self.remaining,
-            'retry_after_millis': self.retryAfterMillis,
+            'retry_after_ms': self.retryAfterMs,
         };
     }
 }

--- a/clients/javascript/src/models/rateLimitGetRemainingOut.ts
+++ b/clients/javascript/src/models/rateLimitGetRemainingOut.ts
@@ -4,7 +4,7 @@ export interface RateLimitGetRemainingOut {
     /** Number of tokens remaining */
     remaining: number;
     /** Milliseconds until at least one token is available (only present when remaining is 0) */
-    retryAfterMillis?: number | null;
+    retryAfterMs?: number | null;
 }
 
 export const RateLimitGetRemainingOutSerializer = {
@@ -12,7 +12,7 @@ export const RateLimitGetRemainingOutSerializer = {
     _fromJsonObject(object: any): RateLimitGetRemainingOut {
         return {
             remaining: object['remaining'],
-            retryAfterMillis: object['retry_after_millis'],
+            retryAfterMs: object['retry_after_ms'],
         };
     },
 
@@ -20,7 +20,7 @@ export const RateLimitGetRemainingOutSerializer = {
     _toJsonObject(self: RateLimitGetRemainingOut): any {
         return {
             'remaining': self.remaining,
-            'retry_after_millis': self.retryAfterMillis,
+            'retry_after_ms': self.retryAfterMs,
         };
     }
 }

--- a/clients/javascript/src/models/rateLimitTokenBucketConfig.ts
+++ b/clients/javascript/src/models/rateLimitTokenBucketConfig.ts
@@ -6,7 +6,7 @@ export interface RateLimitTokenBucketConfig {
     /** Number of tokens to add per refill interval */
     refillAmount: number;
     /** Interval in milliseconds between refills (minimum 1 millisecond) */
-    refillIntervalMillis?: number;
+    refillIntervalMs?: number;
 }
 
 export const RateLimitTokenBucketConfigSerializer = {
@@ -15,7 +15,7 @@ export const RateLimitTokenBucketConfigSerializer = {
         return {
             capacity: object['capacity'],
             refillAmount: object['refill_amount'],
-            refillIntervalMillis: object['refill_interval_millis'],
+            refillIntervalMs: object['refill_interval_ms'],
         };
     },
 
@@ -24,7 +24,7 @@ export const RateLimitTokenBucketConfigSerializer = {
         return {
             'capacity': self.capacity,
             'refill_amount': self.refillAmount,
-            'refill_interval_millis': self.refillIntervalMillis,
+            'refill_interval_ms': self.refillIntervalMs,
         };
     }
 }

--- a/clients/javascript/src/models/retention.ts
+++ b/clients/javascript/src/models/retention.ts
@@ -1,7 +1,7 @@
 // this file is @generated
 
 export interface Retention {
-    millis?: number;
+    ms?: number;
     bytes?: number;
 }
 
@@ -9,7 +9,7 @@ export const RetentionSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject(object: any): Retention {
         return {
-            millis: object['millis'],
+            ms: object['ms'],
             bytes: object['bytes'],
         };
     },
@@ -17,7 +17,7 @@ export const RetentionSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _toJsonObject(self: Retention): any {
         return {
-            'millis': self.millis,
+            'ms': self.ms,
             'bytes': self.bytes,
         };
     }

--- a/clients/python/coyote/apis/msgs_queue.py
+++ b/clients/python/coyote/apis/msgs_queue.py
@@ -38,7 +38,7 @@ class MsgsQueueAsync(ApiBase):
             topic=topic,
             consumer_group=consumer_group,
             batch_size=msg_queue_receive_in.batch_size,
-            lease_duration_millis=msg_queue_receive_in.lease_duration_millis,
+            lease_duration_ms=msg_queue_receive_in.lease_duration_ms,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -158,7 +158,7 @@ class MsgsQueue(ApiBase):
             topic=topic,
             consumer_group=consumer_group,
             batch_size=msg_queue_receive_in.batch_size,
-            lease_duration_millis=msg_queue_receive_in.lease_duration_millis,
+            lease_duration_ms=msg_queue_receive_in.lease_duration_ms,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/clients/python/coyote/apis/msgs_stream.py
+++ b/clients/python/coyote/apis/msgs_stream.py
@@ -31,7 +31,7 @@ class MsgsStreamAsync(ApiBase):
             topic=topic,
             consumer_group=consumer_group,
             batch_size=msg_stream_receive_in.batch_size,
-            lease_duration_millis=msg_stream_receive_in.lease_duration_millis,
+            lease_duration_ms=msg_stream_receive_in.lease_duration_ms,
             default_starting_position=msg_stream_receive_in.default_starting_position,
         ).model_dump(exclude_none=True)
 
@@ -109,7 +109,7 @@ class MsgsStream(ApiBase):
             topic=topic,
             consumer_group=consumer_group,
             batch_size=msg_stream_receive_in.batch_size,
-            lease_duration_millis=msg_stream_receive_in.lease_duration_millis,
+            lease_duration_ms=msg_stream_receive_in.lease_duration_ms,
             default_starting_position=msg_stream_receive_in.default_starting_position,
         ).model_dump(exclude_none=True)
 

--- a/clients/python/coyote/models/auth_token_create_in.py
+++ b/clients/python/coyote/models/auth_token_create_in.py
@@ -14,7 +14,7 @@ class AuthTokenCreateIn(BaseModel):
 
     suffix: t.Optional[str] = None
 
-    expiry_millis: t.Optional[int] = Field(default=None, alias="expiry_millis")
+    expiry_ms: t.Optional[int] = Field(default=None, alias="expiry_ms")
     """Milliseconds from now until the token expires."""
 
     metadata: t.Optional[t.Dict[str, str]] = None

--- a/clients/python/coyote/models/auth_token_expire_in.py
+++ b/clients/python/coyote/models/auth_token_expire_in.py
@@ -10,5 +10,5 @@ class AuthTokenExpireIn(BaseModel):
 
     id: str
 
-    expiry_millis: t.Optional[int] = Field(default=None, alias="expiry_millis")
+    expiry_ms: t.Optional[int] = Field(default=None, alias="expiry_ms")
     """Milliseconds from now until the token expires. `None` means expire immediately."""

--- a/clients/python/coyote/models/auth_token_rotate_in.py
+++ b/clients/python/coyote/models/auth_token_rotate_in.py
@@ -14,5 +14,5 @@ class AuthTokenRotateIn(BaseModel):
 
     suffix: t.Optional[str] = None
 
-    expiry_millis: t.Optional[int] = Field(default=None, alias="expiry_millis")
+    expiry_ms: t.Optional[int] = Field(default=None, alias="expiry_ms")
     """Milliseconds from now until the old token expires. `None` means expire immediately."""

--- a/clients/python/coyote/models/auth_token_update_in.py
+++ b/clients/python/coyote/models/auth_token_update_in.py
@@ -12,7 +12,7 @@ class AuthTokenUpdateIn(BaseModel):
 
     name: t.Optional[str] = None
 
-    expiry_millis: t.Optional[int] = Field(default=None, alias="expiry_millis")
+    expiry_ms: t.Optional[int] = Field(default=None, alias="expiry_ms")
 
     metadata: t.Optional[t.Dict[str, str]] = None
 

--- a/clients/python/coyote/models/msg_queue_receive_in.py
+++ b/clients/python/coyote/models/msg_queue_receive_in.py
@@ -10,9 +10,7 @@ class MsgQueueReceiveIn(BaseModel):
 
     batch_size: t.Optional[int] = Field(default=None, alias="batch_size")
 
-    lease_duration_millis: t.Optional[int] = Field(
-        default=None, alias="lease_duration_millis"
-    )
+    lease_duration_ms: t.Optional[int] = Field(default=None, alias="lease_duration_ms")
 
 
 class _MsgQueueReceiveIn(BaseModel):
@@ -24,6 +22,4 @@ class _MsgQueueReceiveIn(BaseModel):
 
     batch_size: t.Optional[int] = Field(default=None, alias="batch_size")
 
-    lease_duration_millis: t.Optional[int] = Field(
-        default=None, alias="lease_duration_millis"
-    )
+    lease_duration_ms: t.Optional[int] = Field(default=None, alias="lease_duration_ms")

--- a/clients/python/coyote/models/msg_stream_receive_in.py
+++ b/clients/python/coyote/models/msg_stream_receive_in.py
@@ -10,9 +10,7 @@ class MsgStreamReceiveIn(BaseModel):
 
     batch_size: t.Optional[int] = Field(default=None, alias="batch_size")
 
-    lease_duration_millis: t.Optional[int] = Field(
-        default=None, alias="lease_duration_millis"
-    )
+    lease_duration_ms: t.Optional[int] = Field(default=None, alias="lease_duration_ms")
 
     default_starting_position: t.Optional[str] = Field(
         default=None, alias="default_starting_position"
@@ -28,9 +26,7 @@ class _MsgStreamReceiveIn(BaseModel):
 
     batch_size: t.Optional[int] = Field(default=None, alias="batch_size")
 
-    lease_duration_millis: t.Optional[int] = Field(
-        default=None, alias="lease_duration_millis"
-    )
+    lease_duration_ms: t.Optional[int] = Field(default=None, alias="lease_duration_ms")
 
     default_starting_position: t.Optional[str] = Field(
         default=None, alias="default_starting_position"

--- a/clients/python/coyote/models/rate_limit_check_out.py
+++ b/clients/python/coyote/models/rate_limit_check_out.py
@@ -12,7 +12,5 @@ class RateLimitCheckOut(BaseModel):
     remaining: int
     """Number of tokens remaining"""
 
-    retry_after_millis: t.Optional[int] = Field(
-        default=None, alias="retry_after_millis"
-    )
+    retry_after_ms: t.Optional[int] = Field(default=None, alias="retry_after_ms")
     """Milliseconds until enough tokens are available (only present when allowed is false)"""

--- a/clients/python/coyote/models/rate_limit_get_remaining_out.py
+++ b/clients/python/coyote/models/rate_limit_get_remaining_out.py
@@ -9,7 +9,5 @@ class RateLimitGetRemainingOut(BaseModel):
     remaining: int
     """Number of tokens remaining"""
 
-    retry_after_millis: t.Optional[int] = Field(
-        default=None, alias="retry_after_millis"
-    )
+    retry_after_ms: t.Optional[int] = Field(default=None, alias="retry_after_ms")
     """Milliseconds until at least one token is available (only present when remaining is 0)"""

--- a/clients/python/coyote/models/rate_limit_token_bucket_config.py
+++ b/clients/python/coyote/models/rate_limit_token_bucket_config.py
@@ -12,7 +12,7 @@ class RateLimitTokenBucketConfig(BaseModel):
     refill_amount: int = Field(alias="refill_amount")
     """Number of tokens to add per refill interval"""
 
-    refill_interval_millis: t.Optional[int] = Field(
-        default=None, alias="refill_interval_millis"
+    refill_interval_ms: t.Optional[int] = Field(
+        default=None, alias="refill_interval_ms"
     )
     """Interval in milliseconds between refills (minimum 1 millisecond)"""

--- a/clients/python/coyote/models/retention.py
+++ b/clients/python/coyote/models/retention.py
@@ -5,6 +5,6 @@ from ..internal.base_model import BaseModel
 
 
 class Retention(BaseModel):
-    millis: t.Optional[int] = None
+    ms: t.Optional[int] = None
 
     bytes: t.Optional[int] = None

--- a/clients/rust/src/api/msgs_queue.rs
+++ b/clients/rust/src/api/msgs_queue.rs
@@ -26,7 +26,7 @@ impl<'a> MsgsQueue<'a> {
             topic,
             consumer_group,
             batch_size: msg_queue_receive_in.batch_size,
-            lease_duration_millis: msg_queue_receive_in.lease_duration_millis,
+            lease_duration_ms: msg_queue_receive_in.lease_duration_ms,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1/msgs/queue/receive")

--- a/clients/rust/src/api/msgs_stream.rs
+++ b/clients/rust/src/api/msgs_stream.rs
@@ -25,7 +25,7 @@ impl<'a> MsgsStream<'a> {
             topic,
             consumer_group,
             batch_size: msg_stream_receive_in.batch_size,
-            lease_duration_millis: msg_stream_receive_in.lease_duration_millis,
+            lease_duration_ms: msg_stream_receive_in.lease_duration_ms,
             default_starting_position: msg_stream_receive_in.default_starting_position,
         };
 

--- a/clients/rust/src/models/auth_token_create_in.rs
+++ b/clients/rust/src/models/auth_token_create_in.rs
@@ -16,7 +16,7 @@ pub struct AuthTokenCreateIn {
 
     /// Milliseconds from now until the token expires.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry_millis: Option<u64>,
+    pub expiry_ms: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<std::collections::HashMap<String, String>>,
@@ -38,7 +38,7 @@ impl AuthTokenCreateIn {
             name,
             prefix: None,
             suffix: None,
-            expiry_millis: None,
+            expiry_ms: None,
             metadata: None,
             owner_id,
             scopes: None,
@@ -61,8 +61,8 @@ impl AuthTokenCreateIn {
         self
     }
 
-    pub fn with_expiry_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.expiry_millis = value.into();
+    pub fn with_expiry_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.expiry_ms = value.into();
         self
     }
 

--- a/clients/rust/src/models/auth_token_expire_in.rs
+++ b/clients/rust/src/models/auth_token_expire_in.rs
@@ -10,7 +10,7 @@ pub struct AuthTokenExpireIn {
 
     /// Milliseconds from now until the token expires. `None` means expire immediately.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry_millis: Option<u64>,
+    pub expiry_ms: Option<u64>,
 }
 
 impl AuthTokenExpireIn {
@@ -18,7 +18,7 @@ impl AuthTokenExpireIn {
         Self {
             namespace: None,
             id,
-            expiry_millis: None,
+            expiry_ms: None,
         }
     }
 
@@ -27,8 +27,8 @@ impl AuthTokenExpireIn {
         self
     }
 
-    pub fn with_expiry_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.expiry_millis = value.into();
+    pub fn with_expiry_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.expiry_ms = value.into();
         self
     }
 }

--- a/clients/rust/src/models/auth_token_rotate_in.rs
+++ b/clients/rust/src/models/auth_token_rotate_in.rs
@@ -16,7 +16,7 @@ pub struct AuthTokenRotateIn {
 
     /// Milliseconds from now until the old token expires. `None` means expire immediately.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry_millis: Option<u64>,
+    pub expiry_ms: Option<u64>,
 }
 
 impl AuthTokenRotateIn {
@@ -26,7 +26,7 @@ impl AuthTokenRotateIn {
             id,
             prefix: None,
             suffix: None,
-            expiry_millis: None,
+            expiry_ms: None,
         }
     }
 
@@ -45,8 +45,8 @@ impl AuthTokenRotateIn {
         self
     }
 
-    pub fn with_expiry_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.expiry_millis = value.into();
+    pub fn with_expiry_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.expiry_ms = value.into();
         self
     }
 }

--- a/clients/rust/src/models/auth_token_update_in.rs
+++ b/clients/rust/src/models/auth_token_update_in.rs
@@ -12,7 +12,7 @@ pub struct AuthTokenUpdateIn {
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry_millis: Option<u64>,
+    pub expiry_ms: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<std::collections::HashMap<String, String>>,
@@ -30,7 +30,7 @@ impl AuthTokenUpdateIn {
             namespace: None,
             id,
             name: None,
-            expiry_millis: None,
+            expiry_ms: None,
             metadata: None,
             scopes: None,
             enabled: None,
@@ -47,8 +47,8 @@ impl AuthTokenUpdateIn {
         self
     }
 
-    pub fn with_expiry_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.expiry_millis = value.into();
+    pub fn with_expiry_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.expiry_ms = value.into();
         self
     }
 

--- a/clients/rust/src/models/msg_queue_receive_in.rs
+++ b/clients/rust/src/models/msg_queue_receive_in.rs
@@ -10,7 +10,7 @@ pub struct MsgQueueReceiveIn {
     pub batch_size: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lease_duration_millis: Option<u64>,
+    pub lease_duration_ms: Option<u64>,
 }
 
 impl MsgQueueReceiveIn {
@@ -18,7 +18,7 @@ impl MsgQueueReceiveIn {
         Self {
             namespace: None,
             batch_size: None,
-            lease_duration_millis: None,
+            lease_duration_ms: None,
         }
     }
 
@@ -32,8 +32,8 @@ impl MsgQueueReceiveIn {
         self
     }
 
-    pub fn with_lease_duration_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.lease_duration_millis = value.into();
+    pub fn with_lease_duration_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.lease_duration_ms = value.into();
         self
     }
 }
@@ -51,5 +51,5 @@ pub(crate) struct MsgQueueReceiveIn_ {
     pub batch_size: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lease_duration_millis: Option<u64>,
+    pub lease_duration_ms: Option<u64>,
 }

--- a/clients/rust/src/models/msg_stream_receive_in.rs
+++ b/clients/rust/src/models/msg_stream_receive_in.rs
@@ -10,7 +10,7 @@ pub struct MsgStreamReceiveIn {
     pub batch_size: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lease_duration_millis: Option<u64>,
+    pub lease_duration_ms: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_starting_position: Option<String>,
@@ -21,7 +21,7 @@ impl MsgStreamReceiveIn {
         Self {
             namespace: None,
             batch_size: None,
-            lease_duration_millis: None,
+            lease_duration_ms: None,
             default_starting_position: None,
         }
     }
@@ -36,8 +36,8 @@ impl MsgStreamReceiveIn {
         self
     }
 
-    pub fn with_lease_duration_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.lease_duration_millis = value.into();
+    pub fn with_lease_duration_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.lease_duration_ms = value.into();
         self
     }
 
@@ -60,7 +60,7 @@ pub(crate) struct MsgStreamReceiveIn_ {
     pub batch_size: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lease_duration_millis: Option<u64>,
+    pub lease_duration_ms: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_starting_position: Option<String>,

--- a/clients/rust/src/models/rate_limit_check_out.rs
+++ b/clients/rust/src/models/rate_limit_check_out.rs
@@ -11,7 +11,7 @@ pub struct RateLimitCheckOut {
 
     /// Milliseconds until enough tokens are available (only present when allowed is false)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_after_millis: Option<u64>,
+    pub retry_after_ms: Option<u64>,
 }
 
 impl RateLimitCheckOut {
@@ -19,12 +19,12 @@ impl RateLimitCheckOut {
         Self {
             allowed,
             remaining,
-            retry_after_millis: None,
+            retry_after_ms: None,
         }
     }
 
-    pub fn with_retry_after_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.retry_after_millis = value.into();
+    pub fn with_retry_after_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.retry_after_ms = value.into();
         self
     }
 }

--- a/clients/rust/src/models/rate_limit_get_remaining_out.rs
+++ b/clients/rust/src/models/rate_limit_get_remaining_out.rs
@@ -8,19 +8,19 @@ pub struct RateLimitGetRemainingOut {
 
     /// Milliseconds until at least one token is available (only present when remaining is 0)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_after_millis: Option<u64>,
+    pub retry_after_ms: Option<u64>,
 }
 
 impl RateLimitGetRemainingOut {
     pub fn new(remaining: u64) -> Self {
         Self {
             remaining,
-            retry_after_millis: None,
+            retry_after_ms: None,
         }
     }
 
-    pub fn with_retry_after_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.retry_after_millis = value.into();
+    pub fn with_retry_after_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.retry_after_ms = value.into();
         self
     }
 }

--- a/clients/rust/src/models/rate_limit_token_bucket_config.rs
+++ b/clients/rust/src/models/rate_limit_token_bucket_config.rs
@@ -11,7 +11,7 @@ pub struct RateLimitTokenBucketConfig {
 
     /// Interval in milliseconds between refills (minimum 1 millisecond)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub refill_interval_millis: Option<u64>,
+    pub refill_interval_ms: Option<u64>,
 }
 
 impl RateLimitTokenBucketConfig {
@@ -19,12 +19,12 @@ impl RateLimitTokenBucketConfig {
         Self {
             capacity,
             refill_amount,
-            refill_interval_millis: None,
+            refill_interval_ms: None,
         }
     }
 
-    pub fn with_refill_interval_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.refill_interval_millis = value.into();
+    pub fn with_refill_interval_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.refill_interval_ms = value.into();
         self
     }
 }

--- a/clients/rust/src/models/retention.rs
+++ b/clients/rust/src/models/retention.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Retention {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub millis: Option<u64>,
+    pub ms: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes: Option<u64>,
@@ -13,13 +13,13 @@ pub struct Retention {
 impl Retention {
     pub fn new() -> Self {
         Self {
-            millis: None,
+            ms: None,
             bytes: None,
         }
     }
 
-    pub fn with_millis(mut self, value: impl Into<Option<u64>>) -> Self {
-        self.millis = value.into();
+    pub fn with_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.ms = value.into();
         self
     }
 

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -475,8 +475,8 @@ impl JsonSchema for ConsumerGroup {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct Retention {
-    #[serde(default = "default_retention_millis")]
-    pub millis: NonZeroU64,
+    #[serde(default = "default_retention_ms")]
+    pub ms: NonZeroU64,
     #[serde(default = "default_retention_bytes")]
     pub bytes: NonZeroU64,
 }
@@ -484,13 +484,13 @@ pub struct Retention {
 impl Default for Retention {
     fn default() -> Self {
         Self {
-            millis: default_retention_millis(),
+            ms: default_retention_ms(),
             bytes: default_retention_bytes(),
         }
     }
 }
 
-pub fn default_retention_millis() -> NonZeroU64 {
+pub fn default_retention_ms() -> NonZeroU64 {
     (Duration::from_hours(24 * 30).as_millis() as u64)
         .try_into()
         .unwrap()

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -9,7 +9,7 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use super::{CreateNamespaceResponse, MsgsRaftState, MsgsRequest};
-use crate::entities::{Retention, default_retention_bytes, default_retention_millis};
+use crate::entities::{Retention, default_retention_bytes, default_retention_ms};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateNamespaceOperation {
@@ -35,7 +35,7 @@ impl CreateNamespaceOperation {
         let op = CreateNamespace::new(
             self.name,
             StreamConfig {
-                retention_period: Duration::from_millis(self.retention.millis.get()),
+                retention_period: Duration::from_millis(self.retention.ms.get()),
             },
             self.storage_type,
             Some(self.retention.bytes),
@@ -56,17 +56,17 @@ pub struct CreateNamespaceResponseData {
 
 impl From<CreateNamespaceOutput<StreamConfig>> for CreateNamespaceResponseData {
     fn from(value: CreateNamespaceOutput<StreamConfig>) -> Self {
-        let millis = u64::try_from(value.config.retention_period.as_millis())
+        let ms = u64::try_from(value.config.retention_period.as_millis())
             .ok()
             .and_then(|ms| ms.try_into().ok())
-            .unwrap_or_else(default_retention_millis);
+            .unwrap_or_else(default_retention_ms);
         let bytes = value
             .max_storage_bytes
             .unwrap_or_else(default_retention_bytes);
 
         Self {
             name: value.name,
-            retention: Retention { millis, bytes },
+            retention: Retention { ms, bytes },
             storage_type: value.storage_type,
             created: value.created,
             updated: value.updated,

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -23,7 +23,7 @@ pub struct QueueReceiveOperation {
     partition: Option<Partition>,
     consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
-    lease_duration_millis: DurationMs,
+    lease_duration_ms: DurationMs,
 }
 
 impl QueueReceiveOperation {
@@ -32,7 +32,7 @@ impl QueueReceiveOperation {
         topic: TopicIn,
         consumer_group: ConsumerGroup,
         batch_size: NonZeroU16,
-        lease_duration_millis: DurationMs,
+        lease_duration_ms: DurationMs,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
@@ -44,7 +44,7 @@ impl QueueReceiveOperation {
             partition,
             consumer_group,
             batch_size,
-            lease_duration_millis,
+            lease_duration_ms,
         })
     }
 
@@ -56,7 +56,7 @@ impl QueueReceiveOperation {
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<QueueReceiveMsg> = Vec::with_capacity(remaining.into());
 
-            let expiry = now + self.lease_duration_millis;
+            let expiry = now + self.lease_duration_ms;
 
             let mut batch = state.db.batch();
 

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -25,7 +25,7 @@ pub struct StreamReceiveOperation {
     partition: Option<Partition>,
     consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
-    lease_duration_millis: DurationMs,
+    lease_duration_ms: DurationMs,
     default_starting_position: SeekPosition,
 }
 
@@ -35,7 +35,7 @@ impl StreamReceiveOperation {
         topic: TopicIn,
         consumer_group: ConsumerGroup,
         batch_size: NonZeroU16,
-        lease_duration_millis: DurationMs,
+        lease_duration_ms: DurationMs,
         default_starting_position: SeekPosition,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
@@ -48,7 +48,7 @@ impl StreamReceiveOperation {
             partition,
             consumer_group,
             batch_size,
-            lease_duration_millis,
+            lease_duration_ms,
             default_starting_position,
         })
     }
@@ -59,7 +59,7 @@ impl StreamReceiveOperation {
         spawn_blocking_in_current_span(move || {
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<StreamReceiveMsg> = Vec::with_capacity(remaining as usize);
-            let expiry = now + self.lease_duration_millis;
+            let expiry = now + self.lease_duration_ms;
 
             let mut batch = state.db.batch();
 

--- a/crates/rate-limit/src/algorithms.rs
+++ b/crates/rate-limit/src/algorithms.rs
@@ -25,13 +25,13 @@ impl TokenBucket {
         let mut new_last_refill = last_refill;
 
         if last_refill < now {
-            let elapsed_millis: u64 = now
+            let elapsed_ms: u64 = now
                 .duration_since(last_refill)
                 .as_millis()
                 .try_into()
                 .unwrap();
-            let refill_interval_millis: u64 = self.refill_interval.as_millis();
-            let intervals = elapsed_millis / refill_interval_millis;
+            let refill_interval_ms: u64 = self.refill_interval.as_millis();
+            let intervals = elapsed_ms / refill_interval_ms;
 
             capacity += intervals * self.refill_rate;
             capacity = capacity.min(self.bucket_size);

--- a/docs/content/modules/msgs.mdx
+++ b/docs/content/modules/msgs.mdx
@@ -22,7 +22,7 @@ A namespace groups topics together with shared retention and persistence setting
   "persistence": "ephemeral",
   "retention": {
     "bytes": 4194304,
-    "millis": 604800
+    "ms": 604800
   }
 }
 ```
@@ -104,8 +104,8 @@ Publishing is the same across all delivery modes.
   "topic": "orders",
   "consumer_group": "G1",
   "batch_size": 100,
-  "batch_wait_millis": 10000,
-  "lease_duration_millis": 300000
+  "batch_wait_ms": 10000,
+  "lease_duration_ms": 300000
 }
 ```
 
@@ -162,7 +162,7 @@ Queue and FIFO share the same API shape — substitute `fifo` for `queue` to use
   "topic": "orders",
   "consumer_group": "G1",
   "batch_size": 10,
-  "lease_duration_millis": 30000
+  "lease_duration_ms": 30000
 }
 ```
 
@@ -195,7 +195,7 @@ Extends the processing lease on a message you haven't finished yet. Use this whe
   "topic": "orders",
   "consumer_group": "G1",
   "msg_id": "msg-abc",
-  "lease_duration_millis": 10000
+  "lease_duration_ms": 10000
 }
 ```
 

--- a/docs/content/modules/msgs/fifo.mdx
+++ b/docs/content/modules/msgs/fifo.mdx
@@ -17,7 +17,7 @@ coyote.msgs.fifo.receive(
     topic="topic-123",  // Topic to consume from
     consumer_group: "group1", // The consumer group to use
     // Wait until batch_size messages are available,
-    // or batch_wait_millis has passed (whichever comes first).
+    // or batch_wait_ms has passed (whichever comes first).
     batch_size: 100,
     batch_wait_ms: 10_000,
     // How long a consumer owns a message before it goes back to the queue if unacknowledged.

--- a/docs/content/modules/msgs/queue.mdx
+++ b/docs/content/modules/msgs/queue.mdx
@@ -17,7 +17,7 @@ coyote.msgs.queue.receive(
     topic="topic-123",  // Topic to consume from
     consumer_group: "group1", // The consumer group to use
     // Wait until batch_size messages are available,
-    // or batch_wait_millis has passed (whichever comes first).
+    // or batch_wait_ms has passed (whichever comes first).
     batch_size: 100,
     batch_wait_ms: 10_000,
     // How long a consumer owns a message before it goes back to the queue if unacknowledged.

--- a/docs/content/modules/msgs/stream.mdx
+++ b/docs/content/modules/msgs/stream.mdx
@@ -48,11 +48,11 @@ coyote.msgs.stream.receive(
     topic="topic-123",        // Topic (or specific partition) to consume from
     consumer_group="group1",  // The consumer group to use
     // Wait until batch_size messages are available,
-    // or batch_wait_millis has passed (whichever comes first).
+    // or batch_wait_ms has passed (whichever comes first).
     batch_size: 100,
-    batch_wait_millis: 10_000,
+    batch_wait_ms: 10_000,
     // How long a consumer holds a batch before it is considered abandoned.
-    lease_duration_millis: 500_000
+    lease_duration_ms: 500_000
 )
 ```
 

--- a/openapi.json
+++ b/openapi.json
@@ -3466,7 +3466,7 @@
             "type": "string",
             "nullable": true
           },
-          "expiry_millis": {
+          "expiry_ms": {
             "description": "Milliseconds from now until the token expires.",
             "type": "integer",
             "format": "uint64",
@@ -3613,7 +3613,7 @@
           "id": {
             "type": "string"
           },
-          "expiry_millis": {
+          "expiry_ms": {
             "description": "Milliseconds from now until the token expires. `None` means expire immediately.",
             "type": "integer",
             "format": "uint64",
@@ -3755,7 +3755,7 @@
             "type": "string",
             "nullable": true
           },
-          "expiry_millis": {
+          "expiry_ms": {
             "description": "Milliseconds from now until the old token expires. `None` means expire immediately.",
             "type": "integer",
             "format": "uint64",
@@ -3805,7 +3805,7 @@
             "type": "string",
             "nullable": true
           },
-          "expiry_millis": {
+          "expiry_ms": {
             "type": "integer",
             "format": "uint64",
             "nullable": true
@@ -4741,7 +4741,7 @@
           },
           "retention": {
             "default": {
-              "millis": 2592000000,
+              "ms": 2592000000,
               "bytes": 1000000000000
             },
             "$ref": "#/components/schemas/Retention"
@@ -5039,7 +5039,7 @@
             "maximum": 65535,
             "default": 10
           },
-          "lease_duration_millis": {
+          "lease_duration_ms": {
             "type": "integer",
             "format": "uint64",
             "default": 30000
@@ -5149,7 +5149,7 @@
             "maximum": 65535,
             "default": 10
           },
-          "lease_duration_millis": {
+          "lease_duration_ms": {
             "type": "integer",
             "format": "uint64",
             "default": 300000
@@ -5391,7 +5391,7 @@
             "format": "uint64",
             "minimum": 0
           },
-          "retry_after_millis": {
+          "retry_after_ms": {
             "description": "Milliseconds until enough tokens are available (only present when allowed is false)",
             "type": "integer",
             "format": "uint64",
@@ -5531,7 +5531,7 @@
             "format": "uint64",
             "minimum": 0
           },
-          "retry_after_millis": {
+          "retry_after_ms": {
             "description": "Milliseconds until at least one token is available (only present when remaining is 0)",
             "type": "integer",
             "format": "uint64",
@@ -5585,7 +5585,7 @@
             "format": "uint64",
             "minimum": 1
           },
-          "refill_interval_millis": {
+          "refill_interval_ms": {
             "description": "Interval in milliseconds between refills (minimum 1 millisecond)",
             "type": "integer",
             "format": "uint64",
@@ -5601,7 +5601,7 @@
       "Retention": {
         "type": "object",
         "properties": {
-          "millis": {
+          "ms": {
             "type": "integer",
             "format": "uint64",
             "minimum": 1,

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -263,7 +263,7 @@ pub async fn run(app_config: AppConfig, raft_state: RaftState) -> anyhow::Result
     }
 
     tracing::info!(
-        duration_millis = (Instant::now() - t).as_millis(),
+        duration_ms = (Instant::now() - t).as_millis(),
         "Finished bootstrapping."
     );
 
@@ -351,7 +351,7 @@ mod tests {
     #[test]
     fn msgs_with_options() {
         let cmd: BootstrapCommand =
-            r#"msgs namespace create {"name":"myns","retention":{"millis":60000,"bytes":500}}"#
+            r#"msgs namespace create {"name":"myns","retention":{"ms":60000,"bytes":500}}"#
                 .parse()
                 .unwrap();
         let BootstrapCommand::Msgs(v) = cmd else {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -357,7 +357,7 @@ mod tests {
         let BootstrapCommand::Msgs(v) = cmd else {
             panic!()
         };
-        assert_eq!(v.retention.millis.get(), 60000);
+        assert_eq!(v.retention.ms.get(), 60000);
         assert_eq!(v.retention.bytes.get(), 500);
     }
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -356,7 +356,7 @@ pub struct ClusterConfiguration {
     /// Trigger a background snapshot after this many milliseconds
     #[serde(
         rename = "snapshot_after_ms",
-        with = "crate::serde::duration::opt_millis",
+        with = "crate::serde::duration::opt_ms",
         default = "defaults::cluster_snapshot_after_time"
     )]
     pub snapshot_after_time: Option<Duration>,

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -135,7 +135,7 @@ impl TableRow for Log {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct LogIndex {
-    unix_timestamp_millis: u64,
+    unix_timestamp_ms: u64,
     log_id: u64,
 }
 
@@ -144,7 +144,7 @@ impl TableRow for LogIndex {
     type Key = u64;
 
     fn get_key(&self) -> Cow<'_, Self::Key> {
-        Cow::Owned(self.unix_timestamp_millis)
+        Cow::Owned(self.unix_timestamp_ms)
     }
 }
 
@@ -397,7 +397,7 @@ impl CoyoteLogs {
         log_index: u64,
     ) -> anyhow::Result<()> {
         let rec = LogIndex {
-            unix_timestamp_millis: timestamp.as_millisecond() as u64,
+            unix_timestamp_ms: timestamp.as_millisecond() as u64,
             log_id: log_index,
         };
         tracing::trace!(?rec, "recording log/timestamp checkpoint");

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -24,7 +24,7 @@ pub(crate) mod duration {
     }
 
     /// Deserialize an Optional<Duration> as a number of milliseconds
-    pub(crate) mod opt_millis {
+    pub(crate) mod opt_ms {
         use serde::{Deserialize, Deserializer, Serialize, Serializer};
         use std::time::Duration;
 

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -71,7 +71,7 @@ pub struct AuthTokenCreateIn {
     pub prefix: String,
     pub suffix: Option<String>,
     /// Milliseconds from now until the token expires.
-    pub expiry_millis: Option<DurationMs>,
+    pub expiry_ms: Option<DurationMs>,
     #[serde(default)]
     pub metadata: Metadata,
     pub owner_id: String,
@@ -115,7 +115,7 @@ async fn auth_token_create(
         namespace,
         data.name,
         token.hash(),
-        data.expiry_millis.map(|ms| repl.time.now() + ms),
+        data.expiry_ms.map(|ms| repl.time.now() + ms),
         data.metadata,
         data.owner_id,
         data.scopes,
@@ -138,7 +138,7 @@ pub struct AuthTokenExpireIn {
     pub namespace: Option<String>,
     pub id: Public<AuthTokenId>,
     /// Milliseconds from now until the token expires. `None` means expire immediately.
-    pub expiry_millis: Option<DurationMs>,
+    pub expiry_ms: Option<DurationMs>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -156,7 +156,7 @@ async fn auth_token_expire(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let expiry = data.expiry_millis.map(|ms| repl.time.now() + ms);
+    let expiry = data.expiry_ms.map(|ms| repl.time.now() + ms);
     let operation = ExpireAuthTokenOperation::new(namespace, data.id.into_inner(), expiry);
     let _ = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(AuthTokenExpireOut {}))
@@ -280,7 +280,7 @@ pub struct AuthTokenUpdateIn {
     pub namespace: Option<String>,
     pub id: Public<AuthTokenId>,
     pub name: Option<String>,
-    pub expiry_millis: Option<DurationMs>,
+    pub expiry_ms: Option<DurationMs>,
     pub metadata: Option<Metadata>,
     pub scopes: Option<Vec<String>>,
     pub enabled: Option<bool>,
@@ -305,7 +305,7 @@ async fn auth_token_update(
         namespace,
         data.id.into_inner(),
         data.name,
-        data.expiry_millis.map(|ms| repl.time.now() + ms),
+        data.expiry_ms.map(|ms| repl.time.now() + ms),
         data.metadata,
         data.scopes,
         data.enabled,
@@ -322,7 +322,7 @@ pub struct AuthTokenRotateIn {
     pub prefix: String,
     pub suffix: Option<String>,
     /// Milliseconds from now until the old token expires. `None` means expire immediately.
-    pub expiry_millis: Option<DurationMs>,
+    pub expiry_ms: Option<DurationMs>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -346,7 +346,7 @@ async fn auth_token_rotate(
         .ok_or_not_found()?;
 
     let token = TokenPlaintext::generate(&data.prefix, data.suffix.as_deref())?;
-    let old_expiry = data.expiry_millis.map(|ms| repl.time.now() + ms);
+    let old_expiry = data.expiry_ms.map(|ms| repl.time.now() + ms);
     let operation = RotateAuthTokenOperation::new(
         namespace,
         data.id.into_inner(),

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -10,7 +10,7 @@ use coyote_msgs::{
     MsgsNamespace,
     entities::{
         ConsumerGroup, MsgId, Offset, QueueMsgOut, Retention, SeekPosition, StreamMsgOut, TopicIn,
-        TopicName, TopicPartition, default_retention_bytes, default_retention_millis,
+        TopicName, TopicPartition, default_retention_bytes, default_retention_ms,
     },
     operations::{
         CreateNamespaceOperation, PublishOperation, QueueAckOperation, QueueConfigureOperation,
@@ -99,17 +99,17 @@ async fn get_namespace(
         .fetch_namespace_admin(&data.name)?
         .ok_or_not_found()?;
 
-    let millis = u64::try_from(namespace.config.retention_period.as_millis())
+    let ms = u64::try_from(namespace.config.retention_period.as_millis())
         .ok()
         .and_then(|ms| ms.try_into().ok())
-        .unwrap_or_else(default_retention_millis);
+        .unwrap_or_else(default_retention_ms);
     let bytes = namespace
         .max_storage_bytes
         .unwrap_or_else(default_retention_bytes);
 
     Ok(MsgPackOrJson(MsgNamespaceGetOut {
         name: namespace.name,
-        retention: Retention { millis, bytes },
+        retention: Retention { ms, bytes },
         storage_type: namespace.storage_type,
         created: namespace.created,
         updated: namespace.updated,
@@ -173,7 +173,7 @@ fn default_batch_size() -> NonZeroU16 {
     NonZeroU16::new(10).unwrap()
 }
 
-fn default_lease_duration_millis() -> DurationMs {
+fn default_lease_duration_ms() -> DurationMs {
     DurationMs::from_mins(5)
 }
 
@@ -186,8 +186,8 @@ struct MsgStreamReceiveIn {
     pub consumer_group: ConsumerGroup,
     #[serde(default = "default_batch_size")]
     pub batch_size: NonZeroU16,
-    #[serde(default = "default_lease_duration_millis")]
-    pub lease_duration_millis: DurationMs,
+    #[serde(default = "default_lease_duration_ms")]
+    pub lease_duration_ms: DurationMs,
     #[serde(default)]
     pub default_starting_position: SeekPosition,
 }
@@ -217,7 +217,7 @@ async fn stream_receive(
         data.topic,
         data.consumer_group,
         data.batch_size,
-        data.lease_duration_millis,
+        data.lease_duration_ms,
         data.default_starting_position,
     )?;
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
@@ -331,7 +331,7 @@ async fn stream_seek(
 // queue/receive
 // ---------------------------------------------------------------------------
 
-fn default_queue_lease_duration_millis() -> DurationMs {
+fn default_queue_lease_duration_ms() -> DurationMs {
     DurationMs::from_secs(30)
 }
 
@@ -344,8 +344,8 @@ struct MsgQueueReceiveIn {
     pub consumer_group: ConsumerGroup,
     #[serde(default = "default_batch_size")]
     pub batch_size: NonZeroU16,
-    #[serde(default = "default_queue_lease_duration_millis")]
-    pub lease_duration_millis: DurationMs,
+    #[serde(default = "default_queue_lease_duration_ms")]
+    pub lease_duration_ms: DurationMs,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -374,7 +374,7 @@ async fn queue_receive(
         data.topic,
         data.consumer_group,
         data.batch_size,
-        data.lease_duration_millis,
+        data.lease_duration_ms,
     )?;
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -28,7 +28,7 @@ impl From<RateLimitTokenBucketConfig> for TokenBucket {
         TokenBucket {
             bucket_size: val.capacity,
             refill_rate: val.refill_amount,
-            refill_interval: val.refill_interval_millis,
+            refill_interval: val.refill_interval_ms,
         }
     }
 }
@@ -45,11 +45,11 @@ pub struct RateLimitTokenBucketConfig {
 
     /// Interval in milliseconds between refills (minimum 1 millisecond)
     #[validate(range(min = 1))]
-    #[serde(default = "default_interval_millis")]
-    pub refill_interval_millis: DurationMs,
+    #[serde(default = "default_interval_ms")]
+    pub refill_interval_ms: DurationMs,
 }
 
-fn default_interval_millis() -> DurationMs {
+fn default_interval_ms() -> DurationMs {
     1000.into()
 }
 
@@ -84,7 +84,7 @@ pub struct RateLimitCheckOut {
 
     /// Milliseconds until enough tokens are available (only present when allowed is false)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_after_millis: Option<u64>,
+    pub retry_after_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -107,7 +107,7 @@ pub struct RateLimitGetRemainingOut {
 
     /// Milliseconds until at least one token is available (only present when remaining is 0)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_after_millis: Option<u64>,
+    pub retry_after_ms: Option<u64>,
 }
 
 /// Rate Limiter Check and Consume
@@ -132,7 +132,7 @@ async fn rate_limit_limit(
     Ok(MsgPackOrJson(RateLimitCheckOut {
         allowed: response.allowed,
         remaining: response.remaining,
-        retry_after_millis: response
+        retry_after_ms: response
             .retry_after
             .map(|t: std::time::Duration| t.as_millis() as u64),
     }))
@@ -162,7 +162,7 @@ async fn rate_limit_get_remaining(
 
     Ok(MsgPackOrJson(RateLimitGetRemainingOut {
         remaining,
-        retry_after_millis: retry_after.map(|t| t.as_millis() as u64),
+        retry_after_ms: retry_after.map(|t| t.as_millis() as u64),
     }))
 }
 

--- a/tests/it/auth_token.rs
+++ b/tests/it/auth_token.rs
@@ -121,7 +121,7 @@ async fn test_auth_token_expire_in_future() -> TestResult {
 
     client
         .post("auth-token/expire")
-        .json(json!({ "id": id, "expiry_millis": 500 }))
+        .json(json!({ "id": id, "expiry_ms": 500 }))
         .await?
         .ensure(StatusCode::OK)?;
 
@@ -289,7 +289,7 @@ async fn test_auth_token_rotate_with_expiry() -> TestResult {
 
     client
         .post("auth-token/rotate")
-        .json(json!({ "id": id, "expiry_millis": 1000 }))
+        .json(json!({ "id": id, "expiry_ms": 1000 }))
         .await?
         .ensure(StatusCode::OK)?;
 

--- a/tests/it/msgs/namespace.rs
+++ b/tests/it/msgs/namespace.rs
@@ -24,7 +24,7 @@ async fn create_namespace_with_defaults() -> TestResult {
     assert_eq!(response["name"], "my-namespace");
     assert_eq!(response["storage_type"], "Persistent");
     // Default retention: 30 days in millis, 1TB in bytes
-    assert_eq!(response["retention"]["millis"], 2_592_000_000u64);
+    assert_eq!(response["retention"]["ms"], 2_592_000_000u64);
     assert_eq!(response["retention"]["bytes"], 1_000_000_000_000u64);
     assert!(response["created"].is_string());
     assert!(response["updated"].is_string());
@@ -47,7 +47,7 @@ async fn create_namespace_with_custom_config() -> TestResult {
             "storage_type": "Ephemeral",
             "retention": {
                 "bytes": 4194304,
-                "millis": 604800000
+                "ms": 604800000
             }
         }))
         .await?
@@ -61,7 +61,7 @@ async fn create_namespace_with_custom_config() -> TestResult {
         json!({
             "name": "custom-ns",
             "storage_type": "Ephemeral",
-            "retention": { "bytes": 4194304, "millis": 604800000 },
+            "retention": { "bytes": 4194304, "ms": 604800000 },
             "created": ts,
             "updated": ts,
         })
@@ -83,7 +83,7 @@ async fn create_namespace_upserts() -> TestResult {
         .json(json!({
             "name": "upsert-ns",
             "storage_type": "Ephemeral",
-            "retention": { "bytes": 1024, "millis": 9999 }
+            "retention": { "bytes": 1024, "ms": 9999 }
         }))
         .await?
         .expect(StatusCode::OK)
@@ -93,7 +93,7 @@ async fn create_namespace_upserts() -> TestResult {
     assert_eq!(first["name"], "upsert-ns");
     assert_eq!(first["storage_type"], "Ephemeral");
     assert_eq!(first["retention"]["bytes"], 1024);
-    assert_eq!(first["retention"]["millis"], 9999);
+    assert_eq!(first["retention"]["ms"], 9999);
 
     // Upsert with different retention and storage type
     let second = client
@@ -101,7 +101,7 @@ async fn create_namespace_upserts() -> TestResult {
         .json(json!({
             "name": "upsert-ns",
             "storage_type": "Persistent",
-            "retention": { "bytes": 2048, "millis": 60000 }
+            "retention": { "bytes": 2048, "ms": 60000 }
         }))
         .await?
         .expect(StatusCode::OK)
@@ -110,7 +110,7 @@ async fn create_namespace_upserts() -> TestResult {
     assert_eq!(second["name"], "upsert-ns");
     assert_eq!(second["storage_type"], "Persistent");
     assert_eq!(second["retention"]["bytes"], 2048);
-    assert_eq!(second["retention"]["millis"], 60000);
+    assert_eq!(second["retention"]["ms"], 60000);
     // created timestamp should remain the same
     assert_eq!(second["created"], created_ts);
     // updated timestamp should change
@@ -133,7 +133,7 @@ async fn get_namespace() -> TestResult {
         .json(json!({
             "name": "get-test-ns",
             "storage_type": "Ephemeral",
-            "retention": { "bytes": 5000, "millis": 30000 }
+            "retention": { "bytes": 5000, "ms": 30000 }
         }))
         .await?
         .expect(StatusCode::OK)
@@ -152,7 +152,7 @@ async fn get_namespace() -> TestResult {
     assert_eq!(response["name"], "get-test-ns");
     assert_eq!(response["storage_type"], "Ephemeral");
     assert_eq!(response["retention"]["bytes"], 5000);
-    assert_eq!(response["retention"]["millis"], 30000);
+    assert_eq!(response["retention"]["ms"], 30000);
     assert_eq!(response["created"], created["created"]);
     assert_eq!(response["updated"], created["updated"]);
 

--- a/tests/it/msgs/queue.rs
+++ b/tests/it/msgs/queue.rs
@@ -166,7 +166,7 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
         .json(json!({
             "topic": "ns-q-ack:t1",
             "consumer_group": "test-cg",
-            "lease_duration_millis": 1000,
+            "lease_duration_ms": 1000,
         }))
         .await?
         .expect(StatusCode::OK)
@@ -241,7 +241,7 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
         .json(json!({
             "topic": "ns-q-redeliver:t1",
             "consumer_group": "test-cg",
-            "lease_duration_millis": 1000,
+            "lease_duration_ms": 1000,
         }))
         .await?
         .expect(StatusCode::OK)
@@ -382,7 +382,7 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
         .json(json!({
             "topic": "ns-q-partial:t1",
             "consumer_group": "test-cg",
-            "lease_duration_millis": 1000,
+            "lease_duration_ms": 1000,
         }))
         .await?
         .expect(StatusCode::OK)
@@ -628,7 +628,7 @@ async fn nack_sends_to_dlq() -> TestResult {
         .json(json!({
             "topic": "ns-q-nack:t1",
             "consumer_group": "test-cg",
-            "lease_duration_millis": 1000,
+            "lease_duration_ms": 1000,
         }))
         .await?
         .expect(StatusCode::OK)
@@ -922,7 +922,7 @@ async fn nack_retries_before_dlq() -> TestResult {
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
-            "lease_duration_millis": 500,
+            "lease_duration_ms": 500,
         }))
         .await?
         .expect(StatusCode::OK)
@@ -968,7 +968,7 @@ async fn nack_retries_before_dlq() -> TestResult {
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
-            "lease_duration_millis": 500,
+            "lease_duration_ms": 500,
         }))
         .await?
         .expect(StatusCode::OK)
@@ -1057,7 +1057,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "consumer_group": "test-cg",
-            "lease_duration_millis": 500,
+            "lease_duration_ms": 500,
         }))
         .await?
         .expect(StatusCode::OK)
@@ -1084,7 +1084,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "consumer_group": "test-cg",
-            "lease_duration_millis": 500,
+            "lease_duration_ms": 500,
         }))
         .await?
         .expect(StatusCode::OK)

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -310,7 +310,7 @@ async fn stream_receive_with_defaults() -> TestResult {
         .await?
         .expect(StatusCode::OK);
 
-    // Call without specifying batch_size or lease_duration_millis
+    // Call without specifying batch_size or lease_duration_ms
     let response = client
         .post("msgs/stream/receive")
         .json(json!({

--- a/tests/it/rate_limit.rs
+++ b/tests/it/rate_limit.rs
@@ -23,7 +23,7 @@ async fn call_limit_token_bucket(
             "config": {
                 "capacity": capacity,
                 "refill_amount": refill_amount,
-                "refill_interval_millis": refill_interval_seconds * 1000
+                "refill_interval_ms": refill_interval_seconds * 1000
             }
         }))
         .await?
@@ -55,7 +55,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
     .await?;
     assert_eq!(response["allowed"], true);
     assert_eq!(response["remaining"], 4);
-    assert_eq!(response["retry_after_millis"], json!(null));
+    assert_eq!(response["retry_after_ms"], json!(null));
 
     let response = call_limit_token_bucket(
         &client,
@@ -68,7 +68,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
     .await?;
     assert_eq!(response["allowed"], true);
     assert_eq!(response["remaining"], 2);
-    assert_eq!(response["retry_after_millis"], json!(null));
+    assert_eq!(response["retry_after_ms"], json!(null));
 
     let response = call_limit_token_bucket(
         &client,
@@ -81,7 +81,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
     .await?;
     assert_eq!(response["allowed"], true);
     assert_eq!(response["remaining"], 0);
-    assert_eq!(response["retry_after_millis"], json!(null));
+    assert_eq!(response["retry_after_ms"], json!(null));
 
     let response = call_limit_token_bucket(
         &client,
@@ -94,7 +94,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
     .await?;
     assert_eq!(response["allowed"], false);
     assert_eq!(response["remaining"], 0);
-    assert!(response["retry_after_millis"].is_number());
+    assert!(response["retry_after_ms"].is_number());
 
     time.fast_forward(Duration::from_secs(1));
 
@@ -105,7 +105,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
             "config": {
                 "capacity": capacity,
                 "refill_amount": refill_amount,
-                "refill_interval_millis": refill_interval * 1000
+                "refill_interval_ms": refill_interval * 1000
             }
         }))
         .await?
@@ -113,7 +113,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
         .json();
 
     assert_eq!(response["remaining"], capacity);
-    assert_eq!(response["retry_after_millis"], json!(null));
+    assert_eq!(response["retry_after_ms"], json!(null));
 
     Ok(())
 }
@@ -163,7 +163,7 @@ async fn test_rate_limiter_refill_interval() -> TestResult {
                 "config": {
                 "capacity": capacity,
                 "refill_amount": refill_amount,
-                "refill_interval_millis": refill_interval * 1000
+                "refill_interval_ms": refill_interval * 1000
             }
         }))
         .await?
@@ -171,7 +171,7 @@ async fn test_rate_limiter_refill_interval() -> TestResult {
         .json();
 
     assert_eq!(response["remaining"], 6); // fill up to capacity
-    assert_eq!(response["retry_after_millis"], json!(null));
+    assert_eq!(response["retry_after_ms"], json!(null));
 
     Ok(())
 }

--- a/tests/it/stream.rs
+++ b/tests/it/stream.rs
@@ -19,7 +19,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 },
+//             "retention": { "bytes": 1024, "ms": 9999 },
 //             "storage_type": "Ephemeral"
 //         }))
 //         .await?
@@ -32,7 +32,7 @@
 //         response,
 //         json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 },
+//             "retention": { "bytes": 1024, "ms": 9999 },
 //             "storage_type": "Ephemeral",
 //             "created": ts,
 //             "updated": ts,
@@ -74,7 +74,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -183,7 +183,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -267,7 +267,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -357,7 +357,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -453,7 +453,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -586,7 +586,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -695,7 +695,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -789,7 +789,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -922,7 +922,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)
@@ -1028,7 +1028,7 @@
 //         .post("msgs/namespace/create")
 //         .json(json!({
 //             "name": "test-stream",
-//             "retention": { "bytes": 1024, "millis": 9999 }
+//             "retention": { "bytes": 1024, "ms": 9999 }
 //         }))
 //         .await?
 //         .expect(StatusCode::OK)


### PR DESCRIPTION
For consistency. 

I also changed a few variables here and there (that were not API-facing), just as a way to nudge people to use ms in the future. 

Closes https://github.com/svix/coyote-private/issues/148