### PR TITLE
Move namespaces to the request body in msgs topics

### DIFF
--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -199,7 +199,7 @@ impl TopicIn {
     pub fn topic_name(&self) -> &TopicName {
         match self {
             TopicIn::TopicName(topic_name) => topic_name,
-            TopicIn::TopicPartition(topic_partition) => &topic_partition.raw,
+            TopicIn::TopicPartition(topic_partition) => &topic_partition.topic,
         }
     }
 }

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -118,13 +118,13 @@ impl JsonSchema for TopicName {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TopicPartition {
-    pub raw: TopicName,
+    pub topic: TopicName,
     pub partition: Partition,
 }
 
 impl TopicPartition {
-    pub fn new(raw: TopicName, partition: Partition) -> Self {
-        Self { raw, partition }
+    pub fn new(topic: TopicName, partition: Partition) -> Self {
+        Self { topic, partition }
     }
 }
 
@@ -139,8 +139,8 @@ impl TryFrom<String> for TopicPartition {
             .parse()
             .map_err(|_| Error::internal("invalid partition index in topic"))?;
         let partition = Partition::new(idx)?;
-        let raw = TopicName::new(topic.to_owned())?;
-        Ok(Self { raw, partition })
+        let topic = TopicName::new(topic.to_owned())?;
+        Ok(Self { topic, partition })
     }
 }
 
@@ -149,7 +149,7 @@ impl fmt::Display for TopicPartition {
         write!(
             f,
             "{}{}{}",
-            self.raw, TOPIC_PARTITION_DELIMITER, self.partition.0
+            self.topic, TOPIC_PARTITION_DELIMITER, self.partition.0
         )
     }
 }

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, fmt, num::NonZeroU64, ops::Deref, str::FromStr, time::Duration};
 
 use coyote_error::Error;
-use coyote_namespace::{entities::NamespaceName, parse_namespace};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{
@@ -18,8 +17,6 @@ pub const DEFAULT_PARTITION_COUNT: u16 = 1;
 pub const MAX_PARTITION_COUNT: u16 = 64;
 
 pub const TOPIC_PARTITION_DELIMITER: &str = "~";
-
-pub const NAMESPACE_DELIMITER: char = ':';
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -57,19 +54,16 @@ impl FromStr for Partition {
 /// Carries the `namespace` that owns this topic. Serializes as `"namespace:topic"`, or just
 /// `"topic"` when the namespace is the default.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TopicName {
-    namespace: Option<NamespaceName>,
-    topic: String,
-}
+pub struct TopicName(String);
 
 impl TopicName {
-    pub fn new(namespace: Option<NamespaceName>, topic: String) -> Result<Self, Error> {
+    pub fn new(topic: String) -> Result<Self, Error> {
         if topic.contains(TOPIC_PARTITION_DELIMITER) {
             Err(Error::internal("invalid topic"))
         } else if topic.len() > 64 {
             Err(Error::internal("topic cannot exceed 64 bytes"))
         } else {
-            Ok(Self { namespace, topic })
+            Ok(Self(topic))
         }
     }
 }
@@ -79,17 +73,13 @@ impl Deref for TopicName {
     type Target = str;
 
     fn deref(&self) -> &str {
-        &self.topic
+        &self.0
     }
 }
 
 impl fmt::Display for TopicName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(namespace) = &self.namespace {
-            write!(f, "{}{}{}", namespace, NAMESPACE_DELIMITER, self.topic)
-        } else {
-            write!(f, "{}", self.topic)
-        }
+        write!(f, "{}", self.0)
     }
 }
 
@@ -108,8 +98,7 @@ impl<'de> Deserialize<'de> for TopicName {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        let (ns, topic) = parse_namespace(&s);
-        Self::new(ns.map(|x| x.to_owned()), topic.to_owned()).map_err(de::Error::custom)
+        Self::new(s).map_err(de::Error::custom)
     }
 }
 
@@ -143,15 +132,14 @@ impl TryFrom<String> for TopicPartition {
     type Error = Error;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let (ns, rest) = parse_namespace(&value);
-        let (topic, idx_str) = rest
+        let (topic, idx_str) = value
             .rsplit_once(TOPIC_PARTITION_DELIMITER)
             .ok_or_else(|| Error::internal("missing '~' separator in topic"))?;
         let idx: u16 = idx_str
             .parse()
             .map_err(|_| Error::internal("invalid partition index in topic"))?;
         let partition = Partition::new(idx)?;
-        let raw = TopicName::new(ns.map(|x| x.to_owned()), topic.to_owned())?;
+        let raw = TopicName::new(topic.to_owned())?;
         Ok(Self { raw, partition })
     }
 }
@@ -222,14 +210,13 @@ impl<'de> Deserialize<'de> for TopicIn {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        let (ns, rest) = parse_namespace(&s);
-        if rest.contains(TOPIC_PARTITION_DELIMITER) {
-            // Re-parse the full string via Topic::try_from (it handles default namespace too)
+        if s.contains(TOPIC_PARTITION_DELIMITER) {
+            // Re-parse the full string via TopicPartition::try_from
             TopicPartition::try_from(s)
                 .map(TopicIn::TopicPartition)
                 .map_err(de::Error::custom)
         } else {
-            TopicName::new(ns.map(|x| x.to_owned()), rest.to_owned())
+            TopicName::new(s)
                 .map(TopicIn::TopicName)
                 .map_err(de::Error::custom)
         }

--- a/crates/msgs/src/operations/mod.rs
+++ b/crates/msgs/src/operations/mod.rs
@@ -68,12 +68,10 @@ mod tests {
 
         let op = PublishOperation::new(
             NamespaceId::nil(),
-            TopicIn::TopicName(
-                TopicName::new(Some("my-ns".to_string()), "my-topic".to_string()).unwrap(),
-            ),
+            TopicIn::TopicName(TopicName::new("my-topic".to_string()).unwrap()),
             vec![],
         )
         .unwrap();
-        assert_eq!(MsgsOperation::Publish(op).key_name(), "my-ns:my-topic");
+        assert_eq!(MsgsOperation::Publish(op).key_name(), "my-topic");
     }
 }

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -33,7 +33,7 @@ impl PublishOperation {
                         "msg key cannot be specified alongside a specific partition",
                     ));
                 }
