### PR TITLE
Add required access metadata to input structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "aide 0.16.0-alpha.2",
  "axum",
  "bytes",
+ "coyote-authorization",
  "http",
  "http-body-util",
  "mime",

--- a/crates/coyote-authorization/src/lib.rs
+++ b/crates/coyote-authorization/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt};
 
+use coyote_id::Module;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -85,4 +86,11 @@ pub struct AccessRule {
 pub enum AccessRuleEffect {
     Allow,
     Deny,
+}
+
+pub struct RequestedOperation<'a> {
+    pub module: Module,
+    pub namespace: Option<&'a str>,
+    pub key: Option<&'a str>,
+    pub action: &'static str,
 }

--- a/crates/coyote-proto/Cargo.toml
+++ b/crates/coyote-proto/Cargo.toml
@@ -13,6 +13,7 @@ ignored = ["schemars"]
 aide.workspace = true
 axum.workspace = true
 bytes.workspace = true
+coyote-authorization.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 mime.workspace = true

--- a/crates/coyote-proto/src/lib.rs
+++ b/crates/coyote-proto/src/lib.rs
@@ -4,6 +4,7 @@ mod msgpack;
 mod msgpack_client;
 mod msgpack_or_json;
 pub mod prelude;
+mod request_input;
 mod validation;
 
 pub use self::{
@@ -11,5 +12,6 @@ pub use self::{
     internal_client::{InternalClient, InternalRequest, InternalRequestError},
     msgpack::MsgPack,
     msgpack_or_json::{MsgPackOrJson, capture_accept_hdr},
+    request_input::{AccessMetadata, RequestInput},
     validation::{ValidationErrorBody, ValidationErrorItem, validation_error, validation_errors},
 };

--- a/crates/coyote-proto/src/msgpack_or_json.rs
+++ b/crates/coyote-proto/src/msgpack_or_json.rs
@@ -69,7 +69,8 @@ pub struct MsgPackOrJson<T>(pub T);
 
 impl<T, S> FromRequest<S> for MsgPackOrJson<T>
 where
-    T: DeserializeOwned + Validate,
+    // FIXME(@svix-jplatte): extra bound commented out to avoid merge issues
+    T: DeserializeOwned + Validate, // + RequestInput,
     S: Send + Sync,
 {
     type Rejection = MsgPackOrJsonRejection;

--- a/crates/coyote-proto/src/request_input.rs
+++ b/crates/coyote-proto/src/request_input.rs
@@ -1,0 +1,10 @@
+use coyote_authorization::RequestedOperation;
+
+pub trait RequestInput {
+    fn access_metadata(&self) -> AccessMetadata<'_>;
+}
+
+pub enum AccessMetadata<'a> {
+    AdminOnly,
+    RuleProtected(RequestedOperation<'a>),
+}

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -72,6 +72,12 @@ impl TopicName {
             Ok(Self { namespace, topic })
         }
     }
+
+    // FIXME(@svix-jplatte): This is used by the macro in endpoints/msgs.rs
+    // Update the macro to be less stupid and remove this weird identity method.
+    pub fn name(&self) -> &Self {
+        self
+    }
 }
 
 /// Derefs to the topic name (without namespace or partition).
@@ -136,6 +142,10 @@ pub struct TopicPartition {
 impl TopicPartition {
     pub fn new(raw: TopicName, partition: Partition) -> Self {
         Self { raw, partition }
+    }
+
+    pub fn name(&self) -> &TopicName {
+        &self.raw
     }
 }
 
@@ -212,6 +222,13 @@ impl TopicIn {
         match self {
             TopicIn::TopicName(topic_name) => topic_name,
             TopicIn::TopicPartition(topic_partition) => &topic_partition.raw,
+        }
+    }
+
+    pub fn name(&self) -> &TopicName {
+        match self {
+            Self::TopicName(name) => name,
+            Self::TopicPartition(part) => &part.raw,
         }
     }
 }

