### PR TITLE
msgs: add scheduled message delivery via delay_ms

### DIFF
--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -340,6 +340,10 @@ pub struct MsgIn {
     pub headers: HashMap<String, String>,
     /// Optional partition key. Messages with the same key are routed to the same partition.
     pub key: Option<String>,
+    /// Optional delay in milliseconds. The message will not be delivered to queue consumers
+    /// until `delay_ms` has elapsed from the time of publish.
+    #[serde(default)]
+    pub delay_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -350,6 +354,8 @@ pub struct StreamMsgOut {
     #[serde(default)]
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_at: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -359,6 +365,8 @@ pub struct QueueMsgOut {
     #[serde(default)]
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_at: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -16,6 +16,8 @@ use crate::{
     tables::{MsgRow, TopicRow},
 };
 
+use jiff::SignedDuration;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublishOperation {
     namespace_id: NamespaceId,
@@ -158,10 +160,15 @@ fn write_msg_batch(
         let start_offset = offset;
 
         for msg in msgs {
+            let scheduled_at = msg.delay_ms.map(|ms| {
+                now.checked_add(SignedDuration::from_millis(ms as i64))
+                    .expect("scheduled_at overflow")
+            });
             let msg = MsgRow {
                 value: msg.value,
                 headers: msg.headers,
                 timestamp: now,
+                scheduled_at,
             };
             batch.insert_row(
                 msg_table,

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -141,6 +141,7 @@ fn forward_to_dlq(
             value: original.value,
             headers: original.headers,
             timestamp: original.timestamp,
+            scheduled_at: None,
         },
     )?;
 

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -190,6 +190,24 @@ fn lease_available_msgs(
             continue;
         }
 
+        // If the message is scheduled for future delivery, write a synthetic lease with
+        // expiry = scheduled_at so subsequent scans skip it via the lease table without
+        // re-checking the message body.
+        if let Some(scheduled_at) = msg.scheduled_at
+            && scheduled_at > now
+        {
+            batch.insert_row(
+                &state.metadata_tables,
+                QueueLeaseRow::key_for(topic_id, &msg_id, consumer_group),
+                &QueueLeaseRow {
+                    expiry: scheduled_at,
+                    dlq: false,
+                    attempt_count: 0,
+                },
+            )?;
+            continue;
+        }
+
         // Preserve retry_count from previous lease so nack retries are tracked correctly
         let attempt_count = existing_lease.map(|l| l.attempt_count).unwrap_or(0);
 
@@ -208,6 +226,7 @@ fn lease_available_msgs(
             value: msg.value,
             headers: msg.headers,
             timestamp: msg.timestamp,
+            scheduled_at: msg.scheduled_at,
         });
 
         count += 1;
@@ -255,6 +274,7 @@ pub struct QueueReceiveMsg {
     pub value: Vec<u8>,
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,
+    pub scheduled_at: Option<Timestamp>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -145,6 +145,7 @@ impl StreamReceiveOperation {
                             headers: msg.headers,
                             offset: lease.offset + i as u64,
                             topic: topic.clone(),
+                            scheduled_at: msg.scheduled_at,
                         }),
                 );
 
@@ -180,6 +181,7 @@ pub struct StreamReceiveMsg {
     pub value: Vec<u8>,
     pub headers: std::collections::HashMap<String, String>,
     pub timestamp: Timestamp,
+    pub scheduled_at: Option<Timestamp>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -253,6 +253,8 @@ pub(crate) struct MsgRow {
     pub value: Vec<u8>,
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,
+    #[serde(default)]
+    pub scheduled_at: Option<Timestamp>,
 }
 
 impl MsgRow {

--- a/openapi.json
+++ b/openapi.json
@@ -5547,6 +5547,14 @@
             "description": "Optional partition key. Messages with the same key are routed to the same partition.",
             "type": "string",
             "nullable": true
+          },
+          "delay_ms": {
+            "description": "Optional delay in milliseconds. The message will not be delivered to queue consumers\nuntil `delay_ms` has elapsed from the time of publish.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "default": null,
+            "nullable": true
           }
         },
         "required": [
@@ -6147,6 +6155,11 @@
           "timestamp": {
             "type": "string",
             "format": "date-time"
+          },
+          "scheduled_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           }
         },
         "required": [
@@ -6474,6 +6487,11 @@
           "timestamp": {
             "type": "string",
             "format": "date-time"
+          },
+          "scheduled_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           }
         },
         "required": [

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -226,6 +226,7 @@ async fn stream_receive(
                 value: m.value,
                 headers: m.headers,
                 timestamp: m.timestamp,
+                scheduled_at: m.scheduled_at,
             })
             .collect(),
     }))
@@ -381,6 +382,7 @@ async fn queue_receive(
                 value: m.value,
                 headers: m.headers,
                 timestamp: m.timestamp,
+                scheduled_at: m.scheduled_at,
             })
             .collect(),
     }))

