### PR TITLE
Make k8s-specific fields in crd work

### DIFF
--- a/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
+++ b/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
@@ -45,7 +45,8 @@
                 "properties": {
                   "affinity": {
                     "description": "Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity).",
-                    "type": "object"
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
                   "apiPort": {
                     "default": 8080,
@@ -312,7 +313,8 @@
                   "tolerations": {
                     "description": "Tolerations to allow pods to be scheduled onto nodes with matching taints.",
                     "items": {
-                      "type": "object"
+                      "type": "object",
+                      "x-kubernetes-preserve-unknown-fields": true
                     },
                     "type": "array"
                   },
@@ -320,7 +322,8 @@
                     "default": [],
                     "description": "Topology spread constraints for pod scheduling.\nUse this to spread pods across availability zones or nodes.\nSee: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/",
                     "items": {
-                      "type": "object"
+                      "type": "object",
+                      "x-kubernetes-preserve-unknown-fields": true
                     },
                     "type": "array"
                   }

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -256,17 +256,17 @@ fn nodes_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
 fn topology_spread_constraints_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({
         "type": "array",
-        "items": { "type": "object" }
+        "items": { "type": "object", "x-kubernetes-preserve-unknown-fields": true }
     })
 }
 
 fn tolerations_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({
         "type": "array",
-        "items": { "type": "object" }
+        "items": { "type": "object", "x-kubernetes-preserve-unknown-fields": true }
     })
 }
 
 fn affinity_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
-    schemars::json_schema!({ "type": "object" })
+    schemars::json_schema!({ "type": "object", "x-kubernetes-preserve-unknown-fields": true })
 }


### PR DESCRIPTION
Right now deploys are failing b/c our CR is
effectively ignoring the config we have defined
in our Helm chart, ie here
```
    nodeSelector:
      db-name: coyote
    tolerations:
      - key: db-name
        operator: Equal
        value: coyote
        effect: NoSchedule
```

The changes here prevent us from needing to redefine the k8s schemas for tolerations, affinity, etc., by instead just accepting whatever is defined. Currently, since we don't have the fields for `key`, `operator`, etc., explicitly defined in our CRD schema, k8s just ignores them.

Long term, it might be good for us to explicitly (re-)define all the fields that the k8s API expects in pod specifications, but the clickhouse operator does the same thing, so I think this is a reasonable short-term solution.