-                (tp.raw, Some(tp.partition))
+                (tp.topic, Some(tp.partition))
             }
             TopicIn::TopicName(tn) => (tn, None),
         };

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -35,7 +35,7 @@ impl QueueReceiveOperation {
         lease_duration_ms: DurationMs,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
-            TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
+            TopicIn::TopicPartition(tp) => (tp.topic, Some(tp.partition)),
             TopicIn::TopicName(tn) => (tn, None),
         };
         Ok(Self {

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -44,7 +44,7 @@ impl StreamCommitOperation {
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &topic.raw),
+                TopicRow::key_for(self.namespace_id, &topic.topic),
             )?
             .ok_or_else(|| Error::invalid_user_input("partition must exist"))?;
 

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -39,7 +39,7 @@ impl StreamReceiveOperation {
         default_starting_position: SeekPosition,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
-            TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
+            TopicIn::TopicPartition(tp) => (tp.topic, Some(tp.partition)),
             TopicIn::TopicName(tn) => (tn, None),
         };
         Ok(Self {

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -36,7 +36,7 @@ impl StreamSeekOperation {
         target: SeekTarget,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
-            TopicIn::TopicPartition(tp) => (tp.raw, Some(tp.partition)),
+            TopicIn::TopicPartition(tp) => (tp.topic, Some(tp.partition)),
             TopicIn::TopicName(tn) => (tn, None),
         };
 

--- a/tests/it/msgs/publish.rs
+++ b/tests/it/msgs/publish.rs
@@ -21,7 +21,8 @@ async fn publish_to_topic() -> TestResult {
     let response = client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns1:my-topic",
+            "namespace": "ns1",
+            "topic": "my-topic",
             "msgs": [
                 { "value": "hello".as_bytes() },
                 { "value": "world".as_bytes() },
@@ -41,7 +42,7 @@ async fn publish_to_topic() -> TestResult {
 
     // Each topic should have a partition
     for topic in topics {
-        assert!(topic["topic"].assert_str().starts_with("ns1:my-topic~"));
+        assert!(topic["topic"].assert_str().starts_with("my-topic~"));
     }
 
     Ok(())
@@ -64,7 +65,8 @@ async fn publish_with_partition_key() -> TestResult {
     let response = client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-key:keyed-topic",
+            "namespace": "ns-key",
+            "topic": "keyed-topic",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "user-123" },
                 { "value": "b".as_bytes(), "key": "user-123" },
@@ -85,11 +87,7 @@ async fn publish_with_partition_key() -> TestResult {
 
     // Each topic should have a partition
     for topic in topics {
-        assert!(
-            topic["topic"]
-                .assert_str()
-                .starts_with("ns-key:keyed-topic~")
-        );
+        assert!(topic["topic"].assert_str().starts_with("keyed-topic~"));
     }
 
     Ok(())
@@ -112,14 +110,15 @@ async fn publish_directly_to_partition() -> TestResult {
     // Configure the topic to have 4 partitions.
     client
         .post("v1.msgs.topic.configure")
-        .json(json!({ "topic": "ns-direct:my-topic", "partitions": 4 }))
+        .json(json!({ "namespace": "ns-direct", "topic": "my-topic", "partitions": 4 }))
         .await?
         .expect(StatusCode::OK);
 
     let response = client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-direct:my-topic~2",
+            "namespace": "ns-direct",
+            "topic": "my-topic~2",
             "msgs": [
                 { "value": "a".as_bytes() },
                 { "value": "b".as_bytes() },
@@ -139,11 +138,7 @@ async fn publish_directly_to_partition() -> TestResult {
 
     // Each topic should have a partition
     for topic in topics {
-        assert!(
-            topic["topic"]
-                .assert_str()
-                .starts_with("ns-direct:my-topic~2")
-        );
+        assert!(topic["topic"].assert_str().starts_with("my-topic~2"));
     }
 
     Ok(())

--- a/tests/it/msgs/queue.rs
+++ b/tests/it/msgs/queue.rs
@@ -24,7 +24,8 @@ async fn queue_receive_returns_published_messages() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-queue:my-topic",
+            "namespace": "ns-queue",
+            "topic": "my-topic",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -37,7 +38,8 @@ async fn queue_receive_returns_published_messages() -> TestResult {
     let response = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-queue:my-topic",
+            "namespace": "ns-queue",
+            "topic": "my-topic",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -73,7 +75,8 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-lease:t1",
+            "namespace": "ns-q-lease",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -86,7 +89,8 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
     let r1 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-lease:t1",
+            "namespace": "ns-q-lease",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "batch_size": 1,
         }))
@@ -102,7 +106,8 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
     let r2 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-lease:t1",
+            "namespace": "ns-q-lease",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "batch_size": 1,
         }))
@@ -118,7 +123,8 @@ async fn queue_receive_leases_individual_messages() -> TestResult {
     let r3 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-lease:t1",
+            "namespace": "ns-q-lease",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -150,7 +156,8 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-ack:t1",
+            "namespace": "ns-q-ack",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -164,7 +171,8 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
     let r1 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-ack:t1",
+            "namespace": "ns-q-ack",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "lease_duration_ms": 1000,
         }))
@@ -180,7 +188,8 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
     client
         .post("v1.msgs.queue.ack")
         .json(json!({
-            "topic": "ns-q-ack:t1",
+            "namespace": "ns-q-ack",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "msg_ids": msg_ids,
         }))
@@ -194,7 +203,8 @@ async fn queue_ack_prevents_redelivery() -> TestResult {
     let r2 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-ack:t1",
+            "namespace": "ns-q-ack",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -226,7 +236,8 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-redeliver:t1",
+            "namespace": "ns-q-redeliver",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -239,7 +250,8 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
     let r1 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-redeliver:t1",
+            "namespace": "ns-q-redeliver",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "lease_duration_ms": 1000,
         }))
@@ -255,7 +267,8 @@ async fn unacked_messages_redelivered_after_lease_expiry() -> TestResult {
     let r2 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-redeliver:t1",
+            "namespace": "ns-q-redeliver",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -320,7 +333,8 @@ async fn queue_starts_from_earliest() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-earliest:t1",
+            "namespace": "ns-q-earliest",
+            "topic": "t1",
             "msgs": (0..5)
                 .map(|i| json!({ "value": format!("msg-{i}").as_bytes(), "key": "k1" }))
                 .collect::<Vec<_>>(),
@@ -332,7 +346,8 @@ async fn queue_starts_from_earliest() -> TestResult {
     let response = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-earliest:t1",
+            "namespace": "ns-q-earliest",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -366,7 +381,8 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-partial:t1",
+            "namespace": "ns-q-partial",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -380,7 +396,8 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
     let r1 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-partial:t1",
+            "namespace": "ns-q-partial",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "lease_duration_ms": 1000,
         }))