--- a/tests/it/msgs/mod.rs
+++ b/tests/it/msgs/mod.rs
@@ -1,6 +1,7 @@
 mod namespace;
 mod publish;
 mod queue;
+mod scheduled;
 mod stream_receive;
 mod stream_seek;
 mod topic_configure;

--- a/tests/it/msgs/scheduled.rs
+++ b/tests/it/msgs/scheduled.rs
@@ -1,0 +1,371 @@
+use std::time::Duration;
+
+use serde_json::json;
+use test_utils::{
+    JsonFastAndLoose as _, StatusCode, TestResult,
+    server::{TestContext, start_server},
+};
+
+/// scheduled message delivered after delay elapses but not before
+#[tokio::test]
+async fn scheduled_msg_delivered_after_delay() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-sched-queue-deliver" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish a message with a 5-second delay
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-sched-queue-deliver:t1",
+            "msgs": [{ "value": "delayed".as_bytes(), "delay_ms": 5_000u64 }],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Immediately — should get nothing from the queue
+    let r = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-sched-queue-hold:t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(
+        r["msgs"].assert_array().len(),
+        0,
+        "scheduled message should not be delivered before delay elapses"
+    );
+
+    // Fast-forward but before the delay
+    time.fast_forward(Duration::from_secs(3));
+    let r = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-sched-queue-hold:t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(
+        r["msgs"].assert_array().len(),
+        0,
+        "scheduled message should not be delivered before delay elapses"
+    );
+
+    // Fast-forward past the delay
+    time.fast_forward(Duration::from_secs(3));
+
+    // Should now be deliverable
+    let r = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-sched-queue-deliver:t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r["msgs"].assert_array();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "scheduled message should be delivered after delay"
+    );
+    assert_eq!(msgs[0]["value"], json!("delayed".as_bytes()));
+
+    Ok(())
+}
+
+/// mix of immediate and scheduled messages — immediate delivered first
+#[tokio::test]
+async fn immediate_msg_delivered_while_scheduled_msg_held() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-sched-queue-mix" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish one immediate and one scheduled message (same partition key so same partition)
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-sched-queue-mix:t1",
+            "msgs": [
+                { "value": "immediate1".as_bytes(), "key": "k1" },
+                { "value": "delayed".as_bytes(), "key": "k1", "delay_ms": 10_000u64 },
+                { "value": "immediate2".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should get only the immediate message
+    let r = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-sched-queue-mix:t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r["msgs"].assert_array();
+    assert_eq!(msgs.len(), 2, "only immediates message should be delivered");
+    assert_eq!(msgs[0]["value"], json!("immediate1".as_bytes()));
+    assert_eq!(msgs[1]["value"], json!("immediate2".as_bytes()));
+
+    // Fast-forward and ack the immediate message to advance the cursor past it
+    let msg_id = msgs[0]["msg_id"].assert_str();
+    client
+        .post("v1.msgs.queue.ack")
+        .json(json!({
+            "topic": "ns-sched-queue-mix:t1",
+            "consumer_group": "cg",
+            "msg_ids": [msg_id],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+    let msg_id = msgs[1]["msg_id"].assert_str();
+    client
+        .post("v1.msgs.queue.ack")
+        .json(json!({
+            "topic": "ns-sched-queue-mix:t1",
+            "consumer_group": "cg",
+            "msg_ids": [msg_id],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Fast-forward past the delay
+    time.fast_forward(Duration::from_secs(11));
+
+    // Now the delayed message should be available
+    let r2 = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-sched-queue-mix:t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = r2["msgs"].assert_array();
+    assert_eq!(
+        msgs2.len(),
+        1,
+        "delayed message should be delivered after delay"
+    );
+    assert_eq!(msgs2[0]["value"], json!("delayed".as_bytes()));
+
+    Ok(())
+}
+
+/// delay_ms=0 is treated as immediate
+#[tokio::test]
+async fn zero_delay_ms_is_immediate() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-sched-zero-delay" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-sched-zero-delay:t1",
+            "msgs": [{ "value": "immediate".as_bytes(), "delay_ms": 0u64 }],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let r = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-sched-zero-delay:t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(
+        r["msgs"].assert_array().len(),
+        1,
+        "delay_ms=0 should be delivered immediately"
+    );
+
+    Ok(())
+}
+
+/// Stream: scheduled message visible immediately with scheduled_at set
+#[tokio::test]
+async fn stream_sees_scheduled_msg_immediately() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-sched-stream-vis" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish a message with a delay
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-sched-stream-vis:t1",
+            "msgs": [{ "value": "future".as_bytes(), "delay_ms": 60_000u64 }],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Stream receive from earliest — should see the message immediately
+    let r = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "topic": "ns-sched-stream-vis:t1",
+            "consumer_group": "cg",
+            "default_starting_position": "earliest",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r["msgs"].assert_array();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "stream should see scheduled message immediately"
+    );
+    assert!(
+        !msgs[0]["scheduled_at"].is_null(),
+        "scheduled_at should be set on stream message"
+    );
+
+    Ok(())
+}
+
+/// scheduled_at is present on delivered message
+#[tokio::test]
+async fn queue_msg_has_scheduled_at_after_delivery() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-sched-queue-field" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-sched-queue-field:t1",
+            "msgs": [{ "value": "x".as_bytes(), "delay_ms": 1_000u64 }],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    time.fast_forward(Duration::from_secs(2));
+
+    let r = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-sched-queue-field:t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r["msgs"].assert_array();
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        !msgs[0]["scheduled_at"].is_null(),
+        "scheduled_at should be present on delivered queue message"
+    );
+
+    Ok(())
+}
+
+/// no scheduled_at on message published without delay
+#[tokio::test]
+async fn no_scheduled_at_on_immediate_message() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-sched-no-field" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-sched-no-field:t1",
+            "msgs": [{ "value": "x".as_bytes() }],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let r = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-sched-no-field:t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r["msgs"].assert_array();
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        msgs[0]["scheduled_at"].is_null(),
+        "scheduled_at should be absent for messages published without delay"
+    );
+
+    Ok(())
+}

