### PR TITLE
cluster: move the manual-initialization API to the admin API

### DIFF
--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -278,6 +278,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         opentelemetry_sample_ratio: None,
         opentelemetry_service_name: "coyote-test".to_string(),
         environment: Environment::Dev,
+        bootstrap_max_wait_time: Some(Duration::from_secs(1)),
         cluster: ClusterConfiguration {
             advertised_address: None,
             listen_address: Some(cluster_addr),

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -278,7 +278,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         opentelemetry_sample_ratio: None,
         opentelemetry_service_name: "coyote-test".to_string(),
         environment: Environment::Dev,
-        bootstrap_max_wait_time: Some(Duration::from_secs(1)),
+        bootstrap_max_wait_time: Some(Duration::from_secs(10)),
         cluster: ClusterConfiguration {
             advertised_address: None,
             listen_address: Some(cluster_addr),

--- a/openapi.json
+++ b/openapi.json
@@ -77,6 +77,83 @@
         ]
       }
     },
+    "/api/v1.admin.cluster.initialize": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Cluster Initialize",
+        "description": "Initialize this node as the leader of a new cluster\n\nThis operation may only be performed against a node which has not been\ninitialized and is not currently a member of a cluster.",
+        "operationId": "v1.admin.cluster.initialize",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClusterInitializeIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClusterInitializeOut"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
     "/api/v1.admin.cluster.remove-node": {
       "post": {
         "tags": [
@@ -4062,6 +4139,20 @@
       },
       "CacheSetOut": {
         "type": "object"
+      },
+      "ClusterInitializeIn": {
+        "type": "object"
+      },
+      "ClusterInitializeOut": {
+        "type": "object",
+        "properties": {
+          "cluster_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster_id"
+        ]
       },
       "ClusterRemoveNodeIn": {
         "type": "object",

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -221,21 +221,38 @@ fn load_commands(
     Ok(commands)
 }
 
-pub async fn run(app_config: AppConfig, raft_state: RaftState) -> anyhow::Result<()> {
-    let t = Instant::now();
-    // FIXME: Do something smarter here:
-    let mut retries = 100;
+async fn wait_for_up(config: &AppConfig, raft_state: &RaftState) -> anyhow::Result<()> {
+    let mut deadline: std::pin::Pin<Box<dyn Future<Output = ()> + Send>> =
+        if let Some(time) = config.bootstrap_max_wait_time {
+            Box::pin(tokio::time::sleep(time))
+        } else {
+            Box::pin(futures_util::future::pending())
+        };
     let shutdown = crate::shutting_down_token();
-    while !raft_state.is_up().await && retries > 0 {
-        retries -= 1;
-        if shutdown
-            .run_until_cancelled(tokio::time::sleep(std::time::Duration::from_millis(100)))
-            .await
-            .is_none()
-        {
-            anyhow::bail!("shut down before bootstrap finished");
+    let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
+
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                anyhow::bail!("process shut down before bootstrap finished");
+            }
+            _ = deadline.as_mut() => {
+                anyhow::bail!("bootstrap timeout exceeded");
+            },
+            _ = interval.tick() => {
+                if raft_state.is_up().await {
+                    tracing::trace!("cluster is up");
+                    return Ok(())
+                }
+            }
         }
     }
+}
+
+pub async fn run(app_config: AppConfig, raft_state: RaftState) -> anyhow::Result<()> {
+    let t = Instant::now();
+
+    wait_for_up(&app_config, &raft_state).await?;
 
     let commands = load_commands(
         app_config.bootstrap_cfg_path.as_deref(),

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -468,6 +468,16 @@ pub struct ConfigurationInner {
     #[serde(default)]
     pub bootstrap_cfg: Option<String>,
 
+    /// Maximum time to wait for cluster initialization at startup
+    ///
+    /// If this is unset, we will wait indefinitely.
+    #[serde(
+        rename = "bootstrap_max_wait_ms",
+        with = "crate::serde::duration::opt_ms",
+        default
+    )]
+    pub bootstrap_max_wait_time: Option<Duration>,
+
     /// A pre-set admin token to use instead of having coyote generate one automatically.
     ///
     /// Under normal circumstances you should not set this, and instead let coyote generate the
@@ -620,6 +630,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         environment,
         bootstrap_cfg_path,
         bootstrap_cfg,
+        bootstrap_max_wait_time,
         admin_token,
         cluster:
             ClusterConfiguration {
@@ -701,6 +712,9 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
     }
     if let Some(value) = env_var_ms("COYOTE_CLUSTER_SNAPSHOT_AFTER_MS")? {
         *cluster_snapshot_after_time = Some(value);
+    }
+    if let Some(value) = env_var_ms("COYOTE_BOOTSTRAP_MAX_WAIT_MS")? {
+        *bootstrap_max_wait_time = Some(value);
     }
 
     config.validate()?;

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::disallowed_types)] // we can't use MsgPackOrJson because these endpoints are not OpenAPI-based
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::Arc;
 
 use axum::{
     Extension, Json,
@@ -20,7 +20,7 @@ use openraft::{
 use serde::Serialize;
 use tap::{Pipe, TapFallible};
 
-use super::{Node, NodeId, handle::RaftState, network::detect_address, proto::*, raft::TypeConfig};
+use super::{Node, NodeId, handle::RaftState, proto::*, raft::TypeConfig};
 use crate::{AppState, Configuration};
 
 #[derive(Clone)]
@@ -66,8 +66,7 @@ pub fn router(cfg: &Configuration) -> axum::Router<AppState> {
         .route(
             "/repl/raft/admin/change-membership",
             post(change_membership),
-        )
-        .route("/repl/raft/admin/initialize", post(initialize));
+        );
 
     if let Some(secret) = &cfg.cluster.secret {
         authenticated = authenticated
@@ -78,6 +77,7 @@ pub fn router(cfg: &Configuration) -> axum::Router<AppState> {
     let unauthenticated = axum::Router::new()
         .route("/repl/raft/admin/metrics", get(metrics))
         .route("/repl/discover", get(discover))
+        .route("/repl/node-id", get(get_node_id))
         .route("/repl/raft/admin/force-snapshot", post(force_snapshot)) // TODO: should this be unauth?
         .route("/repl/health", get(health));
 
@@ -192,6 +192,12 @@ async fn handle_forwarded_write(
 
 // Administrative functions
 
+async fn get_node_id(Extension(raft_state): Extension<RaftState>) -> MsgPack<GetNodeIdResponse> {
+    MsgPack(GetNodeIdResponse {
+        node_id: raft_state.node_id,
+    })
+}
+
 async fn discover(
     State(app_state): State<AppState>,
     Extension(raft_state): Extension<RaftState>,
@@ -278,23 +284,6 @@ async fn change_membership(
     state
         .raft
         .change_membership(request.desired_node_ids.clone(), false)
-        .await
-        .pipe(admin_response)
-}
-
-async fn initialize(
-    State(app_state): State<AppState>,
-    Extension(state): Extension<RaftState>,
-) -> impl IntoResponse {
-    let addr = match detect_address(&app_state.cfg) {
-        Ok(a) => a,
-        Err(_e) => return internal_error("could not find any valid addresses"),
-    };
-    let my_node = Node::new(addr);
-    let nodes = [(state.node_id, my_node)]
-        .into_iter()
-        .collect::<BTreeMap<_, _>>();
-    super::raft::initialize_cluster(&state.raft, nodes)
         .await
         .pipe(admin_response)
 }

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::BTreeMap,
-    net::SocketAddr,
     time::{Duration, Instant},
 };
 
@@ -34,31 +33,15 @@ pub(super) struct Discovery {
     network: NetworkFactory,
 }
 
-fn is_not_any(s: &SocketAddr) -> bool {
-    match s {
-        SocketAddr::V4(s) => s.ip().is_unspecified(),
-        SocketAddr::V6(s) => s.ip().is_unspecified(),
-    }
-}
-
 impl Discovery {
-    pub(super) fn new(
+    pub(super) async fn new(
         cfg: Configuration,
         raft: Raft,
         my_node_id: NodeId,
         network: NetworkFactory,
     ) -> anyhow::Result<Self> {
-        let client = build_client(&cfg, cfg.cluster.discovery_request_timeout)?;
-        let cluster_addr = cfg.cluster.listen_address(&cfg);
-        let my_addr = if let Some(addr) = &cfg.cluster.advertised_address {
-            addr.clone()
-        } else if is_not_any(&cluster_addr) {
-            tracing::debug!(listen_address=?cluster_addr, "advertised_address not passed, but listen_address is not INADDR_ANY, so using that");
-            cluster_addr.into()
-        } else {
-            tracing::debug!("advertised_address not passed, attempting to detect local socketaddr");
-            PeerAddr::SocketAddr(detect_address(&cfg)?)
-        };
+        let client = build_client(&cfg, cfg.cluster.discovery_request_timeout, false)?;
+        let my_addr = detect_address(&cfg, my_node_id).await?;
         Ok(Self {
             my_addr,
             client,

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -388,7 +388,8 @@ impl RaftState {
             tracing::debug!("node already has cluster information; skipping discovery");
         } else {
             tracing::debug!("node has no cluster information; kicking off discovery");
-            let disco = Discovery::new(self.cfg.clone(), self.raft.clone(), self.node_id, network)?;
+            let disco =
+                Discovery::new(self.cfg.clone(), self.raft.clone(), self.node_id, network).await?;
             if let Err(err) = disco.discover_cluster().await {
                 tracing::error!(
                     ?err,

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -7,11 +7,11 @@ mod discovery;
 mod errors;
 mod handle;
 mod logs;
-mod network;
+pub(crate) mod network;
 mod node;
 mod operations;
 pub mod proto;
-mod raft;
+pub(crate) mod raft;
 mod serialized_state_machine;
 mod state_machine;
 

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::cfg::Configuration;
+use crate::cfg::{Configuration, PeerAddr};
 
 use super::{Node, NodeId, proto, raft::TypeConfig};
 use anyhow::Context;
@@ -19,10 +19,11 @@ use tap::Pipe;
 
 pub(super) fn build_client(
     cfg: &Configuration,
-    _request_timeout: Duration,
+    request_timeout: Duration,
+    include_secret: bool,
 ) -> anyhow::Result<reqwest::Client> {
     let mut headers = HeaderMap::new();
-    if let Some(secret) = &cfg.cluster.secret {
+    if include_secret && let Some(secret) = &cfg.cluster.secret {
         let header_value = format!("Bearer {secret}");
         let header_value =
             HeaderValue::from_str(&header_value).context("invalid interserver secret")?;
@@ -30,6 +31,7 @@ pub(super) fn build_client(
     }
     let client = reqwest::Client::builder()
         .connect_timeout(cfg.cluster.connection_timeout)
+        .timeout(request_timeout)
         .http2_prior_knowledge()
         .default_headers(headers)
         .build()
@@ -46,7 +48,7 @@ pub(super) struct NetworkFactory {
 impl NetworkFactory {
     pub(super) fn new(cfg: &Configuration) -> anyhow::Result<Self> {
         Ok(Self {
-            client: build_client(cfg, cfg.cluster.replication_request_timeout)?,
+            client: build_client(cfg, cfg.cluster.replication_request_timeout, true)?,
             cfg: cfg.clone(),
         })
     }
@@ -268,16 +270,72 @@ impl NetworkFactory {
     }
 }
 
-pub(super) fn detect_address(cfg: &Configuration) -> anyhow::Result<SocketAddr> {
-    // TODO: this should handle the address changing, which it currently can't
+fn is_unspecified(s: &SocketAddr) -> bool {
+    match s {
+        SocketAddr::V4(s) => s.ip().is_unspecified(),
+        SocketAddr::V6(s) => s.ip().is_unspecified(),
+    }
+}
+
+async fn search_for_self_in_peers(
+    seeds: &[PeerAddr],
+    cfg: &Configuration,
+    my_node_id: NodeId,
+) -> anyhow::Result<Option<PeerAddr>> {
+    let client = build_client(cfg, Duration::from_secs(2), false)?;
+    for peer in seeds {
+        let url = peer.as_base_url().join("/repl/node-id")?;
+        let Ok(response) = client.get(url).send().await else {
+            tracing::debug!(?peer, "skipping seed peer because it is not responding");
+            continue;
+        };
+        let Ok(body) = response.msgpack::<proto::GetNodeIdResponse>().await else {
+            tracing::debug!(
+                ?peer,
+                "skipping seed peer because it returned an invalid body"
+            );
+            continue;
+        };
+        if body.node_id == my_node_id {
+            return Ok(Some(peer.clone()));
+        }
+    }
+    Ok(None)
+}
+
+pub(crate) async fn detect_address(
+    cfg: &Configuration,
+    my_node_id: NodeId,
+) -> anyhow::Result<PeerAddr> {
+    if let Some(addr) = &cfg.cluster.advertised_address {
+        tracing::debug!(?addr, "using configured advertised_address");
+        return Ok(addr.clone());
+    }
+
+    let cluster_addr = cfg.cluster.listen_address(cfg);
+    if !is_unspecified(&cluster_addr) {
+        tracing::debug!(addr=?cluster_addr, "using configured cluster listen_address");
+        return Ok(PeerAddr::SocketAddr(cluster_addr));
+    }
+
+    if !cfg.cluster.seed_nodes.is_empty()
+        && let Some(addr) =
+            search_for_self_in_peers(&cfg.cluster.seed_nodes, cfg, my_node_id).await?
+    {
+        tracing::debug!(?addr, "using address from seed_nodes");
+        return Ok(addr);
+    }
+
+    tracing::debug!("falling back to looking on all local interfaces");
+
     // TODO: this should handle dual-homed (ipv4 + ipv6) systems
-    let port = cfg.cluster.listen_address(cfg).port();
+    let port = cluster_addr.port();
     for interface in pnet::datalink::interfaces() {
         if !interface.is_up() || interface.is_loopback() || interface.ips.is_empty() {
             continue;
         }
         if let Some(ip) = interface.ips.iter().find(|i| i.is_ipv4()) {
-            return Ok(SocketAddr::new(ip.ip(), port));
+            return Ok(PeerAddr::SocketAddr(SocketAddr::new(ip.ip(), port)));
         }
     }
     anyhow::bail!("unable to find any valid interfaces");

--- a/src/core/cluster/proto.rs
+++ b/src/core/cluster/proto.rs
@@ -14,6 +14,11 @@ use super::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
+pub(super) struct GetNodeIdResponse {
+    pub node_id: NodeId,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub(super) struct DiscoverClusterResponse {
     pub cluster_name: String,
     pub cluster_id: Option<ClusterId>,

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -33,17 +33,16 @@ openraft::declare_raft_types!(
 
 pub type Raft = openraft::Raft<TypeConfig>;
 
-pub(super) async fn initialize_cluster(
+pub(crate) async fn initialize_cluster(
     raft: &Raft,
     cluster: BTreeMap<NodeId, Node>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ClusterId> {
     let start = Instant::now();
     let voters = cluster.keys().copied().collect::<Vec<_>>();
     match raft.initialize(cluster).await {
         Ok(_) => {}
         Err(RaftError::APIError(InitializeError::NotAllowed(_))) => {
-            tracing::debug!("cluster already initialized, ignoring");
-            return Ok(());
+            anyhow::bail!("cluster already initialized");
         }
         Err(err) => {
             tracing::error!(?err, "error initializing cluster");
@@ -64,7 +63,7 @@ pub(super) async fn initialize_cluster(
     .await
     .tap_err(|err| tracing::error!(?err, "failed to set initial cluster id"))?;
     tracing::debug!(elapsed=?start.elapsed(), "initialization finished");
-    Ok(())
+    Ok(new_id)
 }
 
 pub async fn initialize_raft(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use coyote_core::Monotime;
 use coyote_error::Error;
 use coyote_proto::{InternalClient, InternalRequest, InternalRequestError};
 use fjall_utils::{Databases, ReadonlyDatabases};
+use http::StatusCode;
 use opentelemetry::metrics::Meter;
 use tokio::{
     net::TcpListener,
@@ -108,11 +109,12 @@ pub struct AppState {
     pub(crate) time: Monotime,
 }
 
+#[derive(Debug, Serialize)]
+struct MinimalError {
+    message: &'static str,
+}
+
 fn handle_panic(err: Box<dyn std::any::Any + Send + 'static>) -> axum::response::Response {
-    #[derive(Debug, Serialize)]
-    struct MinimalError {
-        message: &'static str,
-    }
     if let Some(err) = err.downcast_ref::<String>() {
         tracing::error!(?err, "Unhandled panic");
     } else if let Some(err) = err.downcast_ref::<&'static str>() {
@@ -121,7 +123,7 @@ fn handle_panic(err: Box<dyn std::any::Any + Send + 'static>) -> axum::response:
         tracing::error!("Unhandled non-string panic");
     }
     (
-        http::StatusCode::INTERNAL_SERVER_ERROR,
+        StatusCode::INTERNAL_SERVER_ERROR,
         coyote_proto::MsgPackOrJson(MinimalError {
             message: "unhandled internal panic",
         }),
@@ -283,6 +285,29 @@ pub async fn run(cfg: Configuration) {
     run_with_listeners(cfg, None, None, Monotime::initial()).await
 }
 
+static BOOTSTRAPPED: AtomicBool = AtomicBool::new(false);
+
+async fn fail_until_bootstrapped(
+    path: Option<axum::extract::MatchedPath>,
+    request: axum::extract::Request,
+    next: middleware::Next,
+) -> axum::response::Response {
+    let ignore_bootstrap = if let Some(path) = path {
+        path.as_str().starts_with("/api/v1.admin.cluster.")
+    } else {
+        // don't wait for bootstrap for things axum will return a 404 on
+        true
+    };
+    if !(ignore_bootstrap || BOOTSTRAPPED.load(Ordering::Relaxed)) {
+        let response = coyote_proto::MsgPackOrJson(MinimalError {
+            message: "this node has not yet finished bootstarpping",
+        });
+        return (StatusCode::INTERNAL_SERVER_ERROR, response).into_response();
+    }
+
+    next.run(request).await
+}
+
 /// Run the server with the given configuration and initial state
 ///
 /// This is public for integration tests to use it, but should not be used
@@ -309,7 +334,8 @@ pub async fn run_with_listeners(
 
     let v1_router = v1::router(Some(app_state.clone()))
         .with_state::<()>(app_state.clone())
-        .layer(Extension(raft_state.clone()));
+        .layer(Extension(raft_state.clone()))
+        .layer(middleware::from_fn(fail_until_bootstrapped));
 
     let interserver_started_barrier = Arc::new(Barrier::new(2));
 
@@ -370,11 +396,19 @@ pub async fn run_with_listeners(
             .await
             .expect("Error binding to listen_address"),
     };
-    tracing::debug!("API: Listening on {}", listener.local_addr().unwrap());
+    tokio::task::spawn({
+        let cfg = cfg.clone();
+        let raft_state = raft_state.clone();
+        async move {
+            if let Err(err) = bootstrap::run(cfg, raft_state).await {
+                tracing::error!(?err, "bootstrap failed");
+                start_shut_down();
+            }
+            BOOTSTRAPPED.store(true, Ordering::SeqCst);
+        }
+    });
 
-    bootstrap::run(cfg, raft_state.clone())
-        .await
-        .expect("bootstrapping failed");
+    tracing::debug!("API: Listening on {}", listener.local_addr().unwrap());
 
     let listener = listener.tap_io(move |tcp_stream| {
         if let Err(err) = tcp_stream.set_nodelay(true) {

--- a/src/v1/endpoints/admin/cluster.rs
+++ b/src/v1/endpoints/admin/cluster.rs
@@ -9,7 +9,7 @@ use aide::axum::{
 };
 use axum::{Extension, extract::State};
 use coyote_derive::aide_annotate;
-use coyote_error::ResultExt;
+use coyote_error::{Error, ResultExt};
 use coyote_proto::MsgPackOrJson;
 use futures_util::StreamExt;
 use schemars::JsonSchema;
@@ -173,6 +173,40 @@ async fn cluster_status(
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, JsonSchema)]
+struct ClusterInitializeIn {}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+struct ClusterInitializeOut {
+    cluster_id: ClusterId,
+}
+
+/// Initialize this node as the leader of a new cluster
+///
+/// This operation may only be performed against a node which has not been
+/// initialized and is not currently a member of a cluster.
+#[aide_annotate(op_id = "v1.admin.cluster.initialize")]
+async fn cluster_initialize(
+    State(app_state): State<AppState>,
+    Extension(repl): Extension<RaftState>,
+    MsgPackOrJson(_data): MsgPackOrJson<ClusterInitializeIn>,
+) -> Result<MsgPackOrJson<ClusterInitializeOut>> {
+    let node_id = repl.node_id;
+    let addr = crate::core::cluster::network::detect_address(&app_state.cfg, node_id)
+        .await
+        .map_err(|err| {
+            Error::internal(format!("Could not discover local node address: {err:?}"))
+        })?;
+    let my_node = Node::from(addr);
+    let nodes = [(node_id, my_node)]
+        .into_iter()
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let cluster_id = crate::core::cluster::raft::initialize_cluster(&repl.raft, nodes)
+        .await
+        .or_internal_error()?;
+    Ok(MsgPackOrJson(ClusterInitializeOut { cluster_id }))
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Validate, JsonSchema)]
 struct ClusterRemoveNodeIn {
     node_id: NodeId,
 }
@@ -205,6 +239,11 @@ pub fn router() -> ApiRouter<AppState> {
         .api_route_with(
             cluster_status_path,
             get_with(cluster_status, cluster_status_operation),
+            &tag,
+        )
+        .api_route_with(
+            cluster_initialize_path,
+            post_with(cluster_initialize, cluster_initialize_operation),
             &tag,
         )
         .api_route_with(

--- a/z-clients/cli/src/cmds/api/admin_cluster.rs
+++ b/z-clients/cli/src/cmds/api/admin_cluster.rs
@@ -13,6 +13,14 @@ pub struct AdminClusterArgs {
 pub enum AdminClusterCommands {
     /// Get information about the current cluster
     Status {},
+    /// Initialize this node as the leader of a new cluster
+    ///
+    /// This operation may only be performed against a node which has not been
+    /// initialized and is not currently a member of a cluster.
+    Initialize {
+        cluster_initialize_in:
+            Option<crate::json::JsonOf<coyote_client::models::ClusterInitializeIn>>,
+    },
     /// Remove a node from the cluster.
     ///
     /// This operation executes immediately and the node must be wiped and reset
@@ -31,6 +39,16 @@ impl AdminClusterCommands {
         match self {
             Self::Status {} => {
                 let resp = client.admin().cluster().status().await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Initialize {
+                cluster_initialize_in,
+            } => {
+                let resp = client
+                    .admin()
+                    .cluster()
+                    .initialize(cluster_initialize_in.unwrap_or_default().into_inner())
+                    .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
             Self::RemoveNode {

--- a/z-clients/cli/src/cmds/cluster.rs
+++ b/z-clients/cli/src/cmds/cluster.rs
@@ -1,7 +1,10 @@
 use clap::{Args, Subcommand};
 use colored_json::Paint;
 use comfy_table::{Attribute, Cell, Table};
-use coyote_client::{CoyoteClient, models::ClusterRemoveNodeIn};
+use coyote_client::{
+    CoyoteClient,
+    models::{ClusterInitializeIn, ClusterInitializeOut, ClusterRemoveNodeIn},
+};
 use itertools::Itertools;
 
 #[derive(Args)]
@@ -29,6 +32,8 @@ pub enum ClusterCommands {
     },
     /// Remove a node immediately from the cluster
     RemoveNode(RemoveNodeArgs),
+    /// Initialize a new single-node cluster
+    Initialize,
 }
 
 impl ClusterCommands {
@@ -40,6 +45,7 @@ impl ClusterCommands {
         match self {
             Self::Status { json } => print_status(json, client, color_mode).await,
             Self::RemoveNode(args) => remove_node(args, client).await,
+            Self::Initialize => initialize(client).await,
         }
     }
 }
@@ -160,4 +166,21 @@ async fn remove_node(args: RemoveNodeArgs, client: &CoyoteClient) -> anyhow::Res
         })
         .await?;
     Ok(())
+}
+
+async fn initialize(client: &CoyoteClient) -> anyhow::Result<()> {
+    match client
+        .admin()
+        .cluster()
+        .initialize(ClusterInitializeIn::default())
+        .await
+    {
+        Ok(ClusterInitializeOut { cluster_id, .. }) => {
+            println!("cluster successfully initialized with ID {cluster_id}");
+            Ok(())
+        }
+        Err(err) => {
+            anyhow::bail!("error initializing cluster: {:?}", err);
+        }
+    }
 }

--- a/z-clients/go/internal/apis/admin_cluster.go
+++ b/z-clients/go/internal/apis/admin_cluster.go
@@ -30,6 +30,23 @@ func (adminCluster AdminCluster) Status(
 	)
 }
 
+// Initialize this node as the leader of a new cluster
+//
+// This operation may only be performed against a node which has not been
+// initialized and is not currently a member of a cluster.
+func (adminCluster AdminCluster) Initialize(
+	ctx context.Context,
+	clusterInitializeIn coyote_models.ClusterInitializeIn,
+) (*coyote_models.ClusterInitializeOut, error) {
+	return coyote_proto.ExecuteRequest[coyote_models.ClusterInitializeIn, coyote_models.ClusterInitializeOut](
+		ctx,
+		adminCluster.client,
+		"POST",
+		"/api/v1.admin.cluster.initialize",
+		&clusterInitializeIn,
+	)
+}
+
 // Remove a node from the cluster.
 //
 // This operation executes immediately and the node must be wiped and reset

--- a/z-clients/go/internal/models/cluster_initialize_in.go
+++ b/z-clients/go/internal/models/cluster_initialize_in.go
@@ -1,0 +1,6 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type ClusterInitializeIn struct {
+}

--- a/z-clients/go/internal/models/cluster_initialize_out.go
+++ b/z-clients/go/internal/models/cluster_initialize_out.go
@@ -1,0 +1,7 @@
+package coyote_models
+
+// This file is @generated DO NOT EDIT
+
+type ClusterInitializeOut struct {
+	ClusterId string `msgpack:"cluster_id"`
+}

--- a/z-clients/go/models.go
+++ b/z-clients/go/models.go
@@ -33,6 +33,8 @@ type (
 	CacheGetOut                   = coyote_models.CacheGetOut
 	CacheSetIn                    = coyote_models.CacheSetIn
 	CacheSetOut                   = coyote_models.CacheSetOut
+	ClusterInitializeIn           = coyote_models.ClusterInitializeIn
+	ClusterInitializeOut          = coyote_models.ClusterInitializeOut
 	ClusterRemoveNodeIn           = coyote_models.ClusterRemoveNodeIn
 	ClusterRemoveNodeOut          = coyote_models.ClusterRemoveNodeOut
 	ClusterStatusOut              = coyote_models.ClusterStatusOut

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/AdminCluster.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/AdminCluster.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Set;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
+import com.svix.coyote.models.ClusterInitializeIn;
+import com.svix.coyote.models.ClusterInitializeOut;
 import com.svix.coyote.models.ClusterRemoveNodeIn;
 import com.svix.coyote.models.ClusterRemoveNodeOut;
 import com.svix.coyote.models.ClusterStatusOut;
@@ -36,6 +38,40 @@ public class AdminCluster {
             null,
             null,
             ClusterStatusOut.class
+        );
+    }
+
+    /**
+* Initialize this node as the leader of a new cluster
+* 
+* This operation may only be performed against a node which has not been
+* initialized and is not currently a member of a cluster.
+*/
+    public ClusterInitializeOut initialize(
+        final ClusterInitializeIn clusterInitializeIn
+    ) throws IOException, ApiException {
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath("/api/v1.admin.cluster.initialize");
+
+        return this.client.executeRequest(
+            "POST",
+            url.build(),
+            null,
+            clusterInitializeIn,
+            ClusterInitializeOut.class
+        );
+    }
+
+    /**
+* Initialize this node as the leader of a new cluster
+* 
+* This operation may only be performed against a node which has not been
+* initialized and is not currently a member of a cluster.
+*/
+    public ClusterInitializeOut initialize(
+        
+    ) throws IOException, ApiException {
+        return this.initialize(
+            new ClusterInitializeIn()
         );
     }
 

--- a/z-clients/java/src/main/java/com/svix/coyote/models/ClusterInitializeIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/ClusterInitializeIn.java
@@ -1,0 +1,52 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
+public class ClusterInitializeIn {
+    public ClusterInitializeIn() {}
+
+    /**
+     * Create an instance of ClusterInitializeIn given a JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of ClusterInitializeIn
+     * @throws JsonProcessingException if the JSON string is invalid with respect to ClusterInitializeIn
+     */
+    public static ClusterInitializeIn fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, ClusterInitializeIn.class);
+    }
+
+    /**
+     * Convert an instance of ClusterInitializeIn to a JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/z-clients/java/src/main/java/com/svix/coyote/models/ClusterInitializeOut.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/ClusterInitializeOut.java
@@ -1,0 +1,72 @@
+// this file is @generated
+package com.svix.coyote.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.svix.coyote.Utils;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
+public class ClusterInitializeOut {
+    @JsonProperty("cluster_id") private String clusterId;
+    public ClusterInitializeOut() {}
+
+    public ClusterInitializeOut clusterId(String clusterId) {
+        this.clusterId = clusterId;
+        return this;
+    }
+
+    /**
+    * Get clusterId
+    *
+     * @return clusterId
+     */
+    @javax.annotation.Nonnull
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    public void setClusterId(String clusterId) {
+        this.clusterId = clusterId;
+    }
+
+    /**
+     * Create an instance of ClusterInitializeOut given a JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of ClusterInitializeOut
+     * @throws JsonProcessingException if the JSON string is invalid with respect to ClusterInitializeOut
+     */
+    public static ClusterInitializeOut fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, ClusterInitializeOut.class);
+    }
+
+    /**
+     * Convert an instance of ClusterInitializeOut to a JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/z-clients/javascript/src/apis/adminCluster.ts
+++ b/z-clients/javascript/src/apis/adminCluster.ts
@@ -1,6 +1,14 @@
 // this file is @generated
 
 import {
+    type ClusterInitializeIn,
+    ClusterInitializeInSerializer,
+} from '../models/clusterInitializeIn';
+import {
+    type ClusterInitializeOut,
+    ClusterInitializeOutSerializer,
+} from '../models/clusterInitializeOut';
+import {
     type ClusterRemoveNodeIn,
     ClusterRemoveNodeInSerializer,
 } from '../models/clusterRemoveNodeIn';
@@ -26,6 +34,25 @@ export class AdminCluster {
         return request.send(
             this.requestCtx,
             ClusterStatusOutSerializer._fromJsonObject,
+        );
+    }/**
+* Initialize this node as the leader of a new cluster
+* 
+* This operation may only be performed against a node which has not been
+* initialized and is not currently a member of a cluster.
+*/
+    public initialize(
+        clusterInitializeIn: ClusterInitializeIn,
+    ): Promise<ClusterInitializeOut> {
+        const request = new CoyoteRequest(HttpMethod.POST, "/api/v1.admin.cluster.initialize");
+
+        request.setBody(
+            ClusterInitializeInSerializer._toJsonObject(clusterInitializeIn)
+        );
+        
+        return request.send(
+            this.requestCtx,
+            ClusterInitializeOutSerializer._fromJsonObject,
         );
     }/**
 * Remove a node from the cluster.

--- a/z-clients/javascript/src/models/clusterInitializeIn.ts
+++ b/z-clients/javascript/src/models/clusterInitializeIn.ts
@@ -1,0 +1,19 @@
+// this file is @generated
+// biome-ignore-all lint/suspicious/noEmptyInterface: forwards compat
+
+export interface ClusterInitializeIn {
+}
+
+export const ClusterInitializeInSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(_object: any): ClusterInitializeIn {
+        return {
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(_self: ClusterInitializeIn): any {
+        return {
+        };
+    }
+}

--- a/z-clients/javascript/src/models/clusterInitializeOut.ts
+++ b/z-clients/javascript/src/models/clusterInitializeOut.ts
@@ -1,0 +1,21 @@
+// this file is @generated
+
+export interface ClusterInitializeOut {
+    clusterId: string;
+}
+
+export const ClusterInitializeOutSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(object: any): ClusterInitializeOut {
+        return {
+            clusterId: object['cluster_id'],
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(self: ClusterInitializeOut): any {
+        return {
+            'cluster_id': self.clusterId,
+        };
+    }
+}

--- a/z-clients/python/coyote/apis/admin_cluster.py
+++ b/z-clients/python/coyote/apis/admin_cluster.py
@@ -2,6 +2,8 @@
 
 from ..internal.api_common import ApiBase
 from ..models import (
+    ClusterInitializeIn,
+    ClusterInitializeOut,
     ClusterRemoveNodeIn,
     ClusterRemoveNodeOut,
     ClusterStatusOut,
@@ -18,6 +20,23 @@ class AdminClusterAsync(ApiBase):
             method="get",
             path="/api/v1.admin.cluster.status",
             response_type=ClusterStatusOut,
+        )
+
+    async def initialize(
+        self,
+        cluster_initialize_in: ClusterInitializeIn = ClusterInitializeIn(),
+    ) -> ClusterInitializeOut:
+        """Initialize this node as the leader of a new cluster
+
+        This operation may only be performed against a node which has not been
+        initialized and is not currently a member of a cluster."""
+        body = cluster_initialize_in.model_dump(exclude_none=True)
+
+        return await self._request_asyncio(
+            method="post",
+            path="/api/v1.admin.cluster.initialize",
+            body=body,
+            response_type=ClusterInitializeOut,
         )
 
     async def remove_node(
@@ -48,6 +67,23 @@ class AdminCluster(ApiBase):
             method="get",
             path="/api/v1.admin.cluster.status",
             response_type=ClusterStatusOut,
+        )
+
+    def initialize(
+        self,
+        cluster_initialize_in: ClusterInitializeIn = ClusterInitializeIn(),
+    ) -> ClusterInitializeOut:
+        """Initialize this node as the leader of a new cluster
+
+        This operation may only be performed against a node which has not been
+        initialized and is not currently a member of a cluster."""
+        body = cluster_initialize_in.model_dump(exclude_none=True)
+
+        return self._request_sync(
+            method="post",
+            path="/api/v1.admin.cluster.initialize",
+            body=body,
+            response_type=ClusterInitializeOut,
         )
 
     def remove_node(

--- a/z-clients/python/coyote/models/__init__.py
+++ b/z-clients/python/coyote/models/__init__.py
@@ -27,6 +27,8 @@ from .cache_get_namespace_out import CacheGetNamespaceOut
 from .cache_get_out import CacheGetOut
 from .cache_set_in import CacheSetIn
 from .cache_set_out import CacheSetOut
+from .cluster_initialize_in import ClusterInitializeIn
+from .cluster_initialize_out import ClusterInitializeOut
 from .cluster_remove_node_in import ClusterRemoveNodeIn
 from .cluster_remove_node_out import ClusterRemoveNodeOut
 from .cluster_status_out import ClusterStatusOut
@@ -130,6 +132,8 @@ __all__ = [
     "CacheGetOut",
     "CacheSetIn",
     "CacheSetOut",
+    "ClusterInitializeIn",
+    "ClusterInitializeOut",
     "ClusterRemoveNodeIn",
     "ClusterRemoveNodeOut",
     "ClusterStatusOut",

--- a/z-clients/python/coyote/models/cluster_initialize_in.py
+++ b/z-clients/python/coyote/models/cluster_initialize_in.py
@@ -1,0 +1,7 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class ClusterInitializeIn(BaseModel):
+    pass

--- a/z-clients/python/coyote/models/cluster_initialize_out.py
+++ b/z-clients/python/coyote/models/cluster_initialize_out.py
@@ -1,0 +1,8 @@
+# this file is @generated
+from pydantic import Field
+
+from ..internal.base_model import BaseModel
+
+
+class ClusterInitializeOut(BaseModel):
+    cluster_id: str = Field(alias="cluster_id")

--- a/z-clients/rust/src/api/admin_cluster.rs
+++ b/z-clients/rust/src/api/admin_cluster.rs
@@ -17,6 +17,20 @@ impl<'a> AdminCluster<'a> {
             .await
     }
 
+    /// Initialize this node as the leader of a new cluster
+    ///
+    /// This operation may only be performed against a node which has not been
+    /// initialized and is not currently a member of a cluster.
+    pub async fn initialize(
+        &self,
+        cluster_initialize_in: ClusterInitializeIn,
+    ) -> Result<ClusterInitializeOut> {
+        crate::request::Request::new(http::Method::POST, "/api/v1.admin.cluster.initialize")
+            .with_body(cluster_initialize_in)
+            .execute(self.cfg)
+            .await
+    }
+
     /// Remove a node from the cluster.
     ///
     /// This operation executes immediately and the node must be wiped and reset

--- a/z-clients/rust/src/models/cluster_initialize_in.rs
+++ b/z-clients/rust/src/models/cluster_initialize_in.rs
@@ -1,0 +1,11 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ClusterInitializeIn {}
+
+impl ClusterInitializeIn {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/z-clients/rust/src/models/cluster_initialize_out.rs
+++ b/z-clients/rust/src/models/cluster_initialize_out.rs
@@ -1,0 +1,13 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ClusterInitializeOut {
+    pub cluster_id: String,
+}
+
+impl ClusterInitializeOut {
+    pub fn new(cluster_id: String) -> Self {
+        Self { cluster_id }
+    }
+}

--- a/z-clients/rust/src/models/mod.rs
+++ b/z-clients/rust/src/models/mod.rs
@@ -29,6 +29,8 @@ mod cache_get_namespace_out;
 mod cache_get_out;
 mod cache_set_in;
 mod cache_set_out;
+mod cluster_initialize_in;
+mod cluster_initialize_out;
 mod cluster_remove_node_in;
 mod cluster_remove_node_out;
 mod cluster_status_out;
@@ -119,6 +121,7 @@ pub use self::{
     cache_delete_out::CacheDeleteOut, cache_get_in::CacheGetIn,
     cache_get_namespace_in::CacheGetNamespaceIn, cache_get_namespace_out::CacheGetNamespaceOut,
     cache_get_out::CacheGetOut, cache_set_in::CacheSetIn, cache_set_out::CacheSetOut,
+    cluster_initialize_in::ClusterInitializeIn, cluster_initialize_out::ClusterInitializeOut,
     cluster_remove_node_in::ClusterRemoveNodeIn, cluster_remove_node_out::ClusterRemoveNodeOut,
     cluster_status_out::ClusterStatusOut, consistency::Consistency,
     eviction_policy::EvictionPolicy, idempotency_abort_in::IdempotencyAbortIn,


### PR DESCRIPTION
This makes a bunch of changes:

 - It removes the `/repl/raft/admin/initialize` for manually-initializing new clusters and replaces it with a regular OpenAPI-backed cluster-admin API (including CLI support)
 - It changes bootstrap to wait for an amount of time specified in the config file instead of for 10 seconds
 - The regular API server now returns 500's until bootstrap finished (except for the cluster endpoints) instead of not running at all
 - Inter-broker address discovery is improved and centralized