@@ -397,7 +414,8 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
     client
         .post("v1.msgs.queue.ack")
         .json(json!({
-            "topic": "ns-q-partial:t1",
+            "namespace": "ns-q-partial",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "msg_ids": [first_id, last_id],
         }))
@@ -411,7 +429,8 @@ async fn partial_ack_redelivers_unacked() -> TestResult {
     let r2 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-partial:t1",
+            "namespace": "ns-q-partial",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -450,7 +469,8 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-concurrent:t1",
+            "namespace": "ns-q-concurrent",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -467,7 +487,8 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
     let r_a = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-concurrent:t1",
+            "namespace": "ns-q-concurrent",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "batch_size": 3,
         }))
@@ -482,7 +503,8 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
     let r_b = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-concurrent:t1",
+            "namespace": "ns-q-concurrent",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "batch_size": 3,
         }))
@@ -507,7 +529,8 @@ async fn concurrent_queue_consumers_no_overlap() -> TestResult {
     let r_c = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-concurrent:t1",
+            "namespace": "ns-q-concurrent",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -539,7 +562,8 @@ async fn queue_consumer_groups_independent() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-cg:t1",
+            "namespace": "ns-q-cg",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -553,7 +577,8 @@ async fn queue_consumer_groups_independent() -> TestResult {
     let r_a = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-cg:t1",
+            "namespace": "ns-q-cg",
+            "topic": "t1",
             "consumer_group": "group-a",
         }))
         .await?
@@ -568,7 +593,8 @@ async fn queue_consumer_groups_independent() -> TestResult {
     client
         .post("v1.msgs.queue.ack")
         .json(json!({
-            "topic": "ns-q-cg:t1",
+            "namespace": "ns-q-cg",
+            "topic": "t1",
             "consumer_group": "group-a",
             "msg_ids": msg_ids_a,
         }))
@@ -579,7 +605,8 @@ async fn queue_consumer_groups_independent() -> TestResult {
     let r_b = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-cg:t1",
+            "namespace": "ns-q-cg",
+            "topic": "t1",
             "consumer_group": "group-b",
         }))
         .await?
@@ -613,7 +640,8 @@ async fn nack_sends_to_dlq() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-nack:t1",
+            "namespace": "ns-q-nack",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -626,7 +654,8 @@ async fn nack_sends_to_dlq() -> TestResult {
     let r1 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-nack:t1",
+            "namespace": "ns-q-nack",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "lease_duration_ms": 1000,
         }))