--- a/z-clients/go/internal/models/msg_in.go
+++ b/z-clients/go/internal/models/msg_in.go
@@ -6,4 +6,7 @@ type MsgIn struct {
 	Value   []uint8            `msgpack:"value"`
 	Headers *map[string]string `msgpack:"headers,omitempty"`
 	Key     *string            `msgpack:"key,omitempty"` // Optional partition key. Messages with the same key are routed to the same partition.
+	// Optional delay in milliseconds. The message will not be delivered to queue consumers
+	// until `delay_ms` has elapsed from the time of publish.
+	DelayMs *uint64 `msgpack:"delay_ms,omitempty"`
 }

--- a/z-clients/go/internal/models/queue_msg_out.go
+++ b/z-clients/go/internal/models/queue_msg_out.go
@@ -7,8 +7,9 @@ import (
 )
 
 type QueueMsgOut struct {
-	MsgId     string             `msgpack:"msg_id"`
-	Value     []uint8            `msgpack:"value"`
-	Headers   *map[string]string `msgpack:"headers,omitempty"`
-	Timestamp time.Time          `msgpack:"timestamp"`
+	MsgId       string             `msgpack:"msg_id"`
+	Value       []uint8            `msgpack:"value"`
+	Headers     *map[string]string `msgpack:"headers,omitempty"`
+	Timestamp   time.Time          `msgpack:"timestamp"`
+	ScheduledAt *time.Time         `msgpack:"scheduled_at,omitempty"`
 }

