### PR TITLE
gha: comment on PRs with junit results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@cargo-nextest
       - uses: ubicloud/rust-cache@v2
@@ -70,6 +72,30 @@ jobs:
       - name: Run tests
         id: test
         run: bash .github/test-report.sh
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test-report
+          path: |
+            ./junit.xml
+            ./coverage-html
+          retention-days: 7
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: ${{ always() && github.ref != 'refs/heads/main' }}
+        with:
+          report_paths: './junit.xml'
+          comment: true
+          check_retries: true
+          job_summary: true
+          detailed_summary: true
+          fail_on_parse_error: true
+          include_time_in_summary: true
+          group_suite: true
+          skip_annotations: true
+          check_name: 'Coyote CI JUnit'
+          job_name: 'Coyote CI'
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         if: github.ref != 'refs/heads/main'
@@ -91,15 +117,6 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
           body: 'Test Coverage: ${{ steps.test.outputs.coverage_percent }}%'
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v6
-        if: always()
-        with:
-          name: test-report
-          path: |
-            ./junit.xml
-            ./coverage-html
-          retention-days: 7
   check-codegen:
     name: Check openapi.json and SDK freshness
     runs-on: ubicloud-standard-4-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
         id: test
         run: bash .github/test-report.sh
       - name: Upload Test Report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
+        id: upload-report
         if: always()
         with:
           name: test-report
@@ -97,26 +98,24 @@ jobs:
           check_name: 'Coyote CI JUnit'
           job_name: 'Coyote CI'
       - name: Find Comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v4
         if: github.ref != 'refs/heads/main'
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: 'Test Coverage:'
-      - name: Create comment
-        if: github.ref != 'refs/heads/main' && steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v1
+      - name: Upsert comment
+        if: github.ref != 'refs/heads/main'
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body: 'Test Coverage: ${{ steps.test.outputs.coverage_percent }}%'
-      - name: Update comment
-        if: github.ref != 'refs/heads/main' && steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v1
-        with:
+          body: |
+            Test Coverage: ${{ steps.test.outputs.coverage_percent }}%
+
+            [Artifact download](${{ steps.upload-report.outputs.artifact-url}})
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
-          body: 'Test Coverage: ${{ steps.test.outputs.coverage_percent }}%'
   check-codegen:
     name: Check openapi.json and SDK freshness
     runs-on: ubicloud-standard-4-ubuntu-2404


### PR DESCRIPTION
I find this helpful in svix-webhooks-private because it lets me see failures without digging into the stderr

Also cleans up the coverage-reporting stuff a bit