@@ -642,7 +671,8 @@ async fn nack_sends_to_dlq() -> TestResult {
     client
         .post("v1.msgs.queue.nack")
         .json(json!({
-            "topic": "ns-q-nack:t1",
+            "namespace": "ns-q-nack",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "msg_ids": msg_ids,
         }))
@@ -656,7 +686,8 @@ async fn nack_sends_to_dlq() -> TestResult {
     let r2 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-nack:t1",
+            "namespace": "ns-q-nack",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -689,7 +720,8 @@ async fn nack_then_redrive_makes_available() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-redrive:t1",
+            "namespace": "ns-q-redrive",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -702,7 +734,8 @@ async fn nack_then_redrive_makes_available() -> TestResult {
     let r1 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-redrive:t1",
+            "namespace": "ns-q-redrive",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -718,7 +751,8 @@ async fn nack_then_redrive_makes_available() -> TestResult {
     client
         .post("v1.msgs.queue.nack")
         .json(json!({
-            "topic": "ns-q-redrive:t1",
+            "namespace": "ns-q-redrive",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "msg_ids": msg_ids,
         }))
@@ -729,7 +763,8 @@ async fn nack_then_redrive_makes_available() -> TestResult {
     client
         .post("v1.msgs.queue.redrive-dlq")
         .json(json!({
-            "topic": "ns-q-redrive:t1",
+            "namespace": "ns-q-redrive",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -739,7 +774,8 @@ async fn nack_then_redrive_makes_available() -> TestResult {
     let r2 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-redrive:t1",
+            "namespace": "ns-q-redrive",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -816,7 +852,8 @@ async fn redrive_dlq_no_dlq_messages() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-redrive-noop:t1",
+            "namespace": "ns-q-redrive-noop",
+            "topic": "t1",
             "msgs": [{ "value": "a".as_bytes(), "key": "k1" }],
         }))
         .await?
@@ -826,7 +863,8 @@ async fn redrive_dlq_no_dlq_messages() -> TestResult {
     client
         .post("v1.msgs.queue.redrive-dlq")
         .json(json!({
-            "topic": "ns-q-redrive-noop:t1",
+            "namespace": "ns-q-redrive-noop",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -852,7 +890,8 @@ async fn configure_retry_schedule() -> TestResult {
     let response = client
         .post("v1.msgs.queue.configure")
         .json(json!({
-            "topic": "ns-q-cfg:t1",
+            "namespace": "ns-q-cfg",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "retry_schedule": [1000, 5000, 10000],
         }))
@@ -867,17 +906,18 @@ async fn configure_retry_schedule() -> TestResult {
     let response2 = client
         .post("v1.msgs.queue.configure")
         .json(json!({
-            "topic": "ns-q-cfg:t1",
+            "namespace": "ns-q-cfg",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "retry_schedule": [2000],
-            "dlq_topic": "ns-q-cfg:t1-dlq",
+            "dlq_topic": "t1-dlq",
         }))
         .await?
         .expect(StatusCode::OK)
         .json();
 
     assert_eq!(response2["retry_schedule"], json!([2000]));
-    assert_eq!(response2["dlq_topic"], json!("ns-q-cfg:t1-dlq"));
+    assert_eq!(response2["dlq_topic"], json!("t1-dlq"));
 
     Ok(())
 }
@@ -900,7 +940,8 @@ async fn nack_retries_before_dlq() -> TestResult {
     client
         .post("v1.msgs.queue.configure")
         .json(json!({
-            "topic": "ns-q-retry:t1",
+                "namespace": "ns-q-retry",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "retry_schedule": [1000],
         }))
@@ -910,7 +951,8 @@ async fn nack_retries_before_dlq() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-retry:t1",
+            "namespace": "ns-q-retry",
+            "topic": "t1",
             "msgs": [{ "value": "a".as_bytes(), "key": "k1" }],
         }))
         .await?
@@ -920,7 +962,8 @@ async fn nack_retries_before_dlq() -> TestResult {
     let r1 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-retry:t1",
+            "namespace": "ns-q-retry",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "lease_duration_ms": 500,
         }))
@@ -936,7 +979,8 @@ async fn nack_retries_before_dlq() -> TestResult {
     client
         .post("v1.msgs.queue.nack")
         .json(json!({
-            "topic": "ns-q-retry:t1",
+            "namespace": "ns-q-retry",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "msg_ids": [msg_id],
         }))
@@ -947,7 +991,8 @@ async fn nack_retries_before_dlq() -> TestResult {
     let r2 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-retry:t1",
+            "namespace": "ns-q-retry",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -966,7 +1011,8 @@ async fn nack_retries_before_dlq() -> TestResult {
     let r3 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-retry:t1",
+            "namespace": "ns-q-retry",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "lease_duration_ms": 500,
         }))
@@ -986,7 +1032,8 @@ async fn nack_retries_before_dlq() -> TestResult {
     client
         .post("v1.msgs.queue.nack")
         .json(json!({
-            "topic": "ns-q-retry:t1",
+            "namespace": "ns-q-retry",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "msg_ids": [msg_id],
         }))
@@ -1000,7 +1047,8 @@ async fn nack_retries_before_dlq() -> TestResult {
     let r4 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-retry:t1",
+            "namespace": "ns-q-retry",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -1034,10 +1082,11 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     client
         .post("v1.msgs.queue.configure")
         .json(json!({
-            "topic": "ns-q-dlqfwd:t1",
+            "namespace": "ns-q-dlqfwd",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "retry_schedule": [1000],
-            "dlq_topic": "ns-q-dlqfwd:t1-dlq",
+            "dlq_topic": "t1-dlq",
         }))
         .await?
         .expect(StatusCode::OK);
@@ -1045,7 +1094,8 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-q-dlqfwd:t1",
+            "namespace": "ns-q-dlqfwd",
+            "topic": "t1",
             "msgs": [{ "value": "a".as_bytes(), "key": "k1" }],
         }))
         .await?
@@ -1055,7 +1105,8 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     let r1 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-dlqfwd:t1",
+            "namespace": "ns-q-dlqfwd",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "lease_duration_ms": 500,
         }))
@@ -1068,7 +1119,8 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     client
         .post("v1.msgs.queue.nack")
         .json(json!({
-            "topic": "ns-q-dlqfwd:t1",
+            "namespace": "ns-q-dlqfwd",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "msg_ids": [msg_id],
         }))
@@ -1082,7 +1134,8 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     let r2 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-dlqfwd:t1",
+            "namespace": "ns-q-dlqfwd",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "lease_duration_ms": 500,
         }))
@@ -1095,7 +1148,8 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     client
         .post("v1.msgs.queue.nack")
         .json(json!({
-            "topic": "ns-q-dlqfwd:t1",
+            "namespace": "ns-q-dlqfwd",
+            "topic": "t1",
             "consumer_group": "test-cg",
             "msg_ids": [msg_id],
         }))
@@ -1107,7 +1161,8 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     let r3 = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-dlqfwd:t1",
+            "namespace": "ns-q-dlqfwd",
+            "topic": "t1",
             "consumer_group": "test-cg",
         }))
         .await?
@@ -1119,7 +1174,8 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     let r_dlq = client
         .post("v1.msgs.queue.receive")
         .json(json!({
-            "topic": "ns-q-dlqfwd:t1-dlq",
+            "namespace": "ns-q-dlqfwd",
+            "topic": "t1-dlq",
             "consumer_group": "test-cg",
         }))
         .await?

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -25,7 +25,8 @@ async fn stream_receive_returns_published_messages() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-recv:my-topic",
+            "namespace": "ns-recv",
+            "topic": "my-topic",
             "consumer_group": "cg1",
         }))
         .await?
@@ -34,7 +35,8 @@ async fn stream_receive_returns_published_messages() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-recv:my-topic",
+            "namespace": "ns-recv",
+            "topic": "my-topic",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "user-1" },
                 { "value": "b".as_bytes(), "key": "user-1" },
@@ -47,7 +49,8 @@ async fn stream_receive_returns_published_messages() -> TestResult {
     let response = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-recv:my-topic",
+            "namespace": "ns-recv",
+            "topic": "my-topic",
             "consumer_group": "cg1",
         }))
         .await?