--- a/z-clients/go/internal/models/stream_msg_out.go
+++ b/z-clients/go/internal/models/stream_msg_out.go
@@ -7,9 +7,10 @@ import (
 )
 
 type StreamMsgOut struct {
-	Offset    uint64             `msgpack:"offset"`
-	Topic     string             `msgpack:"topic"`
-	Value     []uint8            `msgpack:"value"`
-	Headers   *map[string]string `msgpack:"headers,omitempty"`
-	Timestamp time.Time          `msgpack:"timestamp"`
+	Offset      uint64             `msgpack:"offset"`
+	Topic       string             `msgpack:"topic"`
+	Value       []uint8            `msgpack:"value"`
+	Headers     *map[string]string `msgpack:"headers,omitempty"`
+	Timestamp   time.Time          `msgpack:"timestamp"`
+	ScheduledAt *time.Time         `msgpack:"scheduled_at,omitempty"`
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/models/MsgIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/MsgIn.java
@@ -31,6 +31,7 @@ public class MsgIn {
     @JsonProperty private List<Byte> value;
     @JsonProperty private Map<String,String> headers;
     @JsonProperty private String key;
+    @JsonProperty("delay_ms") private Long delayMs;
     public MsgIn() {}
 
     public MsgIn value(List<Byte> value) {
@@ -102,6 +103,26 @@ public class MsgIn {
 
     public void setKey(String key) {
         this.key = key;
+    }
+
+    public MsgIn delayMs(Long delayMs) {
+        this.delayMs = delayMs;
+        return this;
+    }
+
+    /**
+    * Optional delay in milliseconds. The message will not be delivered to queue consumers
+until `delay_ms` has elapsed from the time of publish.
+    *
+     * @return delayMs
+     */
+    @javax.annotation.Nullable
+    public Long getDelayMs() {
+        return delayMs;
+    }
+
+    public void setDelayMs(Long delayMs) {
+        this.delayMs = delayMs;
     }
 
     /**

--- a/z-clients/java/src/main/java/com/svix/coyote/models/QueueMsgOut.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/QueueMsgOut.java
@@ -32,6 +32,7 @@ public class QueueMsgOut {
     @JsonProperty private List<Byte> value;
     @JsonProperty private Map<String,String> headers;
     @JsonProperty private OffsetDateTime timestamp;
+    @JsonProperty("scheduled_at") private OffsetDateTime scheduledAt;
     public QueueMsgOut() {}
 
     public QueueMsgOut msgId(String msgId) {
@@ -122,6 +123,25 @@ public class QueueMsgOut {
 
     public void setTimestamp(OffsetDateTime timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public QueueMsgOut scheduledAt(OffsetDateTime scheduledAt) {
+        this.scheduledAt = scheduledAt;
+        return this;
+    }
+
+    /**
+    * Get scheduledAt
+    *
+     * @return scheduledAt
+     */
+    @javax.annotation.Nullable
+    public OffsetDateTime getScheduledAt() {
+        return scheduledAt;
+    }
+
+    public void setScheduledAt(OffsetDateTime scheduledAt) {
+        this.scheduledAt = scheduledAt;
     }
 
     /**

--- a/z-clients/java/src/main/java/com/svix/coyote/models/StreamMsgOut.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/StreamMsgOut.java
@@ -33,6 +33,7 @@ public class StreamMsgOut {
     @JsonProperty private List<Byte> value;
     @JsonProperty private Map<String,String> headers;
     @JsonProperty private OffsetDateTime timestamp;
+    @JsonProperty("scheduled_at") private OffsetDateTime scheduledAt;
     public StreamMsgOut() {}
 
     public StreamMsgOut offset(Long offset) {
@@ -142,6 +143,25 @@ public class StreamMsgOut {
 
     public void setTimestamp(OffsetDateTime timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public StreamMsgOut scheduledAt(OffsetDateTime scheduledAt) {
+        this.scheduledAt = scheduledAt;
+        return this;
+    }
+
+    /**
+    * Get scheduledAt
+    *
+     * @return scheduledAt
+     */
+    @javax.annotation.Nullable
+    public OffsetDateTime getScheduledAt() {
+        return scheduledAt;
+    }
+
+    public void setScheduledAt(OffsetDateTime scheduledAt) {
+        this.scheduledAt = scheduledAt;
     }
 
     /**

--- a/z-clients/javascript/src/models/msgIn.ts
+++ b/z-clients/javascript/src/models/msgIn.ts
@@ -5,6 +5,11 @@ export interface MsgIn {
     headers?: { [key: string]: string };
     /** Optional partition key. Messages with the same key are routed to the same partition. */
     key?: string | null;
+    /**
+     * Optional delay in milliseconds. The message will not be delivered to queue consumers
+     * until `delay_ms` has elapsed from the time of publish.
+     */
+    delayMs?: number | null;
 }
 
 export const MsgInSerializer = {
@@ -14,6 +19,7 @@ export const MsgInSerializer = {
             value: object['value'],
             headers: object['headers'],
             key: object['key'],
+            delayMs: object['delay_ms'],
         };
     },
 
@@ -23,6 +29,7 @@ export const MsgInSerializer = {
             'value': self.value,
             'headers': self.headers,
             'key': self.key,
+            'delay_ms': self.delayMs,
         };
     }
 }

--- a/z-clients/javascript/src/models/queueMsgOut.ts
+++ b/z-clients/javascript/src/models/queueMsgOut.ts
@@ -5,6 +5,7 @@ export interface QueueMsgOut {
     value: number[];
     headers?: { [key: string]: string };
     timestamp: Date;
+    scheduledAt?: Date | null;
 }
 
 export const QueueMsgOutSerializer = {
@@ -15,6 +16,7 @@ export const QueueMsgOutSerializer = {
             value: object['value'],
             headers: object['headers'],
             timestamp: new Date(object['timestamp']),
+            scheduledAt: object['scheduled_at'] ? new Date(object['scheduled_at']) : null,
         };
     },
 
@@ -25,6 +27,7 @@ export const QueueMsgOutSerializer = {
             'value': self.value,
             'headers': self.headers,
             'timestamp': self.timestamp,
+            'scheduled_at': self.scheduledAt,
         };
     }
 }

