### PR TITLE
Propogate error codes from raft layer, use this in stream.receive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,6 @@ dependencies = [
 name = "coyote-operations"
 version = "0.0.1"
 dependencies = [
- "axum",
  "coyote-core",
  "coyote-error",
  "futures-util",

--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -76,7 +76,52 @@ impl Error {
     }
 
     pub fn operation(code: StatusCode, detail: Option<String>) -> Self {
-        Self::new(ErrorType::Operation { code, detail })
+        Self::new(ErrorType::Operation {
+            status: code,
+            error_code: None,
+            detail,
+        })
+    }
+
+    pub fn operation_with_code(status: StatusCode, error_code: String, detail: String) -> Self {
+        Self::new(ErrorType::Operation {
+            status,
+            error_code: Some(error_code),
+            detail: Some(detail),
+        })
+    }
+
+    /// Decompose into HTTP status, optional error code, and optional detail message.
+    pub fn into_parts(self) -> (StatusCode, Option<String>, Option<String>) {
+        match *self.0 {
+            ErrorType::BadRequest(body) => (
+                StatusCode::BAD_REQUEST,
+                Some(body.code().to_owned()),
+                Some(body.detail().to_owned()),
+            ),
+            ErrorType::NotFound(body) => (
+                StatusCode::NOT_FOUND,
+                Some(body.code().to_owned()),
+                Some(body.detail().to_owned()),
+            ),
+            ErrorType::Authentication(body) => (
+                StatusCode::UNAUTHORIZED,
+                Some(body.code().to_owned()),
+                Some(body.detail().to_owned()),
+            ),
+            ErrorType::Authorization(body) => (
+                StatusCode::FORBIDDEN,
+                Some(body.code().to_owned()),
+                Some(body.detail().to_owned()),
+            ),
+            ErrorType::Validation(_) => (StatusCode::UNPROCESSABLE_ENTITY, None, None),
+            ErrorType::Operation {
+                status,
+                error_code,
+                detail,
+            } => (status, error_code, detail),
+            ErrorType::Internal { .. } => (StatusCode::INTERNAL_SERVER_ERROR, None, None),
+        }
     }
 
     #[track_caller]
@@ -120,10 +165,20 @@ impl IntoResponse for Error {
                 (StatusCode::FORBIDDEN, Json(body)).into_response()
             }
             ErrorType::Operation {
-                code,
+                status,
+                error_code: Some(error_code),
                 detail: Some(detail),
-            } => (code, detail).into_response(),
-            ErrorType::Operation { code, detail: _ } => code.into_response(),
+            } => (
+                status,
+                Json(json!({ "code": error_code, "detail": detail })),
+            )
+                .into_response(),
+            ErrorType::Operation {
+                status,
+                detail: Some(detail),
+                ..
+            } => (status, detail).into_response(),
+            ErrorType::Operation { status, .. } => status.into_response(),
             ErrorType::Internal { trace, message } => {
                 tracing::error!(
                     location = ?trace.into_iter().map(ToString::to_string).collect::<Vec<_>>(),
@@ -204,7 +259,8 @@ pub enum ErrorType {
 
     /// An error from an Operation application
     Operation {
-        code: StatusCode,
+        status: StatusCode,
+        error_code: Option<String>,
         detail: Option<String>,
     },
 }
@@ -218,11 +274,11 @@ impl fmt::Display for ErrorType {
             Self::Authentication(s) => write!(f, "authn {s}"),
             Self::Authorization(s) => write!(f, "authz {s}"),
             Self::Validation(s) => s.fmt(f),
-            Self::Operation { detail, code } => {
+            Self::Operation { detail, status, .. } => {
                 if let Some(detail) = detail {
                     detail.fmt(f)
                 } else {
-                    write!(f, "code {code}")
+                    write!(f, "code {status}")
                 }
             }
         }

--- a/crates/coyote-operations/Cargo.toml
+++ b/crates/coyote-operations/Cargo.toml
@@ -6,7 +6,6 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-axum.workspace = true
 coyote-core.workspace = true
 coyote-error.workspace = true
 futures-util.workspace = true

--- a/crates/coyote-operations/src/lib.rs
+++ b/crates/coyote-operations/src/lib.rs
@@ -1,4 +1,3 @@
-use axum::response::IntoResponse;
 use opentelemetry::{Context, trace::TraceContextExt};
 use std::{collections::HashMap, fmt::Debug};
 
@@ -146,22 +145,29 @@ impl From<Context> for OperationRequestMetadata {
 pub struct OperationError {
     #[serde(with = "http_serde::status_code")]
     status: http::StatusCode,
-    msg: String,
+    error_code: Option<String>,
+    detail: Option<String>,
 }
 
 impl From<coyote_error::Error> for OperationError {
     fn from(value: coyote_error::Error) -> Self {
-        let msg = value.to_string();
+        let (status, error_code, detail) = value.into_parts();
         Self {
-            status: value.into_response().status(),
-            msg,
+            status,
+            error_code,
+            detail,
         }
     }
 }
 
 impl From<OperationError> for coyote_error::Error {
     fn from(value: OperationError) -> Self {
-        Self::operation(value.status, None)
+        match value.error_code {
+            Some(code) => {
+                Self::operation_with_code(value.status, code, value.detail.unwrap_or_default())
+            }
+            None => Self::operation(value.status, value.detail),
+        }
     }
 }
 
@@ -169,7 +175,8 @@ impl From<JoinError> for OperationError {
     fn from(value: JoinError) -> Self {
         Self {
             status: http::StatusCode::INTERNAL_SERVER_ERROR,
-            msg: format!("Error joining thread: {value}"),
+            error_code: None,
+            detail: Some(format!("Error joining thread: {value}")),
         }
     }
 }

--- a/crates/coyote-proto/src/error.rs
+++ b/crates/coyote-proto/src/error.rs
@@ -18,6 +18,16 @@ impl StandardErrorBody {
     }
 }
 
+impl StandardErrorBody {
+    pub fn code(&self) -> &str {
+        self.code
+    }
+
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
 impl fmt::Display for StandardErrorBody {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { code, detail } = self;

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -160,7 +160,10 @@ impl StreamReceiveOperation {
             }
 
             if no_lease_available {
-                return Err(Error::invalid_user_input("no available leases"));
+                return Err(Error::bad_request(
+                    "no_available_leases",
+                    "no available leases",
+                ));
             }
 
             batch.commit().map_err(Error::from)?;

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -124,14 +124,16 @@ async fn stream_receive_no_duplicates_within_lease() -> TestResult {
     assert_eq!(r1["msgs"].assert_array().len(), 2);
 
     // Second receive with the same CG — partition is locked, returns error
-    let _r2 = client
+    let r2 = client
         .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-nodup:t1",
             "consumer_group": "cg1",
         }))
         .await?
-        .expect(StatusCode::BAD_REQUEST);
+        .expect(StatusCode::BAD_REQUEST)
+        .json();
+    assert_eq!(r2["code"], "no_available_leases");
 
     // Commit the first batch to unlock the partition.
     // The response topic already includes the namespace, so we can pass it directly.
@@ -379,14 +381,16 @@ async fn partition_locked_until_lease_expired_or_committed() -> TestResult {
     assert_eq!(r_a["msgs"].assert_array().len(), 2);
 
     // Consumer B (same CG) — partition is locked, returns error
-    let _ = client
+    let r_b_locked = client
         .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-lock:t1",
             "consumer_group": "cg1",
         }))
         .await?
-        .expect(StatusCode::BAD_REQUEST);
+        .expect(StatusCode::BAD_REQUEST)
+        .json();
+    assert_eq!(r_b_locked["code"], "no_available_leases");
 
     // Consumer A commits — unlocks the partition.
     // The response topic already includes the namespace.
@@ -750,6 +754,7 @@ async fn concurrent_receives_same_cg_no_overlap() -> TestResult {
             total_msgs += msgs.len();
         } else {
             assert!(matches!(resp.status(), StatusCode::BAD_REQUEST));
+            assert_eq!(resp.json()["code"], "no_available_leases");
         }
     }
 
@@ -829,14 +834,16 @@ async fn partial_commit_preserves_lease() -> TestResult {
         .expect(StatusCode::OK);
 
     // Lease should still be held — second receive must fail
-    client
+    let locked = client
         .post("v1.msgs.stream.receive")
         .json(json!({
             "topic": "ns-partial:t1",
             "consumer_group": "cg1",
         }))
         .await?
-        .expect(StatusCode::BAD_REQUEST);
+        .expect(StatusCode::BAD_REQUEST)
+        .json();
+    assert_eq!(locked["code"], "no_available_leases");
 
     // Commit the last offset in the batch — should release the lease
     client


### PR DESCRIPTION
For stream, return a 400 (BAD_REQUEST) when a consumer can't read from a topic because all the current partitions are locked.

We need a way to disambiguate this error condition from other error conditions, which entails using a custom error_code.

This adds that error code (and updates tests to validate the behavior). This necessitated allowing error codes to propagate through the raft layer, so there was some refactoring there.