### PR TITLE
Enable metrics for api server

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,10 @@ pub async fn run_with_listeners(
 
     let v1_router = v1::router(Some(app_state.clone()))
         .with_state::<()>(app_state.clone())
+        .layer(middleware::from_fn_with_state(
+            app_state.clone(),
+            core::otel_spans::request_metrics_middleware,
+        ))
         .layer(Extension(raft_state.clone()))
         .layer(middleware::from_fn(fail_until_bootstrapped));
 

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -3,23 +3,13 @@
 
 use aide::axum::ApiRouter;
 
-use crate::{
-    AppState,
-    core::{auth::authorization, otel_spans::request_metrics_middleware},
-};
+use crate::{AppState, core::auth::authorization};
 
 pub mod endpoints;
 pub mod utils;
 
 pub fn router(state: Option<AppState>) -> ApiRouter<AppState> {
     let mut ret: ApiRouter<AppState> = ApiRouter::new();
-
-    if let Some(state) = &state {
-        ret = ret.layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            request_metrics_middleware,
-        ));
-    }
 
     let unauthenticated_router: ApiRouter<AppState> =
         ApiRouter::new().merge(endpoints::health::router());


### PR DESCRIPTION
These were only working for raft server. Add them
to API as well.