--- a/z-clients/javascript/src/models/streamMsgOut.ts
+++ b/z-clients/javascript/src/models/streamMsgOut.ts
@@ -6,6 +6,7 @@ export interface StreamMsgOut {
     value: number[];
     headers?: { [key: string]: string };
     timestamp: Date;
+    scheduledAt?: Date | null;
 }
 
 export const StreamMsgOutSerializer = {
@@ -17,6 +18,7 @@ export const StreamMsgOutSerializer = {
             value: object['value'],
             headers: object['headers'],
             timestamp: new Date(object['timestamp']),
+            scheduledAt: object['scheduled_at'] ? new Date(object['scheduled_at']) : null,
         };
     },
 
@@ -28,6 +30,7 @@ export const StreamMsgOutSerializer = {
             'value': self.value,
             'headers': self.headers,
             'timestamp': self.timestamp,
+            'scheduled_at': self.scheduledAt,
         };
     }
 }

--- a/z-clients/python/coyote/models/msg_in.py
+++ b/z-clients/python/coyote/models/msg_in.py
@@ -1,5 +1,6 @@
 # this file is @generated
 import typing as t
+from pydantic import Field
 
 from ..internal.base_model import BaseModel
 
@@ -11,3 +12,7 @@ class MsgIn(BaseModel):
 
     key: t.Optional[str] = None
     """Optional partition key. Messages with the same key are routed to the same partition."""
+
+    delay_ms: t.Optional[int] = Field(default=None, alias="delay_ms")
+    """Optional delay in milliseconds. The message will not be delivered to queue consumers
+    until `delay_ms` has elapsed from the time of publish."""

