### PR TITLE
Helm: Add support for upgrading the CRD

### DIFF
--- a/infra/helm-coyote/charts/crds/templates/_helpers.tpl
+++ b/infra/helm-coyote/charts/crds/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/* Name for the upgrade job and its associated resources */}}
+{{/* Name for the upgrade job and its associated resources */}}
+{{- define "coyote.crds.upgrade.name" -}}
+{{- printf "%s-upgrade-crds" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "coyote.crds.upgrade.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: crds-upgrade
+{{- end -}}
+
+{{/* ServiceAccount name for the upgrade job */}}
+{{- define "coyote.crds.upgrade.serviceAccountName" -}}
+{{- if .Values.upgrade.serviceAccount.create -}}
+    {{ default (include "coyote.crds.upgrade.name" .) .Values.upgrade.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.upgrade.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/infra/helm-coyote/charts/crds/templates/upgrade/clusterrole.yaml
+++ b/infra/helm-coyote/charts/crds/templates/upgrade/clusterrole.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.upgrade.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "coyote.crds.upgrade.name" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "coyote.crds.upgrade.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - create
+      - patch
+      - update
+      - get
+      - list
+    resourceNames:
+      - coyoteclusters.coyote.svix.com
+{{- end }}

--- a/infra/helm-coyote/charts/crds/templates/upgrade/clusterrolebinding.yaml
+++ b/infra/helm-coyote/charts/crds/templates/upgrade/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.upgrade.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "coyote.crds.upgrade.name" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "coyote.crds.upgrade.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "coyote.crds.upgrade.serviceAccountName" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "coyote.crds.upgrade.name" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/infra/helm-coyote/charts/crds/templates/upgrade/crds.yaml
+++ b/infra/helm-coyote/charts/crds/templates/upgrade/crds.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.upgrade.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "coyote.crds.upgrade.name" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "coyote.crds.upgrade.labels" . | nindent 4 }}
+data:
+  crd.json: |
+{{ .Files.Get "crds/coyoteclusters.json" | indent 4 }}
+{{- end }}

--- a/infra/helm-coyote/charts/crds/templates/upgrade/job.yaml
+++ b/infra/helm-coyote/charts/crds/templates/upgrade/job.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.upgrade.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "coyote.crds.upgrade.name" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.upgrade.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "coyote.crds.upgrade.labels" . | nindent 4 }}
+    {{- with .Values.upgrade.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      {{- with .Values.upgrade.podLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.upgrade.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "coyote.crds.upgrade.serviceAccountName" . }}
+      containers:
+        - name: kubectl
+          {{- $kubeVersion := (ternary (printf "%s.0" .Capabilities.KubeVersion.Version) (regexFind "v\\d+\\.\\d+\\.\\d+" .Capabilities.KubeVersion.Version) (regexMatch "^v\\d+\\.\\d+$" .Capabilities.KubeVersion.Version)) }}
+          {{- $tag := .Values.upgrade.image.kubectl.tag | default $kubeVersion }}
+          image: "{{ .Values.upgrade.image.kubectl.registry }}/{{ .Values.upgrade.image.kubectl.repository }}:{{ $tag }}"
+          imagePullPolicy: "{{ .Values.upgrade.image.kubectl.pullPolicy }}"
+          command:
+            - kubectl
+          args:
+            - apply
+            - --server-side
+            {{- if .Values.upgrade.forceConflicts }}
+            - --force-conflicts
+            {{- end }}
+            - --filename
+            - /crds/crd.json
+          {{- with .Values.upgrade.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.upgrade.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /crds/
+              name: crds
+      volumes:
+        - name: crds
+          configMap:
+            name: {{ include "coyote.crds.upgrade.name" . }}
+      restartPolicy: OnFailure
+      {{- with .Values.upgrade.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.upgrade.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.upgrade.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.upgrade.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/infra/helm-coyote/charts/crds/templates/upgrade/serviceaccount.yaml
+++ b/infra/helm-coyote/charts/crds/templates/upgrade/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.upgrade.enabled .Values.upgrade.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.upgrade.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "coyote.crds.upgrade.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.upgrade.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "coyote.crds.upgrade.labels" . | nindent 4 }}
+{{- end }}

--- a/infra/helm-coyote/charts/crds/values.yaml
+++ b/infra/helm-coyote/charts/crds/values.yaml
@@ -1,0 +1,49 @@
+## Upgrade job settings.
+## When enabled, a pre-install/pre-upgrade/pre-rollback Job will apply the CRD
+## via `kubectl apply --server-side`, allowing Helm upgrades to update the CRD
+## schema without manual intervention.
+upgrade:
+  enabled: false
+
+  # If true, pass --force-conflicts to kubectl apply (resolves field-manager
+  # conflicts that can arise when the CRD was previously applied by another tool)
+  forceConflicts: false
+
+  image:
+    kubectl:
+      registry: registry.k8s.io
+      repository: kubectl
+      # Defaults to the Kubernetes server version if left empty.
+      tag: ""
+      pullPolicy: IfNotPresent
+
+  serviceAccount:
+    create: true
+    # Defaults to the job name if left empty.
+    name: ""
+    annotations: {}
+    automountServiceAccountToken: true
+
+  resources: {}
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  annotations: {}
+  labels: {}
+  podAnnotations: {}
+  podLabels: {}

--- a/infra/helm-coyote/values.yaml
+++ b/infra/helm-coyote/values.yaml
@@ -1,6 +1,12 @@
 crds:
   # Install the CoyoteCluster CRD.
   enabled: true
+  # Run a pre-install/pre-upgrade Job that applies the CRD via
+  # `kubectl apply --server-side`, enabling automatic CRD schema upgrades.
+  # See charts/crds/values.yaml for full configuration options.
+  upgrade:
+    enabled: true
+    forceConflicts: true
 
 operator:
   image:


### PR DESCRIPTION
This mimics the `kube-prometheus-stack` Helm chart in allowing the CRD to be updated by setting the Helm value `crd.upgrade.enabled` to true. If enabled, the CRD subchart will run a hook that updates (forcibly, if enabled) the CRD via a separate kubectl job.