--- a/src/v1/endpoints/admin/auth_token.rs
+++ b/src/v1/endpoints/admin/auth_token.rs
@@ -58,6 +58,8 @@ pub struct AdminAuthTokenCreateIn {
     pub enabled: bool,
 }
 
+admin_request_input!(AdminAuthTokenCreateIn);
+
 fn default_true() -> bool {
     true
 }
@@ -114,6 +116,8 @@ pub struct AdminAuthTokenExpireIn {
     pub expiry_ms: Option<DurationMs>,
 }
 
+admin_request_input!(AdminAuthTokenExpireIn);
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AdminAuthTokenExpireOut {}
 
@@ -144,6 +148,8 @@ async fn auth_token_expire(
 pub struct AdminAuthTokenRotateIn {
     pub id: Public<AuthTokenId>,
 }
+
+admin_request_input!(AdminAuthTokenRotateIn);
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AdminAuthTokenRotateOut {
@@ -188,6 +194,8 @@ pub struct AdminAuthTokenDeleteIn {
     pub id: Public<AuthTokenId>,
 }
 
+admin_request_input!(AdminAuthTokenDeleteIn);
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AdminAuthTokenDeleteOut {
     pub success: bool,
@@ -219,6 +227,8 @@ async fn auth_token_delete(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AdminAuthTokenListIn {}
+
+admin_request_input!(AdminAuthTokenListIn);
 
 pub type AdminAuthTokenListOut = ListResponse<AdminAuthTokenOut>;
 
@@ -278,6 +288,8 @@ pub struct AdminAuthTokenUpdateIn {
     pub enabled: Option<bool>,
 }
 
+admin_request_input!(AdminAuthTokenUpdateIn);
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AdminAuthTokenUpdateOut {}
 
@@ -310,6 +322,8 @@ async fn auth_token_update(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AdminAuthTokenWhoamiIn {}
+
+admin_request_input!(AdminAuthTokenWhoamiIn);
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AdminAuthTokenWhoamiOut {

--- a/src/v1/endpoints/admin/cluster.rs
+++ b/src/v1/endpoints/admin/cluster.rs
@@ -175,6 +175,8 @@ async fn cluster_status(
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, JsonSchema)]
 struct ClusterInitializeIn {}
 
+admin_request_input!(ClusterInitializeIn);
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 struct ClusterInitializeOut {
     cluster_id: ClusterId,
@@ -210,6 +212,8 @@ async fn cluster_initialize(
 struct ClusterRemoveNodeIn {
     node_id: NodeId,
 }
+
+admin_request_input!(ClusterRemoveNodeIn);
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 struct ClusterRemoveNodeOut {

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -15,12 +15,13 @@ use coyote_auth_token::{
         UpdateAuthTokenOperation,
     },
 };
+use coyote_authorization::RequestedOperation;
 use coyote_core::types::{DurationMs, Metadata};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt, ResultExt};
-use coyote_id::{AuthTokenId, Public};
+use coyote_id::{AuthTokenId, Module, Public};
 use coyote_namespace::entities::NamespaceName;
-use coyote_proto::MsgPackOrJson;
+use coyote_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -32,6 +33,25 @@ use crate::{
     error::Result,
     v1::utils::{ListResponse, openapi_tag},
 };
+
+fn auth_token_access_metadata<'a>(ns: Option<&'a str>, action: &'static str) -> AccessMetadata<'a> {
+    AccessMetadata::RuleProtected(RequestedOperation {
+        module: Module::AuthToken,
+        namespace: ns,
+        key: None,
+        action,
+    })
+}
+
+macro_rules! request_input {
+    ($ty:ty, $action:literal) => {
+        impl RequestInput for $ty {
+            fn access_metadata(&self) -> AccessMetadata<'_> {
+                auth_token_access_metadata(self.namespace.as_deref(), $action)
+            }
+        }
+    };
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthTokenOut {
@@ -81,6 +101,8 @@ pub struct AuthTokenCreateIn {
     #[serde(default = "default_true")]
     pub enabled: bool,
 }
+
+request_input!(AuthTokenCreateIn, "Create");
 
 fn default_true() -> bool {
     true
@@ -141,6 +163,8 @@ pub struct AuthTokenExpireIn {
     pub expiry_ms: Option<DurationMs>,
 }
 
+request_input!(AuthTokenExpireIn, "Expire");
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthTokenExpireOut {}
 
@@ -167,6 +191,8 @@ pub struct AuthTokenDeleteIn {
     pub namespace: Option<String>,
     pub id: Public<AuthTokenId>,
 }
+
+request_input!(AuthTokenDeleteIn, "Delete");
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthTokenDeleteOut {
@@ -203,6 +229,8 @@ pub struct AuthTokenVerifyIn {
     pub namespace: Option<String>,
     pub token: String,
 }
+
+request_input!(AuthTokenVerifyIn, "Verify");
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthTokenVerifyOut {
@@ -242,6 +270,8 @@ pub struct AuthTokenListIn {
     pub namespace: Option<String>,
     pub owner_id: String,
 }
+
+request_input!(AuthTokenListIn, "List");
 
 pub type AuthTokenListOut = ListResponse<AuthTokenOut>;
 
@@ -286,6 +316,8 @@ pub struct AuthTokenUpdateIn {
     pub enabled: Option<bool>,
 }
 
+request_input!(AuthTokenUpdateIn, "Update");
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthTokenUpdateOut {}
 
@@ -324,6 +356,8 @@ pub struct AuthTokenRotateIn {
     /// Milliseconds from now until the old token expires. `None` means expire immediately.
     pub expiry_ms: Option<DurationMs>,
 }
+
+request_input!(AuthTokenRotateIn, "Rotate");
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthTokenRotateOut {
@@ -370,6 +404,8 @@ struct AuthTokenGetNamespaceIn {
     pub name: NamespaceName,
 }
 
+admin_request_input!(AuthTokenGetNamespaceIn);
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct AuthTokenGetNamespaceOut {
     pub name: NamespaceName,
@@ -384,6 +420,8 @@ pub(crate) struct AuthTokenCreateNamespaceIn {
     pub name: NamespaceName,
     pub max_storage_bytes: Option<NonZeroU64>,
 }
+
+admin_request_input!(AuthTokenCreateNamespaceIn);
 
 impl From<AuthTokenCreateNamespaceIn> for CreateAuthTokenNamespaceOperation {
     fn from(v: AuthTokenCreateNamespaceIn) -> Self {

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -5,6 +5,7 @@ use std::num::NonZeroU64;
 
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
+use coyote_authorization::RequestedOperation;
 use coyote_cache::{
     CacheModel,
     operations::{CreateCacheOperation, DeleteOperation, SetOperation},
@@ -12,18 +13,42 @@ use coyote_cache::{
 use coyote_core::types::{Consistency, DurationMs, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt, ResultExt};
+use coyote_id::Module;
 use coyote_kv::kvcontroller::KvModel;
 use coyote_namespace::{
     Namespace,
     entities::{CacheConfig, EvictionPolicy, NamespaceName},
 };
-use coyote_proto::MsgPackOrJson;
+use coyote_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::{AppState, core::cluster::RaftState, error::Result, v1::utils::openapi_tag};
+
+fn cache_access_metadata<'a>(
+    ns: Option<&'a str>,
+    key: &'a EntityKey,
+    action: &'static str,
+) -> AccessMetadata<'a> {
+    AccessMetadata::RuleProtected(RequestedOperation {
+        module: Module::Cache,
+        namespace: ns,
+        key: Some(key.as_str()),
+        action,
+    })
+}
+
+macro_rules! request_input {
+    ($ty:ty, $action:literal) => {
+        impl RequestInput for $ty {
+            fn access_metadata(&self) -> AccessMetadata<'_> {
+                cache_access_metadata(self.namespace.as_deref(), &self.key, $action)
+            }
+        }
+    };
+}
 
 pub type CacheNamespace = Namespace<CacheConfig>;
 
@@ -40,6 +65,8 @@ pub struct CacheSetIn {
     /// Time to live in milliseconds
     pub ttl: DurationMs,
 }
+
+request_input!(CacheSetIn, "Set");
 
 impl CacheSetIn {
     fn into_model(self, when: Timestamp) -> CacheModel {
@@ -68,6 +95,8 @@ pub struct CacheGetIn {
     pub consistency: Consistency,
 }
 
+request_input!(CacheGetIn, "Get");
+
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 pub struct CacheGetOut {
     /// Time of expiry
@@ -95,6 +124,8 @@ pub struct CacheDeleteIn {
     pub key: EntityKey,
 }
 
+request_input!(CacheDeleteIn, "Delete");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct CacheDeleteOut {
     pub success: bool,
@@ -117,6 +148,8 @@ pub(crate) struct CacheCreateNamespaceIn {
     #[serde(default)]
     pub eviction_policy: EvictionPolicy,
 }
+
+admin_request_input!(CacheCreateNamespaceIn);
 
 impl From<CacheCreateNamespaceIn> for CreateCacheOperation {
     fn from(v: CacheCreateNamespaceIn) -> Self {
@@ -209,6 +242,8 @@ async fn cache_del(
 struct CacheGetNamespaceIn {
     pub name: NamespaceName,
 }
+
+admin_request_input!(CacheGetNamespaceIn);
 
 /// Create cache namespace
 #[aide_annotate(op_id = "v1.cache.namespace.create")]

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -5,9 +5,11 @@ use std::num::NonZeroU64;
 
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
+use coyote_authorization::RequestedOperation;
 use coyote_core::types::{DurationS, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt as _, ResultExt};
+use coyote_id::Module;
 use coyote_idempotency::{
     IdempotencyStartResult,
     operations::{
@@ -18,13 +20,36 @@ use coyote_namespace::{
     Namespace,
     entities::{IdempotencyConfig, NamespaceName},
 };
-use coyote_proto::MsgPackOrJson;
+use coyote_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::{AppState, core::cluster::RaftState, error::Result, v1::utils::openapi_tag};
+
+fn idempotency_metadata<'a>(
+    ns: Option<&'a str>,
+    key: &'a EntityKey,
+    action: &'static str,
+) -> AccessMetadata<'a> {
+    AccessMetadata::RuleProtected(RequestedOperation {
+        module: Module::Idempotency,
+        namespace: ns,
+        key: Some(key.as_str()),
+        action,
+    })
+}
+
+macro_rules! request_input {
+    ($ty:ty, $action:literal) => {
+        impl RequestInput for $ty {
+            fn access_metadata(&self) -> AccessMetadata<'_> {
+                idempotency_metadata(self.namespace.as_deref(), &self.key, $action)
+            }
+        }
+    };
+}
 
 pub type IdempotencyNamespace = Namespace<IdempotencyConfig>;
 
@@ -45,6 +70,8 @@ pub struct IdempotencyStartIn {
     #[validate(range(min = 1))]
     pub ttl: DurationS,
 }
+
+request_input!(IdempotencyStartIn, "Start");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "status", content = "data", rename_all = "snake_case")]
@@ -91,6 +118,8 @@ pub struct IdempotencyCompleteIn {
     pub ttl: DurationS,
 }
 
+request_input!(IdempotencyCompleteIn, "Complete");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct IdempotencyCompleteOut {}
 
@@ -103,6 +132,8 @@ pub struct IdempotencyAbortIn {
     #[validate(nested)]
     pub key: EntityKey,
 }
+
+request_input!(IdempotencyAbortIn, "Abort");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct IdempotencyAbortOut {}
@@ -171,6 +202,8 @@ struct IdempotencyGetNamespaceIn {
     pub name: NamespaceName,
 }
 
+admin_request_input!(IdempotencyGetNamespaceIn);
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct IdempotencyGetNamespaceOut {
     pub name: NamespaceName,
@@ -185,6 +218,8 @@ pub(crate) struct IdempotencyCreateNamespaceIn {
     pub name: NamespaceName,
     pub max_storage_bytes: Option<NonZeroU64>,
 }
+
+admin_request_input!(IdempotencyCreateNamespaceIn);
 
 impl From<IdempotencyCreateNamespaceIn> for CreateIdempotencyOperation {
     fn from(v: IdempotencyCreateNamespaceIn) -> Self {

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -5,22 +5,47 @@ use std::num::NonZeroU64;
 
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
+use coyote_authorization::RequestedOperation;
 use coyote_core::types::{Consistency, DurationMs, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt, ResultExt};
+use coyote_id::Module;
 use coyote_kv::{
     KvNamespace,
     kvcontroller::{KvModel, OperationBehavior},
     operations::{CreateKvOperation, DeleteOperation, SetOperation, SetResponseData},
 };
 use coyote_namespace::entities::NamespaceName;
-use coyote_proto::MsgPackOrJson;
+use coyote_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::{AppState, core::cluster::RaftState, error::Result, v1::utils::openapi_tag};
+
+fn kv_metadata<'a>(
+    ns: Option<&'a str>,
+    key: &'a EntityKey,
+    action: &'static str,
+) -> AccessMetadata<'a> {
+    AccessMetadata::RuleProtected(RequestedOperation {
+        module: Module::Kv,
+        namespace: ns,
+        key: Some(key.as_str()),
+        action,
+    })
+}
+
+macro_rules! request_input {
+    ($ty:ty, $action:literal) => {
+        impl RequestInput for $ty {
+            fn access_metadata(&self) -> AccessMetadata<'_> {
+                kv_metadata(self.namespace.as_deref(), &self.key, $action)
+            }
+        }
+    };
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Validate, JsonSchema)]
 #[schemars(extend("x-positional" = ["key"]))]
@@ -45,6 +70,8 @@ pub struct KvSetIn {
     pub version: Option<u64>,
 }
 
+request_input!(KvSetIn, "Set");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct KvSetOut {
     /// Whether the operation succeeded or was a noop due to pre-conditions.
@@ -63,6 +90,8 @@ pub struct KvGetIn {
     #[serde(default = "Consistency::strong")]
     pub consistency: Consistency,
 }
+
+request_input!(KvGetIn, "Get");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct KvGetOut {
@@ -95,6 +124,8 @@ pub struct KvDeleteIn {
     #[validate(nested)]
     pub key: EntityKey,
 }
+
+request_input!(KvDeleteIn, "Delete");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct KvDeleteOut {
@@ -192,6 +223,8 @@ struct KvGetNamespaceIn {
     pub name: NamespaceName,
 }
 
+admin_request_input!(KvGetNamespaceIn);
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct KvGetNamespaceOut {
     pub name: NamespaceName,
@@ -206,6 +239,8 @@ pub(crate) struct KvCreateNamespaceIn {
     pub name: NamespaceName,
     pub max_storage_bytes: Option<NonZeroU64>,
 }
+
+admin_request_input!(KvCreateNamespaceIn);
 
 impl From<KvCreateNamespaceIn> for CreateKvOperation {
     fn from(v: KvCreateNamespaceIn) -> Self {

--- a/src/v1/endpoints/mod.rs
+++ b/src/v1/endpoints/mod.rs
@@ -1,6 +1,16 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+macro_rules! admin_request_input {
+    ($ty:ty) => {
+        impl coyote_proto::RequestInput for $ty {
+            fn access_metadata(&self) -> coyote_proto::AccessMetadata<'_> {
+                coyote_proto::AccessMetadata::AdminOnly
+            }
+        }
+    };
+}
+
 pub mod admin;
 pub mod auth_token;
 pub mod cache;

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -3,9 +3,11 @@ use std::num::NonZeroU16;
 use crate::{AppState, core::cluster::RaftState, v1::utils::openapi_tag};
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
+use coyote_authorization::RequestedOperation;
 use coyote_core::types::DurationMs;
 use coyote_derive::aide_annotate;
 use coyote_error::{Error, OptionExt, Result, ResultExt};
+use coyote_id::Module;
 use coyote_msgs::{
     MsgsNamespace,
     entities::{
@@ -20,11 +22,34 @@ use coyote_msgs::{
     },
 };
 use coyote_namespace::entities::NamespaceName;
-use coyote_proto::MsgPackOrJson;
+use coyote_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
+
+fn msgs_metadata<'a>(
+    ns: Option<&'a str>,
+    tp: &'a TopicName,
+    action: &'static str,
+) -> AccessMetadata<'a> {
+    AccessMetadata::RuleProtected(RequestedOperation {
+        module: Module::Msgs,
+        namespace: ns,
+        key: Some(tp),
+        action,
+    })
+}
+
+macro_rules! request_input {
+    ($ty:ty, $action:literal) => {
+        impl RequestInput for $ty {
+            fn access_metadata(&self) -> AccessMetadata<'_> {
+                msgs_metadata(self.namespace.as_deref(), self.topic.name(), $action)
+            }
+        }
+    };
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 #[schemars(extend("x-positional" = ["name"]))]
@@ -33,6 +58,8 @@ pub(crate) struct MsgNamespaceCreateIn {
     #[serde(default)]
     pub retention: Retention,
 }
+
+admin_request_input!(MsgNamespaceCreateIn);
 
 impl From<MsgNamespaceCreateIn> for CreateNamespaceOperation {
     fn from(v: MsgNamespaceCreateIn) -> Self {
@@ -70,6 +97,8 @@ async fn create_namespace(
 struct MsgNamespaceGetIn {
     pub name: NamespaceName,
 }
+
+admin_request_input!(MsgNamespaceGetIn);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgNamespaceGetOut {
@@ -118,6 +147,8 @@ struct MsgPublishIn {
     pub topic: TopicIn,
     pub msgs: Vec<coyote_msgs::entities::MsgIn>,
 }
+
+request_input!(MsgPublishIn, "Publish");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgPublishOutTopic {
@@ -186,6 +217,8 @@ struct MsgStreamReceiveIn {
     pub default_starting_position: SeekPosition,
 }
 
+request_input!(MsgStreamReceiveIn, "Receive");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgStreamReceiveOut {
     pub msgs: Vec<StreamMsgOut>,
@@ -246,6 +279,8 @@ struct MsgStreamCommitIn {
     pub offset: u64,
 }
 
+request_input!(MsgStreamCommitIn, "Commit");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgStreamCommitOut {}
 
@@ -285,6 +320,8 @@ struct MsgStreamSeekIn {
     pub offset: Option<Offset>,
     pub position: Option<SeekPosition>,
 }
+
+request_input!(MsgStreamSeekIn, "Seek");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgStreamSeekOut {}
@@ -342,6 +379,8 @@ struct MsgQueueReceiveIn {
     #[serde(default = "default_queue_lease_duration_ms")]
     pub lease_duration_ms: DurationMs,
 }
+
+request_input!(MsgQueueReceiveIn, "Receive");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgQueueReceiveOut {
@@ -402,6 +441,8 @@ struct MsgQueueAckIn {
     pub msg_ids: Vec<MsgId>,
 }
 
+request_input!(MsgQueueAckIn, "Ack");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgQueueAckOut {}
 
@@ -441,6 +482,8 @@ struct MsgQueueConfigureIn {
     pub retry_schedule: Vec<u64>,
     pub dlq_topic: Option<TopicName>,
 }
+
+request_input!(MsgQueueConfigureIn, "Configure");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgQueueConfigureOut {
@@ -492,6 +535,8 @@ struct MsgQueueNackIn {
     pub msg_ids: Vec<MsgId>,
 }
 
+request_input!(MsgQueueNackIn, "Nack");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgQueueNackOut {}
 
@@ -530,6 +575,8 @@ struct MsgQueueRedriveDlqIn {
     pub consumer_group: ConsumerGroup,
 }
 
+request_input!(MsgQueueRedriveDlqIn, "RedriveDlq");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgQueueRedriveDlqOut {}
 
@@ -563,6 +610,8 @@ struct MsgTopicConfigureIn {
     pub topic: TopicName,
     pub partitions: u16,
 }
+
+request_input!(MsgTopicConfigureIn, "Configure");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct MsgTopicConfigureOut {

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -5,11 +5,13 @@ use std::num::NonZeroU64;
 
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
+use coyote_authorization::RequestedOperation;
 use coyote_core::types::{DurationMs, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt, ResultExt};
+use coyote_id::Module;
 use coyote_namespace::entities::NamespaceName;
-use coyote_proto::MsgPackOrJson;
+use coyote_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
 use coyote_rate_limit::operations::{CreateRateLimitOperation, LimitOperation, ResetOperation};
 use jiff::Timestamp;
 use schemars::JsonSchema;
@@ -22,6 +24,29 @@ use crate::{AppState, core::cluster::RaftState, error::Result, v1::utils::openap
 pub use coyote_rate_limit::TokenBucket;
 
 pub use coyote_rate_limit::RateLimitNamespace;
+
+fn rate_limit_metadata<'a>(
+    ns: Option<&'a str>,
+    key: &'a EntityKey,
+    action: &'static str,
+) -> AccessMetadata<'a> {
+    AccessMetadata::RuleProtected(RequestedOperation {
+        module: Module::RateLimit,
+        namespace: ns,
+        key: Some(key.as_str()),
+        action,
+    })
+}
+
+macro_rules! request_input {
+    ($ty:ty, $action:literal) => {
+        impl RequestInput for $ty {
+            fn access_metadata(&self) -> AccessMetadata<'_> {
+                rate_limit_metadata(self.namespace.as_deref(), &self.key, $action)
+            }
+        }
+    };
+}
 
 impl From<RateLimitTokenBucketConfig> for TokenBucket {
     fn from(val: RateLimitTokenBucketConfig) -> Self {
@@ -70,6 +95,8 @@ pub struct RateLimitCheckIn {
     pub config: RateLimitTokenBucketConfig,
 }
 
+request_input!(RateLimitCheckIn, "Check");
+
 fn default_tokens() -> u64 {
     1
 }
@@ -99,6 +126,8 @@ pub struct RateLimitGetRemainingIn {
     #[validate(nested)]
     pub config: RateLimitTokenBucketConfig,
 }
+
+request_input!(RateLimitGetRemainingIn, "Read");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RateLimitGetRemainingOut {
@@ -179,6 +208,8 @@ pub struct RateLimitResetIn {
     pub config: RateLimitTokenBucketConfig,
 }
 
+request_input!(RateLimitResetIn, "Reset");
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct RateLimitResetOut {}
 
@@ -209,6 +240,8 @@ pub(crate) struct RateLimitCreateNamespaceIn {
     pub max_storage_bytes: Option<NonZeroU64>,
 }
 
+admin_request_input!(RateLimitCreateNamespaceIn);
+
 impl From<RateLimitCreateNamespaceIn> for CreateRateLimitOperation {
     fn from(v: RateLimitCreateNamespaceIn) -> Self {
         CreateRateLimitOperation::new(v.name, v.max_storage_bytes)
@@ -228,6 +261,8 @@ struct RateLimitCreateNamespaceOut {
 struct RateLimitGetNamespaceIn {
     pub name: NamespaceName,
 }
+
+admin_request_input!(RateLimitGetNamespaceIn);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct RateLimitGetNamespaceOut {


### PR DESCRIPTION
Please ignore the action strings in `request_input!()` invocations for review, and let's have the module owners assign sensible ones post merge :)

Part of https://github.com/svix/coyote-private/issues/68.