### PR TITLE
Give benchmark pod unique name

### DIFF
--- a/.github/workflows/benchmark-env.yml
+++ b/.github/workflows/benchmark-env.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run benchmark
         timeout-minutes: 10
         run: |
-          kubectl run benchmark \
+          kubectl run benchmark-${{ inputs.image_tag }}-${{ github.run_attempt }} \
             --image=${{ env.IMAGE }} \
             --restart=Never \
             --rm \


### PR DESCRIPTION
It happened to conflict w/ a pod I'd launched manually. Let's avoid that.