### PR TITLE
Make the URL be based on the op_id

### DIFF
--- a/benchmarks/benches/idempotency.rs
+++ b/benchmarks/benches/idempotency.rs
@@ -27,7 +27,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("idempotency/start").json(json!({
+                    std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                         "key": &key,
                         "ttl": 60
                     })))
@@ -37,7 +37,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
 
                     std::hint::black_box(
                         client
-                            .post("idempotency/abort")
+                            .post("v1.idempotency.abort")
                             .json(json!({ "key": &key })),
                     )
                     .await
@@ -54,7 +54,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("idempotency/start").json(json!({
+                    std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                         "key": &key,
                         "ttl": 60
                     })))
@@ -62,7 +62,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
                     .unwrap()
                     .expect(StatusCode::OK);
 
-                    std::hint::black_box(client.post("idempotency/complete").json(json!({
+                    std::hint::black_box(client.post("v1.idempotency.complete").json(json!({
                         "key": &key,
                         "response": "ok".as_bytes(),
                         "ttl": 60
@@ -79,7 +79,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
     let initialize_idempotency = |key: &str, payload: &[u8]| {
         rt.block_on(async {
             client
-                .post("idempotency/start")
+                .post("v1.idempotency.start")
                 .json(json!({
                     "key": key,
                     "ttl": 60
@@ -90,7 +90,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
 
         rt.block_on(async {
             client
-                .post("idempotency/complete")
+                .post("v1.idempotency.complete")
                 .json(json!({
                 "key": key,
                 "response": payload,
@@ -110,7 +110,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
     group.bench_function("idempotency_small_payload", |b| {
         b.iter(|| {
             rt.block_on(async {
-                std::hint::black_box(client.post("idempotency/start").json(json!({
+                std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                     "key": &test_key,
                     "ttl": 60
                 })))
@@ -129,7 +129,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
     group.bench_function("idempotency_medium_payload", |b| {
         b.iter(|| {
             rt.block_on(async {
-                std::hint::black_box(client.post("idempotency/start").json(json!({
+                std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                     "key": &test_key,
                     "ttl": 60
                 })))
@@ -148,7 +148,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
     group.bench_function("idempotency_large_payload", |b| {
         b.iter(|| {
             rt.block_on(async {
-                std::hint::black_box(client.post("idempotency/start").json(json!({
+                std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                     "key": &test_key,
                     "ttl": 60
                 })))

--- a/benchmarks/benches/rate_limit.rs
+++ b/benchmarks/benches/rate_limit.rs
@@ -29,7 +29,7 @@ fn bench_rate_limiter<'a, M: Measurement>(
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("rate-limit/limit").json(json!({
+                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
                         "key": key,
                         "units": 1,
                         "method": "token_bucket",
@@ -53,7 +53,7 @@ fn bench_rate_limiter<'a, M: Measurement>(
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("rate-limit/limit").json(json!({
+                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
                         "key": key,
                         "units": 1,
                         "method": "token_bucket",
@@ -77,7 +77,7 @@ fn bench_rate_limiter<'a, M: Measurement>(
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("rate-limit/limit").json(json!({
+                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
                         "key": key,
                         "units": 1,
                         "method": "token_bucket",
@@ -101,7 +101,7 @@ fn bench_rate_limiter<'a, M: Measurement>(
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("rate-limit/limit").json(json!({
+                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
                         "key": key,
                         "units": 1,
                         "method": "fixed_window",
@@ -124,7 +124,7 @@ fn bench_rate_limiter<'a, M: Measurement>(
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("rate-limit/limit").json(json!({
+                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
                         "key": key,
                         "units": 1,
                         "method": "fixed_window",

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> anyhow::Result<ExitCode> {
 
     let router = coyote::v1::router(None);
     _ = aide::axum::ApiRouter::new()
-        .nest("/api/v1", router)
+        .nest("/api", router)
         .finish_api_with(&mut openapi, coyote::openapi::add_security_scheme);
 
     coyote::openapi::postprocess_spec(&mut openapi);

--- a/codegen/templates/go/api_resource.go.jinja
+++ b/codegen/templates/go/api_resource.go.jinja
@@ -13,7 +13,7 @@ import (
 
 
 type {{ resource_type_name }} struct {
-	{% if resource.operations | length > 0 -%}
+	{% if resource.operations | length > 0 or resource.subresources | length > 0 -%}
 	client *coyote_proto.HttpClient
 	{%- endif %}
 }

--- a/codegen/templates/python/api_resource.py.jinja
+++ b/codegen/templates/python/api_resource.py.jinja
@@ -5,11 +5,13 @@ from dataclasses import dataclass
 from deprecated import deprecated
 
 from ..internal.api_common import ApiBase, BaseOptions, serialize_params
+{%- if referenced_components %}
 from ..models import (
     {%- for c in referenced_components %}
     {{ c | to_upper_camel_case }},
     {%- endfor %}
 )
+{%- endif %}
 {% for _, sub in resource.subresources | items -%}
 from .{{ sub.name | to_snake_case }} import (
     {{ sub.name | to_upper_camel_case }},

--- a/crates/coyote-derive/src/aide.rs
+++ b/crates/coyote-derive/src/aide.rs
@@ -75,13 +75,7 @@ pub(crate) fn expand_aide_annotate(
         }
     }
 
-    let operation_path = format!(
-        "/{}",
-        operation_id
-            .strip_prefix("v1.")
-            .unwrap_or(&operation_id)
-            .replace('.', "/")
-    );
+    let operation_path = format!("/{operation_id}");
 
     let description = doc_comment_from_attributes(&item.attrs);
 

--- a/crates/coyote-derive/src/aide.rs
+++ b/crates/coyote-derive/src/aide.rs
@@ -25,6 +25,8 @@ pub(crate) fn expand_aide_annotate(
     // The documentation function's name will always be the name of the
     // original function suffixed with `_operation`.
     let operation_ident = format_ident!("{}_operation", item.sig.ident);
+    // The route path const will be the function name suffixed with `_path`.
+    let path_ident = format_ident!("{}_path", item.sig.ident);
     let visibility = item.vis.clone();
 
     // Allow overriding operation ID and summary via arguments
@@ -49,6 +51,12 @@ pub(crate) fn expand_aide_annotate(
 
         if arg.path.is_ident("op_id") {
             operation_id = arg_as_litstr()?.value();
+            if operation_id.contains('_') {
+                return Err(syn::Error::new_spanned(
+                    &arg.value,
+                    "op_id must not contain underscores; use hyphens instead",
+                ));
+            }
         } else if arg.path.is_ident("op_summary") {
             operation_summary = arg_as_litstr()?.value();
         } else if arg.path.is_ident("op_deprecated") {
@@ -66,6 +74,14 @@ pub(crate) fn expand_aide_annotate(
             return Err(syn::Error::new_spanned(arg.path, msg));
         }
     }
+
+    let operation_path = format!(
+        "/{}",
+        operation_id
+            .strip_prefix("v1.")
+            .unwrap_or(&operation_id)
+            .replace('.', "/")
+    );
 
     let description = doc_comment_from_attributes(&item.attrs);
 
@@ -103,6 +119,9 @@ pub(crate) fn expand_aide_annotate(
 
     Ok(quote! {
         #item
+
+        #[allow(non_upper_case_globals)]
+        #visibility const #path_ident: &str = #operation_path;
 
         #visibility fn #operation_ident(
             op: ::aide::transform::TransformOperation,

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -108,7 +108,7 @@ impl TestServerBuilder {
             Arc::new(cfg)
         };
 
-        let base_uri = format!("http://{addr}/api/v1");
+        let base_uri = format!("http://{addr}/api");
 
         let time = Monotime::initial();
         time.update_now();
@@ -189,7 +189,7 @@ async fn wait_for_initialized(
     max_wait: Duration,
 ) -> anyhow::Result<(NodeId, ClusterId)> {
     tracing::info!("waiting for server to boot up");
-    let main_url = format!("http://{main_addr}/api/v1/health/ping");
+    let main_url = format!("http://{main_addr}/api/v1.health.ping");
     let url = format!("http://{repl_addr}/repl/health");
     let deadline = Instant::now() + max_wait;
     let client = reqwest::Client::new();

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -238,7 +238,7 @@ fn build_container(
     volume_mounts: Vec<VolumeMount>,
 ) -> Container {
     let cluster_port = spec.cluster_port();
-    const API_HEALTH_ENDPOINT: &str = "/api/v1/health/ping";
+    const API_HEALTH_ENDPOINT: &str = "/api/v1.health.ping";
     const CLUSTER_HEALTH_ENDPOINT: &str = "/repl/health";
 
     Container {

--- a/openapi.json
+++ b/openapi.json
@@ -84,7 +84,7 @@
         ],
         "summary": "Cluster Remove Node",
         "description": "Remove a node from the cluster.\n\nThis operation executes immediately and the node must be wiped and reset\nbefore it can safely be added to the cluster.",
-        "operationId": "v1.admin.cluster-remove-node",
+        "operationId": "v1.admin.cluster.remove-node",
         "requestBody": {
           "content": {
             "application/json": {
@@ -161,7 +161,7 @@
         ],
         "summary": "Auth Token Create",
         "description": "Create Auth Token",
-        "operationId": "v1.auth_token.create",
+        "operationId": "v1.auth-token.create",
         "requestBody": {
           "content": {
             "application/json": {
@@ -238,7 +238,7 @@
         ],
         "summary": "Auth Token Expire",
         "description": "Expire Auth Token",
-        "operationId": "v1.auth_token.expire",
+        "operationId": "v1.auth-token.expire",
         "requestBody": {
           "content": {
             "application/json": {
@@ -315,7 +315,7 @@
         ],
         "summary": "Auth Token Delete",
         "description": "Delete Auth Token",
-        "operationId": "v1.auth_token.delete",
+        "operationId": "v1.auth-token.delete",
         "requestBody": {
           "content": {
             "application/json": {
@@ -392,7 +392,7 @@
         ],
         "summary": "Auth Token Verify",
         "description": "Verify Auth Token",
-        "operationId": "v1.auth_token.verify",
+        "operationId": "v1.auth-token.verify",
         "requestBody": {
           "content": {
             "application/json": {
@@ -469,7 +469,7 @@
         ],
         "summary": "Auth Token List",
         "description": "List Auth Tokens",
-        "operationId": "v1.auth_token.list",
+        "operationId": "v1.auth-token.list",
         "requestBody": {
           "content": {
             "application/json": {
@@ -546,7 +546,7 @@
         ],
         "summary": "Auth Token Update",
         "description": "Update Auth Token",
-        "operationId": "v1.auth_token.update",
+        "operationId": "v1.auth-token.update",
         "requestBody": {
           "content": {
             "application/json": {
@@ -623,7 +623,7 @@
         ],
         "summary": "Auth Token Rotate",
         "description": "Rotate Auth Token",
-        "operationId": "v1.auth_token.rotate",
+        "operationId": "v1.auth-token.rotate",
         "requestBody": {
           "content": {
             "application/json": {
@@ -700,7 +700,7 @@
         ],
         "summary": "Auth Token Create Namespace",
         "description": "Create Auth Token namespace",
-        "operationId": "v1.auth_token.namespace.create",
+        "operationId": "v1.auth-token.namespace.create",
         "requestBody": {
           "content": {
             "application/json": {
@@ -777,7 +777,7 @@
         ],
         "summary": "Auth Token Get Namespace",
         "description": "Get Auth Token namespace",
-        "operationId": "v1.auth_token.namespace.get",
+        "operationId": "v1.auth-token.namespace.get",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1624,7 +1624,7 @@
         ],
         "summary": "Rate Limit Limit",
         "description": "Rate Limiter Check and Consume",
-        "operationId": "v1.rate_limit.limit",
+        "operationId": "v1.rate-limit.limit",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1701,7 +1701,7 @@
         ],
         "summary": "Rate Limit Get Remaining",
         "description": "Rate Limiter Get Remaining",
-        "operationId": "v1.rate_limit.get_remaining",
+        "operationId": "v1.rate-limit.get-remaining",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1778,7 +1778,7 @@
         ],
         "summary": "Rate Limit Reset",
         "description": "Rate Limiter Reset",
-        "operationId": "v1.rate_limit.reset",
+        "operationId": "v1.rate-limit.reset",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1855,7 +1855,7 @@
         ],
         "summary": "Rate Limit Create Namespace",
         "description": "Create rate limiter namespace",
-        "operationId": "v1.rate_limit.namespace.create",
+        "operationId": "v1.rate-limit.namespace.create",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1932,7 +1932,7 @@
         ],
         "summary": "Rate Limit Get Namespace",
         "description": "Get rate limiter namespace",
-        "operationId": "v1.rate_limit.namespace.get",
+        "operationId": "v1.rate-limit.namespace.get",
         "requestBody": {
           "content": {
             "application/json": {

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     }
   },
   "paths": {
-    "/api/v1/admin/cluster/status": {
+    "/api/v1.admin.cluster.status": {
       "get": {
         "tags": [
           "Admin"
@@ -77,7 +77,7 @@
         ]
       }
     },
-    "/api/v1/admin/cluster/remove-node": {
+    "/api/v1.admin.cluster.remove-node": {
       "post": {
         "tags": [
           "Admin"
@@ -154,7 +154,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/create": {
+    "/api/v1.auth-token.create": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -231,7 +231,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/expire": {
+    "/api/v1.auth-token.expire": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -308,7 +308,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/delete": {
+    "/api/v1.auth-token.delete": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -385,7 +385,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/verify": {
+    "/api/v1.auth-token.verify": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -462,7 +462,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/list": {
+    "/api/v1.auth-token.list": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -539,7 +539,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/update": {
+    "/api/v1.auth-token.update": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -616,7 +616,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/rotate": {
+    "/api/v1.auth-token.rotate": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -693,7 +693,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/namespace/create": {
+    "/api/v1.auth-token.namespace.create": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -770,7 +770,7 @@
         ]
       }
     },
-    "/api/v1/auth-token/namespace/get": {
+    "/api/v1.auth-token.namespace.get": {
       "post": {
         "tags": [
           "Auth Tokens"
@@ -847,7 +847,7 @@
         ]
       }
     },
-    "/api/v1/cache/set": {
+    "/api/v1.cache.set": {
       "post": {
         "tags": [
           "Cache"
@@ -924,7 +924,7 @@
         ]
       }
     },
-    "/api/v1/cache/get": {
+    "/api/v1.cache.get": {
       "post": {
         "tags": [
           "Cache"
@@ -1001,7 +1001,7 @@
         ]
       }
     },
-    "/api/v1/cache/namespace/create": {
+    "/api/v1.cache.namespace.create": {
       "post": {
         "tags": [
           "Cache"
@@ -1078,7 +1078,7 @@
         ]
       }
     },
-    "/api/v1/cache/namespace/get": {
+    "/api/v1.cache.namespace.get": {
       "post": {
         "tags": [
           "Cache"
@@ -1155,7 +1155,7 @@
         ]
       }
     },
-    "/api/v1/cache/delete": {
+    "/api/v1.cache.delete": {
       "post": {
         "tags": [
           "Cache"
@@ -1232,7 +1232,7 @@
         ]
       }
     },
-    "/api/v1/kv/set": {
+    "/api/v1.kv.set": {
       "post": {
         "tags": [
           "Key Value Store"
@@ -1309,7 +1309,7 @@
         ]
       }
     },
-    "/api/v1/kv/get": {
+    "/api/v1.kv.get": {
       "post": {
         "tags": [
           "Key Value Store"
@@ -1386,7 +1386,7 @@
         ]
       }
     },
-    "/api/v1/kv/namespace/create": {
+    "/api/v1.kv.namespace.create": {
       "post": {
         "tags": [
           "Key Value Store"
@@ -1463,7 +1463,7 @@
         ]
       }
     },
-    "/api/v1/kv/namespace/get": {
+    "/api/v1.kv.namespace.get": {
       "post": {
         "tags": [
           "Key Value Store"
@@ -1540,7 +1540,7 @@
         ]
       }
     },
-    "/api/v1/kv/delete": {
+    "/api/v1.kv.delete": {
       "post": {
         "tags": [
           "Key Value Store"
@@ -1617,7 +1617,7 @@
         ]
       }
     },
-    "/api/v1/rate-limit/limit": {
+    "/api/v1.rate-limit.limit": {
       "post": {
         "tags": [
           "Rate Limiter"
@@ -1694,7 +1694,7 @@
         ]
       }
     },
-    "/api/v1/rate-limit/get-remaining": {
+    "/api/v1.rate-limit.get-remaining": {
       "post": {
         "tags": [
           "Rate Limiter"
@@ -1771,7 +1771,7 @@
         ]
       }
     },
-    "/api/v1/rate-limit/reset": {
+    "/api/v1.rate-limit.reset": {
       "post": {
         "tags": [
           "Rate Limiter"
@@ -1848,7 +1848,7 @@
         ]
       }
     },
-    "/api/v1/rate-limit/namespace/create": {
+    "/api/v1.rate-limit.namespace.create": {
       "post": {
         "tags": [
           "Rate Limiter"
@@ -1925,7 +1925,7 @@
         ]
       }
     },
-    "/api/v1/rate-limit/namespace/get": {
+    "/api/v1.rate-limit.namespace.get": {
       "post": {
         "tags": [
           "Rate Limiter"
@@ -2002,7 +2002,7 @@
         ]
       }
     },
-    "/api/v1/idempotency/start": {
+    "/api/v1.idempotency.start": {
       "post": {
         "tags": [
           "Idempotency"
@@ -2079,7 +2079,7 @@
         ]
       }
     },
-    "/api/v1/idempotency/complete": {
+    "/api/v1.idempotency.complete": {
       "post": {
         "tags": [
           "Idempotency"
@@ -2156,7 +2156,7 @@
         ]
       }
     },
-    "/api/v1/idempotency/abort": {
+    "/api/v1.idempotency.abort": {
       "post": {
         "tags": [
           "Idempotency"
@@ -2233,7 +2233,7 @@
         ]
       }
     },
-    "/api/v1/idempotency/namespace/create": {
+    "/api/v1.idempotency.namespace.create": {
       "post": {
         "tags": [
           "Idempotency"
@@ -2310,7 +2310,7 @@
         ]
       }
     },
-    "/api/v1/idempotency/namespace/get": {
+    "/api/v1.idempotency.namespace.get": {
       "post": {
         "tags": [
           "Idempotency"
@@ -2387,7 +2387,7 @@
         ]
       }
     },
-    "/api/v1/msgs/namespace/create": {
+    "/api/v1.msgs.namespace.create": {
       "post": {
         "tags": [
           "Msgs"
@@ -2464,7 +2464,7 @@
         ]
       }
     },
-    "/api/v1/msgs/namespace/get": {
+    "/api/v1.msgs.namespace.get": {
       "post": {
         "tags": [
           "Msgs"
@@ -2541,7 +2541,7 @@
         ]
       }
     },
-    "/api/v1/msgs/publish": {
+    "/api/v1.msgs.publish": {
       "post": {
         "tags": [
           "Msgs"
@@ -2618,7 +2618,7 @@
         ]
       }
     },
-    "/api/v1/msgs/stream/receive": {
+    "/api/v1.msgs.stream.receive": {
       "post": {
         "tags": [
           "Msgs"
@@ -2695,7 +2695,7 @@
         ]
       }
     },
-    "/api/v1/msgs/stream/commit": {
+    "/api/v1.msgs.stream.commit": {
       "post": {
         "tags": [
           "Msgs"
@@ -2772,7 +2772,7 @@
         ]
       }
     },
-    "/api/v1/msgs/stream/seek": {
+    "/api/v1.msgs.stream.seek": {
       "post": {
         "tags": [
           "Msgs"
@@ -2849,7 +2849,7 @@
         ]
       }
     },
-    "/api/v1/msgs/queue/receive": {
+    "/api/v1.msgs.queue.receive": {
       "post": {
         "tags": [
           "Msgs"
@@ -2926,7 +2926,7 @@
         ]
       }
     },
-    "/api/v1/msgs/queue/ack": {
+    "/api/v1.msgs.queue.ack": {
       "post": {
         "tags": [
           "Msgs"
@@ -3003,7 +3003,7 @@
         ]
       }
     },
-    "/api/v1/msgs/queue/configure": {
+    "/api/v1.msgs.queue.configure": {
       "post": {
         "tags": [
           "Msgs"
@@ -3080,7 +3080,7 @@
         ]
       }
     },
-    "/api/v1/msgs/queue/nack": {
+    "/api/v1.msgs.queue.nack": {
       "post": {
         "tags": [
           "Msgs"
@@ -3157,7 +3157,7 @@
         ]
       }
     },
-    "/api/v1/msgs/queue/redrive-dlq": {
+    "/api/v1.msgs.queue.redrive-dlq": {
       "post": {
         "tags": [
           "Msgs"
@@ -3234,7 +3234,7 @@
         ]
       }
     },
-    "/api/v1/msgs/topic/configure": {
+    "/api/v1.msgs.topic.configure": {
       "post": {
         "tags": [
           "Msgs"
@@ -3311,7 +3311,7 @@
         ]
       }
     },
-    "/api/v1/health/ping": {
+    "/api/v1.health.ping": {
       "get": {
         "tags": [
           "Health"
@@ -3378,7 +3378,7 @@
         ]
       }
     },
-    "/api/v1/health/error": {
+    "/api/v1.health.error": {
       "post": {
         "tags": [
           "Health"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some(Commands::Healthcheck { server_url }) = args.command {
         let client = reqwest::Client::new();
         let response = client
-            .head(format!("{server_url}/api/v1/health"))
+            .head(format!("{server_url}/api/v1.health"))
             .send()
             .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ pub async fn run_with_listeners(
 
     // Initialize all routes which need to be part of OpenAPI first.
     let api_router = ApiRouter::new()
-        .nest_api_service("/api/v1", v1_router)
+        .nest_api_service("/api", v1_router)
         .finish_api(&mut openapi);
 
     tokio::spawn(run_internal(api_router.clone(), internal_req_rx));

--- a/src/v1/endpoints/admin/cluster.rs
+++ b/src/v1/endpoints/admin/cluster.rs
@@ -186,7 +186,7 @@ struct ClusterRemoveNodeOut {
 ///
 /// This operation executes immediately and the node must be wiped and reset
 /// before it can safely be added to the cluster.
-#[aide_annotate(op_id = "v1.admin.cluster-remove-node")]
+#[aide_annotate(op_id = "v1.admin.cluster.remove-node")]
 async fn cluster_remove_node(
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<ClusterRemoveNodeIn>,
@@ -203,12 +203,12 @@ pub fn router() -> ApiRouter<AppState> {
 
     ApiRouter::new()
         .api_route_with(
-            "/admin/cluster/status",
+            cluster_status_path,
             get_with(cluster_status, cluster_status_operation),
             &tag,
         )
         .api_route_with(
-            "/admin/cluster/remove-node",
+            cluster_remove_node_path,
             post_with(cluster_remove_node, cluster_remove_node_operation),
             &tag,
         )

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -99,7 +99,7 @@ pub struct AuthTokenCreateOut {
 }
 
 /// Create Auth Token
-#[aide_annotate(op_id = "v1.auth_token.create")]
+#[aide_annotate(op_id = "v1.auth-token.create")]
 async fn auth_token_create(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -145,7 +145,7 @@ pub struct AuthTokenExpireIn {
 pub struct AuthTokenExpireOut {}
 
 /// Expire Auth Token
-#[aide_annotate(op_id = "v1.auth_token.expire")]
+#[aide_annotate(op_id = "v1.auth-token.expire")]
 async fn auth_token_expire(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -182,7 +182,7 @@ impl From<DeleteResponseData> for AuthTokenDeleteOut {
 }
 
 /// Delete Auth Token
-#[aide_annotate(op_id = "v1.auth_token.delete")]
+#[aide_annotate(op_id = "v1.auth-token.delete")]
 async fn auth_token_delete(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -210,7 +210,7 @@ pub struct AuthTokenVerifyOut {
 }
 
 /// Verify Auth Token
-#[aide_annotate(op_id = "v1.auth_token.verify")]
+#[aide_annotate(op_id = "v1.auth-token.verify")]
 async fn auth_token_verify(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -246,7 +246,7 @@ pub struct AuthTokenListIn {
 pub type AuthTokenListOut = ListResponse<AuthTokenOut>;
 
 /// List Auth Tokens
-#[aide_annotate(op_id = "v1.auth_token.list")]
+#[aide_annotate(op_id = "v1.auth-token.list")]
 async fn auth_token_list(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -290,7 +290,7 @@ pub struct AuthTokenUpdateIn {
 pub struct AuthTokenUpdateOut {}
 
 /// Update Auth Token
-#[aide_annotate(op_id = "v1.auth_token.update")]
+#[aide_annotate(op_id = "v1.auth-token.update")]
 async fn auth_token_update(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -334,7 +334,7 @@ pub struct AuthTokenRotateOut {
 }
 
 /// Rotate Auth Token
-#[aide_annotate(op_id = "v1.auth_token.rotate")]
+#[aide_annotate(op_id = "v1.auth-token.rotate")]
 async fn auth_token_rotate(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -401,7 +401,7 @@ struct AuthTokenCreateNamespaceOut {
 }
 
 /// Create Auth Token namespace
-#[aide_annotate(op_id = "v1.auth_token.namespace.create")]
+#[aide_annotate(op_id = "v1.auth-token.namespace.create")]
 async fn auth_token_create_namespace(
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<AuthTokenCreateNamespaceIn>,
@@ -417,7 +417,7 @@ async fn auth_token_create_namespace(
 }
 
 /// Get Auth Token namespace
-#[aide_annotate(op_id = "v1.auth_token.namespace.get")]
+#[aide_annotate(op_id = "v1.auth-token.namespace.get")]
 async fn auth_token_get_namespace(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -443,42 +443,42 @@ pub fn router() -> ApiRouter<AppState> {
 
     ApiRouter::new()
         .api_route_with(
-            "/auth-token/create",
+            auth_token_create_path,
             post_with(auth_token_create, auth_token_create_operation),
             &tag,
         )
         .api_route_with(
-            "/auth-token/expire",
+            auth_token_expire_path,
             post_with(auth_token_expire, auth_token_expire_operation),
             &tag,
         )
         .api_route_with(
-            "/auth-token/delete",
+            auth_token_delete_path,
             post_with(auth_token_delete, auth_token_delete_operation),
             &tag,
         )
         .api_route_with(
-            "/auth-token/verify",
+            auth_token_verify_path,
             post_with(auth_token_verify, auth_token_verify_operation),
             &tag,
         )
         .api_route_with(
-            "/auth-token/list",
+            auth_token_list_path,
             post_with(auth_token_list, auth_token_list_operation),
             &tag,
         )
         .api_route_with(
-            "/auth-token/update",
+            auth_token_update_path,
             post_with(auth_token_update, auth_token_update_operation),
             &tag,
         )
         .api_route_with(
-            "/auth-token/rotate",
+            auth_token_rotate_path,
             post_with(auth_token_rotate, auth_token_rotate_operation),
             &tag,
         )
         .api_route_with(
-            "/auth-token/namespace/create",
+            auth_token_create_namespace_path,
             post_with(
                 auth_token_create_namespace,
                 auth_token_create_namespace_operation,
@@ -486,7 +486,7 @@ pub fn router() -> ApiRouter<AppState> {
             &tag,
         )
         .api_route_with(
-            "/auth-token/namespace/get",
+            auth_token_get_namespace_path,
             post_with(auth_token_get_namespace, auth_token_get_namespace_operation),
             &tag,
         )

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -256,27 +256,27 @@ pub fn router() -> ApiRouter<AppState> {
 
     ApiRouter::new()
         .api_route_with(
-            "/cache/set",
+            cache_set_path,
             post_with(cache_set, cache_set_operation),
             &tag,
         )
         .api_route_with(
-            "/cache/get",
+            cache_get_path,
             post_with(cache_get, cache_get_operation),
             &tag,
         )
         .api_route_with(
-            "/cache/namespace/create",
+            cache_create_namespace_path,
             post_with(cache_create_namespace, cache_create_namespace_operation),
             &tag,
         )
         .api_route_with(
-            "/cache/namespace/get",
+            cache_get_namespace_path,
             post_with(cache_get_namespace, cache_get_namespace_operation),
             &tag,
         )
         .api_route_with(
-            "/cache/delete",
+            cache_del_path,
             post_with(cache_del, cache_del_operation),
             &tag,
         )

--- a/src/v1/endpoints/health.rs
+++ b/src/v1/endpoints/health.rs
@@ -44,8 +44,8 @@ pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Health");
 
     let router = ApiRouter::new()
-        .api_route_with("/health/ping", get_with(ping, ping_operation), &tag)
-        .api_route_with("/health/error", post_with(error, error_operation), &tag);
+        .api_route_with(ping_path, get_with(ping, ping_operation), &tag)
+        .api_route_with(error_path, post_with(error, error_operation), &tag);
 
     #[cfg(debug_assertions)]
     let router = router.route("/health/panic", post(panic));

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -249,22 +249,22 @@ pub fn router() -> ApiRouter<AppState> {
 
     ApiRouter::new()
         .api_route_with(
-            "/idempotency/start",
+            idempotency_start_path,
             post_with(idempotency_start, idempotency_start_operation),
             &tag,
         )
         .api_route_with(
-            "/idempotency/complete",
+            idempotency_complete_path,
             post_with(idempotency_complete, idempotency_complete_operation),
             &tag,
         )
         .api_route_with(
-            "/idempotency/abort",
+            idempotency_abort_path,
             post_with(idempotency_abort, idempotency_abort_operation),
             &tag,
         )
         .api_route_with(
-            "/idempotency/namespace/create",
+            idempotency_create_namespace_path,
             post_with(
                 idempotency_create_namespace,
                 idempotency_create_namespace_operation,
@@ -272,7 +272,7 @@ pub fn router() -> ApiRouter<AppState> {
             &tag,
         )
         .api_route_with(
-            "/idempotency/namespace/get",
+            idempotency_get_namespace_path,
             post_with(
                 idempotency_get_namespace,
                 idempotency_get_namespace_operation,

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -265,17 +265,17 @@ pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Key Value Store");
 
     ApiRouter::new()
-        .api_route_with("/kv/set", post_with(kv_set, kv_set_operation), &tag)
-        .api_route_with("/kv/get", post_with(kv_get, kv_get_operation), &tag)
+        .api_route_with(kv_set_path, post_with(kv_set, kv_set_operation), &tag)
+        .api_route_with(kv_get_path, post_with(kv_get, kv_get_operation), &tag)
         .api_route_with(
-            "/kv/namespace/create",
+            kv_create_namespace_path,
             post_with(kv_create_namespace, kv_create_namespace_operation),
             &tag,
         )
         .api_route_with(
-            "/kv/namespace/get",
+            kv_get_namespace_path,
             post_with(kv_get_namespace, kv_get_namespace_operation),
             &tag,
         )
-        .api_route_with("/kv/delete", post_with(kv_del, kv_del_operation), &tag)
+        .api_route_with(kv_del_path, post_with(kv_del, kv_del_operation), &tag)
 }

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -594,58 +594,58 @@ pub fn router() -> ApiRouter<AppState> {
 
     ApiRouter::new()
         .api_route_with(
-            "/msgs/namespace/create",
+            create_namespace_path,
             post_with(create_namespace, create_namespace_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/namespace/get",
+            get_namespace_path,
             post_with(get_namespace, get_namespace_operation),
             &tag,
         )
-        .api_route_with("/msgs/publish", post_with(publish, publish_operation), &tag)
+        .api_route_with(publish_path, post_with(publish, publish_operation), &tag)
         .api_route_with(
-            "/msgs/stream/receive",
+            stream_receive_path,
             post_with(stream_receive, stream_receive_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/stream/commit",
+            stream_commit_path,
             post_with(stream_commit, stream_commit_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/stream/seek",
+            stream_seek_path,
             post_with(stream_seek, stream_seek_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/queue/receive",
+            queue_receive_path,
             post_with(queue_receive, queue_receive_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/queue/ack",
+            queue_ack_path,
             post_with(queue_ack, queue_ack_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/queue/configure",
+            queue_configure_path,
             post_with(queue_configure, queue_configure_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/queue/nack",
+            queue_nack_path,
             post_with(queue_nack, queue_nack_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/queue/redrive-dlq",
+            queue_redrive_dlq_path,
             post_with(queue_redrive_dlq, queue_redrive_dlq_operation),
             &tag,
         )
         .api_route_with(
-            "/msgs/topic/configure",
+            topic_configure_path,
             post_with(topic_configure, topic_configure_operation),
             &tag,
         )

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -111,7 +111,7 @@ pub struct RateLimitGetRemainingOut {
 }
 
 /// Rate Limiter Check and Consume
-#[aide_annotate(op_id = "v1.rate_limit.limit")]
+#[aide_annotate(op_id = "v1.rate-limit.limit")]
 async fn rate_limit_limit(
     Extension(repl): Extension<RaftState>,
     State(state): State<AppState>,
@@ -139,7 +139,7 @@ async fn rate_limit_limit(
 }
 
 /// Rate Limiter Get Remaining
-#[aide_annotate(op_id = "v1.rate_limit.get_remaining")]
+#[aide_annotate(op_id = "v1.rate-limit.get-remaining")]
 async fn rate_limit_get_remaining(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -183,7 +183,7 @@ pub struct RateLimitResetIn {
 pub struct RateLimitResetOut {}
 
 /// Rate Limiter Reset
-#[aide_annotate(op_id = "v1.rate_limit.reset")]
+#[aide_annotate(op_id = "v1.rate-limit.reset")]
 async fn rate_limit_reset(
     Extension(repl): Extension<RaftState>,
     State(state): State<AppState>,
@@ -239,7 +239,7 @@ struct RateLimitGetNamespaceOut {
 }
 
 /// Create rate limiter namespace
-#[aide_annotate(op_id = "v1.rate_limit.namespace.create")]
+#[aide_annotate(op_id = "v1.rate-limit.namespace.create")]
 async fn rate_limit_create_namespace(
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<RateLimitCreateNamespaceIn>,
@@ -255,7 +255,7 @@ async fn rate_limit_create_namespace(
 }
 
 /// Get rate limiter namespace
-#[aide_annotate(op_id = "v1.rate_limit.namespace.get")]
+#[aide_annotate(op_id = "v1.rate-limit.namespace.get")]
 async fn rate_limit_get_namespace(
     State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
@@ -281,22 +281,22 @@ pub fn router() -> ApiRouter<AppState> {
 
     ApiRouter::new()
         .api_route_with(
-            "/rate-limit/limit",
+            rate_limit_limit_path,
             post_with(rate_limit_limit, rate_limit_limit_operation),
             &tag,
         )
         .api_route_with(
-            "/rate-limit/get-remaining",
+            rate_limit_get_remaining_path,
             post_with(rate_limit_get_remaining, rate_limit_get_remaining_operation),
             &tag,
         )
         .api_route_with(
-            "/rate-limit/reset",
+            rate_limit_reset_path,
             post_with(rate_limit_reset, rate_limit_reset_operation),
             &tag,
         )
         .api_route_with(
-            "/rate-limit/namespace/create",
+            rate_limit_create_namespace_path,
             post_with(
                 rate_limit_create_namespace,
                 rate_limit_create_namespace_operation,
@@ -304,7 +304,7 @@ pub fn router() -> ApiRouter<AppState> {
             &tag,
         )
         .api_route_with(
-            "/rate-limit/namespace/get",
+            rate_limit_get_namespace_path,
             post_with(rate_limit_get_namespace, rate_limit_get_namespace_operation),
             &tag,
         )

--- a/tests/it/admin.rs
+++ b/tests/it/admin.rs
@@ -24,7 +24,7 @@ async fn test_cluster_status() -> TestResult {
         .await;
 
     let cluster_status = client
-        .get("admin/cluster/status")
+        .get("v1.admin.cluster.status")
         .await?
         .expect(StatusCode::OK)
         .json();
@@ -81,7 +81,7 @@ async fn test_cluster_remove() -> TestResult {
 
     // make sure both nodes are present
     let cluster_status = client
-        .get("admin/cluster/status")
+        .get("v1.admin.cluster.status")
         .await?
         .expect(StatusCode::OK)
         .json();
@@ -100,7 +100,7 @@ async fn test_cluster_remove() -> TestResult {
 
     // now remove the second node
     let resp = client
-        .post("admin/cluster/remove-node")
+        .post("v1.admin.cluster.remove-node")
         .json(json!({"node_id": second_node_id}))
         .await?
         .expect(StatusCode::OK)
@@ -108,7 +108,7 @@ async fn test_cluster_remove() -> TestResult {
     assert_eq!(resp["node_id"].assert_str(), second_node_id.to_string());
 
     let cluster_status = client
-        .get("admin/cluster/status")
+        .get("v1.admin.cluster.status")
         .await?
         .expect(StatusCode::OK)
         .json();

--- a/tests/it/auth_token.rs
+++ b/tests/it/auth_token.rs
@@ -12,7 +12,7 @@ async fn create_token(
     owner_id: &str,
 ) -> TestResult<(String, String)> {
     let resp = client
-        .post("auth-token/create")
+        .post("v1.auth-token.create")
         .json(json!({
             "name": name,
             "owner_id": owner_id,
@@ -29,7 +29,7 @@ async fn create_token(
 #[allow(clippy::disallowed_types)]
 async fn verify_token(client: &TestClient, token: &str) -> TestResult<serde_json::Value> {
     let resp = client
-        .post("auth-token/verify")
+        .post("v1.auth-token.verify")
         .json(json!({ "token": token }))
         .await?
         .ensure(StatusCode::OK)?
@@ -44,7 +44,7 @@ async fn verify_token_with_namespace(
     namespace: Option<&str>,
 ) -> TestResult<serde_json::Value> {
     let resp = client
-        .post("auth-token/verify")
+        .post("v1.auth-token.verify")
         .json(json!({ "token": token, "namespace": namespace }))
         .await?
         .ensure(StatusCode::OK)?
@@ -97,7 +97,7 @@ async fn test_auth_token_expire_immediately() -> TestResult {
     let (id, token) = create_token(&client, "expire-now", "user-2").await?;
 
     client
-        .post("auth-token/expire")
+        .post("v1.auth-token.expire")
         .json(json!({ "id": id }))
         .await?
         .ensure(StatusCode::OK)?;
@@ -120,7 +120,7 @@ async fn test_auth_token_expire_in_future() -> TestResult {
     let (id, token) = create_token(&client, "expire-future", "user-3").await?;
 
     client
-        .post("auth-token/expire")
+        .post("v1.auth-token.expire")
         .json(json!({ "id": id, "expiry_ms": 500 }))
         .await?
         .ensure(StatusCode::OK)?;
@@ -148,7 +148,7 @@ async fn test_auth_token_delete() -> TestResult {
     verify_token(&client, &token).await?;
 
     let resp = client
-        .post("auth-token/delete")
+        .post("v1.auth-token.delete")
         .json(json!({ "id": id }))
         .await?
         .ensure(StatusCode::OK)?
@@ -170,7 +170,7 @@ async fn test_auth_token_delete_nonexistent() -> TestResult {
     } = start_server().await;
 
     let resp = client
-        .post("auth-token/delete")
+        .post("v1.auth-token.delete")
         .json(json!({ "id": "key_06egrha0d5x9x8wa4kfcy1prhr" }))
         .await?
         .ensure(StatusCode::OK)?
@@ -191,7 +191,7 @@ async fn test_auth_token_update() -> TestResult {
     let (id, token) = create_token(&client, "original-name", "user-5").await?;
 
     client
-        .post("auth-token/update")
+        .post("v1.auth-token.update")
         .json(json!({
             "id": id,
             "name": "renamed",
@@ -216,7 +216,7 @@ async fn test_auth_token_namespace_create_and_get() -> TestResult {
     } = start_server().await;
 
     let resp = client
-        .post("auth-token/namespace/create")
+        .post("v1.auth-token.namespace.create")
         .json(json!({ "name": "at-ns-1" }))
         .await?
         .ensure(StatusCode::OK)?
@@ -227,7 +227,7 @@ async fn test_auth_token_namespace_create_and_get() -> TestResult {
     assert!(resp["updated"].is_string());
 
     let get_resp = client
-        .post("auth-token/namespace/get")
+        .post("v1.auth-token.namespace.get")
         .json(json!({ "name": "at-ns-1" }))
         .await?
         .ensure(StatusCode::OK)?
@@ -251,7 +251,7 @@ async fn test_auth_token_rotate() -> TestResult {
     let (id, old_token) = create_token(&client, "rotate-me", "user-r1").await?;
 
     let resp = client
-        .post("auth-token/rotate")
+        .post("v1.auth-token.rotate")
         .json(json!({ "id": id }))
         .await?
         .ensure(StatusCode::OK)?
@@ -287,7 +287,7 @@ async fn test_auth_token_rotate_with_expiry() -> TestResult {
     let (id, old_token) = create_token(&client, "rotate-grace", "user-r2").await?;
 
     client
-        .post("auth-token/rotate")
+        .post("v1.auth-token.rotate")
         .json(json!({ "id": id, "expiry_ms": 1000 }))
         .await?
         .ensure(StatusCode::OK)?;
@@ -314,7 +314,7 @@ async fn test_auth_token_rotate_nonexistent() -> TestResult {
     } = start_server().await;
 
     client
-        .post("auth-token/rotate")
+        .post("v1.auth-token.rotate")
         .json(json!({ "id": "key_06egrha0d5x9x8wa4kfcy1prhr" }))
         .await?
         .ensure_not_found()?;
@@ -331,7 +331,7 @@ async fn test_auth_token_namespace_get_not_found() -> TestResult {
     } = start_server().await;
 
     client
-        .post("auth-token/namespace/get")
+        .post("v1.auth-token.namespace.get")
         .json(json!({ "name": "no-such-ns" }))
         .await?
         .ensure_not_found()?;
@@ -348,13 +348,13 @@ async fn test_auth_token_in_custom_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("auth-token/namespace/create")
+        .post("v1.auth-token.namespace.create")
         .json(json!({ "name": "custom-at-ns" }))
         .await?
         .ensure(StatusCode::OK)?;
 
     let resp = client
-        .post("auth-token/create")
+        .post("v1.auth-token.create")
         .json(json!({
             "namespace": "custom-at-ns",
             "name": "ns-token",
@@ -367,7 +367,7 @@ async fn test_auth_token_in_custom_namespace() -> TestResult {
     let token = resp["token"].assert_str();
 
     client
-        .post("auth-token/verify")
+        .post("v1.auth-token.verify")
         .json(json!({
             "namespace": "custom-at-ns",
             "token": token,

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -4,7 +4,7 @@ use test_utils::{TestClient, TestResult, server::TestServerBuilder};
 
 async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
     let default_kv = client
-        .post("kv/namespace/get")
+        .post("v1.kv.namespace.get")
         .json(json!({"name": "default"}))
         .await?
         .expect(StatusCode::OK)
@@ -12,7 +12,7 @@ async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
     assert_eq!(default_kv["max_storage_bytes"], 1000);
 
     let default_cache = client
-        .post("cache/namespace/get")
+        .post("v1.cache.namespace.get")
         .json(json!({"name": "default"}))
         .await?
         .expect(StatusCode::OK)
@@ -21,7 +21,7 @@ async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
     assert_eq!(default_cache["eviction_policy"], "NoEviction");
 
     let default_idempotency = client
-        .post("idempotency/namespace/get")
+        .post("v1.idempotency.namespace.get")
         .json(json!({"name": "default"}))
         .await?
         .expect(StatusCode::OK)
@@ -29,7 +29,7 @@ async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
     assert_eq!(default_idempotency["name"], "default");
 
     let kv1 = client
-        .post("kv/namespace/get")
+        .post("v1.kv.namespace.get")
         .json(json!({"name": "kv1"}))
         .await?
         .expect(StatusCode::OK)
@@ -38,7 +38,7 @@ async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
     assert_eq!(kv1["max_storage_bytes"], 2000);
 
     let kv2 = client
-        .post("kv/namespace/get")
+        .post("v1.kv.namespace.get")
         .json(json!({"name": "kv2"}))
         .await?
         .expect(StatusCode::OK)
@@ -47,7 +47,7 @@ async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
     assert_eq!(kv2["max_storage_bytes"], 3000);
 
     let cache1 = client
-        .post("cache/namespace/get")
+        .post("v1.cache.namespace.get")
         .json(json!({"name": "cache1"}))
         .await?
         .expect(StatusCode::OK)
@@ -56,7 +56,7 @@ async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
     assert_eq!(cache1["eviction_policy"], "LeastRecentlyUsed");
 
     let msgs2 = client
-        .post("msgs/namespace/get")
+        .post("v1.msgs.namespace.get")
         .json(json!({"name": "msgs2"}))
         .await?
         .expect(StatusCode::OK)

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -6,7 +6,7 @@ use test_utils::{
 
 async fn cache_set(client: &TestClient, key: &str, expire_in: u64, value: &str) -> TestResult<()> {
     client
-        .post("cache/set")
+        .post("v1.cache.set")
         .json(json!({
             "key": key,
             "ttl": expire_in,
@@ -20,7 +20,7 @@ async fn cache_set(client: &TestClient, key: &str, expire_in: u64, value: &str) 
 #[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
 async fn cache_get(client: &TestClient, key: &str) -> TestResult<serde_json::Value> {
     let response = client
-        .post("cache/get")
+        .post("v1.cache.get")
         .json(json!({
             "key": key
         }))
@@ -47,7 +47,7 @@ async fn test_cache_set_and_get() -> TestResult {
 
     // set should fail if namespace doesn't exist:
     client
-        .post("cache/set")
+        .post("v1.cache.set")
         .json(json!({
             "namespace": "nonexistentnamespace",
             "key": "key1",
@@ -70,7 +70,7 @@ async fn test_cache_set_get_and_delete() -> TestResult {
     } = start_server().await;
 
     let delete_response = client
-        .post("cache/delete")
+        .post("v1.cache.delete")
         .json(json!({
             "key": "test-key-2"
         }))
@@ -86,7 +86,7 @@ async fn test_cache_set_get_and_delete() -> TestResult {
     assert_eq!(response["value"], json!("another-value".as_bytes()));
 
     let delete_response = client
-        .post("cache/delete")
+        .post("v1.cache.delete")
         .json(json!({
             "key": "test-key-2"
         }))
@@ -97,7 +97,7 @@ async fn test_cache_set_get_and_delete() -> TestResult {
     assert_eq!(delete_response["success"], true);
 
     let response = client
-        .post("cache/get")
+        .post("v1.cache.get")
         .json(json!({
             "key": "test-key-2"
         }))
@@ -118,7 +118,7 @@ async fn create_namespace_with_defaults() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("cache/namespace/create")
+        .post("v1.cache.namespace.create")
         .json(json!({
             "name": "my-namespace",
         }))
@@ -143,7 +143,7 @@ async fn create_namespace_with_custom_config() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("cache/namespace/create")
+        .post("v1.cache.namespace.create")
         .json(json!({
             "name": "custom-ns",
             "eviction_policy": "LeastRecentlyUsed",
@@ -176,7 +176,7 @@ async fn create_namespace_upserts() -> TestResult {
     } = start_server().await;
 
     let first = client
-        .post("cache/namespace/create")
+        .post("v1.cache.namespace.create")
         .json(json!({
             "name": "upsert-ns",
         }))
@@ -189,7 +189,7 @@ async fn create_namespace_upserts() -> TestResult {
 
     // Upsert
     let second = client
-        .post("cache/namespace/create")
+        .post("v1.cache.namespace.create")
         .json(json!({
             "name": "upsert-ns",
         }))
@@ -216,7 +216,7 @@ async fn get_namespace() -> TestResult {
 
     // Create a namespace first
     let created = client
-        .post("cache/namespace/create")
+        .post("v1.cache.namespace.create")
         .json(json!({
             "name": "get-test-ns",
         }))
@@ -226,7 +226,7 @@ async fn get_namespace() -> TestResult {
 
     // Get it back
     let response = client
-        .post("cache/namespace/get")
+        .post("v1.cache.namespace.get")
         .json(json!({
             "name": "get-test-ns",
         }))
@@ -250,7 +250,7 @@ async fn get_namespace_not_found() -> TestResult {
     } = start_server().await;
 
     client
-        .post("cache/namespace/get")
+        .post("v1.cache.namespace.get")
         .json(json!({
             "name": "nonexistent-ns",
         }))

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -9,7 +9,7 @@ use test_utils::{
 #[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
 async fn start(client: &TestClient, key: &str, ttl_seconds: u64) -> TestResult<serde_json::Value> {
     let response = client
-        .post("idempotency/start")
+        .post("v1.idempotency.start")
         .json(json!({
             "key": key,
             "ttl": ttl_seconds
@@ -27,7 +27,7 @@ async fn complete(
     ttl_seconds: u64,
 ) -> TestResult<()> {
     client
-        .post("idempotency/complete")
+        .post("v1.idempotency.complete")
         .json(json!({
             "key": key,
             "response": response.as_bytes(),
@@ -40,7 +40,7 @@ async fn complete(
 
 async fn abandon(client: &TestClient, key: &str) -> TestResult<()> {
     client
-        .post("idempotency/abort")
+        .post("v1.idempotency.abort")
         .json(json!({
             "key": key
         }))
@@ -64,7 +64,7 @@ async fn test_idempotency_start_and_complete() -> TestResult {
 
     // start again should return locked
     let response = client
-        .post("idempotency/start")
+        .post("v1.idempotency.start")
         .json(json!({
             "key": "k2",
             "ttl": 60
@@ -192,7 +192,7 @@ async fn test_idempotency_validation() -> TestResult {
     } = start_server().await;
 
     client
-        .post("idempotency/start")
+        .post("v1.idempotency.start")
         .json(json!({
             "key": "k",
             "ttl": 0
@@ -201,7 +201,7 @@ async fn test_idempotency_validation() -> TestResult {
         .expect(StatusCode::UNPROCESSABLE_ENTITY);
 
     client
-        .post("idempotency/start")
+        .post("v1.idempotency.start")
         .json(json!({
             "key": "k"
             // TTL missing
@@ -221,7 +221,7 @@ async fn create_namespace_with_defaults() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("idempotency/namespace/create")
+        .post("v1.idempotency.namespace.create")
         .json(json!({
             "name": "my-namespace",
         }))
@@ -245,7 +245,7 @@ async fn create_namespace_with_custom_config() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("idempotency/namespace/create")
+        .post("v1.idempotency.namespace.create")
         .json(json!({
             "name": "custom-ns",
             "max_storage_bytes": 1024,
@@ -278,7 +278,7 @@ async fn create_namespace_upserts() -> TestResult {
     } = start_server().await;
 
     let first = client
-        .post("idempotency/namespace/create")
+        .post("v1.idempotency.namespace.create")
         .json(json!({
             "name": "upsert-ns",
         }))
@@ -291,7 +291,7 @@ async fn create_namespace_upserts() -> TestResult {
 
     // Upsert
     let second = client
-        .post("idempotency/namespace/create")
+        .post("v1.idempotency.namespace.create")
         .json(json!({
             "name": "upsert-ns",
         }))
@@ -318,7 +318,7 @@ async fn get_namespace() -> TestResult {
 
     // Create a namespace first
     let created = client
-        .post("idempotency/namespace/create")
+        .post("v1.idempotency.namespace.create")
         .json(json!({
             "name": "get-test-ns",
         }))
@@ -328,7 +328,7 @@ async fn get_namespace() -> TestResult {
 
     // Get it back
     let response = client
-        .post("idempotency/namespace/get")
+        .post("v1.idempotency.namespace.get")
         .json(json!({
             "name": "get-test-ns",
         }))
@@ -352,7 +352,7 @@ async fn get_namespace_not_found() -> TestResult {
     } = start_server().await;
 
     client
-        .post("idempotency/namespace/get")
+        .post("v1.idempotency.namespace.get")
         .json(json!({
             "name": "nonexistent-ns",
         }))

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -15,7 +15,7 @@ async fn kv_set(
     behavior: &str,
 ) -> anyhow::Result<()> {
     let response = client
-        .post("kv/set")
+        .post("v1.kv.set")
         .json(json!({
             "key": key,
             "ttl": expire_in,
@@ -37,7 +37,7 @@ async fn kv_set_unsuccessful(
     behavior: &str,
 ) -> anyhow::Result<()> {
     let response = client
-        .post("kv/set")
+        .post("v1.kv.set")
         .json(json!({
             "key": key,
             "ttl": expire_in,
@@ -54,7 +54,7 @@ async fn kv_set_unsuccessful(
 #[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
 async fn kv_get(client: &TestClient, key: &str) -> TestResult<serde_json::Value> {
     let response = client
-        .post("kv/get")
+        .post("v1.kv.get")
         .json(json!({
             "key": key
         }))
@@ -66,7 +66,7 @@ async fn kv_get(client: &TestClient, key: &str) -> TestResult<serde_json::Value>
 
 async fn kv_not_found(client: &TestClient, key: &str) -> anyhow::Result<()> {
     let response = client
-        .post("kv/get")
+        .post("v1.kv.get")
         .json(json!({
             "key": key
         }))
@@ -116,7 +116,7 @@ async fn test_kv_set_and_get() -> TestResult {
 
     // set should fail if namespace doesn't exist:
     client
-        .post("kv/set")
+        .post("v1.kv.set")
         .json(json!({
             "namespace": "nonexistentnamespace",
             "key": "key1",
@@ -151,7 +151,7 @@ async fn test_kv_set_with_insert_and_delete() -> TestResult {
     assert_eq!(response["expiry"], json!(null));
 
     let delete_response = client
-        .post("kv/delete")
+        .post("v1.kv.delete")
         .json(json!({
             "key": "kv-key-2"
         }))
@@ -244,7 +244,7 @@ async fn test_kv_binary_data() -> TestResult {
 
     let binary_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     client
-        .post("kv/set")
+        .post("v1.kv.set")
         .json(json!({
             "key": "kv-key-4",
             "value": binary_data,
@@ -258,7 +258,7 @@ async fn test_kv_binary_data() -> TestResult {
 
     let empty_vec: Vec<u8> = vec![];
     client
-        .post("kv/set")
+        .post("v1.kv.set")
         .json(json!({
             "key": "kv-key-4",
             "value": empty_vec,
@@ -285,7 +285,7 @@ async fn test_kv_validation() -> TestResult {
 
     for key in invalid_keys {
         client
-            .post("kv/set")
+            .post("v1.kv.set")
             .json(json!({
                 "key": key,
                 "value": "test".as_bytes(),
@@ -296,7 +296,7 @@ async fn test_kv_validation() -> TestResult {
     }
 
     client
-        .post("kv/set")
+        .post("v1.kv.set")
         .json(json!({
             "key": "kv-key-3",
             "value": "test".as_bytes(),
@@ -307,7 +307,7 @@ async fn test_kv_validation() -> TestResult {
         .expect(StatusCode::UNPROCESSABLE_ENTITY);
 
     client
-        .post("kv/set")
+        .post("v1.kv.set")
         .json(json!({
             "key": "kv-key-3",
             "value": "test".as_bytes(),
@@ -329,7 +329,7 @@ async fn test_kv_delete() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("kv/delete")
+        .post("v1.kv.delete")
         .json(json!({
             "key": "kv-key-5"
         }))
@@ -342,7 +342,7 @@ async fn test_kv_delete() -> TestResult {
     kv_set(&client, "kv-key-5", None, "value-5", "upsert").await?;
 
     let response = client
-        .post("kv/delete")
+        .post("v1.kv.delete")
         .json(json!({
             "key": "kv-key-5"
         }))
@@ -365,7 +365,7 @@ async fn create_namespace_with_defaults() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("kv/namespace/create")
+        .post("v1.kv.namespace.create")
         .json(json!({
             "name": "my-namespace",
         }))
@@ -389,7 +389,7 @@ async fn create_namespace_with_custom_config() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("kv/namespace/create")
+        .post("v1.kv.namespace.create")
         .json(json!({
             "name": "custom-ns",
             "max_storage_bytes": 1024,
@@ -422,7 +422,7 @@ async fn create_namespace_upserts() -> TestResult {
     } = start_server().await;
 
     let first = client
-        .post("kv/namespace/create")
+        .post("v1.kv.namespace.create")
         .json(json!({
             "name": "upsert-ns",
         }))
@@ -435,7 +435,7 @@ async fn create_namespace_upserts() -> TestResult {
 
     // Upsert
     let second = client
-        .post("kv/namespace/create")
+        .post("v1.kv.namespace.create")
         .json(json!({
             "name": "upsert-ns",
         }))
@@ -462,7 +462,7 @@ async fn get_namespace() -> TestResult {
 
     // Create a namespace first
     let created = client
-        .post("kv/namespace/create")
+        .post("v1.kv.namespace.create")
         .json(json!({
             "name": "get-test-ns",
         }))
@@ -472,7 +472,7 @@ async fn get_namespace() -> TestResult {
 
     // Get it back
     let response = client
-        .post("kv/namespace/get")
+        .post("v1.kv.namespace.get")
         .json(json!({
             "name": "get-test-ns",
         }))
@@ -496,7 +496,7 @@ async fn get_namespace_not_found() -> TestResult {
     } = start_server().await;
 
     client
-        .post("kv/namespace/get")
+        .post("v1.kv.namespace.get")
         .json(json!({
             "name": "nonexistent-ns",
         }))

--- a/tests/it/msgpack.rs
+++ b/tests/it/msgpack.rs
@@ -27,7 +27,7 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
     } = start_server().await;
 
     client
-        .post("cache/set")
+        .post("v1.cache.set")
         .header("accept", "application/json")
         .msgpack(CacheSetIn {
             key: "test-key-1",
@@ -38,7 +38,7 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
         .expect(StatusCode::OK);
 
     let response = client
-        .post("cache/get")
+        .post("v1.cache.get")
         .header("accept", "application/json")
         .msgpack(CacheGetIn { key: "test-key-1" })
         .await?
@@ -67,7 +67,7 @@ async fn test_cache_set_and_get_msgpack_out() -> TestResult {
     } = start_server().await;
 
     client
-        .post("cache/set")
+        .post("v1.cache.set")
         .json(json!({
             "key": "test-key-1",
             "ttl": 60000,
@@ -77,7 +77,7 @@ async fn test_cache_set_and_get_msgpack_out() -> TestResult {
         .expect(StatusCode::OK);
 
     let response = client
-        .post("cache/get")
+        .post("v1.cache.get")
         .header("accept", "application/msgpack")
         .json(json!({ "key": "test-key-1" }))
         .await?

--- a/tests/it/msgs/namespace.rs
+++ b/tests/it/msgs/namespace.rs
@@ -13,7 +13,7 @@ async fn create_namespace_with_defaults() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({
             "name": "my-namespace",
         }))
@@ -40,7 +40,7 @@ async fn create_namespace_with_custom_config() -> TestResult {
     } = start_server().await;
 
     let response = client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({
             "name": "custom-ns",
             "retention": {
@@ -76,7 +76,7 @@ async fn create_namespace_upserts() -> TestResult {
     } = start_server().await;
 
     let first = client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({
             "name": "upsert-ns",
             "retention": { "bytes": 1024, "ms": 9999 }
@@ -92,7 +92,7 @@ async fn create_namespace_upserts() -> TestResult {
 
     // Upsert with different retention
     let second = client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({
             "name": "upsert-ns",
             "retention": { "bytes": 2048, "ms": 60000 }
@@ -122,7 +122,7 @@ async fn get_namespace() -> TestResult {
 
     // Create a namespace first
     let created = client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({
             "name": "get-test-ns",
             "retention": { "bytes": 5000, "ms": 30000 }
@@ -133,7 +133,7 @@ async fn get_namespace() -> TestResult {
 
     // Get it back
     let response = client
-        .post("msgs/namespace/get")
+        .post("v1.msgs.namespace.get")
         .json(json!({
             "name": "get-test-ns",
         }))
@@ -159,7 +159,7 @@ async fn get_namespace_not_found() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/get")
+        .post("v1.msgs.namespace.get")
         .json(json!({
             "name": "nonexistent-ns",
         }))

--- a/tests/it/msgs/publish.rs
+++ b/tests/it/msgs/publish.rs
@@ -13,13 +13,13 @@ async fn publish_to_topic() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns1" }))
         .await?
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns1:my-topic",
             "msgs": [
@@ -56,13 +56,13 @@ async fn publish_with_partition_key() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-key" }))
         .await?
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-key:keyed-topic",
             "msgs": [
@@ -104,20 +104,20 @@ async fn publish_directly_to_partition() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-direct" }))
         .await?
         .expect(StatusCode::OK);
 
     // Configure the topic to have 4 partitions.
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({ "topic": "ns-direct:my-topic", "partitions": 4 }))
         .await?
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-direct:my-topic~2",
             "msgs": [
@@ -158,7 +158,7 @@ async fn publish_rejects_out_of_range_partition() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-range" }))
         .await?
         .expect(StatusCode::OK);
@@ -166,7 +166,7 @@ async fn publish_rejects_out_of_range_partition() -> TestResult {
     // Default topic has 1 partition (index 0 only).
     // Publishing to partition 1 should fail.
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "namespace": "ns-range",
             "topic": "my-topic~1",
@@ -187,13 +187,13 @@ async fn publish_rejects_malformed_partition_topic() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-bad" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "namespace": "ns-bad",
             "topic": "my-topic~abc",
@@ -214,7 +214,7 @@ async fn publish_to_nonexistent_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "namespace": "does-not-exist",
             "topic": "topic",
@@ -235,13 +235,13 @@ async fn publish_keyless_same_partition() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-kl" }))
         .await?
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "namespace": "ns-kl",
             "topic": "keyless-topic",
@@ -281,7 +281,7 @@ async fn publish_to_default_namespace() -> TestResult {
 
     // No namespace creation — default namespace is auto-created.
     let response = client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "my-topic",
             "msgs": [
@@ -318,14 +318,14 @@ async fn default_namespace_isolated_from_named() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "other" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer groups before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "shared-name",
             "consumer_group": "cg1",
@@ -334,7 +334,7 @@ async fn default_namespace_isolated_from_named() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "namespace": "other",
             "topic": "shared-name",
@@ -345,7 +345,7 @@ async fn default_namespace_isolated_from_named() -> TestResult {
 
     // Publish to default namespace (no prefix)
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "shared-name",
             "msgs": [{ "value": "default-msg".as_bytes() }],
@@ -355,7 +355,7 @@ async fn default_namespace_isolated_from_named() -> TestResult {
 
     // Publish to "other" namespace
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "namespace": "other",
             "topic": "shared-name",
@@ -366,7 +366,7 @@ async fn default_namespace_isolated_from_named() -> TestResult {
 
     // Receive from default — should only see 1 message
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "shared-name",
             "consumer_group": "cg1",
@@ -386,7 +386,7 @@ async fn default_namespace_isolated_from_named() -> TestResult {
 
     // Receive from "other" — should only see 1 message
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "namespace": "other",
             "topic": "shared-name",

--- a/tests/it/msgs/queue.rs
+++ b/tests/it/msgs/queue.rs
@@ -16,13 +16,13 @@ async fn queue_receive_returns_published_messages() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-queue" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-queue:my-topic",
             "msgs": [
@@ -35,7 +35,7 @@ async fn queue_receive_returns_published_messages() -> TestResult {
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-queue:my-topic",
             "consumer_group": "test-cg",
@@ -65,13 +65,13 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-lease" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-lease:t1",
             "msgs": [
@@ -84,7 +84,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
 
     // First receive gets message "a"
     let r1 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-lease:t1",
             "consumer_group": "test-cg",
@@ -100,7 +100,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
 
     // Second receive gets message "b" (message "a" is leased, skipped)
     let r2 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-lease:t1",
             "consumer_group": "test-cg",
@@ -116,7 +116,7 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
 
     // Third receive — all messages leased, should be empty
     let r3 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-lease:t1",
             "consumer_group": "test-cg",
@@ -142,13 +142,13 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-ack" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-ack:t1",
             "msgs": [
@@ -162,7 +162,7 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
 
     // Receive with a short lease
     let r1 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-ack:t1",
             "consumer_group": "test-cg",
@@ -178,7 +178,7 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
     // Ack all messages
     let msg_ids: Vec<&str> = msgs.iter().map(|m| m["msg_id"].assert_str()).collect();
     client
-        .post("msgs/queue/ack")
+        .post("v1.msgs.queue.ack")
         .json(json!({
             "topic": "ns-q-ack:t1",
             "consumer_group": "test-cg",
@@ -192,7 +192,7 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
 
     // Receive again — all messages were acked, should get nothing
     let r2 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-ack:t1",
             "consumer_group": "test-cg",
@@ -218,13 +218,13 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-redeliver" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-redeliver:t1",
             "msgs": [
@@ -237,7 +237,7 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
 
     // Receive with a very short lease
     let r1 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-redeliver:t1",
             "consumer_group": "test-cg",
@@ -253,7 +253,7 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
 
     // Receive again — should get the same messages
     let r2 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-redeliver:t1",
             "consumer_group": "test-cg",
@@ -290,7 +290,7 @@ async fn queue_receive_nonexistent_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "namespace": "does-not-exist",
             "topic": "t1",
@@ -311,14 +311,14 @@ async fn queue_starts_from_earliest() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-earliest" }))
         .await?
         .expect(StatusCode::OK);
 
     // Publish messages BEFORE any queue consumer exists
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-earliest:t1",
             "msgs": (0..5)
@@ -330,7 +330,7 @@ async fn queue_starts_from_earliest() -> TestResult {
 
     // First queue.receive should get ALL existing messages (unlike stream which starts from latest)
     let response = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-earliest:t1",
             "consumer_group": "test-cg",
@@ -358,13 +358,13 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-partial" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-partial:t1",
             "msgs": [
@@ -378,7 +378,7 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
 
     // Receive with short lease
     let r1 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-partial:t1",
             "consumer_group": "test-cg",
@@ -395,7 +395,7 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
     let first_id = msgs[0]["msg_id"].assert_str();
     let last_id = msgs[2]["msg_id"].assert_str();
     client
-        .post("msgs/queue/ack")
+        .post("v1.msgs.queue.ack")
         .json(json!({
             "topic": "ns-q-partial:t1",
             "consumer_group": "test-cg",
@@ -409,7 +409,7 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
 
     // Receive again — only the un-acked middle message should be returned
     let r2 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-partial:t1",
             "consumer_group": "test-cg",
@@ -442,13 +442,13 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-concurrent" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-concurrent:t1",
             "msgs": [
@@ -465,7 +465,7 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
 
     // Consumer A receives 3 messages
     let r_a = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-concurrent:t1",
             "consumer_group": "test-cg",
@@ -480,7 +480,7 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
 
     // Consumer B receives remaining 3 messages (first 3 are leased)
     let r_b = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-concurrent:t1",
             "consumer_group": "test-cg",
@@ -505,7 +505,7 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
 
     // Consumer C — all messages leased, should be empty
     let r_c = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-concurrent:t1",
             "consumer_group": "test-cg",
@@ -531,13 +531,13 @@ async fn queue_consumer_groups_independent() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-cg" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-cg:t1",
             "msgs": [
@@ -551,7 +551,7 @@ async fn queue_consumer_groups_independent() -> TestResult {
 
     // Group A receives all messages
     let r_a = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-cg:t1",
             "consumer_group": "group-a",
@@ -566,7 +566,7 @@ async fn queue_consumer_groups_independent() -> TestResult {
     // Ack all messages for group A
     let msg_ids_a: Vec<&str> = msgs_a.iter().map(|m| m["msg_id"].assert_str()).collect();
     client
-        .post("msgs/queue/ack")
+        .post("v1.msgs.queue.ack")
         .json(json!({
             "topic": "ns-q-cg:t1",
             "consumer_group": "group-a",
@@ -577,7 +577,7 @@ async fn queue_consumer_groups_independent() -> TestResult {
 
     // Group B should independently receive all the same messages
     let r_b = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-cg:t1",
             "consumer_group": "group-b",
@@ -605,13 +605,13 @@ async fn nack_sends_to_dlq() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-nack" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-nack:t1",
             "msgs": [
@@ -624,7 +624,7 @@ async fn nack_sends_to_dlq() -> TestResult {
 
     // Receive messages
     let r1 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-nack:t1",
             "consumer_group": "test-cg",
@@ -640,7 +640,7 @@ async fn nack_sends_to_dlq() -> TestResult {
     // Nack all messages
     let msg_ids: Vec<&str> = msgs.iter().map(|m| m["msg_id"].assert_str()).collect();
     client
-        .post("msgs/queue/nack")
+        .post("v1.msgs.queue.nack")
         .json(json!({
             "topic": "ns-q-nack:t1",
             "consumer_group": "test-cg",
@@ -654,7 +654,7 @@ async fn nack_sends_to_dlq() -> TestResult {
 
     // Receive again — nacked messages are in DLQ, should get nothing
     let r2 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-nack:t1",
             "consumer_group": "test-cg",
@@ -681,13 +681,13 @@ async fn nack_then_redrive_makes_available() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-redrive" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-redrive:t1",
             "msgs": [
@@ -700,7 +700,7 @@ async fn nack_then_redrive_makes_available() -> TestResult {
 
     // Receive and nack
     let r1 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-redrive:t1",
             "consumer_group": "test-cg",
@@ -716,7 +716,7 @@ async fn nack_then_redrive_makes_available() -> TestResult {
         .collect();
 
     client
-        .post("msgs/queue/nack")
+        .post("v1.msgs.queue.nack")
         .json(json!({
             "topic": "ns-q-redrive:t1",
             "consumer_group": "test-cg",
@@ -727,7 +727,7 @@ async fn nack_then_redrive_makes_available() -> TestResult {
 
     // Redrive DLQ
     client
-        .post("msgs/queue/redrive-dlq")
+        .post("v1.msgs.queue.redrive-dlq")
         .json(json!({
             "topic": "ns-q-redrive:t1",
             "consumer_group": "test-cg",
@@ -737,7 +737,7 @@ async fn nack_then_redrive_makes_available() -> TestResult {
 
     // Receive again — redriven messages should be available
     let r2 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-redrive:t1",
             "consumer_group": "test-cg",
@@ -764,7 +764,7 @@ async fn nack_nonexistent_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/queue/nack")
+        .post("v1.msgs.queue.nack")
         .json(json!({
             "namespace": "does-not-exist",
             "topic": "t1",
@@ -786,7 +786,7 @@ async fn redrive_dlq_nonexistent_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/queue/redrive-dlq")
+        .post("v1.msgs.queue.redrive-dlq")
         .json(json!({
             "namespace": "does-not-exist",
             "topic": "t1",
@@ -807,14 +807,14 @@ async fn redrive_dlq_no_dlq_messages() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-redrive-noop" }))
         .await?
         .expect(StatusCode::OK);
 
     // Publish a message to create the topic
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-redrive-noop:t1",
             "msgs": [{ "value": "a".as_bytes(), "key": "k1" }],
@@ -824,7 +824,7 @@ async fn redrive_dlq_no_dlq_messages() -> TestResult {
 
     // Redrive with no DLQ messages should succeed as a no-op
     client
-        .post("msgs/queue/redrive-dlq")
+        .post("v1.msgs.queue.redrive-dlq")
         .json(json!({
             "topic": "ns-q-redrive-noop:t1",
             "consumer_group": "test-cg",
@@ -844,13 +844,13 @@ async fn configure_retry_schedule() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-cfg" }))
         .await?
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/queue/configure")
+        .post("v1.msgs.queue.configure")
         .json(json!({
             "topic": "ns-q-cfg:t1",
             "consumer_group": "test-cg",
@@ -865,7 +865,7 @@ async fn configure_retry_schedule() -> TestResult {
 
     // Updating the config should overwrite
     let response2 = client
-        .post("msgs/queue/configure")
+        .post("v1.msgs.queue.configure")
         .json(json!({
             "topic": "ns-q-cfg:t1",
             "consumer_group": "test-cg",
@@ -891,14 +891,14 @@ async fn nack_retries_before_dlq() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-retry" }))
         .await?
         .expect(StatusCode::OK);
 
     // Configure a single retry with 1s delay
     client
-        .post("msgs/queue/configure")
+        .post("v1.msgs.queue.configure")
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
@@ -908,7 +908,7 @@ async fn nack_retries_before_dlq() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-retry:t1",
             "msgs": [{ "value": "a".as_bytes(), "key": "k1" }],
@@ -918,7 +918,7 @@ async fn nack_retries_before_dlq() -> TestResult {
 
     // Receive the message
     let r1 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
@@ -934,7 +934,7 @@ async fn nack_retries_before_dlq() -> TestResult {
 
     // Nack — should schedule for retry, NOT DLQ
     client
-        .post("msgs/queue/nack")
+        .post("v1.msgs.queue.nack")
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
@@ -945,7 +945,7 @@ async fn nack_retries_before_dlq() -> TestResult {
 
     // Immediately after nack, message should NOT be available (retry delay not elapsed)
     let r2 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
@@ -964,7 +964,7 @@ async fn nack_retries_before_dlq() -> TestResult {
 
     // Message should now be available again (retried, not DLQ'd)
     let r3 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
@@ -984,7 +984,7 @@ async fn nack_retries_before_dlq() -> TestResult {
 
     // Nack again — retries exhausted, should go to DLQ
     client
-        .post("msgs/queue/nack")
+        .post("v1.msgs.queue.nack")
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
@@ -998,7 +998,7 @@ async fn nack_retries_before_dlq() -> TestResult {
 
     // Message should now be in DLQ — not available
     let r4 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-retry:t1",
             "consumer_group": "test-cg",
@@ -1025,14 +1025,14 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-q-dlqfwd" }))
         .await?
         .expect(StatusCode::OK);
 
     // Configure with retry schedule and DLQ topic
     client
-        .post("msgs/queue/configure")
+        .post("v1.msgs.queue.configure")
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "consumer_group": "test-cg",
@@ -1043,7 +1043,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "msgs": [{ "value": "a".as_bytes(), "key": "k1" }],
@@ -1053,7 +1053,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
 
     // Receive and nack (first retry)
     let r1 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "consumer_group": "test-cg",
@@ -1066,7 +1066,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     let msg_id = r1["msgs"].assert_array()[0]["msg_id"].assert_str();
 
     client
-        .post("msgs/queue/nack")
+        .post("v1.msgs.queue.nack")
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "consumer_group": "test-cg",
@@ -1080,7 +1080,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
 
     // Receive the retried message and nack again (exhausts retries → forwards to DLQ topic)
     let r2 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "consumer_group": "test-cg",
@@ -1093,7 +1093,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     assert_eq!(r2["msgs"].assert_array().len(), 1);
 
     client
-        .post("msgs/queue/nack")
+        .post("v1.msgs.queue.nack")
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "consumer_group": "test-cg",
@@ -1105,7 +1105,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     // Original topic should have no messages available
     sleep(Duration::from_millis(1500)).await;
     let r3 = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-dlqfwd:t1",
             "consumer_group": "test-cg",
@@ -1117,7 +1117,7 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
 
     // The DLQ topic should have the message
     let r_dlq = client
-        .post("msgs/queue/receive")
+        .post("v1.msgs.queue.receive")
         .json(json!({
             "topic": "ns-q-dlqfwd:t1-dlq",
             "consumer_group": "test-cg",

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -16,14 +16,14 @@ async fn stream_receive_returns_published_messages() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-recv" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-recv:my-topic",
             "consumer_group": "cg1",
@@ -32,7 +32,7 @@ async fn stream_receive_returns_published_messages() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-recv:my-topic",
             "msgs": [
@@ -45,7 +45,7 @@ async fn stream_receive_returns_published_messages() -> TestResult {
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-recv:my-topic",
             "consumer_group": "cg1",
@@ -85,14 +85,14 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-nodup" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-nodup:t1",
             "consumer_group": "cg1",
@@ -101,7 +101,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-nodup:t1",
             "msgs": [
@@ -114,7 +114,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
 
     // First receive gets the messages
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-nodup:t1",
             "consumer_group": "cg1",
@@ -126,7 +126,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
 
     // Second receive with the same CG — partition is locked, returns error
     let _r2 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-nodup:t1",
             "consumer_group": "cg1",
@@ -141,7 +141,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     let last_offset = msgs[1]["offset"].assert_u64();
 
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg1",
@@ -152,7 +152,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
 
     // Publish more messages
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-nodup:t1",
             "msgs": [
@@ -164,7 +164,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
 
     // Third receive gets only the new message
     let r3 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-nodup:t1",
             "consumer_group": "cg1",
@@ -186,14 +186,14 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-cg" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register both consumer groups before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-cg:t1",
             "consumer_group": "group-a",
@@ -202,7 +202,7 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-cg:t1",
             "consumer_group": "group-b",
@@ -211,7 +211,7 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-cg:t1",
             "msgs": [
@@ -223,7 +223,7 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
         .expect(StatusCode::OK);
 
     let r_a = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-cg:t1",
             "consumer_group": "group-a",
@@ -233,7 +233,7 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
         .json();
 
     let r_b = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-cg:t1",
             "consumer_group": "group-b",
@@ -265,7 +265,7 @@ async fn stream_receive_nonexistent_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "namespace": "does-not-exist",
             "topic": "t1",
@@ -286,14 +286,14 @@ async fn stream_receive_with_defaults() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-def" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-def:t1",
             "consumer_group": "cg-default",
@@ -302,7 +302,7 @@ async fn stream_receive_with_defaults() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-def:t1",
             "msgs": [{ "value": "hello".as_bytes(), "key": "k1" }],
@@ -312,7 +312,7 @@ async fn stream_receive_with_defaults() -> TestResult {
 
     // Call without specifying batch_size or lease_duration_ms
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-def:t1",
             "consumer_group": "cg-default",
@@ -336,14 +336,14 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-lock" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-lock:t1",
             "consumer_group": "cg1",
@@ -352,7 +352,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-lock:t1",
             "msgs": [
@@ -368,7 +368,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
 
     // Consumer A receives a small batch — leases the partition
     let r_a = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-lock:t1",
             "consumer_group": "cg1",
@@ -381,7 +381,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
 
     // Consumer B (same CG) — partition is locked, returns error
     let _ = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-lock:t1",
             "consumer_group": "cg1",
@@ -396,7 +396,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     let last_offset = msgs_a[1]["offset"].assert_u64();
 
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg1",
@@ -407,7 +407,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
 
     // Now consumer B can receive the remaining messages
     let r_b = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-lock:t1",
             "consumer_group": "cg1",
@@ -433,14 +433,14 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-concurrent" }))
         .await?
         .expect(StatusCode::OK);
 
     // Default is 1 partition; configure more so "k1" and "k2" hash to different ones.
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "ns-concurrent:t1",
             "partitions": 16,
@@ -450,7 +450,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-concurrent:t1",
             "consumer_group": "cg1",
@@ -460,7 +460,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
 
     // "k1" and "k2" hash to different partitions via djb2
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-concurrent:t1",
             "msgs": [
@@ -481,7 +481,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
 
     // Consumer A: receives with batch_size=5, should get one partition's worth
     let r_a = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-concurrent:t1",
             "consumer_group": "cg1",
@@ -496,7 +496,7 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
 
     // Consumer B: same CG, should get the other partition
     let r_b = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-concurrent:t1",
             "consumer_group": "cg1",
@@ -540,14 +540,14 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-commit" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-commit:t1",
             "consumer_group": "cg1",
@@ -556,7 +556,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-commit:t1",
             "msgs": [
@@ -570,7 +570,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
 
     // Receive all 3 messages
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-commit:t1",
             "consumer_group": "cg1",
@@ -589,7 +589,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
 
     // Commit the last offset we processed
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg1",
@@ -600,7 +600,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
 
     // Receive again — should get nothing (all committed past leases)
     let r2 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-commit:t1",
             "consumer_group": "cg1",
@@ -612,7 +612,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
 
     // Publish more
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-commit:t1",
             "msgs": [
@@ -626,7 +626,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
 
     // Receive — only the new message
     let r3 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-commit:t1",
             "consumer_group": "cg1",
@@ -648,14 +648,14 @@ async fn commit_requires_partition_topic() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-commit-pt" }))
         .await?
         .expect(StatusCode::OK);
 
     // Base topic (no ~partition suffix)
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": "ns-commit-pt:t1",
             "consumer_group": "cg1",
@@ -676,7 +676,7 @@ async fn commit_nonexistent_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "namespace": "does-not-exist",
             "topic": "t1~0",
@@ -698,14 +698,14 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-race" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-race:t1",
             "consumer_group": "cg1",
@@ -715,7 +715,7 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
 
     // Single partition (default) — all messages land on partition 0.
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-race:t1",
             "msgs": [
@@ -732,7 +732,7 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
     for _ in 0..20 {
         let c = client.clone();
         handles.push(tokio::spawn(async move {
-            c.post("msgs/stream/receive")
+            c.post("v1.msgs.stream.receive")
                 .json(json!({
                     "topic": "ns-race:t1",
                     "consumer_group": "cg1",
@@ -771,14 +771,14 @@ async fn partial_commit_preserves_lease() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-partial" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-partial:t1",
             "consumer_group": "cg1",
@@ -788,7 +788,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
 
     // Publish 10 messages
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-partial:t1",
             "msgs": (0..10)
@@ -800,7 +800,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
 
     // Receive only 5 of the 10 messages
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-partial:t1",
             "consumer_group": "cg1",
@@ -819,7 +819,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
 
     // Partial commit: only commit the first message
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg1",
@@ -830,7 +830,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
 
     // Lease should still be held — second receive must fail
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-partial:t1",
             "consumer_group": "cg1",
@@ -840,7 +840,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
 
     // Commit the last offset in the batch — should release the lease
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg1",
@@ -851,7 +851,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
 
     // Lease is now released — receive should succeed with the remaining 5 messages
     let r2 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-partial:t1",
             "consumer_group": "cg1",
@@ -877,14 +877,14 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-latest" }))
         .await?
         .expect(StatusCode::OK);
 
     // Publish 5 messages before any consumer group exists
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-latest:t1",
             "msgs": (0..5)
@@ -896,7 +896,7 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
 
     // First receive with a brand-new CG — should get 0 messages (starts from "now")
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-latest:t1",
             "consumer_group": "cg-new",
@@ -912,7 +912,7 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
 
     // Publish 3 more messages
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-latest:t1",
             "msgs": (0..3)
@@ -924,7 +924,7 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
 
     // Second receive — should get only the 3 new messages
     let r2 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-latest:t1",
             "consumer_group": "cg-new",
@@ -953,7 +953,7 @@ async fn default_namespace_receive_and_commit() -> TestResult {
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "def-topic",
             "consumer_group": "cg-def",
@@ -962,7 +962,7 @@ async fn default_namespace_receive_and_commit() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "def-topic",
             "msgs": [
@@ -976,7 +976,7 @@ async fn default_namespace_receive_and_commit() -> TestResult {
 
     // Receive using unprefixed topic
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "def-topic",
             "consumer_group": "cg-def",
@@ -1002,7 +1002,7 @@ async fn default_namespace_receive_and_commit() -> TestResult {
     let last_offset = last["offset"].assert_u64();
 
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg-def",
@@ -1013,7 +1013,7 @@ async fn default_namespace_receive_and_commit() -> TestResult {
 
     // Receive again — should get nothing since we committed past all messages
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "def-topic",
             "consumer_group": "cg-def",
@@ -1037,14 +1037,14 @@ async fn default_starting_position_earliest_gets_preexisting() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-dsp" }))
         .await?
         .expect(StatusCode::OK);
 
     // Publish 5 messages before any consumer group exists
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-dsp:t1",
             "msgs": (0..5)
@@ -1056,7 +1056,7 @@ async fn default_starting_position_earliest_gets_preexisting() -> TestResult {
 
     // Receive with default_starting_position=earliest — should get all 5 messages
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-dsp:t1",
             "consumer_group": "cg1",

--- a/tests/it/msgs/stream_seek.rs
+++ b/tests/it/msgs/stream_seek.rs
@@ -13,14 +13,14 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-seek-earliest" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-earliest:t1",
             "consumer_group": "cg1",
@@ -30,7 +30,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
 
     // Publish messages
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-seek-earliest:t1",
             "msgs": [
@@ -44,7 +44,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
 
     // Receive all messages
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-earliest:t1",
             "consumer_group": "cg1",
@@ -60,7 +60,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     let partition_topic = msgs[0]["topic"].assert_str();
     let last_offset = msgs[2]["offset"].assert_u64();
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg1",
@@ -71,7 +71,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
 
     // Verify nothing left to consume
     let r2 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-earliest:t1",
             "consumer_group": "cg1",
@@ -83,7 +83,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
 
     // Seek to earliest
     client
-        .post("msgs/stream/seek")
+        .post("v1.msgs.stream.seek")
         .json(json!({
             "topic": "ns-seek-earliest:t1",
             "consumer_group": "cg1",
@@ -94,7 +94,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
 
     // Receive again — should replay all 3 messages
     let r3 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-earliest:t1",
             "consumer_group": "cg1",
@@ -121,14 +121,14 @@ async fn seek_latest_skips_existing() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-seek-latest" }))
         .await?
         .expect(StatusCode::OK);
 
     // Publish messages before any consumer exists
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-seek-latest:t1",
             "msgs": [
@@ -141,7 +141,7 @@ async fn seek_latest_skips_existing() -> TestResult {
 
     // Seek to latest (creates consumer group at the end of the stream)
     client
-        .post("msgs/stream/seek")
+        .post("v1.msgs.stream.seek")
         .json(json!({
             "topic": "ns-seek-latest:t1",
             "consumer_group": "cg1",
@@ -152,7 +152,7 @@ async fn seek_latest_skips_existing() -> TestResult {
 
     // Receive — should get nothing (all messages are before "latest")
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-latest:t1",
             "consumer_group": "cg1",
@@ -168,7 +168,7 @@ async fn seek_latest_skips_existing() -> TestResult {
 
     // Publish new messages
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-seek-latest:t1",
             "msgs": [
@@ -181,7 +181,7 @@ async fn seek_latest_skips_existing() -> TestResult {
 
     // Receive — should get only the new messages
     let r2 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-latest:t1",
             "consumer_group": "cg1",
@@ -207,14 +207,14 @@ async fn seek_to_specific_offset() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-seek-offset" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-offset:t1",
             "consumer_group": "cg1",
@@ -224,7 +224,7 @@ async fn seek_to_specific_offset() -> TestResult {
 
     // Publish 5 messages
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-seek-offset:t1",
             "msgs": (0..5)
@@ -236,7 +236,7 @@ async fn seek_to_specific_offset() -> TestResult {
 
     // Receive to discover the partition topic
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-offset:t1",
             "consumer_group": "cg1",
@@ -252,7 +252,7 @@ async fn seek_to_specific_offset() -> TestResult {
     // Commit past all messages
     let last_offset = msgs[4]["offset"].assert_u64();
     client
-        .post("msgs/stream/commit")
+        .post("v1.msgs.stream.commit")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg1",
@@ -263,7 +263,7 @@ async fn seek_to_specific_offset() -> TestResult {
 
     // Seek to offset 2 (next-to-read semantics: will read from offset 2)
     client
-        .post("msgs/stream/seek")
+        .post("v1.msgs.stream.seek")
         .json(json!({
             "topic": partition_topic,
             "consumer_group": "cg1",
@@ -274,7 +274,7 @@ async fn seek_to_specific_offset() -> TestResult {
 
     // Receive — should get messages starting at offset 2 (3 messages: 2, 3, 4)
     let r2 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-offset:t1",
             "consumer_group": "cg1",
@@ -303,14 +303,14 @@ async fn seek_offset_requires_partition_topic() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-seek-pt" }))
         .await?
         .expect(StatusCode::OK);
 
     // Offset-based seek on a bare topic (no ~partition) should fail
     client
-        .post("msgs/stream/seek")
+        .post("v1.msgs.stream.seek")
         .json(json!({
             "topic": "ns-seek-pt:t1",
             "consumer_group": "cg1",
@@ -331,14 +331,14 @@ async fn seek_position_works_on_topic_level() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-seek-topic" }))
         .await?
         .expect(StatusCode::OK);
 
     // Configure multiple partitions to ensure we can seek on a per-partition basis
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "ns-seek-topic:t1",
             "partitions": 16,
@@ -348,7 +348,7 @@ async fn seek_position_works_on_topic_level() -> TestResult {
 
     // Register consumer group
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-topic:t1",
             "consumer_group": "cg1",
@@ -358,7 +358,7 @@ async fn seek_position_works_on_topic_level() -> TestResult {
 
     // Publish messages to different partitions
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-seek-topic:t1",
             "msgs": [
@@ -373,7 +373,7 @@ async fn seek_position_works_on_topic_level() -> TestResult {
 
     // Seek to earliest on the topic level (applies to all partitions)
     client
-        .post("msgs/stream/seek")
+        .post("v1.msgs.stream.seek")
         .json(json!({
             "topic": "ns-seek-topic:t1",
             "consumer_group": "cg1",
@@ -384,7 +384,7 @@ async fn seek_position_works_on_topic_level() -> TestResult {
 
     // Receive — should get all messages from all partitions
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-topic:t1",
             "consumer_group": "cg1",
@@ -412,7 +412,7 @@ async fn seek_nonexistent_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/stream/seek")
+        .post("v1.msgs.stream.seek")
         .json(json!({
             "namespace": "does-not-exist",
             "topic": "t1",
@@ -434,14 +434,14 @@ async fn seek_clears_lease() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-seek-lease" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-lease:t1",
             "consumer_group": "cg1",
@@ -450,7 +450,7 @@ async fn seek_clears_lease() -> TestResult {
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-seek-lease:t1",
             "msgs": [
@@ -463,7 +463,7 @@ async fn seek_clears_lease() -> TestResult {
 
     // Receive — locks the partition
     let r1 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-lease:t1",
             "consumer_group": "cg1",
@@ -475,7 +475,7 @@ async fn seek_clears_lease() -> TestResult {
 
     // Verify partition is locked
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-lease:t1",
             "consumer_group": "cg1",
@@ -485,7 +485,7 @@ async fn seek_clears_lease() -> TestResult {
 
     // Seek to earliest — should clear the lease
     client
-        .post("msgs/stream/seek")
+        .post("v1.msgs.stream.seek")
         .json(json!({
             "topic": "ns-seek-lease:t1",
             "consumer_group": "cg1",
@@ -496,7 +496,7 @@ async fn seek_clears_lease() -> TestResult {
 
     // Receive again — should succeed (lease cleared) and replay messages
     let r2 = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-seek-lease:t1",
             "consumer_group": "cg1",

--- a/tests/it/msgs/topic_configure.rs
+++ b/tests/it/msgs/topic_configure.rs
@@ -15,14 +15,14 @@ async fn default_is_one_partition() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-def-part" }))
         .await?
         .expect(StatusCode::OK);
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-def-part:t1",
             "consumer_group": "cg1",
@@ -32,7 +32,7 @@ async fn default_is_one_partition() -> TestResult {
 
     // Publish messages with different keys — with 1 partition they all land on the same one.
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-def-part:t1",
             "msgs": [
@@ -45,7 +45,7 @@ async fn default_is_one_partition() -> TestResult {
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-def-part:t1",
             "consumer_group": "cg1",
@@ -77,13 +77,13 @@ async fn configure_topic_partitions() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-conf" }))
         .await?
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "ns-conf:t1",
             "partitions": 4,
@@ -96,7 +96,7 @@ async fn configure_topic_partitions() -> TestResult {
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-conf:t1",
             "consumer_group": "cg1",
@@ -106,7 +106,7 @@ async fn configure_topic_partitions() -> TestResult {
 
     // Publish messages with different keys to spread across partitions
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-conf:t1",
             "msgs": [
@@ -119,7 +119,7 @@ async fn configure_topic_partitions() -> TestResult {
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-conf:t1",
             "consumer_group": "cg1",
@@ -154,13 +154,13 @@ async fn cannot_decrease_partitions() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-dec" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "ns-dec:t1",
             "partitions": 4,
@@ -170,7 +170,7 @@ async fn cannot_decrease_partitions() -> TestResult {
 
     // Attempt to decrease — should be rejected
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "ns-dec:t1",
             "partitions": 2,
@@ -190,13 +190,13 @@ async fn configure_rejects_zero() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-zero" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "ns-zero:t1",
             "partitions": 0,
@@ -216,13 +216,13 @@ async fn configure_rejects_over_max() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-max" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "ns-max:t1",
             "partitions": 65,
@@ -242,7 +242,7 @@ async fn configure_nonexistent_namespace() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "namespace": "does-not-exist",
             "topic": "t1",
@@ -263,13 +263,13 @@ async fn receive_respects_configured_partitions() -> TestResult {
     } = start_server().await;
 
     client
-        .post("msgs/namespace/create")
+        .post("v1.msgs.namespace.create")
         .json(json!({ "name": "ns-recv-conf" }))
         .await?
         .expect(StatusCode::OK);
 
     client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "ns-recv-conf:t1",
             "partitions": 16,
@@ -279,7 +279,7 @@ async fn receive_respects_configured_partitions() -> TestResult {
 
     // Register consumer group after configure so we can receive from the start of the stream
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-recv-conf:t1",
             "consumer_group": "cg1",
@@ -289,7 +289,7 @@ async fn receive_respects_configured_partitions() -> TestResult {
 
     // "k1" and "k2" hash to different partitions with 16 partitions
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "ns-recv-conf:t1",
             "msgs": [
@@ -301,7 +301,7 @@ async fn receive_respects_configured_partitions() -> TestResult {
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-recv-conf:t1",
             "consumer_group": "cg1",
@@ -343,7 +343,7 @@ async fn configure_default_namespace_topic() -> TestResult {
 
     // No namespace creation — default namespace is auto-created.
     let response = client
-        .post("msgs/topic/configure")
+        .post("v1.msgs.topic.configure")
         .json(json!({
             "topic": "def-t1",
             "partitions": 4,
@@ -356,7 +356,7 @@ async fn configure_default_namespace_topic() -> TestResult {
 
     // Register consumer group before publishing
     client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "def-t1",
             "consumer_group": "cg1",
@@ -366,7 +366,7 @@ async fn configure_default_namespace_topic() -> TestResult {
 
     // Publish with different keys to spread across partitions
     client
-        .post("msgs/publish")
+        .post("v1.msgs.publish")
         .json(json!({
             "topic": "def-t1",
             "msgs": [
@@ -379,7 +379,7 @@ async fn configure_default_namespace_topic() -> TestResult {
         .expect(StatusCode::OK);
 
     let response = client
-        .post("msgs/stream/receive")
+        .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "def-t1",
             "consumer_group": "cg1",

--- a/tests/it/rate_limit.rs
+++ b/tests/it/rate_limit.rs
@@ -16,7 +16,7 @@ async fn call_limit_token_bucket(
     refill_interval_seconds: u64,
 ) -> TestResult<serde_json::Value> {
     let response = client
-        .post("rate-limit/limit")
+        .post("v1.rate-limit.limit")
         .json(json!({
             "key": key,
             "tokens": units,
@@ -99,7 +99,7 @@ async fn test_rate_limiter_limit_token_bucket() -> TestResult {
     time.fast_forward(Duration::from_secs(1));
 
     let response = client
-        .post("rate-limit/get-remaining")
+        .post("v1.rate-limit.get-remaining")
         .json(json!({
             "key": "rl-key-1",
             "config": {
@@ -157,7 +157,7 @@ async fn test_rate_limiter_refill_interval() -> TestResult {
     time.fast_forward(Duration::from_secs(3));
 
     let response = client
-        .post("rate-limit/get-remaining")
+        .post("v1.rate-limit.get-remaining")
         .json(json!({
                 "key": "rl-key-1",
                 "config": {

--- a/tests/it/stream.rs
+++ b/tests/it/stream.rs
@@ -16,7 +16,7 @@
 //     } = start_server().await;
 
 //     let response = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 },
@@ -40,7 +40,7 @@
 //     );
 
 //     let update = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream"
 //         }))
@@ -71,7 +71,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -180,7 +180,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -264,7 +264,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -354,7 +354,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -450,7 +450,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -583,7 +583,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -692,7 +692,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -786,7 +786,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -919,7 +919,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }
@@ -1025,7 +1025,7 @@
 //     } = start_server().await;
 
 //     let _stream = client
-//         .post("msgs/namespace/create")
+//         .post("v1.msgs.namespace.create")
 //         .json(json!({
 //             "name": "test-stream",
 //             "retention": { "bytes": 1024, "ms": 9999 }

--- a/z-clients/cli/src/cmds/api/admin.rs
+++ b/z-clients/cli/src/cmds/api/admin.rs
@@ -14,13 +14,6 @@ pub struct AdminArgs {
 #[derive(Subcommand)]
 pub enum AdminCommands {
     Cluster(AdminClusterArgs),
-    /// Remove a node from the cluster.
-    ///
-    /// This operation executes immediately and the node must be wiped and reset
-    /// before it can safely be added to the cluster.
-    ClusterRemoveNode {
-        cluster_remove_node_in: crate::json::JsonOf<coyote_client::models::ClusterRemoveNodeIn>,
-    },
 }
 
 impl AdminCommands {
@@ -32,15 +25,6 @@ impl AdminCommands {
         match self {
             Self::Cluster(args) => {
                 args.command.exec(client, color_mode).await?;
-            }
-            Self::ClusterRemoveNode {
-                cluster_remove_node_in,
-            } => {
-                let resp = client
-                    .admin()
-                    .cluster_remove_node(cluster_remove_node_in.into_inner())
-                    .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/admin_cluster.rs
+++ b/z-clients/cli/src/cmds/api/admin_cluster.rs
@@ -13,6 +13,13 @@ pub struct AdminClusterArgs {
 pub enum AdminClusterCommands {
     /// Get information about the current cluster
     Status {},
+    /// Remove a node from the cluster.
+    ///
+    /// This operation executes immediately and the node must be wiped and reset
+    /// before it can safely be added to the cluster.
+    RemoveNode {
+        cluster_remove_node_in: crate::json::JsonOf<coyote_client::models::ClusterRemoveNodeIn>,
+    },
 }
 
 impl AdminClusterCommands {
@@ -24,6 +31,16 @@ impl AdminClusterCommands {
         match self {
             Self::Status {} => {
                 let resp = client.admin().cluster().status().await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::RemoveNode {
+                cluster_remove_node_in,
+            } => {
+                let resp = client
+                    .admin()
+                    .cluster()
+                    .remove_node(cluster_remove_node_in.into_inner())
+                    .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
         }

--- a/z-clients/cli/src/cmds/cluster.rs
+++ b/z-clients/cli/src/cmds/cluster.rs
@@ -154,7 +154,8 @@ async fn remove_node(args: RemoveNodeArgs, client: &CoyoteClient) -> anyhow::Res
     );
     client
         .admin()
-        .cluster_remove_node(ClusterRemoveNodeIn {
+        .cluster()
+        .remove_node(ClusterRemoveNodeIn {
             node_id: args.node_id,
         })
         .await?;

--- a/z-clients/go/internal/apis/admin.go
+++ b/z-clients/go/internal/apis/admin.go
@@ -3,9 +3,6 @@ package coyote_apis
 // This file is @generated DO NOT EDIT
 
 import (
-	"context"
-
-	coyote_models "github.com/svix/coyote/z-clients/go/internal/models"
 	coyote_proto "github.com/svix/coyote/z-clients/go/internal/proto"
 )
 
@@ -19,21 +16,4 @@ func NewAdmin(client *coyote_proto.HttpClient) Admin {
 
 func (admin Admin) Cluster() AdminCluster {
 	return NewAdminCluster(admin.client)
-}
-
-// Remove a node from the cluster.
-//
-// This operation executes immediately and the node must be wiped and reset
-// before it can safely be added to the cluster.
-func (admin Admin) ClusterRemoveNode(
-	ctx context.Context,
-	clusterRemoveNodeIn coyote_models.ClusterRemoveNodeIn,
-) (*coyote_models.ClusterRemoveNodeOut, error) {
-	return coyote_proto.ExecuteRequest[coyote_models.ClusterRemoveNodeIn, coyote_models.ClusterRemoveNodeOut](
-		ctx,
-		admin.client,
-		"POST",
-		"/api/v1/admin/cluster/remove-node",
-		&clusterRemoveNodeIn,
-	)
 }

--- a/z-clients/go/internal/apis/admin_cluster.go
+++ b/z-clients/go/internal/apis/admin_cluster.go
@@ -29,3 +29,20 @@ func (adminCluster AdminCluster) Status(
 		nil,
 	)
 }
+
+// Remove a node from the cluster.
+//
+// This operation executes immediately and the node must be wiped and reset
+// before it can safely be added to the cluster.
+func (adminCluster AdminCluster) RemoveNode(
+	ctx context.Context,
+	clusterRemoveNodeIn coyote_models.ClusterRemoveNodeIn,
+) (*coyote_models.ClusterRemoveNodeOut, error) {
+	return coyote_proto.ExecuteRequest[coyote_models.ClusterRemoveNodeIn, coyote_models.ClusterRemoveNodeOut](
+		ctx,
+		adminCluster.client,
+		"POST",
+		"/api/v1/admin/cluster/remove-node",
+		&clusterRemoveNodeIn,
+	)
+}

--- a/z-clients/go/internal/apis/admin_cluster.go
+++ b/z-clients/go/internal/apis/admin_cluster.go
@@ -25,7 +25,7 @@ func (adminCluster AdminCluster) Status(
 		ctx,
 		adminCluster.client,
 		"GET",
-		"/api/v1/admin/cluster/status",
+		"/api/v1.admin.cluster.status",
 		nil,
 	)
 }
@@ -42,7 +42,7 @@ func (adminCluster AdminCluster) RemoveNode(
 		ctx,
 		adminCluster.client,
 		"POST",
-		"/api/v1/admin/cluster/remove-node",
+		"/api/v1.admin.cluster.remove-node",
 		&clusterRemoveNodeIn,
 	)
 }

--- a/z-clients/go/internal/apis/auth_token.go
+++ b/z-clients/go/internal/apis/auth_token.go
@@ -30,7 +30,7 @@ func (authToken AuthToken) Create(
 		ctx,
 		authToken.client,
 		"POST",
-		"/api/v1/auth-token/create",
+		"/api/v1.auth-token.create",
 		&authTokenCreateIn,
 	)
 }
@@ -44,7 +44,7 @@ func (authToken AuthToken) Expire(
 		ctx,
 		authToken.client,
 		"POST",
-		"/api/v1/auth-token/expire",
+		"/api/v1.auth-token.expire",
 		&authTokenExpireIn,
 	)
 }
@@ -58,7 +58,7 @@ func (authToken AuthToken) Delete(
 		ctx,
 		authToken.client,
 		"POST",
-		"/api/v1/auth-token/delete",
+		"/api/v1.auth-token.delete",
 		&authTokenDeleteIn,
 	)
 }
@@ -72,7 +72,7 @@ func (authToken AuthToken) Verify(
 		ctx,
 		authToken.client,
 		"POST",
-		"/api/v1/auth-token/verify",
+		"/api/v1.auth-token.verify",
 		&authTokenVerifyIn,
 	)
 }
@@ -86,7 +86,7 @@ func (authToken AuthToken) List(
 		ctx,
 		authToken.client,
 		"POST",
-		"/api/v1/auth-token/list",
+		"/api/v1.auth-token.list",
 		&authTokenListIn,
 	)
 }
@@ -100,7 +100,7 @@ func (authToken AuthToken) Update(
 		ctx,
 		authToken.client,
 		"POST",
-		"/api/v1/auth-token/update",
+		"/api/v1.auth-token.update",
 		&authTokenUpdateIn,
 	)
 }
@@ -114,7 +114,7 @@ func (authToken AuthToken) Rotate(
 		ctx,
 		authToken.client,
 		"POST",
-		"/api/v1/auth-token/rotate",
+		"/api/v1.auth-token.rotate",
 		&authTokenRotateIn,
 	)
 }

--- a/z-clients/go/internal/apis/auth_token_namespace.go
+++ b/z-clients/go/internal/apis/auth_token_namespace.go
@@ -26,7 +26,7 @@ func (authTokenNamespace AuthTokenNamespace) Create(
 		ctx,
 		authTokenNamespace.client,
 		"POST",
-		"/api/v1/auth-token/namespace/create",
+		"/api/v1.auth-token.namespace.create",
 		&authTokenCreateNamespaceIn,
 	)
 }
@@ -40,7 +40,7 @@ func (authTokenNamespace AuthTokenNamespace) Get(
 		ctx,
 		authTokenNamespace.client,
 		"POST",
-		"/api/v1/auth-token/namespace/get",
+		"/api/v1.auth-token.namespace.get",
 		&authTokenGetNamespaceIn,
 	)
 }

--- a/z-clients/go/internal/apis/cache.go
+++ b/z-clients/go/internal/apis/cache.go
@@ -38,7 +38,7 @@ func (cache Cache) Set(
 		ctx,
 		cache.client,
 		"POST",
-		"/api/v1/cache/set",
+		"/api/v1.cache.set",
 		&body,
 	)
 }
@@ -59,7 +59,7 @@ func (cache Cache) Get(
 		ctx,
 		cache.client,
 		"POST",
-		"/api/v1/cache/get",
+		"/api/v1.cache.get",
 		&body,
 	)
 }
@@ -79,7 +79,7 @@ func (cache Cache) Delete(
 		ctx,
 		cache.client,
 		"POST",
-		"/api/v1/cache/delete",
+		"/api/v1.cache.delete",
 		&body,
 	)
 }

--- a/z-clients/go/internal/apis/cache_namespace.go
+++ b/z-clients/go/internal/apis/cache_namespace.go
@@ -26,7 +26,7 @@ func (cacheNamespace CacheNamespace) Create(
 		ctx,
 		cacheNamespace.client,
 		"POST",
-		"/api/v1/cache/namespace/create",
+		"/api/v1.cache.namespace.create",
 		&cacheCreateNamespaceIn,
 	)
 }
@@ -40,7 +40,7 @@ func (cacheNamespace CacheNamespace) Get(
 		ctx,
 		cacheNamespace.client,
 		"POST",
-		"/api/v1/cache/namespace/get",
+		"/api/v1.cache.namespace.get",
 		&cacheGetNamespaceIn,
 	)
 }

--- a/z-clients/go/internal/apis/health.go
+++ b/z-clients/go/internal/apis/health.go
@@ -25,7 +25,7 @@ func (health Health) Ping(
 		ctx,
 		health.client,
 		"GET",
-		"/api/v1/health/ping",
+		"/api/v1.health.ping",
 		nil,
 	)
 }
@@ -38,7 +38,7 @@ func (health Health) Error(
 		ctx,
 		health.client,
 		"POST",
-		"/api/v1/health/error",
+		"/api/v1.health.error",
 		nil,
 	)
 	return err

--- a/z-clients/go/internal/apis/idempotency.go
+++ b/z-clients/go/internal/apis/idempotency.go
@@ -37,7 +37,7 @@ func (idempotency Idempotency) Start(
 		ctx,
 		idempotency.client,
 		"POST",
-		"/api/v1/idempotency/start",
+		"/api/v1.idempotency.start",
 		&body,
 	)
 }
@@ -59,7 +59,7 @@ func (idempotency Idempotency) Complete(
 		ctx,
 		idempotency.client,
 		"POST",
-		"/api/v1/idempotency/complete",
+		"/api/v1.idempotency.complete",
 		&body,
 	)
 }
@@ -79,7 +79,7 @@ func (idempotency Idempotency) Abort(
 		ctx,
 		idempotency.client,
 		"POST",
-		"/api/v1/idempotency/abort",
+		"/api/v1.idempotency.abort",
 		&body,
 	)
 }

--- a/z-clients/go/internal/apis/idempotency_namespace.go
+++ b/z-clients/go/internal/apis/idempotency_namespace.go
@@ -26,7 +26,7 @@ func (idempotencyNamespace IdempotencyNamespace) Create(
 		ctx,
 		idempotencyNamespace.client,
 		"POST",
-		"/api/v1/idempotency/namespace/create",
+		"/api/v1.idempotency.namespace.create",
 		&idempotencyCreateNamespaceIn,
 	)
 }
@@ -40,7 +40,7 @@ func (idempotencyNamespace IdempotencyNamespace) Get(
 		ctx,
 		idempotencyNamespace.client,
 		"POST",
-		"/api/v1/idempotency/namespace/get",
+		"/api/v1.idempotency.namespace.get",
 		&idempotencyGetNamespaceIn,
 	)
 }

--- a/z-clients/go/internal/apis/kv.go
+++ b/z-clients/go/internal/apis/kv.go
@@ -40,7 +40,7 @@ func (kv Kv) Set(
 		ctx,
 		kv.client,
 		"POST",
-		"/api/v1/kv/set",
+		"/api/v1.kv.set",
 		&body,
 	)
 }
@@ -61,7 +61,7 @@ func (kv Kv) Get(
 		ctx,
 		kv.client,
 		"POST",
-		"/api/v1/kv/get",
+		"/api/v1.kv.get",
 		&body,
 	)
 }
@@ -81,7 +81,7 @@ func (kv Kv) Delete(
 		ctx,
 		kv.client,
 		"POST",
-		"/api/v1/kv/delete",
+		"/api/v1.kv.delete",
 		&body,
 	)
 }

--- a/z-clients/go/internal/apis/kv_namespace.go
+++ b/z-clients/go/internal/apis/kv_namespace.go
@@ -26,7 +26,7 @@ func (kvNamespace KvNamespace) Create(
 		ctx,
 		kvNamespace.client,
 		"POST",
-		"/api/v1/kv/namespace/create",
+		"/api/v1.kv.namespace.create",
 		&kvCreateNamespaceIn,
 	)
 }
@@ -40,7 +40,7 @@ func (kvNamespace KvNamespace) Get(
 		ctx,
 		kvNamespace.client,
 		"POST",
-		"/api/v1/kv/namespace/get",
+		"/api/v1.kv.namespace.get",
 		&kvGetNamespaceIn,
 	)
 }

--- a/z-clients/go/internal/apis/msgs.go
+++ b/z-clients/go/internal/apis/msgs.go
@@ -46,7 +46,7 @@ func (msgs Msgs) Publish(
 		ctx,
 		msgs.client,
 		"POST",
-		"/api/v1/msgs/publish",
+		"/api/v1.msgs.publish",
 		&body,
 	)
 }

--- a/z-clients/go/internal/apis/msgs_namespace.go
+++ b/z-clients/go/internal/apis/msgs_namespace.go
@@ -32,7 +32,7 @@ func (msgsNamespace MsgsNamespace) Create(
 		ctx,
 		msgsNamespace.client,
 		"POST",
-		"/api/v1/msgs/namespace/create",
+		"/api/v1.msgs.namespace.create",
 		&body,
 	)
 }
@@ -51,7 +51,7 @@ func (msgsNamespace MsgsNamespace) Get(
 		ctx,
 		msgsNamespace.client,
 		"POST",
-		"/api/v1/msgs/namespace/get",
+		"/api/v1.msgs.namespace.get",
 		&body,
 	)
 }

--- a/z-clients/go/internal/apis/msgs_queue.go
+++ b/z-clients/go/internal/apis/msgs_queue.go
@@ -40,7 +40,7 @@ func (msgsQueue MsgsQueue) Receive(
 		ctx,
 		msgsQueue.client,
 		"POST",
-		"/api/v1/msgs/queue/receive",
+		"/api/v1.msgs.queue.receive",
 		&body,
 	)
 }
@@ -65,7 +65,7 @@ func (msgsQueue MsgsQueue) Ack(
 		ctx,
 		msgsQueue.client,
 		"POST",
-		"/api/v1/msgs/queue/ack",
+		"/api/v1.msgs.queue.ack",
 		&body,
 	)
 }
@@ -92,7 +92,7 @@ func (msgsQueue MsgsQueue) Configure(
 		ctx,
 		msgsQueue.client,
 		"POST",
-		"/api/v1/msgs/queue/configure",
+		"/api/v1.msgs.queue.configure",
 		&body,
 	)
 }
@@ -118,7 +118,7 @@ func (msgsQueue MsgsQueue) Nack(
 		ctx,
 		msgsQueue.client,
 		"POST",
-		"/api/v1/msgs/queue/nack",
+		"/api/v1.msgs.queue.nack",
 		&body,
 	)
 }
@@ -140,7 +140,7 @@ func (msgsQueue MsgsQueue) RedriveDlq(
 		ctx,
 		msgsQueue.client,
 		"POST",
-		"/api/v1/msgs/queue/redrive-dlq",
+		"/api/v1.msgs.queue.redrive-dlq",
 		&body,
 	)
 }

--- a/z-clients/go/internal/apis/msgs_stream.go
+++ b/z-clients/go/internal/apis/msgs_stream.go
@@ -40,7 +40,7 @@ func (msgsStream MsgsStream) Receive(
 		ctx,
 		msgsStream.client,
 		"POST",
-		"/api/v1/msgs/stream/receive",
+		"/api/v1.msgs.stream.receive",
 		&body,
 	)
 }
@@ -66,7 +66,7 @@ func (msgsStream MsgsStream) Commit(
 		ctx,
 		msgsStream.client,
 		"POST",
-		"/api/v1/msgs/stream/commit",
+		"/api/v1.msgs.stream.commit",
 		&body,
 	)
 }
@@ -94,7 +94,7 @@ func (msgsStream MsgsStream) Seek(
 		ctx,
 		msgsStream.client,
 		"POST",
-		"/api/v1/msgs/stream/seek",
+		"/api/v1.msgs.stream.seek",
 		&body,
 	)
 }

--- a/z-clients/go/internal/apis/msgs_topic.go
+++ b/z-clients/go/internal/apis/msgs_topic.go
@@ -35,7 +35,7 @@ func (msgsTopic MsgsTopic) Configure(
 		ctx,
 		msgsTopic.client,
 		"POST",
-		"/api/v1/msgs/topic/configure",
+		"/api/v1.msgs.topic.configure",
 		&body,
 	)
 }

--- a/z-clients/go/internal/apis/rate_limit.go
+++ b/z-clients/go/internal/apis/rate_limit.go
@@ -30,7 +30,7 @@ func (rateLimit RateLimit) Limit(
 		ctx,
 		rateLimit.client,
 		"POST",
-		"/api/v1/rate-limit/limit",
+		"/api/v1.rate-limit.limit",
 		&rateLimitCheckIn,
 	)
 }
@@ -44,7 +44,7 @@ func (rateLimit RateLimit) GetRemaining(
 		ctx,
 		rateLimit.client,
 		"POST",
-		"/api/v1/rate-limit/get-remaining",
+		"/api/v1.rate-limit.get-remaining",
 		&rateLimitGetRemainingIn,
 	)
 }
@@ -58,7 +58,7 @@ func (rateLimit RateLimit) Reset(
 		ctx,
 		rateLimit.client,
 		"POST",
-		"/api/v1/rate-limit/reset",
+		"/api/v1.rate-limit.reset",
 		&rateLimitResetIn,
 	)
 }

--- a/z-clients/go/internal/apis/rate_limit_namespace.go
+++ b/z-clients/go/internal/apis/rate_limit_namespace.go
@@ -26,7 +26,7 @@ func (rateLimitNamespace RateLimitNamespace) Create(
 		ctx,
 		rateLimitNamespace.client,
 		"POST",
-		"/api/v1/rate-limit/namespace/create",
+		"/api/v1.rate-limit.namespace.create",
 		&rateLimitCreateNamespaceIn,
 	)
 }
@@ -40,7 +40,7 @@ func (rateLimitNamespace RateLimitNamespace) Get(
 		ctx,
 		rateLimitNamespace.client,
 		"POST",
-		"/api/v1/rate-limit/namespace/get",
+		"/api/v1.rate-limit.namespace.get",
 		&rateLimitGetNamespaceIn,
 	)
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/Admin.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/Admin.java
@@ -14,33 +14,11 @@ import java.util.Set;
 import lombok.Getter;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
-import com.svix.coyote.models.ClusterRemoveNodeIn;
-import com.svix.coyote.models.ClusterRemoveNodeOut;
 
 public class Admin {
     private final HttpClient client;
 
     public Admin(HttpClient client) {
         this.client = client;
-    }
-
-    /**
-* Remove a node from the cluster.
-* 
-* This operation executes immediately and the node must be wiped and reset
-* before it can safely be added to the cluster.
-*/
-    public ClusterRemoveNodeOut clusterRemoveNode(
-        final ClusterRemoveNodeIn clusterRemoveNodeIn
-    ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/admin/cluster/remove-node");
-
-        return this.client.executeRequest(
-            "POST",
-            url.build(),
-            null,
-            clusterRemoveNodeIn,
-            ClusterRemoveNodeOut.class
-        );
     }
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/AdminCluster.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/AdminCluster.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Set;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
+import com.svix.coyote.models.ClusterRemoveNodeIn;
+import com.svix.coyote.models.ClusterRemoveNodeOut;
 import com.svix.coyote.models.ClusterStatusOut;
 
 public class AdminCluster {
@@ -34,6 +36,26 @@ public class AdminCluster {
             null,
             null,
             ClusterStatusOut.class
+        );
+    }
+
+    /**
+* Remove a node from the cluster.
+* 
+* This operation executes immediately and the node must be wiped and reset
+* before it can safely be added to the cluster.
+*/
+    public ClusterRemoveNodeOut removeNode(
+        final ClusterRemoveNodeIn clusterRemoveNodeIn
+    ) throws IOException, ApiException {
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/admin/cluster/remove-node");
+
+        return this.client.executeRequest(
+            "POST",
+            url.build(),
+            null,
+            clusterRemoveNodeIn,
+            ClusterRemoveNodeOut.class
         );
     }
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/AdminCluster.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/AdminCluster.java
@@ -28,7 +28,7 @@ public class AdminCluster {
     public ClusterStatusOut status(
         
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/admin/cluster/status");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.admin.cluster.status");
 
         return this.client.executeRequest(
             "GET",
@@ -48,7 +48,7 @@ public class AdminCluster {
     public ClusterRemoveNodeOut removeNode(
         final ClusterRemoveNodeIn clusterRemoveNodeIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/admin/cluster/remove-node");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.admin.cluster.remove-node");
 
         return this.client.executeRequest(
             "POST",

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/AuthToken.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/AuthToken.java
@@ -40,7 +40,7 @@ public class AuthToken {
     public AuthTokenCreateOut create(
         final AuthTokenCreateIn authTokenCreateIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/create");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.create");
 
         return this.client.executeRequest(
             "POST",
@@ -55,7 +55,7 @@ public class AuthToken {
     public AuthTokenExpireOut expire(
         final AuthTokenExpireIn authTokenExpireIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/expire");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.expire");
 
         return this.client.executeRequest(
             "POST",
@@ -70,7 +70,7 @@ public class AuthToken {
     public AuthTokenDeleteOut delete(
         final AuthTokenDeleteIn authTokenDeleteIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/delete");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.delete");
 
         return this.client.executeRequest(
             "POST",
@@ -85,7 +85,7 @@ public class AuthToken {
     public AuthTokenVerifyOut verify(
         final AuthTokenVerifyIn authTokenVerifyIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/verify");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.verify");
 
         return this.client.executeRequest(
             "POST",
@@ -100,7 +100,7 @@ public class AuthToken {
     public ListResponseAuthTokenOut list(
         final AuthTokenListIn authTokenListIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/list");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.list");
 
         return this.client.executeRequest(
             "POST",
@@ -115,7 +115,7 @@ public class AuthToken {
     public AuthTokenUpdateOut update(
         final AuthTokenUpdateIn authTokenUpdateIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/update");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.update");
 
         return this.client.executeRequest(
             "POST",
@@ -130,7 +130,7 @@ public class AuthToken {
     public AuthTokenRotateOut rotate(
         final AuthTokenRotateIn authTokenRotateIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/rotate");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.rotate");
 
         return this.client.executeRequest(
             "POST",

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/AuthTokenNamespace.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/AuthTokenNamespace.java
@@ -29,7 +29,7 @@ public class AuthTokenNamespace {
     public AuthTokenCreateNamespaceOut create(
         final AuthTokenCreateNamespaceIn authTokenCreateNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/namespace/create");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.namespace.create");
 
         return this.client.executeRequest(
             "POST",
@@ -44,7 +44,7 @@ public class AuthTokenNamespace {
     public AuthTokenGetNamespaceOut get(
         final AuthTokenGetNamespaceIn authTokenGetNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/auth-token/namespace/get");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.auth-token.namespace.get");
 
         return this.client.executeRequest(
             "POST",

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/Cache.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/Cache.java
@@ -36,7 +36,7 @@ public class Cache {
         String key,
         final CacheSetIn cacheSetIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/cache/set");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.cache.set");
         CacheSetIn_ body = new CacheSetIn_(
             cacheSetIn.getNamespace(),
             key,
@@ -58,7 +58,7 @@ public class Cache {
         String key,
         final CacheGetIn cacheGetIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/cache/get");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.cache.get");
         CacheGetIn_ body = new CacheGetIn_(
             cacheGetIn.getNamespace(),
             key,
@@ -89,7 +89,7 @@ public class Cache {
         String key,
         final CacheDeleteIn cacheDeleteIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/cache/delete");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.cache.delete");
         CacheDeleteIn_ body = new CacheDeleteIn_(
             cacheDeleteIn.getNamespace(),
             key

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/CacheNamespace.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/CacheNamespace.java
@@ -29,7 +29,7 @@ public class CacheNamespace {
     public CacheCreateNamespaceOut create(
         final CacheCreateNamespaceIn cacheCreateNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/cache/namespace/create");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.cache.namespace.create");
 
         return this.client.executeRequest(
             "POST",
@@ -44,7 +44,7 @@ public class CacheNamespace {
     public CacheGetNamespaceOut get(
         final CacheGetNamespaceIn cacheGetNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/cache/namespace/get");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.cache.namespace.get");
 
         return this.client.executeRequest(
             "POST",

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/Health.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/Health.java
@@ -26,7 +26,7 @@ public class Health {
     public PingOut ping(
         
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/health/ping");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.health.ping");
 
         return this.client.executeRequest(
             "GET",
@@ -41,7 +41,7 @@ public class Health {
     public void error(
         
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/health/error");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.health.error");
 
         this.client.executeRequest(
             "POST",

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/Idempotency.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/Idempotency.java
@@ -36,7 +36,7 @@ public class Idempotency {
         String key,
         final IdempotencyStartIn idempotencyStartIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/idempotency/start");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.idempotency.start");
         IdempotencyStartIn_ body = new IdempotencyStartIn_(
             idempotencyStartIn.getNamespace(),
             key,
@@ -57,7 +57,7 @@ public class Idempotency {
         String key,
         final IdempotencyCompleteIn idempotencyCompleteIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/idempotency/complete");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.idempotency.complete");
         IdempotencyCompleteIn_ body = new IdempotencyCompleteIn_(
             idempotencyCompleteIn.getNamespace(),
             key,
@@ -79,7 +79,7 @@ public class Idempotency {
         String key,
         final IdempotencyAbortIn idempotencyAbortIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/idempotency/abort");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.idempotency.abort");
         IdempotencyAbortIn_ body = new IdempotencyAbortIn_(
             idempotencyAbortIn.getNamespace(),
             key

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/IdempotencyNamespace.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/IdempotencyNamespace.java
@@ -29,7 +29,7 @@ public class IdempotencyNamespace {
     public IdempotencyCreateNamespaceOut create(
         final IdempotencyCreateNamespaceIn idempotencyCreateNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/idempotency/namespace/create");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.idempotency.namespace.create");
 
         return this.client.executeRequest(
             "POST",
@@ -44,7 +44,7 @@ public class IdempotencyNamespace {
     public IdempotencyGetNamespaceOut get(
         final IdempotencyGetNamespaceIn idempotencyGetNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/idempotency/namespace/get");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.idempotency.namespace.get");
 
         return this.client.executeRequest(
             "POST",

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/Kv.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/Kv.java
@@ -36,7 +36,7 @@ public class Kv {
         String key,
         final KvSetIn kvSetIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/kv/set");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.kv.set");
         KvSetIn_ body = new KvSetIn_(
             kvSetIn.getNamespace(),
             key,
@@ -60,7 +60,7 @@ public class Kv {
         String key,
         final KvGetIn kvGetIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/kv/get");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.kv.get");
         KvGetIn_ body = new KvGetIn_(
             kvGetIn.getNamespace(),
             key,
@@ -91,7 +91,7 @@ public class Kv {
         String key,
         final KvDeleteIn kvDeleteIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/kv/delete");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.kv.delete");
         KvDeleteIn_ body = new KvDeleteIn_(
             kvDeleteIn.getNamespace(),
             key

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/KvNamespace.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/KvNamespace.java
@@ -29,7 +29,7 @@ public class KvNamespace {
     public KvCreateNamespaceOut create(
         final KvCreateNamespaceIn kvCreateNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/kv/namespace/create");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.kv.namespace.create");
 
         return this.client.executeRequest(
             "POST",
@@ -44,7 +44,7 @@ public class KvNamespace {
     public KvGetNamespaceOut get(
         final KvGetNamespaceIn kvGetNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/kv/namespace/get");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.kv.namespace.get");
 
         return this.client.executeRequest(
             "POST",

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/Msgs.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/Msgs.java
@@ -30,7 +30,7 @@ public class Msgs {
         String topic,
         final MsgPublishIn msgPublishIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/publish");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.publish");
         MsgPublishIn_ body = new MsgPublishIn_(
             msgPublishIn.getNamespace(),
             topic,

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsNamespace.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsNamespace.java
@@ -32,7 +32,7 @@ public class MsgsNamespace {
         String name,
         final MsgNamespaceCreateIn msgNamespaceCreateIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/namespace/create");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.namespace.create");
         MsgNamespaceCreateIn_ body = new MsgNamespaceCreateIn_(
             name,
             msgNamespaceCreateIn.getRetention()
@@ -62,7 +62,7 @@ public class MsgsNamespace {
         String name,
         final MsgNamespaceGetIn msgNamespaceGetIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/namespace/get");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.namespace.get");
         MsgNamespaceGetIn_ body = new MsgNamespaceGetIn_(
             name
         );

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsQueue.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsQueue.java
@@ -48,7 +48,7 @@ public class MsgsQueue {
         String consumerGroup,
         final MsgQueueReceiveIn msgQueueReceiveIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/queue/receive");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.queue.receive");
         MsgQueueReceiveIn_ body = new MsgQueueReceiveIn_(
             msgQueueReceiveIn.getNamespace(),
             topic,
@@ -94,7 +94,7 @@ public class MsgsQueue {
         String consumerGroup,
         final MsgQueueAckIn msgQueueAckIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/queue/ack");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.queue.ack");
         MsgQueueAckIn_ body = new MsgQueueAckIn_(
             msgQueueAckIn.getNamespace(),
             topic,
@@ -122,7 +122,7 @@ public class MsgsQueue {
         String consumerGroup,
         final MsgQueueConfigureIn msgQueueConfigureIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/queue/configure");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.queue.configure");
         MsgQueueConfigureIn_ body = new MsgQueueConfigureIn_(
             msgQueueConfigureIn.getNamespace(),
             topic,
@@ -168,7 +168,7 @@ public class MsgsQueue {
         String consumerGroup,
         final MsgQueueNackIn msgQueueNackIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/queue/nack");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.queue.nack");
         MsgQueueNackIn_ body = new MsgQueueNackIn_(
             msgQueueNackIn.getNamespace(),
             topic,
@@ -191,7 +191,7 @@ public class MsgsQueue {
         String consumerGroup,
         final MsgQueueRedriveDlqIn msgQueueRedriveDlqIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/queue/redrive-dlq");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.queue.redrive-dlq");
         MsgQueueRedriveDlqIn_ body = new MsgQueueRedriveDlqIn_(
             msgQueueRedriveDlqIn.getNamespace(),
             topic,

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
@@ -41,7 +41,7 @@ public class MsgsStream {
         String consumerGroup,
         final MsgStreamReceiveIn msgStreamReceiveIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/stream/receive");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.stream.receive");
         MsgStreamReceiveIn_ body = new MsgStreamReceiveIn_(
             msgStreamReceiveIn.getNamespace(),
             topic,
@@ -88,7 +88,7 @@ public class MsgsStream {
         String consumerGroup,
         final MsgStreamCommitIn msgStreamCommitIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/stream/commit");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.stream.commit");
         MsgStreamCommitIn_ body = new MsgStreamCommitIn_(
             msgStreamCommitIn.getNamespace(),
             topic,
@@ -117,7 +117,7 @@ public class MsgsStream {
         String consumerGroup,
         final MsgStreamSeekIn msgStreamSeekIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/stream/seek");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.stream.seek");
         MsgStreamSeekIn_ body = new MsgStreamSeekIn_(
             msgStreamSeekIn.getNamespace(),
             topic,

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsTopic.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsTopic.java
@@ -33,7 +33,7 @@ public class MsgsTopic {
         String topic,
         final MsgTopicConfigureIn msgTopicConfigureIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/msgs/topic/configure");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.msgs.topic.configure");
         MsgTopicConfigureIn_ body = new MsgTopicConfigureIn_(
             msgTopicConfigureIn.getNamespace(),
             topic,

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/RateLimit.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/RateLimit.java
@@ -32,7 +32,7 @@ public class RateLimit {
     public RateLimitCheckOut limit(
         final RateLimitCheckIn rateLimitCheckIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/rate-limit/limit");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.rate-limit.limit");
 
         return this.client.executeRequest(
             "POST",
@@ -47,7 +47,7 @@ public class RateLimit {
     public RateLimitGetRemainingOut getRemaining(
         final RateLimitGetRemainingIn rateLimitGetRemainingIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/rate-limit/get-remaining");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.rate-limit.get-remaining");
 
         return this.client.executeRequest(
             "POST",
@@ -62,7 +62,7 @@ public class RateLimit {
     public RateLimitResetOut reset(
         final RateLimitResetIn rateLimitResetIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/rate-limit/reset");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.rate-limit.reset");
 
         return this.client.executeRequest(
             "POST",

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/RateLimitNamespace.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/RateLimitNamespace.java
@@ -29,7 +29,7 @@ public class RateLimitNamespace {
     public RateLimitCreateNamespaceOut create(
         final RateLimitCreateNamespaceIn rateLimitCreateNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/rate-limit/namespace/create");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.rate-limit.namespace.create");
 
         return this.client.executeRequest(
             "POST",
@@ -44,7 +44,7 @@ public class RateLimitNamespace {
     public RateLimitGetNamespaceOut get(
         final RateLimitGetNamespaceIn rateLimitGetNamespaceIn
     ) throws IOException, ApiException {
-        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1/rate-limit/namespace/get");
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.rate-limit.namespace.get");
 
         return this.client.executeRequest(
             "POST",

--- a/z-clients/javascript/src/apis/admin.ts
+++ b/z-clients/javascript/src/apis/admin.ts
@@ -1,13 +1,5 @@
 // this file is @generated
 
-import {
-    type ClusterRemoveNodeIn,
-    ClusterRemoveNodeInSerializer,
-} from '../models/clusterRemoveNodeIn';
-import {
-    type ClusterRemoveNodeOut,
-    ClusterRemoveNodeOutSerializer,
-} from '../models/clusterRemoveNodeOut';
 import { AdminCluster } from './adminCluster';
 import { HttpMethod, CoyoteRequest, type CoyoteRequestContext } from "../request";
 
@@ -18,25 +10,6 @@ export class Admin {
         return new AdminCluster(this.requestCtx);
     }
 
-    /**
-* Remove a node from the cluster.
-* 
-* This operation executes immediately and the node must be wiped and reset
-* before it can safely be added to the cluster.
-*/
-    public clusterRemoveNode(
-        clusterRemoveNodeIn: ClusterRemoveNodeIn,
-    ): Promise<ClusterRemoveNodeOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/admin/cluster/remove-node");
-
-        request.setBody(
-            ClusterRemoveNodeInSerializer._toJsonObject(clusterRemoveNodeIn)
-        );
-        
-        return request.send(
-            this.requestCtx,
-            ClusterRemoveNodeOutSerializer._fromJsonObject,
-        );
-    }
+    
 }
 

--- a/z-clients/javascript/src/apis/adminCluster.ts
+++ b/z-clients/javascript/src/apis/adminCluster.ts
@@ -1,6 +1,14 @@
 // this file is @generated
 
 import {
+    type ClusterRemoveNodeIn,
+    ClusterRemoveNodeInSerializer,
+} from '../models/clusterRemoveNodeIn';
+import {
+    type ClusterRemoveNodeOut,
+    ClusterRemoveNodeOutSerializer,
+} from '../models/clusterRemoveNodeOut';
+import {
     type ClusterStatusOut,
     ClusterStatusOutSerializer,
 } from '../models/clusterStatusOut';
@@ -18,6 +26,25 @@ export class AdminCluster {
         return request.send(
             this.requestCtx,
             ClusterStatusOutSerializer._fromJsonObject,
+        );
+    }/**
+* Remove a node from the cluster.
+* 
+* This operation executes immediately and the node must be wiped and reset
+* before it can safely be added to the cluster.
+*/
+    public removeNode(
+        clusterRemoveNodeIn: ClusterRemoveNodeIn,
+    ): Promise<ClusterRemoveNodeOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/admin/cluster/remove-node");
+
+        request.setBody(
+            ClusterRemoveNodeInSerializer._toJsonObject(clusterRemoveNodeIn)
+        );
+        
+        return request.send(
+            this.requestCtx,
+            ClusterRemoveNodeOutSerializer._fromJsonObject,
         );
     }
 }

--- a/z-clients/javascript/src/apis/adminCluster.ts
+++ b/z-clients/javascript/src/apis/adminCluster.ts
@@ -20,7 +20,7 @@ export class AdminCluster {
     /** Get information about the current cluster */
     public status(
     ): Promise<ClusterStatusOut> {
-        const request = new CoyoteRequest(HttpMethod.GET, "/api/v1/admin/cluster/status");
+        const request = new CoyoteRequest(HttpMethod.GET, "/api/v1.admin.cluster.status");
 
         
         return request.send(
@@ -36,7 +36,7 @@ export class AdminCluster {
     public removeNode(
         clusterRemoveNodeIn: ClusterRemoveNodeIn,
     ): Promise<ClusterRemoveNodeOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/admin/cluster/remove-node");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.admin.cluster.remove-node");
 
         request.setBody(
             ClusterRemoveNodeInSerializer._toJsonObject(clusterRemoveNodeIn)

--- a/z-clients/javascript/src/apis/authToken.ts
+++ b/z-clients/javascript/src/apis/authToken.ts
@@ -70,7 +70,7 @@ export class AuthToken {
     public create(
         authTokenCreateIn: AuthTokenCreateIn,
     ): Promise<AuthTokenCreateOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/create");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.create");
 
         request.setBody(
             AuthTokenCreateInSerializer._toJsonObject(authTokenCreateIn)
@@ -84,7 +84,7 @@ export class AuthToken {
     public expire(
         authTokenExpireIn: AuthTokenExpireIn,
     ): Promise<AuthTokenExpireOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/expire");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.expire");
 
         request.setBody(
             AuthTokenExpireInSerializer._toJsonObject(authTokenExpireIn)
@@ -98,7 +98,7 @@ export class AuthToken {
     public delete(
         authTokenDeleteIn: AuthTokenDeleteIn,
     ): Promise<AuthTokenDeleteOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/delete");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.delete");
 
         request.setBody(
             AuthTokenDeleteInSerializer._toJsonObject(authTokenDeleteIn)
@@ -112,7 +112,7 @@ export class AuthToken {
     public verify(
         authTokenVerifyIn: AuthTokenVerifyIn,
     ): Promise<AuthTokenVerifyOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/verify");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.verify");
 
         request.setBody(
             AuthTokenVerifyInSerializer._toJsonObject(authTokenVerifyIn)
@@ -126,7 +126,7 @@ export class AuthToken {
     public list(
         authTokenListIn: AuthTokenListIn,
     ): Promise<ListResponseAuthTokenOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/list");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.list");
 
         request.setBody(
             AuthTokenListInSerializer._toJsonObject(authTokenListIn)
@@ -140,7 +140,7 @@ export class AuthToken {
     public update(
         authTokenUpdateIn: AuthTokenUpdateIn,
     ): Promise<AuthTokenUpdateOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/update");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.update");
 
         request.setBody(
             AuthTokenUpdateInSerializer._toJsonObject(authTokenUpdateIn)
@@ -154,7 +154,7 @@ export class AuthToken {
     public rotate(
         authTokenRotateIn: AuthTokenRotateIn,
     ): Promise<AuthTokenRotateOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/rotate");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.rotate");
 
         request.setBody(
             AuthTokenRotateInSerializer._toJsonObject(authTokenRotateIn)

--- a/z-clients/javascript/src/apis/authTokenNamespace.ts
+++ b/z-clients/javascript/src/apis/authTokenNamespace.ts
@@ -25,7 +25,7 @@ export class AuthTokenNamespace {
     public create(
         authTokenCreateNamespaceIn: AuthTokenCreateNamespaceIn,
     ): Promise<AuthTokenCreateNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/namespace/create");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.namespace.create");
 
         request.setBody(
             AuthTokenCreateNamespaceInSerializer._toJsonObject(authTokenCreateNamespaceIn)
@@ -39,7 +39,7 @@ export class AuthTokenNamespace {
     public get(
         authTokenGetNamespaceIn: AuthTokenGetNamespaceIn,
     ): Promise<AuthTokenGetNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/auth-token/namespace/get");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.auth-token.namespace.get");
 
         request.setBody(
             AuthTokenGetNamespaceInSerializer._toJsonObject(authTokenGetNamespaceIn)

--- a/z-clients/javascript/src/apis/cache.ts
+++ b/z-clients/javascript/src/apis/cache.ts
@@ -39,7 +39,7 @@ export class Cache {
         key: string,
         cacheSetIn: CacheSetIn,
     ): Promise<CacheSetOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/set");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.cache.set");
 
         request.setBody(
             CacheSetInSerializer._toJsonObject({
@@ -57,7 +57,7 @@ export class Cache {
         key: string,
         cacheGetIn: CacheGetIn,
     ): Promise<CacheGetOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/get");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.cache.get");
 
         request.setBody(
             CacheGetInSerializer._toJsonObject({
@@ -75,7 +75,7 @@ export class Cache {
         key: string,
         cacheDeleteIn: CacheDeleteIn,
     ): Promise<CacheDeleteOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/delete");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.cache.delete");
 
         request.setBody(
             CacheDeleteInSerializer._toJsonObject({

--- a/z-clients/javascript/src/apis/cacheNamespace.ts
+++ b/z-clients/javascript/src/apis/cacheNamespace.ts
@@ -25,7 +25,7 @@ export class CacheNamespace {
     public create(
         cacheCreateNamespaceIn: CacheCreateNamespaceIn,
     ): Promise<CacheCreateNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/namespace/create");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.cache.namespace.create");
 
         request.setBody(
             CacheCreateNamespaceInSerializer._toJsonObject(cacheCreateNamespaceIn)
@@ -39,7 +39,7 @@ export class CacheNamespace {
     public get(
         cacheGetNamespaceIn: CacheGetNamespaceIn,
     ): Promise<CacheGetNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/cache/namespace/get");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.cache.namespace.get");
 
         request.setBody(
             CacheGetNamespaceInSerializer._toJsonObject(cacheGetNamespaceIn)

--- a/z-clients/javascript/src/apis/health.ts
+++ b/z-clients/javascript/src/apis/health.ts
@@ -12,7 +12,7 @@ export class Health {
     /** Verify the server is up and running. */
     public ping(
     ): Promise<PingOut> {
-        const request = new CoyoteRequest(HttpMethod.GET, "/api/v1/health/ping");
+        const request = new CoyoteRequest(HttpMethod.GET, "/api/v1.health.ping");
 
         
         return request.send(
@@ -22,7 +22,7 @@ export class Health {
     }/** Intentionally return an error */
     public error(
     ): Promise<void> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/health/error");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.health.error");
 
         
         return request.sendNoResponseBody(this.requestCtx);

--- a/z-clients/javascript/src/apis/idempotency.ts
+++ b/z-clients/javascript/src/apis/idempotency.ts
@@ -39,7 +39,7 @@ export class Idempotency {
         key: string,
         idempotencyStartIn: IdempotencyStartIn,
     ): Promise<IdempotencyStartOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/start");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.idempotency.start");
 
         request.setBody(
             IdempotencyStartInSerializer._toJsonObject({
@@ -57,7 +57,7 @@ export class Idempotency {
         key: string,
         idempotencyCompleteIn: IdempotencyCompleteIn,
     ): Promise<IdempotencyCompleteOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/complete");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.idempotency.complete");
 
         request.setBody(
             IdempotencyCompleteInSerializer._toJsonObject({
@@ -75,7 +75,7 @@ export class Idempotency {
         key: string,
         idempotencyAbortIn: IdempotencyAbortIn,
     ): Promise<IdempotencyAbortOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/abort");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.idempotency.abort");
 
         request.setBody(
             IdempotencyAbortInSerializer._toJsonObject({

--- a/z-clients/javascript/src/apis/idempotencyNamespace.ts
+++ b/z-clients/javascript/src/apis/idempotencyNamespace.ts
@@ -25,7 +25,7 @@ export class IdempotencyNamespace {
     public create(
         idempotencyCreateNamespaceIn: IdempotencyCreateNamespaceIn,
     ): Promise<IdempotencyCreateNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/namespace/create");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.idempotency.namespace.create");
 
         request.setBody(
             IdempotencyCreateNamespaceInSerializer._toJsonObject(idempotencyCreateNamespaceIn)
@@ -39,7 +39,7 @@ export class IdempotencyNamespace {
     public get(
         idempotencyGetNamespaceIn: IdempotencyGetNamespaceIn,
     ): Promise<IdempotencyGetNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/idempotency/namespace/get");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.idempotency.namespace.get");
 
         request.setBody(
             IdempotencyGetNamespaceInSerializer._toJsonObject(idempotencyGetNamespaceIn)

--- a/z-clients/javascript/src/apis/kv.ts
+++ b/z-clients/javascript/src/apis/kv.ts
@@ -39,7 +39,7 @@ export class Kv {
         key: string,
         kvSetIn: KvSetIn,
     ): Promise<KvSetOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/set");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.kv.set");
 
         request.setBody(
             KvSetInSerializer._toJsonObject({
@@ -57,7 +57,7 @@ export class Kv {
         key: string,
         kvGetIn: KvGetIn,
     ): Promise<KvGetOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/get");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.kv.get");
 
         request.setBody(
             KvGetInSerializer._toJsonObject({
@@ -75,7 +75,7 @@ export class Kv {
         key: string,
         kvDeleteIn: KvDeleteIn,
     ): Promise<KvDeleteOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/delete");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.kv.delete");
 
         request.setBody(
             KvDeleteInSerializer._toJsonObject({

--- a/z-clients/javascript/src/apis/kvNamespace.ts
+++ b/z-clients/javascript/src/apis/kvNamespace.ts
@@ -25,7 +25,7 @@ export class KvNamespace {
     public create(
         kvCreateNamespaceIn: KvCreateNamespaceIn,
     ): Promise<KvCreateNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/namespace/create");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.kv.namespace.create");
 
         request.setBody(
             KvCreateNamespaceInSerializer._toJsonObject(kvCreateNamespaceIn)
@@ -39,7 +39,7 @@ export class KvNamespace {
     public get(
         kvGetNamespaceIn: KvGetNamespaceIn,
     ): Promise<KvGetNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/kv/namespace/get");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.kv.namespace.get");
 
         request.setBody(
             KvGetNamespaceInSerializer._toJsonObject(kvGetNamespaceIn)

--- a/z-clients/javascript/src/apis/msgs.ts
+++ b/z-clients/javascript/src/apis/msgs.ts
@@ -38,7 +38,7 @@ export class Msgs {
         topic: string,
         msgPublishIn: MsgPublishIn,
     ): Promise<MsgPublishOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/publish");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.publish");
 
         request.setBody(
             MsgPublishInSerializer._toJsonObject({

--- a/z-clients/javascript/src/apis/msgsNamespace.ts
+++ b/z-clients/javascript/src/apis/msgsNamespace.ts
@@ -26,7 +26,7 @@ export class MsgsNamespace {
         name: string,
         msgNamespaceCreateIn: MsgNamespaceCreateIn,
     ): Promise<MsgNamespaceCreateOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/namespace/create");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.namespace.create");
 
         request.setBody(
             MsgNamespaceCreateInSerializer._toJsonObject({
@@ -44,7 +44,7 @@ export class MsgsNamespace {
         name: string,
         msgNamespaceGetIn: MsgNamespaceGetIn,
     ): Promise<MsgNamespaceGetOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/namespace/get");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.namespace.get");
 
         request.setBody(
             MsgNamespaceGetInSerializer._toJsonObject({

--- a/z-clients/javascript/src/apis/msgsQueue.ts
+++ b/z-clients/javascript/src/apis/msgsQueue.ts
@@ -57,7 +57,7 @@ export class MsgsQueue {
         consumer_group: string,
         msgQueueReceiveIn: MsgQueueReceiveIn,
     ): Promise<MsgQueueReceiveOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/receive");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.queue.receive");
 
         request.setBody(
             MsgQueueReceiveInSerializer._toJsonObject({
@@ -81,7 +81,7 @@ export class MsgsQueue {
         consumer_group: string,
         msgQueueAckIn: MsgQueueAckIn,
     ): Promise<MsgQueueAckOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/ack");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.queue.ack");
 
         request.setBody(
             MsgQueueAckInSerializer._toJsonObject({
@@ -106,7 +106,7 @@ export class MsgsQueue {
         consumer_group: string,
         msgQueueConfigureIn: MsgQueueConfigureIn,
     ): Promise<MsgQueueConfigureOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/configure");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.queue.configure");
 
         request.setBody(
             MsgQueueConfigureInSerializer._toJsonObject({
@@ -131,7 +131,7 @@ export class MsgsQueue {
         consumer_group: string,
         msgQueueNackIn: MsgQueueNackIn,
     ): Promise<MsgQueueNackOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/nack");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.queue.nack");
 
         request.setBody(
             MsgQueueNackInSerializer._toJsonObject({
@@ -151,7 +151,7 @@ export class MsgsQueue {
         consumer_group: string,
         msgQueueRedriveDlqIn: MsgQueueRedriveDlqIn,
     ): Promise<MsgQueueRedriveDlqOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/queue/redrive-dlq");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.queue.redrive-dlq");
 
         request.setBody(
             MsgQueueRedriveDlqInSerializer._toJsonObject({

--- a/z-clients/javascript/src/apis/msgsStream.ts
+++ b/z-clients/javascript/src/apis/msgsStream.ts
@@ -40,7 +40,7 @@ export class MsgsStream {
         consumer_group: string,
         msgStreamReceiveIn: MsgStreamReceiveIn,
     ): Promise<MsgStreamReceiveOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/receive");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.stream.receive");
 
         request.setBody(
             MsgStreamReceiveInSerializer._toJsonObject({
@@ -65,7 +65,7 @@ export class MsgsStream {
         consumer_group: string,
         msgStreamCommitIn: MsgStreamCommitIn,
     ): Promise<MsgStreamCommitOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/commit");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.stream.commit");
 
         request.setBody(
             MsgStreamCommitInSerializer._toJsonObject({
@@ -91,7 +91,7 @@ export class MsgsStream {
         consumer_group: string,
         msgStreamSeekIn: MsgStreamSeekIn,
     ): Promise<MsgStreamSeekOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/stream/seek");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.stream.seek");
 
         request.setBody(
             MsgStreamSeekInSerializer._toJsonObject({

--- a/z-clients/javascript/src/apis/msgsTopic.ts
+++ b/z-clients/javascript/src/apis/msgsTopic.ts
@@ -22,7 +22,7 @@ export class MsgsTopic {
         topic: string,
         msgTopicConfigureIn: MsgTopicConfigureIn,
     ): Promise<MsgTopicConfigureOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/msgs/topic/configure");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.msgs.topic.configure");
 
         request.setBody(
             MsgTopicConfigureInSerializer._toJsonObject({

--- a/z-clients/javascript/src/apis/rateLimit.ts
+++ b/z-clients/javascript/src/apis/rateLimit.ts
@@ -38,7 +38,7 @@ export class RateLimit {
     public limit(
         rateLimitCheckIn: RateLimitCheckIn,
     ): Promise<RateLimitCheckOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/limit");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.rate-limit.limit");
 
         request.setBody(
             RateLimitCheckInSerializer._toJsonObject(rateLimitCheckIn)
@@ -52,7 +52,7 @@ export class RateLimit {
     public getRemaining(
         rateLimitGetRemainingIn: RateLimitGetRemainingIn,
     ): Promise<RateLimitGetRemainingOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/get-remaining");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.rate-limit.get-remaining");
 
         request.setBody(
             RateLimitGetRemainingInSerializer._toJsonObject(rateLimitGetRemainingIn)
@@ -66,7 +66,7 @@ export class RateLimit {
     public reset(
         rateLimitResetIn: RateLimitResetIn,
     ): Promise<RateLimitResetOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/reset");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.rate-limit.reset");
 
         request.setBody(
             RateLimitResetInSerializer._toJsonObject(rateLimitResetIn)

--- a/z-clients/javascript/src/apis/rateLimitNamespace.ts
+++ b/z-clients/javascript/src/apis/rateLimitNamespace.ts
@@ -25,7 +25,7 @@ export class RateLimitNamespace {
     public create(
         rateLimitCreateNamespaceIn: RateLimitCreateNamespaceIn,
     ): Promise<RateLimitCreateNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/namespace/create");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.rate-limit.namespace.create");
 
         request.setBody(
             RateLimitCreateNamespaceInSerializer._toJsonObject(rateLimitCreateNamespaceIn)
@@ -39,7 +39,7 @@ export class RateLimitNamespace {
     public get(
         rateLimitGetNamespaceIn: RateLimitGetNamespaceIn,
     ): Promise<RateLimitGetNamespaceOut> {
-        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1/rate-limit/namespace/get");
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.rate-limit.namespace.get");
 
         request.setBody(
             RateLimitGetNamespaceInSerializer._toJsonObject(rateLimitGetNamespaceIn)

--- a/z-clients/python/coyote/apis/admin.py
+++ b/z-clients/python/coyote/apis/admin.py
@@ -1,10 +1,6 @@
 # This file is @generated
 
 from ..internal.api_common import ApiBase
-from ..models import (
-    ClusterRemoveNodeIn,
-    ClusterRemoveNodeOut,
-)
 from .admin_cluster import (
     AdminCluster,
     AdminClusterAsync,
@@ -16,42 +12,8 @@ class AdminAsync(ApiBase):
     def cluster(self) -> AdminClusterAsync:
         return AdminClusterAsync(self._client)
 
-    async def cluster_remove_node(
-        self,
-        cluster_remove_node_in: ClusterRemoveNodeIn,
-    ) -> ClusterRemoveNodeOut:
-        """Remove a node from the cluster.
-
-        This operation executes immediately and the node must be wiped and reset
-        before it can safely be added to the cluster."""
-        body = cluster_remove_node_in.model_dump(exclude_none=True)
-
-        return await self._request_asyncio(
-            method="post",
-            path="/api/v1/admin/cluster/remove-node",
-            body=body,
-            response_type=ClusterRemoveNodeOut,
-        )
-
 
 class Admin(ApiBase):
     @property
     def cluster(self) -> AdminCluster:
         return AdminCluster(self._client)
-
-    def cluster_remove_node(
-        self,
-        cluster_remove_node_in: ClusterRemoveNodeIn,
-    ) -> ClusterRemoveNodeOut:
-        """Remove a node from the cluster.
-
-        This operation executes immediately and the node must be wiped and reset
-        before it can safely be added to the cluster."""
-        body = cluster_remove_node_in.model_dump(exclude_none=True)
-
-        return self._request_sync(
-            method="post",
-            path="/api/v1/admin/cluster/remove-node",
-            body=body,
-            response_type=ClusterRemoveNodeOut,
-        )

--- a/z-clients/python/coyote/apis/admin_cluster.py
+++ b/z-clients/python/coyote/apis/admin_cluster.py
@@ -16,7 +16,7 @@ class AdminClusterAsync(ApiBase):
 
         return await self._request_asyncio(
             method="get",
-            path="/api/v1/admin/cluster/status",
+            path="/api/v1.admin.cluster.status",
             response_type=ClusterStatusOut,
         )
 
@@ -32,7 +32,7 @@ class AdminClusterAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/admin/cluster/remove-node",
+            path="/api/v1.admin.cluster.remove-node",
             body=body,
             response_type=ClusterRemoveNodeOut,
         )
@@ -46,7 +46,7 @@ class AdminCluster(ApiBase):
 
         return self._request_sync(
             method="get",
-            path="/api/v1/admin/cluster/status",
+            path="/api/v1.admin.cluster.status",
             response_type=ClusterStatusOut,
         )
 
@@ -62,7 +62,7 @@ class AdminCluster(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/admin/cluster/remove-node",
+            path="/api/v1.admin.cluster.remove-node",
             body=body,
             response_type=ClusterRemoveNodeOut,
         )

--- a/z-clients/python/coyote/apis/admin_cluster.py
+++ b/z-clients/python/coyote/apis/admin_cluster.py
@@ -2,6 +2,8 @@
 
 from ..internal.api_common import ApiBase
 from ..models import (
+    ClusterRemoveNodeIn,
+    ClusterRemoveNodeOut,
     ClusterStatusOut,
 )
 
@@ -18,6 +20,23 @@ class AdminClusterAsync(ApiBase):
             response_type=ClusterStatusOut,
         )
 
+    async def remove_node(
+        self,
+        cluster_remove_node_in: ClusterRemoveNodeIn,
+    ) -> ClusterRemoveNodeOut:
+        """Remove a node from the cluster.
+
+        This operation executes immediately and the node must be wiped and reset
+        before it can safely be added to the cluster."""
+        body = cluster_remove_node_in.model_dump(exclude_none=True)
+
+        return await self._request_asyncio(
+            method="post",
+            path="/api/v1/admin/cluster/remove-node",
+            body=body,
+            response_type=ClusterRemoveNodeOut,
+        )
+
 
 class AdminCluster(ApiBase):
     def status(
@@ -29,4 +48,21 @@ class AdminCluster(ApiBase):
             method="get",
             path="/api/v1/admin/cluster/status",
             response_type=ClusterStatusOut,
+        )
+
+    def remove_node(
+        self,
+        cluster_remove_node_in: ClusterRemoveNodeIn,
+    ) -> ClusterRemoveNodeOut:
+        """Remove a node from the cluster.
+
+        This operation executes immediately and the node must be wiped and reset
+        before it can safely be added to the cluster."""
+        body = cluster_remove_node_in.model_dump(exclude_none=True)
+
+        return self._request_sync(
+            method="post",
+            path="/api/v1/admin/cluster/remove-node",
+            body=body,
+            response_type=ClusterRemoveNodeOut,
         )

--- a/z-clients/python/coyote/apis/auth_token.py
+++ b/z-clients/python/coyote/apis/auth_token.py
@@ -37,7 +37,7 @@ class AuthTokenAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/create",
+            path="/api/v1.auth-token.create",
             body=body,
             response_type=AuthTokenCreateOut,
         )
@@ -51,7 +51,7 @@ class AuthTokenAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/expire",
+            path="/api/v1.auth-token.expire",
             body=body,
             response_type=AuthTokenExpireOut,
         )
@@ -65,7 +65,7 @@ class AuthTokenAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/delete",
+            path="/api/v1.auth-token.delete",
             body=body,
             response_type=AuthTokenDeleteOut,
         )
@@ -79,7 +79,7 @@ class AuthTokenAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/verify",
+            path="/api/v1.auth-token.verify",
             body=body,
             response_type=AuthTokenVerifyOut,
         )
@@ -93,7 +93,7 @@ class AuthTokenAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/list",
+            path="/api/v1.auth-token.list",
             body=body,
             response_type=ListResponseAuthTokenOut,
         )
@@ -107,7 +107,7 @@ class AuthTokenAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/update",
+            path="/api/v1.auth-token.update",
             body=body,
             response_type=AuthTokenUpdateOut,
         )
@@ -121,7 +121,7 @@ class AuthTokenAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/rotate",
+            path="/api/v1.auth-token.rotate",
             body=body,
             response_type=AuthTokenRotateOut,
         )
@@ -141,7 +141,7 @@ class AuthToken(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/create",
+            path="/api/v1.auth-token.create",
             body=body,
             response_type=AuthTokenCreateOut,
         )
@@ -155,7 +155,7 @@ class AuthToken(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/expire",
+            path="/api/v1.auth-token.expire",
             body=body,
             response_type=AuthTokenExpireOut,
         )
@@ -169,7 +169,7 @@ class AuthToken(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/delete",
+            path="/api/v1.auth-token.delete",
             body=body,
             response_type=AuthTokenDeleteOut,
         )
@@ -183,7 +183,7 @@ class AuthToken(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/verify",
+            path="/api/v1.auth-token.verify",
             body=body,
             response_type=AuthTokenVerifyOut,
         )
@@ -197,7 +197,7 @@ class AuthToken(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/list",
+            path="/api/v1.auth-token.list",
             body=body,
             response_type=ListResponseAuthTokenOut,
         )
@@ -211,7 +211,7 @@ class AuthToken(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/update",
+            path="/api/v1.auth-token.update",
             body=body,
             response_type=AuthTokenUpdateOut,
         )
@@ -225,7 +225,7 @@ class AuthToken(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/rotate",
+            path="/api/v1.auth-token.rotate",
             body=body,
             response_type=AuthTokenRotateOut,
         )

--- a/z-clients/python/coyote/apis/auth_token_namespace.py
+++ b/z-clients/python/coyote/apis/auth_token_namespace.py
@@ -19,7 +19,7 @@ class AuthTokenNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/namespace/create",
+            path="/api/v1.auth-token.namespace.create",
             body=body,
             response_type=AuthTokenCreateNamespaceOut,
         )
@@ -33,7 +33,7 @@ class AuthTokenNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/auth-token/namespace/get",
+            path="/api/v1.auth-token.namespace.get",
             body=body,
             response_type=AuthTokenGetNamespaceOut,
         )
@@ -49,7 +49,7 @@ class AuthTokenNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/namespace/create",
+            path="/api/v1.auth-token.namespace.create",
             body=body,
             response_type=AuthTokenCreateNamespaceOut,
         )
@@ -63,7 +63,7 @@ class AuthTokenNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/auth-token/namespace/get",
+            path="/api/v1.auth-token.namespace.get",
             body=body,
             response_type=AuthTokenGetNamespaceOut,
         )

--- a/z-clients/python/coyote/apis/cache.py
+++ b/z-clients/python/coyote/apis/cache.py
@@ -39,7 +39,7 @@ class CacheAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/cache/set",
+            path="/api/v1.cache.set",
             body=body,
             response_type=CacheSetOut,
         )
@@ -58,7 +58,7 @@ class CacheAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/cache/get",
+            path="/api/v1.cache.get",
             body=body,
             response_type=CacheGetOut,
         )
@@ -76,7 +76,7 @@ class CacheAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/cache/delete",
+            path="/api/v1.cache.delete",
             body=body,
             response_type=CacheDeleteOut,
         )
@@ -102,7 +102,7 @@ class Cache(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/cache/set",
+            path="/api/v1.cache.set",
             body=body,
             response_type=CacheSetOut,
         )
@@ -121,7 +121,7 @@ class Cache(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/cache/get",
+            path="/api/v1.cache.get",
             body=body,
             response_type=CacheGetOut,
         )
@@ -139,7 +139,7 @@ class Cache(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/cache/delete",
+            path="/api/v1.cache.delete",
             body=body,
             response_type=CacheDeleteOut,
         )

--- a/z-clients/python/coyote/apis/cache_namespace.py
+++ b/z-clients/python/coyote/apis/cache_namespace.py
@@ -19,7 +19,7 @@ class CacheNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/cache/namespace/create",
+            path="/api/v1.cache.namespace.create",
             body=body,
             response_type=CacheCreateNamespaceOut,
         )
@@ -33,7 +33,7 @@ class CacheNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/cache/namespace/get",
+            path="/api/v1.cache.namespace.get",
             body=body,
             response_type=CacheGetNamespaceOut,
         )
@@ -49,7 +49,7 @@ class CacheNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/cache/namespace/create",
+            path="/api/v1.cache.namespace.create",
             body=body,
             response_type=CacheCreateNamespaceOut,
         )
@@ -63,7 +63,7 @@ class CacheNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/cache/namespace/get",
+            path="/api/v1.cache.namespace.get",
             body=body,
             response_type=CacheGetNamespaceOut,
         )

--- a/z-clients/python/coyote/apis/health.py
+++ b/z-clients/python/coyote/apis/health.py
@@ -14,7 +14,7 @@ class HealthAsync(ApiBase):
 
         return await self._request_asyncio(
             method="get",
-            path="/api/v1/health/ping",
+            path="/api/v1.health.ping",
             response_type=PingOut,
         )
 
@@ -25,7 +25,7 @@ class HealthAsync(ApiBase):
 
         await self._request_asyncio(
             method="post",
-            path="/api/v1/health/error",
+            path="/api/v1.health.error",
         )
 
 
@@ -37,7 +37,7 @@ class Health(ApiBase):
 
         return self._request_sync(
             method="get",
-            path="/api/v1/health/ping",
+            path="/api/v1.health.ping",
             response_type=PingOut,
         )
 
@@ -48,5 +48,5 @@ class Health(ApiBase):
 
         self._request_sync(
             method="post",
-            path="/api/v1/health/error",
+            path="/api/v1.health.error",
         )

--- a/z-clients/python/coyote/apis/idempotency.py
+++ b/z-clients/python/coyote/apis/idempotency.py
@@ -38,7 +38,7 @@ class IdempotencyAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/idempotency/start",
+            path="/api/v1.idempotency.start",
             body=body,
             response_type=IdempotencyStartOut,
         )
@@ -58,7 +58,7 @@ class IdempotencyAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/idempotency/complete",
+            path="/api/v1.idempotency.complete",
             body=body,
             response_type=IdempotencyCompleteOut,
         )
@@ -76,7 +76,7 @@ class IdempotencyAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/idempotency/abort",
+            path="/api/v1.idempotency.abort",
             body=body,
             response_type=IdempotencyAbortOut,
         )
@@ -101,7 +101,7 @@ class Idempotency(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/idempotency/start",
+            path="/api/v1.idempotency.start",
             body=body,
             response_type=IdempotencyStartOut,
         )
@@ -121,7 +121,7 @@ class Idempotency(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/idempotency/complete",
+            path="/api/v1.idempotency.complete",
             body=body,
             response_type=IdempotencyCompleteOut,
         )
@@ -139,7 +139,7 @@ class Idempotency(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/idempotency/abort",
+            path="/api/v1.idempotency.abort",
             body=body,
             response_type=IdempotencyAbortOut,
         )

--- a/z-clients/python/coyote/apis/idempotency_namespace.py
+++ b/z-clients/python/coyote/apis/idempotency_namespace.py
@@ -19,7 +19,7 @@ class IdempotencyNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/idempotency/namespace/create",
+            path="/api/v1.idempotency.namespace.create",
             body=body,
             response_type=IdempotencyCreateNamespaceOut,
         )
@@ -33,7 +33,7 @@ class IdempotencyNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/idempotency/namespace/get",
+            path="/api/v1.idempotency.namespace.get",
             body=body,
             response_type=IdempotencyGetNamespaceOut,
         )
@@ -49,7 +49,7 @@ class IdempotencyNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/idempotency/namespace/create",
+            path="/api/v1.idempotency.namespace.create",
             body=body,
             response_type=IdempotencyCreateNamespaceOut,
         )
@@ -63,7 +63,7 @@ class IdempotencyNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/idempotency/namespace/get",
+            path="/api/v1.idempotency.namespace.get",
             body=body,
             response_type=IdempotencyGetNamespaceOut,
         )

--- a/z-clients/python/coyote/apis/kv.py
+++ b/z-clients/python/coyote/apis/kv.py
@@ -41,7 +41,7 @@ class KvAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/kv/set",
+            path="/api/v1.kv.set",
             body=body,
             response_type=KvSetOut,
         )
@@ -60,7 +60,7 @@ class KvAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/kv/get",
+            path="/api/v1.kv.get",
             body=body,
             response_type=KvGetOut,
         )
@@ -78,7 +78,7 @@ class KvAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/kv/delete",
+            path="/api/v1.kv.delete",
             body=body,
             response_type=KvDeleteOut,
         )
@@ -106,7 +106,7 @@ class Kv(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/kv/set",
+            path="/api/v1.kv.set",
             body=body,
             response_type=KvSetOut,
         )
@@ -125,7 +125,7 @@ class Kv(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/kv/get",
+            path="/api/v1.kv.get",
             body=body,
             response_type=KvGetOut,
         )
@@ -143,7 +143,7 @@ class Kv(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/kv/delete",
+            path="/api/v1.kv.delete",
             body=body,
             response_type=KvDeleteOut,
         )

--- a/z-clients/python/coyote/apis/kv_namespace.py
+++ b/z-clients/python/coyote/apis/kv_namespace.py
@@ -19,7 +19,7 @@ class KvNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/kv/namespace/create",
+            path="/api/v1.kv.namespace.create",
             body=body,
             response_type=KvCreateNamespaceOut,
         )
@@ -33,7 +33,7 @@ class KvNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/kv/namespace/get",
+            path="/api/v1.kv.namespace.get",
             body=body,
             response_type=KvGetNamespaceOut,
         )
@@ -49,7 +49,7 @@ class KvNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/kv/namespace/create",
+            path="/api/v1.kv.namespace.create",
             body=body,
             response_type=KvCreateNamespaceOut,
         )
@@ -63,7 +63,7 @@ class KvNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/kv/namespace/get",
+            path="/api/v1.kv.namespace.get",
             body=body,
             response_type=KvGetNamespaceOut,
         )

--- a/z-clients/python/coyote/apis/msgs.py
+++ b/z-clients/python/coyote/apis/msgs.py
@@ -56,7 +56,7 @@ class MsgsAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/publish",
+            path="/api/v1.msgs.publish",
             body=body,
             response_type=MsgPublishOut,
         )
@@ -93,7 +93,7 @@ class Msgs(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/publish",
+            path="/api/v1.msgs.publish",
             body=body,
             response_type=MsgPublishOut,
         )

--- a/z-clients/python/coyote/apis/msgs_namespace.py
+++ b/z-clients/python/coyote/apis/msgs_namespace.py
@@ -26,7 +26,7 @@ class MsgsNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/namespace/create",
+            path="/api/v1.msgs.namespace.create",
             body=body,
             response_type=MsgNamespaceCreateOut,
         )
@@ -43,7 +43,7 @@ class MsgsNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/namespace/get",
+            path="/api/v1.msgs.namespace.get",
             body=body,
             response_type=MsgNamespaceGetOut,
         )
@@ -63,7 +63,7 @@ class MsgsNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/namespace/create",
+            path="/api/v1.msgs.namespace.create",
             body=body,
             response_type=MsgNamespaceCreateOut,
         )
@@ -80,7 +80,7 @@ class MsgsNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/namespace/get",
+            path="/api/v1.msgs.namespace.get",
             body=body,
             response_type=MsgNamespaceGetOut,
         )

--- a/z-clients/python/coyote/apis/msgs_queue.py
+++ b/z-clients/python/coyote/apis/msgs_queue.py
@@ -43,7 +43,7 @@ class MsgsQueueAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/queue/receive",
+            path="/api/v1.msgs.queue.receive",
             body=body,
             response_type=MsgQueueReceiveOut,
         )
@@ -66,7 +66,7 @@ class MsgsQueueAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/queue/ack",
+            path="/api/v1.msgs.queue.ack",
             body=body,
             response_type=MsgQueueAckOut,
         )
@@ -91,7 +91,7 @@ class MsgsQueueAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/queue/configure",
+            path="/api/v1.msgs.queue.configure",
             body=body,
             response_type=MsgQueueConfigureOut,
         )
@@ -115,7 +115,7 @@ class MsgsQueueAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/queue/nack",
+            path="/api/v1.msgs.queue.nack",
             body=body,
             response_type=MsgQueueNackOut,
         )
@@ -135,7 +135,7 @@ class MsgsQueueAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/queue/redrive-dlq",
+            path="/api/v1.msgs.queue.redrive-dlq",
             body=body,
             response_type=MsgQueueRedriveDlqOut,
         )
@@ -163,7 +163,7 @@ class MsgsQueue(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/queue/receive",
+            path="/api/v1.msgs.queue.receive",
             body=body,
             response_type=MsgQueueReceiveOut,
         )
@@ -186,7 +186,7 @@ class MsgsQueue(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/queue/ack",
+            path="/api/v1.msgs.queue.ack",
             body=body,
             response_type=MsgQueueAckOut,
         )
@@ -211,7 +211,7 @@ class MsgsQueue(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/queue/configure",
+            path="/api/v1.msgs.queue.configure",
             body=body,
             response_type=MsgQueueConfigureOut,
         )
@@ -235,7 +235,7 @@ class MsgsQueue(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/queue/nack",
+            path="/api/v1.msgs.queue.nack",
             body=body,
             response_type=MsgQueueNackOut,
         )
@@ -255,7 +255,7 @@ class MsgsQueue(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/queue/redrive-dlq",
+            path="/api/v1.msgs.queue.redrive-dlq",
             body=body,
             response_type=MsgQueueRedriveDlqOut,
         )

--- a/z-clients/python/coyote/apis/msgs_stream.py
+++ b/z-clients/python/coyote/apis/msgs_stream.py
@@ -37,7 +37,7 @@ class MsgsStreamAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/stream/receive",
+            path="/api/v1.msgs.stream.receive",
             body=body,
             response_type=MsgStreamReceiveOut,
         )
@@ -61,7 +61,7 @@ class MsgsStreamAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/stream/commit",
+            path="/api/v1.msgs.stream.commit",
             body=body,
             response_type=MsgStreamCommitOut,
         )
@@ -87,7 +87,7 @@ class MsgsStreamAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/stream/seek",
+            path="/api/v1.msgs.stream.seek",
             body=body,
             response_type=MsgStreamSeekOut,
         )
@@ -115,7 +115,7 @@ class MsgsStream(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/stream/receive",
+            path="/api/v1.msgs.stream.receive",
             body=body,
             response_type=MsgStreamReceiveOut,
         )
@@ -139,7 +139,7 @@ class MsgsStream(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/stream/commit",
+            path="/api/v1.msgs.stream.commit",
             body=body,
             response_type=MsgStreamCommitOut,
         )
@@ -165,7 +165,7 @@ class MsgsStream(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/stream/seek",
+            path="/api/v1.msgs.stream.seek",
             body=body,
             response_type=MsgStreamSeekOut,
         )

--- a/z-clients/python/coyote/apis/msgs_topic.py
+++ b/z-clients/python/coyote/apis/msgs_topic.py
@@ -26,7 +26,7 @@ class MsgsTopicAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/msgs/topic/configure",
+            path="/api/v1.msgs.topic.configure",
             body=body,
             response_type=MsgTopicConfigureOut,
         )
@@ -49,7 +49,7 @@ class MsgsTopic(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/msgs/topic/configure",
+            path="/api/v1.msgs.topic.configure",
             body=body,
             response_type=MsgTopicConfigureOut,
         )

--- a/z-clients/python/coyote/apis/rate_limit.py
+++ b/z-clients/python/coyote/apis/rate_limit.py
@@ -29,7 +29,7 @@ class RateLimitAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/rate-limit/limit",
+            path="/api/v1.rate-limit.limit",
             body=body,
             response_type=RateLimitCheckOut,
         )
@@ -43,7 +43,7 @@ class RateLimitAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/rate-limit/get-remaining",
+            path="/api/v1.rate-limit.get-remaining",
             body=body,
             response_type=RateLimitGetRemainingOut,
         )
@@ -57,7 +57,7 @@ class RateLimitAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/rate-limit/reset",
+            path="/api/v1.rate-limit.reset",
             body=body,
             response_type=RateLimitResetOut,
         )
@@ -77,7 +77,7 @@ class RateLimit(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/rate-limit/limit",
+            path="/api/v1.rate-limit.limit",
             body=body,
             response_type=RateLimitCheckOut,
         )
@@ -91,7 +91,7 @@ class RateLimit(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/rate-limit/get-remaining",
+            path="/api/v1.rate-limit.get-remaining",
             body=body,
             response_type=RateLimitGetRemainingOut,
         )
@@ -105,7 +105,7 @@ class RateLimit(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/rate-limit/reset",
+            path="/api/v1.rate-limit.reset",
             body=body,
             response_type=RateLimitResetOut,
         )

--- a/z-clients/python/coyote/apis/rate_limit_namespace.py
+++ b/z-clients/python/coyote/apis/rate_limit_namespace.py
@@ -19,7 +19,7 @@ class RateLimitNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/rate-limit/namespace/create",
+            path="/api/v1.rate-limit.namespace.create",
             body=body,
             response_type=RateLimitCreateNamespaceOut,
         )
@@ -33,7 +33,7 @@ class RateLimitNamespaceAsync(ApiBase):
 
         return await self._request_asyncio(
             method="post",
-            path="/api/v1/rate-limit/namespace/get",
+            path="/api/v1.rate-limit.namespace.get",
             body=body,
             response_type=RateLimitGetNamespaceOut,
         )
@@ -49,7 +49,7 @@ class RateLimitNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/rate-limit/namespace/create",
+            path="/api/v1.rate-limit.namespace.create",
             body=body,
             response_type=RateLimitCreateNamespaceOut,
         )
@@ -63,7 +63,7 @@ class RateLimitNamespace(ApiBase):
 
         return self._request_sync(
             method="post",
-            path="/api/v1/rate-limit/namespace/get",
+            path="/api/v1.rate-limit.namespace.get",
             body=body,
             response_type=RateLimitGetNamespaceOut,
         )

--- a/z-clients/rust/src/api/admin.rs
+++ b/z-clients/rust/src/api/admin.rs
@@ -1,6 +1,6 @@
 // this file is @generated
 use super::AdminCluster;
-use crate::{Configuration, error::Result, models::*};
+use crate::Configuration;
 
 pub struct Admin<'a> {
     cfg: &'a Configuration,
@@ -13,19 +13,5 @@ impl<'a> Admin<'a> {
 
     pub fn cluster(&self) -> AdminCluster<'a> {
         AdminCluster::new(self.cfg)
-    }
-
-    /// Remove a node from the cluster.
-    ///
-    /// This operation executes immediately and the node must be wiped and reset
-    /// before it can safely be added to the cluster.
-    pub async fn cluster_remove_node(
-        &self,
-        cluster_remove_node_in: ClusterRemoveNodeIn,
-    ) -> Result<ClusterRemoveNodeOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/admin/cluster/remove-node")
-            .with_body(cluster_remove_node_in)
-            .execute(self.cfg)
-            .await
     }
 }

--- a/z-clients/rust/src/api/admin_cluster.rs
+++ b/z-clients/rust/src/api/admin_cluster.rs
@@ -16,4 +16,18 @@ impl<'a> AdminCluster<'a> {
             .execute(self.cfg)
             .await
     }
+
+    /// Remove a node from the cluster.
+    ///
+    /// This operation executes immediately and the node must be wiped and reset
+    /// before it can safely be added to the cluster.
+    pub async fn remove_node(
+        &self,
+        cluster_remove_node_in: ClusterRemoveNodeIn,
+    ) -> Result<ClusterRemoveNodeOut> {
+        crate::request::Request::new(http::Method::POST, "/api/v1/admin/cluster/remove-node")
+            .with_body(cluster_remove_node_in)
+            .execute(self.cfg)
+            .await
+    }
 }

--- a/z-clients/rust/src/api/admin_cluster.rs
+++ b/z-clients/rust/src/api/admin_cluster.rs
@@ -12,7 +12,7 @@ impl<'a> AdminCluster<'a> {
 
     /// Get information about the current cluster
     pub async fn status(&self) -> Result<ClusterStatusOut> {
-        crate::request::Request::new(http::Method::GET, "/api/v1/admin/cluster/status")
+        crate::request::Request::new(http::Method::GET, "/api/v1.admin.cluster.status")
             .execute(self.cfg)
             .await
     }
@@ -25,7 +25,7 @@ impl<'a> AdminCluster<'a> {
         &self,
         cluster_remove_node_in: ClusterRemoveNodeIn,
     ) -> Result<ClusterRemoveNodeOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/admin/cluster/remove-node")
+        crate::request::Request::new(http::Method::POST, "/api/v1.admin.cluster.remove-node")
             .with_body(cluster_remove_node_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/auth_token.rs
+++ b/z-clients/rust/src/api/auth_token.rs
@@ -20,7 +20,7 @@ impl<'a> AuthToken<'a> {
         &self,
         auth_token_create_in: AuthTokenCreateIn,
     ) -> Result<AuthTokenCreateOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/create")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.create")
             .with_body(auth_token_create_in)
             .execute(self.cfg)
             .await
@@ -31,7 +31,7 @@ impl<'a> AuthToken<'a> {
         &self,
         auth_token_expire_in: AuthTokenExpireIn,
     ) -> Result<AuthTokenExpireOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/expire")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.expire")
             .with_body(auth_token_expire_in)
             .execute(self.cfg)
             .await
@@ -42,7 +42,7 @@ impl<'a> AuthToken<'a> {
         &self,
         auth_token_delete_in: AuthTokenDeleteIn,
     ) -> Result<AuthTokenDeleteOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/delete")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.delete")
             .with_body(auth_token_delete_in)
             .execute(self.cfg)
             .await
@@ -53,7 +53,7 @@ impl<'a> AuthToken<'a> {
         &self,
         auth_token_verify_in: AuthTokenVerifyIn,
     ) -> Result<AuthTokenVerifyOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/verify")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.verify")
             .with_body(auth_token_verify_in)
             .execute(self.cfg)
             .await
@@ -64,7 +64,7 @@ impl<'a> AuthToken<'a> {
         &self,
         auth_token_list_in: AuthTokenListIn,
     ) -> Result<ListResponseAuthTokenOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/list")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.list")
             .with_body(auth_token_list_in)
             .execute(self.cfg)
             .await
@@ -75,7 +75,7 @@ impl<'a> AuthToken<'a> {
         &self,
         auth_token_update_in: AuthTokenUpdateIn,
     ) -> Result<AuthTokenUpdateOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/update")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.update")
             .with_body(auth_token_update_in)
             .execute(self.cfg)
             .await
@@ -86,7 +86,7 @@ impl<'a> AuthToken<'a> {
         &self,
         auth_token_rotate_in: AuthTokenRotateIn,
     ) -> Result<AuthTokenRotateOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/rotate")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.rotate")
             .with_body(auth_token_rotate_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/auth_token_namespace.rs
+++ b/z-clients/rust/src/api/auth_token_namespace.rs
@@ -15,7 +15,7 @@ impl<'a> AuthTokenNamespace<'a> {
         &self,
         auth_token_create_namespace_in: AuthTokenCreateNamespaceIn,
     ) -> Result<AuthTokenCreateNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/namespace/create")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.namespace.create")
             .with_body(auth_token_create_namespace_in)
             .execute(self.cfg)
             .await
@@ -26,7 +26,7 @@ impl<'a> AuthTokenNamespace<'a> {
         &self,
         auth_token_get_namespace_in: AuthTokenGetNamespaceIn,
     ) -> Result<AuthTokenGetNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/auth-token/namespace/get")
+        crate::request::Request::new(http::Method::POST, "/api/v1.auth-token.namespace.get")
             .with_body(auth_token_get_namespace_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/cache.rs
+++ b/z-clients/rust/src/api/cache.rs
@@ -24,7 +24,7 @@ impl<'a> Cache<'a> {
             ttl: cache_set_in.ttl,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/cache/set")
+        crate::request::Request::new(http::Method::POST, "/api/v1.cache.set")
             .with_body(cache_set_in)
             .execute(self.cfg)
             .await
@@ -38,7 +38,7 @@ impl<'a> Cache<'a> {
             consistency: cache_get_in.consistency,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/cache/get")
+        crate::request::Request::new(http::Method::POST, "/api/v1.cache.get")
             .with_body(cache_get_in)
             .execute(self.cfg)
             .await
@@ -55,7 +55,7 @@ impl<'a> Cache<'a> {
             key,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/cache/delete")
+        crate::request::Request::new(http::Method::POST, "/api/v1.cache.delete")
             .with_body(cache_delete_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/cache_namespace.rs
+++ b/z-clients/rust/src/api/cache_namespace.rs
@@ -15,7 +15,7 @@ impl<'a> CacheNamespace<'a> {
         &self,
         cache_create_namespace_in: CacheCreateNamespaceIn,
     ) -> Result<CacheCreateNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/cache/namespace/create")
+        crate::request::Request::new(http::Method::POST, "/api/v1.cache.namespace.create")
             .with_body(cache_create_namespace_in)
             .execute(self.cfg)
             .await
@@ -26,7 +26,7 @@ impl<'a> CacheNamespace<'a> {
         &self,
         cache_get_namespace_in: CacheGetNamespaceIn,
     ) -> Result<CacheGetNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/cache/namespace/get")
+        crate::request::Request::new(http::Method::POST, "/api/v1.cache.namespace.get")
             .with_body(cache_get_namespace_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/health.rs
+++ b/z-clients/rust/src/api/health.rs
@@ -12,14 +12,14 @@ impl<'a> Health<'a> {
 
     /// Verify the server is up and running.
     pub async fn ping(&self) -> Result<PingOut> {
-        crate::request::Request::new(http::Method::GET, "/api/v1/health/ping")
+        crate::request::Request::new(http::Method::GET, "/api/v1.health.ping")
             .execute(self.cfg)
             .await
     }
 
     /// Intentionally return an error
     pub async fn error(&self) -> Result<()> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/health/error")
+        crate::request::Request::new(http::Method::POST, "/api/v1.health.error")
             .returns_nothing()
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/idempotency.rs
+++ b/z-clients/rust/src/api/idempotency.rs
@@ -27,7 +27,7 @@ impl<'a> Idempotency<'a> {
             ttl: idempotency_start_in.ttl,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/start")
+        crate::request::Request::new(http::Method::POST, "/api/v1.idempotency.start")
             .with_body(idempotency_start_in)
             .execute(self.cfg)
             .await
@@ -46,7 +46,7 @@ impl<'a> Idempotency<'a> {
             ttl: idempotency_complete_in.ttl,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/complete")
+        crate::request::Request::new(http::Method::POST, "/api/v1.idempotency.complete")
             .with_body(idempotency_complete_in)
             .execute(self.cfg)
             .await
@@ -63,7 +63,7 @@ impl<'a> Idempotency<'a> {
             key,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/abort")
+        crate::request::Request::new(http::Method::POST, "/api/v1.idempotency.abort")
             .with_body(idempotency_abort_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/idempotency_namespace.rs
+++ b/z-clients/rust/src/api/idempotency_namespace.rs
@@ -15,7 +15,7 @@ impl<'a> IdempotencyNamespace<'a> {
         &self,
         idempotency_create_namespace_in: IdempotencyCreateNamespaceIn,
     ) -> Result<IdempotencyCreateNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/namespace/create")
+        crate::request::Request::new(http::Method::POST, "/api/v1.idempotency.namespace.create")
             .with_body(idempotency_create_namespace_in)
             .execute(self.cfg)
             .await
@@ -26,7 +26,7 @@ impl<'a> IdempotencyNamespace<'a> {
         &self,
         idempotency_get_namespace_in: IdempotencyGetNamespaceIn,
     ) -> Result<IdempotencyGetNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/idempotency/namespace/get")
+        crate::request::Request::new(http::Method::POST, "/api/v1.idempotency.namespace.get")
             .with_body(idempotency_get_namespace_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/kv.rs
+++ b/z-clients/rust/src/api/kv.rs
@@ -26,7 +26,7 @@ impl<'a> Kv<'a> {
             version: kv_set_in.version,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/kv/set")
+        crate::request::Request::new(http::Method::POST, "/api/v1.kv.set")
             .with_body(kv_set_in)
             .execute(self.cfg)
             .await
@@ -40,7 +40,7 @@ impl<'a> Kv<'a> {
             consistency: kv_get_in.consistency,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/kv/get")
+        crate::request::Request::new(http::Method::POST, "/api/v1.kv.get")
             .with_body(kv_get_in)
             .execute(self.cfg)
             .await
@@ -53,7 +53,7 @@ impl<'a> Kv<'a> {
             key,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/kv/delete")
+        crate::request::Request::new(http::Method::POST, "/api/v1.kv.delete")
             .with_body(kv_delete_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/kv_namespace.rs
+++ b/z-clients/rust/src/api/kv_namespace.rs
@@ -15,7 +15,7 @@ impl<'a> KvNamespace<'a> {
         &self,
         kv_create_namespace_in: KvCreateNamespaceIn,
     ) -> Result<KvCreateNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/kv/namespace/create")
+        crate::request::Request::new(http::Method::POST, "/api/v1.kv.namespace.create")
             .with_body(kv_create_namespace_in)
             .execute(self.cfg)
             .await
@@ -23,7 +23,7 @@ impl<'a> KvNamespace<'a> {
 
     /// Get KV namespace
     pub async fn get(&self, kv_get_namespace_in: KvGetNamespaceIn) -> Result<KvGetNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/kv/namespace/get")
+        crate::request::Request::new(http::Method::POST, "/api/v1.kv.namespace.get")
             .with_body(kv_get_namespace_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/msgs.rs
+++ b/z-clients/rust/src/api/msgs.rs
@@ -39,7 +39,7 @@ impl<'a> Msgs<'a> {
             msgs: msg_publish_in.msgs,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/publish")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.publish")
             .with_body(msg_publish_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/msgs_namespace.rs
+++ b/z-clients/rust/src/api/msgs_namespace.rs
@@ -21,7 +21,7 @@ impl<'a> MsgsNamespace<'a> {
             retention: msg_namespace_create_in.retention,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/namespace/create")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.namespace.create")
             .with_body(msg_namespace_create_in)
             .execute(self.cfg)
             .await
@@ -36,7 +36,7 @@ impl<'a> MsgsNamespace<'a> {
         let _unused = msg_namespace_get_in;
         let msg_namespace_get_in = MsgNamespaceGetIn_ { name };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/namespace/get")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.namespace.get")
             .with_body(msg_namespace_get_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/msgs_queue.rs
+++ b/z-clients/rust/src/api/msgs_queue.rs
@@ -29,7 +29,7 @@ impl<'a> MsgsQueue<'a> {
             lease_duration_ms: msg_queue_receive_in.lease_duration_ms,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/queue/receive")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.queue.receive")
             .with_body(msg_queue_receive_in)
             .execute(self.cfg)
             .await
@@ -51,7 +51,7 @@ impl<'a> MsgsQueue<'a> {
             msg_ids: msg_queue_ack_in.msg_ids,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/queue/ack")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.queue.ack")
             .with_body(msg_queue_ack_in)
             .execute(self.cfg)
             .await
@@ -75,7 +75,7 @@ impl<'a> MsgsQueue<'a> {
             dlq_topic: msg_queue_configure_in.dlq_topic,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/queue/configure")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.queue.configure")
             .with_body(msg_queue_configure_in)
             .execute(self.cfg)
             .await
@@ -98,7 +98,7 @@ impl<'a> MsgsQueue<'a> {
             msg_ids: msg_queue_nack_in.msg_ids,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/queue/nack")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.queue.nack")
             .with_body(msg_queue_nack_in)
             .execute(self.cfg)
             .await
@@ -117,7 +117,7 @@ impl<'a> MsgsQueue<'a> {
             consumer_group,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/queue/redrive-dlq")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.queue.redrive-dlq")
             .with_body(msg_queue_redrive_dlq_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/msgs_stream.rs
+++ b/z-clients/rust/src/api/msgs_stream.rs
@@ -29,7 +29,7 @@ impl<'a> MsgsStream<'a> {
             default_starting_position: msg_stream_receive_in.default_starting_position,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/stream/receive")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.stream.receive")
             .with_body(msg_stream_receive_in)
             .execute(self.cfg)
             .await
@@ -52,7 +52,7 @@ impl<'a> MsgsStream<'a> {
             offset: msg_stream_commit_in.offset,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/stream/commit")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.stream.commit")
             .with_body(msg_stream_commit_in)
             .execute(self.cfg)
             .await
@@ -77,7 +77,7 @@ impl<'a> MsgsStream<'a> {
             position: msg_stream_seek_in.position,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/stream/seek")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.stream.seek")
             .with_body(msg_stream_seek_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/msgs_topic.rs
+++ b/z-clients/rust/src/api/msgs_topic.rs
@@ -24,7 +24,7 @@ impl<'a> MsgsTopic<'a> {
             partitions: msg_topic_configure_in.partitions,
         };
 
-        crate::request::Request::new(http::Method::POST, "/api/v1/msgs/topic/configure")
+        crate::request::Request::new(http::Method::POST, "/api/v1.msgs.topic.configure")
             .with_body(msg_topic_configure_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/rate_limit.rs
+++ b/z-clients/rust/src/api/rate_limit.rs
@@ -17,7 +17,7 @@ impl<'a> RateLimit<'a> {
 
     /// Rate Limiter Check and Consume
     pub async fn limit(&self, rate_limit_check_in: RateLimitCheckIn) -> Result<RateLimitCheckOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/rate-limit/limit")
+        crate::request::Request::new(http::Method::POST, "/api/v1.rate-limit.limit")
             .with_body(rate_limit_check_in)
             .execute(self.cfg)
             .await
@@ -28,7 +28,7 @@ impl<'a> RateLimit<'a> {
         &self,
         rate_limit_get_remaining_in: RateLimitGetRemainingIn,
     ) -> Result<RateLimitGetRemainingOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/rate-limit/get-remaining")
+        crate::request::Request::new(http::Method::POST, "/api/v1.rate-limit.get-remaining")
             .with_body(rate_limit_get_remaining_in)
             .execute(self.cfg)
             .await
@@ -36,7 +36,7 @@ impl<'a> RateLimit<'a> {
 
     /// Rate Limiter Reset
     pub async fn reset(&self, rate_limit_reset_in: RateLimitResetIn) -> Result<RateLimitResetOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/rate-limit/reset")
+        crate::request::Request::new(http::Method::POST, "/api/v1.rate-limit.reset")
             .with_body(rate_limit_reset_in)
             .execute(self.cfg)
             .await

--- a/z-clients/rust/src/api/rate_limit_namespace.rs
+++ b/z-clients/rust/src/api/rate_limit_namespace.rs
@@ -15,7 +15,7 @@ impl<'a> RateLimitNamespace<'a> {
         &self,
         rate_limit_create_namespace_in: RateLimitCreateNamespaceIn,
     ) -> Result<RateLimitCreateNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/rate-limit/namespace/create")
+        crate::request::Request::new(http::Method::POST, "/api/v1.rate-limit.namespace.create")
             .with_body(rate_limit_create_namespace_in)
             .execute(self.cfg)
             .await
@@ -26,7 +26,7 @@ impl<'a> RateLimitNamespace<'a> {
         &self,
         rate_limit_get_namespace_in: RateLimitGetNamespaceIn,
     ) -> Result<RateLimitGetNamespaceOut> {
-        crate::request::Request::new(http::Method::POST, "/api/v1/rate-limit/namespace/get")
+        crate::request::Request::new(http::Method::POST, "/api/v1.rate-limit.namespace.get")
             .with_body(rate_limit_get_namespace_in)
             .execute(self.cfg)
             .await


### PR DESCRIPTION
This now uses the op_id as the path. So `api/v1/kv/set` -> `api/v1.kv.set`.
I kept the openapi.json file under `api/v/1/openapi.json` though.

I also fixed a few wrong op-ids that had underscores in them, and blocked underscores from op-ids going forward.

I also fixed an issue with the python generation with nested resources.

Fixes #524