--- a/z-clients/python/coyote/models/queue_msg_out.py
+++ b/z-clients/python/coyote/models/queue_msg_out.py
@@ -14,3 +14,5 @@ class QueueMsgOut(BaseModel):
     headers: t.Optional[t.Dict[str, str]] = None
 
     timestamp: datetime
+
+    scheduled_at: t.Optional[datetime] = Field(default=None, alias="scheduled_at")

--- a/z-clients/python/coyote/models/stream_msg_out.py
+++ b/z-clients/python/coyote/models/stream_msg_out.py
@@ -1,5 +1,6 @@
 # this file is @generated
 import typing as t
+from pydantic import Field
 from datetime import datetime
 
 from ..internal.base_model import BaseModel
@@ -15,3 +16,5 @@ class StreamMsgOut(BaseModel):
     headers: t.Optional[t.Dict[str, str]] = None
 
     timestamp: datetime
+
+    scheduled_at: t.Optional[datetime] = Field(default=None, alias="scheduled_at")

--- a/z-clients/rust/src/models/msg_in.rs
+++ b/z-clients/rust/src/models/msg_in.rs
@@ -11,6 +11,11 @@ pub struct MsgIn {
     /// Optional partition key. Messages with the same key are routed to the same partition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
+
+    /// Optional delay in milliseconds. The message will not be delivered to queue consumers
+    /// until `delay_ms` has elapsed from the time of publish.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delay_ms: Option<u64>,
 }
 
 impl MsgIn {
@@ -19,6 +24,7 @@ impl MsgIn {
             value,
             headers: None,
             key: None,
+            delay_ms: None,
         }
     }
 
@@ -32,6 +38,11 @@ impl MsgIn {
 
     pub fn with_key(mut self, value: impl Into<Option<String>>) -> Self {
         self.key = value.into();
+        self
+    }
+
+    pub fn with_delay_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.delay_ms = value.into();
         self
     }
 }

--- a/z-clients/rust/src/models/queue_msg_out.rs
+++ b/z-clients/rust/src/models/queue_msg_out.rs
@@ -11,6 +11,9 @@ pub struct QueueMsgOut {
     pub headers: Option<std::collections::HashMap<String, String>>,
 
     pub timestamp: jiff::Timestamp,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduled_at: Option<jiff::Timestamp>,
 }
 
 impl QueueMsgOut {
@@ -20,6 +23,7 @@ impl QueueMsgOut {
             value,
             headers: None,
             timestamp,
+            scheduled_at: None,
         }
     }
 
@@ -28,6 +32,11 @@ impl QueueMsgOut {
         value: impl Into<Option<std::collections::HashMap<String, String>>>,
     ) -> Self {
         self.headers = value.into();
+        self
+    }
+
+    pub fn with_scheduled_at(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
+        self.scheduled_at = value.into();
         self
     }
 }

--- a/z-clients/rust/src/models/stream_msg_out.rs
+++ b/z-clients/rust/src/models/stream_msg_out.rs
@@ -13,6 +13,9 @@ pub struct StreamMsgOut {
     pub headers: Option<std::collections::HashMap<String, String>>,
 
     pub timestamp: jiff::Timestamp,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduled_at: Option<jiff::Timestamp>,
 }
 
 impl StreamMsgOut {
@@ -23,6 +26,7 @@ impl StreamMsgOut {
             value,
             headers: None,
             timestamp,
+            scheduled_at: None,
         }
     }
 
@@ -31,6 +35,11 @@ impl StreamMsgOut {
         value: impl Into<Option<std::collections::HashMap<String, String>>>,
     ) -> Self {
         self.headers = value.into();
+        self
+    }
+
+    pub fn with_scheduled_at(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
+        self.scheduled_at = value.into();
         self
     }
 }


### PR DESCRIPTION
Add support for publishing messages with a future delivery time. We support `delay_ms` (so a delay, rather than a specific time).

Queue consumers skip messages whose `scheduled_at` is in the future, so the message sits invisible in the log until its time arrives. Stream consumers see scheduled messages immediately (with `scheduled_at` set in the response), keeping the stream be based on the order of publishing.

No background processes or secondary storage are needed, and the implementation just relies on the existing lease visibility mechanism.