@@ -61,7 +64,7 @@ async fn stream_receive_returns_published_messages() -> TestResult {
         assert!(m["offset"].is_u64());
         let topic = m["topic"].assert_str();
         assert!(
-            topic.starts_with("ns-recv:my-topic~"),
+            topic.starts_with("my-topic~"),
             "topic should be partition-level: {topic}"
         );
         assert!(!m["value"].is_null());
@@ -94,7 +97,8 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-nodup:t1",
+            "namespace": "ns-nodup",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -103,7 +107,8 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-nodup:t1",
+            "namespace": "ns-nodup",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -116,7 +121,8 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-nodup:t1",
+            "namespace": "ns-nodup",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -128,14 +134,14 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     let _r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-nodup:t1",
+            "namespace": "ns-nodup",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
         .expect(StatusCode::BAD_REQUEST);
 
-    // Commit the first batch to unlock the partition.
-    // The response topic already includes the namespace, so we can pass it directly.
+    // Commit the first batch to unlock the partition (same namespace as receive).
     let msgs = r1["msgs"].assert_array();
     let partition_topic = msgs[0]["topic"].assert_str();
     let last_offset = msgs[1]["offset"].assert_u64();
@@ -143,6 +149,7 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     client
         .post("v1.msgs.stream.commit")
         .json(json!({
+            "namespace": "ns-nodup",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -154,7 +161,8 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-nodup:t1",
+            "namespace": "ns-nodup",
+            "topic": "t1",
             "msgs": [
                 { "value": "c".as_bytes(), "key": "k1" },
             ],
@@ -166,7 +174,8 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     let r3 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-nodup:t1",
+            "namespace": "ns-nodup",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -195,7 +204,8 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-cg:t1",
+            "namespace": "ns-cg",
+            "topic": "t1",
             "consumer_group": "group-a",
         }))
         .await?
@@ -204,7 +214,8 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-cg:t1",
+            "namespace": "ns-cg",
+            "topic": "t1",
             "consumer_group": "group-b",
         }))
         .await?
@@ -213,7 +224,8 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-cg:t1",
+            "namespace": "ns-cg",
+            "topic": "t1",
             "msgs": [
                 { "value": "x".as_bytes(), "key": "k1" },
                 { "value": "y".as_bytes(), "key": "k1" },
@@ -225,7 +237,8 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     let r_a = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-cg:t1",
+            "namespace": "ns-cg",
+            "topic": "t1",
             "consumer_group": "group-a",
         }))
         .await?
@@ -235,7 +248,8 @@ async fn different_consumer_groups_get_same_messages() -> TestResult {
     let r_b = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-cg:t1",
+            "namespace": "ns-cg",
+            "topic": "t1",
             "consumer_group": "group-b",
         }))
         .await?
@@ -295,7 +309,8 @@ async fn stream_receive_with_defaults() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-def:t1",
+            "namespace": "ns-def",
+            "topic": "t1",
             "consumer_group": "cg-default",
         }))
         .await?
@@ -304,7 +319,8 @@ async fn stream_receive_with_defaults() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-def:t1",
+            "namespace": "ns-def",
+            "topic": "t1",
             "msgs": [{ "value": "hello".as_bytes(), "key": "k1" }],
         }))
         .await?
@@ -314,7 +330,8 @@ async fn stream_receive_with_defaults() -> TestResult {
     let response = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-def:t1",
+            "namespace": "ns-def",
+            "topic": "t1",
             "consumer_group": "cg-default",
         }))
         .await?
@@ -345,7 +362,8 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-lock:t1",
+            "namespace": "ns-lock",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -354,7 +372,8 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-lock:t1",
+            "namespace": "ns-lock",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -370,7 +389,8 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     let r_a = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-lock:t1",
+            "namespace": "ns-lock",
+            "topic": "t1",
             "consumer_group": "cg1",
             "batch_size": 2,
         }))
@@ -383,14 +403,14 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     let _ = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-lock:t1",
+            "namespace": "ns-lock",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
         .expect(StatusCode::BAD_REQUEST);
 
     // Consumer A commits — unlocks the partition.
-    // The response topic already includes the namespace.
     let msgs_a = r_a["msgs"].assert_array();
     let partition_topic = msgs_a[0]["topic"].assert_str();
     let last_offset = msgs_a[1]["offset"].assert_u64();
@@ -398,6 +418,7 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     client
         .post("v1.msgs.stream.commit")
         .json(json!({
+            "namespace": "ns-lock",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -409,7 +430,8 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     let r_b = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-lock:t1",
+            "namespace": "ns-lock",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -442,7 +464,8 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     client
         .post("v1.msgs.topic.configure")
         .json(json!({
-            "topic": "ns-concurrent:t1",
+            "namespace": "ns-concurrent",
+            "topic": "t1",
             "partitions": 16,
         }))
         .await?
@@ -452,7 +475,8 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-concurrent:t1",
+            "namespace": "ns-concurrent",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -462,7 +486,8 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-concurrent:t1",
+            "namespace": "ns-concurrent",
+            "topic": "t1",
             "msgs": [
                 { "value": "a1".as_bytes(), "key": "k1" },
                 { "value": "a2".as_bytes(), "key": "k1" },
@@ -483,7 +508,8 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     let r_a = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-concurrent:t1",
+            "namespace": "ns-concurrent",
+            "topic": "t1",
             "consumer_group": "cg1",
             "batch_size": 5,
         }))
@@ -498,7 +524,8 @@ async fn concurrent_consumers_receive_from_different_partitions() -> TestResult 
     let r_b = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-concurrent:t1",
+            "namespace": "ns-concurrent",
+            "topic": "t1",
             "consumer_group": "cg1",
             "batch_size": 10,
         }))
