### PR TITLE
rust client: Remove non_exhaustive from enums

### DIFF
--- a/codegen/templates/rust/types/integer_enum.rs.jinja
+++ b/codegen/templates/rust/types/integer_enum.rs.jinja
@@ -4,7 +4,6 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 {{ doc_comment }}
 #[repr(i64)]
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Serialize_repr, Deserialize_repr)]
 pub enum {{ type.name | to_upper_camel_case }} {
     {% for name, value in type.variants -%}

--- a/codegen/templates/rust/types/string_enum.rs.jinja
+++ b/codegen/templates/rust/types/string_enum.rs.jinja
@@ -3,7 +3,6 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 {{ doc_comment }}
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum {{ type.name | to_upper_camel_case }} {
     {% for value in type.values -%}

--- a/codegen/templates/rust/types/struct_enum.rs.jinja
+++ b/codegen/templates/rust/types/struct_enum.rs.jinja
@@ -26,7 +26,6 @@ use super::{
     {% set enum_type_name = type_name %}
 {% endif %}
 
-#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "{{ type.discriminator_field }}", content = "{{ type.content_field }}")]
 pub enum {{ enum_type_name }} {

--- a/z-clients/rust/src/models/consistency.rs
+++ b/z-clients/rust/src/models/consistency.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 ///
 /// Strong consistency (also known as linearizability) guarantees that a read will see all previous
 /// writes. Weak consistency allows stale reads, but can save one or more round trip to the leader.
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Consistency {
     #[serde(rename = "strong")]

--- a/z-clients/rust/src/models/eviction_policy.rs
+++ b/z-clients/rust/src/models/eviction_policy.rs
@@ -3,7 +3,6 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum EvictionPolicy {
     #[serde(rename = "NoEviction")]

--- a/z-clients/rust/src/models/idempotency_start_out.rs
+++ b/z-clients/rust/src/models/idempotency_start_out.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use super::idempotency_completed::IdempotencyCompleted;
 
-#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "status", content = "data")]
 pub enum IdempotencyStartOut {

--- a/z-clients/rust/src/models/operation_behavior.rs
+++ b/z-clients/rust/src/models/operation_behavior.rs
@@ -3,7 +3,6 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum OperationBehavior {
     #[serde(rename = "upsert")]

--- a/z-clients/rust/src/models/seek_position.rs
+++ b/z-clients/rust/src/models/seek_position.rs
@@ -3,7 +3,6 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum SeekPosition {
     #[serde(rename = "earliest")]

--- a/z-clients/rust/src/models/server_state.rs
+++ b/z-clients/rust/src/models/server_state.rs
@@ -3,7 +3,6 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum ServerState {
     #[serde(rename = "Leader")]


### PR DESCRIPTION
it's a bit annoying for users - see https://github.com/svix/svix-webhooks-private/pull/6128#discussion_r2983965857