@@ -549,7 +576,8 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-commit:t1",
+            "namespace": "ns-commit",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -558,7 +586,8 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-commit:t1",
+            "namespace": "ns-commit",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -572,7 +601,8 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-commit:t1",
+            "namespace": "ns-commit",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -582,8 +612,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     let msgs = r1["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
-    // Extract partition-level topic and last offset in the batch.
-    // The response topic already includes the namespace.
+    // Extract partition-level topic and last offset in the batch (commit uses the same namespace).
     let partition_topic = msgs[0]["topic"].assert_str();
     let last_offset = msgs[2]["offset"].assert_u64();
 
@@ -591,6 +620,7 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     client
         .post("v1.msgs.stream.commit")
         .json(json!({
+            "namespace": "ns-commit",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -602,7 +632,8 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     let r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-commit:t1",
+            "namespace": "ns-commit",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -614,7 +645,8 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-commit:t1",
+            "namespace": "ns-commit",
+            "topic": "t1",
             "msgs": [
                 { "value": "d".as_bytes(), "key": "k1" },
             ],
@@ -628,7 +660,8 @@ async fn commit_then_receive_no_duplicates() -> TestResult {
     let r3 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-commit:t1",
+            "namespace": "ns-commit",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -657,7 +690,8 @@ async fn commit_requires_partition_topic() -> TestResult {
     client
         .post("v1.msgs.stream.commit")
         .json(json!({
-            "topic": "ns-commit-pt:t1",
+            "namespace": "ns-commit-pt",
+            "topic": "t1",
             "consumer_group": "cg1",
             "offset": 0,
         }))
@@ -707,7 +741,8 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-race:t1",
+            "namespace": "ns-race",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -717,7 +752,8 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-race:t1",
+            "namespace": "ns-race",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -734,9 +770,10 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
         handles.push(tokio::spawn(async move {
             c.post("v1.msgs.stream.receive")
                 .json(json!({
-                    "topic": "ns-race:t1",
-                    "consumer_group": "cg1",
-                }))
+                        "namespace": "ns-race",
+                "topic": "t1",
+                        "consumer_group": "cg1",
+                    }))
                 .await
         }));
     }
@@ -780,7 +817,8 @@ async fn partial_commit_preserves_lease() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-partial:t1",
+            "namespace": "ns-partial",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -790,7 +828,8 @@ async fn partial_commit_preserves_lease() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-partial:t1",
+            "namespace": "ns-partial",
+            "topic": "t1",
             "msgs": (0..10)
                 .map(|i| json!({ "value": format!("msg-{i}").as_bytes(), "key": "k1" }))
                 .collect::<Vec<_>>(),
@@ -802,7 +841,8 @@ async fn partial_commit_preserves_lease() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-partial:t1",
+            "namespace": "ns-partial",
+            "topic": "t1",
             "consumer_group": "cg1",
             "batch_size": 5,
         }))
@@ -821,6 +861,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
     client
         .post("v1.msgs.stream.commit")
         .json(json!({
+            "namespace": "ns-partial",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": first_offset,
@@ -832,7 +873,8 @@ async fn partial_commit_preserves_lease() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-partial:t1",
+            "namespace": "ns-partial",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -842,6 +884,7 @@ async fn partial_commit_preserves_lease() -> TestResult {
     client
         .post("v1.msgs.stream.commit")
         .json(json!({
+            "namespace": "ns-partial",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -853,7 +896,8 @@ async fn partial_commit_preserves_lease() -> TestResult {
     let r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-partial:t1",
+            "namespace": "ns-partial",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -886,7 +930,8 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-latest:t1",
+            "namespace": "ns-latest",
+            "topic": "t1",
             "msgs": (0..5)
                 .map(|i| json!({ "value": format!("old-{i}").as_bytes(), "key": "k1" }))
                 .collect::<Vec<_>>(),
@@ -898,7 +943,8 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-latest:t1",
+            "namespace": "ns-latest",
+            "topic": "t1",
             "consumer_group": "cg-new",
         }))
         .await?
@@ -914,7 +960,8 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-latest:t1",
+            "namespace": "ns-latest",
+            "topic": "t1",
             "msgs": (0..3)
                 .map(|i| json!({ "value": format!("new-{i}").as_bytes(), "key": "k1" }))
                 .collect::<Vec<_>>(),
@@ -926,7 +973,8 @@ async fn new_consumer_group_starts_from_latest() -> TestResult {
     let r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-latest:t1",
+            "namespace": "ns-latest",
+            "topic": "t1",
             "consumer_group": "cg-new",
         }))
         .await?
@@ -1046,7 +1094,8 @@ async fn default_starting_position_earliest_gets_preexisting() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-dsp:t1",
+            "namespace": "ns-dsp",
+            "topic": "t1",
             "msgs": (0..5)
                 .map(|i| json!({ "value": format!("msg-{i}").as_bytes(), "key": "k1" }))
                 .collect::<Vec<_>>(),
@@ -1058,7 +1107,8 @@ async fn default_starting_position_earliest_gets_preexisting() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-dsp:t1",
+            "namespace": "ns-dsp",
+            "topic": "t1",
             "consumer_group": "cg1",
             "default_starting_position": "earliest",
         }))

--- a/tests/it/msgs/stream_seek.rs
+++ b/tests/it/msgs/stream_seek.rs
@@ -22,7 +22,8 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-earliest:t1",
+            "namespace": "ns-seek-earliest",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -32,7 +33,8 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-seek-earliest:t1",
+            "namespace": "ns-seek-earliest",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -46,7 +48,8 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-earliest:t1",
+            "namespace": "ns-seek-earliest",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -62,6 +65,7 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     client
         .post("v1.msgs.stream.commit")
         .json(json!({
+            "namespace": "ns-seek-earliest",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -73,7 +77,8 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     let r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-earliest:t1",
+            "namespace": "ns-seek-earliest",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -85,7 +90,8 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     client
         .post("v1.msgs.stream.seek")
         .json(json!({
-            "topic": "ns-seek-earliest:t1",
+            "namespace": "ns-seek-earliest",
+            "topic": "t1",
             "consumer_group": "cg1",
             "position": "earliest",
         }))
@@ -96,7 +102,8 @@ async fn seek_earliest_replays_all_messages() -> TestResult {
     let r3 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-earliest:t1",
+            "namespace": "ns-seek-earliest",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -130,7 +137,8 @@ async fn seek_latest_skips_existing() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-seek-latest:t1",
+            "namespace": "ns-seek-latest",
+            "topic": "t1",
             "msgs": [
                 { "value": "old-a".as_bytes(), "key": "k1" },
                 { "value": "old-b".as_bytes(), "key": "k1" },
@@ -143,7 +151,8 @@ async fn seek_latest_skips_existing() -> TestResult {
     client
         .post("v1.msgs.stream.seek")
         .json(json!({
-            "topic": "ns-seek-latest:t1",
+            "namespace": "ns-seek-latest",
+            "topic": "t1",
             "consumer_group": "cg1",
             "position": "latest",
         }))
@@ -154,7 +163,8 @@ async fn seek_latest_skips_existing() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-latest:t1",
+            "namespace": "ns-seek-latest",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -170,7 +180,8 @@ async fn seek_latest_skips_existing() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-seek-latest:t1",
+            "namespace": "ns-seek-latest",
+            "topic": "t1",
             "msgs": [
                 { "value": "new-a".as_bytes(), "key": "k1" },
                 { "value": "new-b".as_bytes(), "key": "k1" },
@@ -183,7 +194,8 @@ async fn seek_latest_skips_existing() -> TestResult {
     let r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-latest:t1",
+            "namespace": "ns-seek-latest",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -216,7 +228,8 @@ async fn seek_to_specific_offset() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-offset:t1",
+            "namespace": "ns-seek-offset",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -226,7 +239,8 @@ async fn seek_to_specific_offset() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-seek-offset:t1",
+            "namespace": "ns-seek-offset",
+            "topic": "t1",
             "msgs": (0..5)
                 .map(|i| json!({ "value": format!("msg-{i}").as_bytes(), "key": "k1" }))
                 .collect::<Vec<_>>(),
@@ -238,7 +252,8 @@ async fn seek_to_specific_offset() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-offset:t1",
+            "namespace": "ns-seek-offset",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -254,6 +269,7 @@ async fn seek_to_specific_offset() -> TestResult {
     client
         .post("v1.msgs.stream.commit")
         .json(json!({
+            "namespace": "ns-seek-offset",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": last_offset,
@@ -265,6 +281,7 @@ async fn seek_to_specific_offset() -> TestResult {
     client
         .post("v1.msgs.stream.seek")
         .json(json!({
+            "namespace": "ns-seek-offset",
             "topic": partition_topic,
             "consumer_group": "cg1",
             "offset": 2,
@@ -276,7 +293,8 @@ async fn seek_to_specific_offset() -> TestResult {
     let r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-offset:t1",
+            "namespace": "ns-seek-offset",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -312,7 +330,8 @@ async fn seek_offset_requires_partition_topic() -> TestResult {
     client
         .post("v1.msgs.stream.seek")
         .json(json!({
-            "topic": "ns-seek-pt:t1",
+            "namespace": "ns-seek-pt",
+            "topic": "t1",
             "consumer_group": "cg1",
             "offset": 0,
         }))
@@ -340,7 +359,8 @@ async fn seek_position_works_on_topic_level() -> TestResult {
     client
         .post("v1.msgs.topic.configure")
         .json(json!({
-            "topic": "ns-seek-topic:t1",
+            "namespace": "ns-seek-topic",
+            "topic": "t1",
             "partitions": 16,
         }))
         .await?
@@ -350,7 +370,8 @@ async fn seek_position_works_on_topic_level() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-topic:t1",
+            "namespace": "ns-seek-topic",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -360,7 +381,8 @@ async fn seek_position_works_on_topic_level() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-seek-topic:t1",
+            "namespace": "ns-seek-topic",
+            "topic": "t1",
             "msgs": [
                 { "value": "a1".as_bytes(), "key": "k1" },
                 { "value": "a2".as_bytes(), "key": "k1" },
@@ -375,7 +397,8 @@ async fn seek_position_works_on_topic_level() -> TestResult {
     client
         .post("v1.msgs.stream.seek")
         .json(json!({
-            "topic": "ns-seek-topic:t1",
+            "namespace": "ns-seek-topic",
+            "topic": "t1",
             "consumer_group": "cg1",
             "position": "earliest",
         }))
@@ -386,7 +409,8 @@ async fn seek_position_works_on_topic_level() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-topic:t1",
+            "namespace": "ns-seek-topic",
+            "topic": "t1",
             "consumer_group": "cg1",
             "batch_size": 10,
         }))
@@ -443,7 +467,8 @@ async fn seek_clears_lease() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-lease:t1",
+            "namespace": "ns-seek-lease",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -452,7 +477,8 @@ async fn seek_clears_lease() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-seek-lease:t1",
+            "namespace": "ns-seek-lease",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k1" },
@@ -465,7 +491,8 @@ async fn seek_clears_lease() -> TestResult {
     let r1 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-lease:t1",
+            "namespace": "ns-seek-lease",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -477,7 +504,8 @@ async fn seek_clears_lease() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-lease:t1",
+            "namespace": "ns-seek-lease",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -487,7 +515,8 @@ async fn seek_clears_lease() -> TestResult {
     client
         .post("v1.msgs.stream.seek")
         .json(json!({
-            "topic": "ns-seek-lease:t1",
+            "namespace": "ns-seek-lease",
+            "topic": "t1",
             "consumer_group": "cg1",
             "position": "earliest",
         }))
@@ -498,7 +527,8 @@ async fn seek_clears_lease() -> TestResult {
     let r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-seek-lease:t1",
+            "namespace": "ns-seek-lease",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?

--- a/tests/it/msgs/topic_configure.rs
+++ b/tests/it/msgs/topic_configure.rs
@@ -63,10 +63,7 @@ async fn default_is_one_partition() -> TestResult {
     // All messages should be on the same single partition
     let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].assert_str()).collect();
     assert_eq!(topics.len(), 1, "all messages should be on one partition");
-    assert!(
-        topics.contains("t1~0"),
-        "single partition should be t1~0"
-    );
+    assert!(topics.contains("t1~0"), "single partition should be t1~0");
 
     Ok(())
 }

--- a/tests/it/msgs/topic_configure.rs
+++ b/tests/it/msgs/topic_configure.rs
@@ -24,7 +24,8 @@ async fn default_is_one_partition() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-def-part:t1",
+            "namespace": "ns-def-part",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -34,7 +35,8 @@ async fn default_is_one_partition() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-def-part:t1",
+            "namespace": "ns-def-part",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "alpha" },
                 { "value": "b".as_bytes(), "key": "beta" },
@@ -47,7 +49,8 @@ async fn default_is_one_partition() -> TestResult {
     let response = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-def-part:t1",
+            "namespace": "ns-def-part",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -61,8 +64,8 @@ async fn default_is_one_partition() -> TestResult {
     let topics: HashSet<&str> = msgs.iter().map(|m| m["topic"].assert_str()).collect();
     assert_eq!(topics.len(), 1, "all messages should be on one partition");
     assert!(
-        topics.contains("ns-def-part:t1~0"),
-        "single partition should be ns-def-part:t1~0"
+        topics.contains("t1~0"),
+        "single partition should be t1~0"
     );
 
     Ok(())
@@ -85,7 +88,8 @@ async fn configure_topic_partitions() -> TestResult {
     let response = client
         .post("v1.msgs.topic.configure")
         .json(json!({
-            "topic": "ns-conf:t1",
+            "namespace": "ns-conf",
+            "topic": "t1",
             "partitions": 4,
         }))
         .await?
@@ -98,7 +102,8 @@ async fn configure_topic_partitions() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-conf:t1",
+            "namespace": "ns-conf",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -108,7 +113,8 @@ async fn configure_topic_partitions() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-conf:t1",
+            "namespace": "ns-conf",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "alpha" },
                 { "value": "b".as_bytes(), "key": "beta" },
@@ -121,7 +127,8 @@ async fn configure_topic_partitions() -> TestResult {
     let response = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-conf:t1",
+            "namespace": "ns-conf",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -131,14 +138,14 @@ async fn configure_topic_partitions() -> TestResult {
     let msgs = response["msgs"].assert_array();
     assert_eq!(msgs.len(), 3);
 
-    // All partition-level topics should be within ns-conf:t1~0..ns-conf:t1~3
+    // All partition-level topics should be within t1~0..t1~3 (namespace ns-conf).
     for m in msgs {
         let topic = m["topic"].assert_str();
         assert!(
-            topic.starts_with("ns-conf:t1~"),
+            topic.starts_with("t1~"),
             "expected partition-level topic: {topic}"
         );
-        let partition: u16 = topic.strip_prefix("ns-conf:t1~").unwrap().parse()?;
+        let partition: u16 = topic.strip_prefix("t1~").unwrap().parse()?;
         assert!(partition < 4, "partition {partition} should be < 4");
     }
 
@@ -162,7 +169,8 @@ async fn cannot_decrease_partitions() -> TestResult {
     client
         .post("v1.msgs.topic.configure")
         .json(json!({
-            "topic": "ns-dec:t1",
+            "namespace": "ns-dec",
+            "topic": "t1",
             "partitions": 4,
         }))
         .await?
@@ -172,7 +180,8 @@ async fn cannot_decrease_partitions() -> TestResult {
     client
         .post("v1.msgs.topic.configure")
         .json(json!({
-            "topic": "ns-dec:t1",
+            "namespace": "ns-dec",
+            "topic": "t1",
             "partitions": 2,
         }))
         .await?
@@ -198,7 +207,8 @@ async fn configure_rejects_zero() -> TestResult {
     client
         .post("v1.msgs.topic.configure")
         .json(json!({
-            "topic": "ns-zero:t1",
+            "namespace": "ns-zero",
+            "topic": "t1",
             "partitions": 0,
         }))
         .await?
@@ -224,7 +234,8 @@ async fn configure_rejects_over_max() -> TestResult {
     client
         .post("v1.msgs.topic.configure")
         .json(json!({
-            "topic": "ns-max:t1",
+            "namespace": "ns-max",
+            "topic": "t1",
             "partitions": 65,
         }))
         .await?
@@ -271,7 +282,8 @@ async fn receive_respects_configured_partitions() -> TestResult {
     client
         .post("v1.msgs.topic.configure")
         .json(json!({
-            "topic": "ns-recv-conf:t1",
+            "namespace": "ns-recv-conf",
+            "topic": "t1",
             "partitions": 16,
         }))
         .await?
@@ -281,7 +293,8 @@ async fn receive_respects_configured_partitions() -> TestResult {
     client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-recv-conf:t1",
+            "namespace": "ns-recv-conf",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -291,7 +304,8 @@ async fn receive_respects_configured_partitions() -> TestResult {
     client
         .post("v1.msgs.publish")
         .json(json!({
-            "topic": "ns-recv-conf:t1",
+            "namespace": "ns-recv-conf",
+            "topic": "t1",
             "msgs": [
                 { "value": "a".as_bytes(), "key": "k1" },
                 { "value": "b".as_bytes(), "key": "k2" },
@@ -303,7 +317,8 @@ async fn receive_respects_configured_partitions() -> TestResult {
     let response = client
         .post("v1.msgs.stream.receive")
         .json(json!({
-            "topic": "ns-recv-conf:t1",
+            "namespace": "ns-recv-conf",
+            "topic": "t1",
             "consumer_group": "cg1",
         }))
         .await?
@@ -323,10 +338,10 @@ async fn receive_respects_configured_partitions() -> TestResult {
 
     for topic in &topics {
         assert!(
-            topic.starts_with("ns-recv-conf:t1~"),
+            topic.starts_with("t1~"),
             "expected partition-level topic: {topic}"
         );
-        let partition: u16 = topic.strip_prefix("ns-recv-conf:t1~").unwrap().parse()?;
+        let partition: u16 = topic.strip_prefix("t1~").unwrap().parse()?;
         assert!(partition < 16, "partition {partition} should be < 16");
     }
 


### PR DESCRIPTION
Follow up of https://github.com/svix/coyote-private/pull/530

I'd missed removing the namespace from the topic name, which made me realize I'd actually missed quite a lot of tests. The namespace in the topic wasn't actually being used (the API was updated), but they probably still worked because they worked with the default ns.

Anyway, this fixes the remaining bits. 