### PR TITLE
Support `max_wait_millis` for stream.receive and queue.receive

### DIFF
--- a/crates/coyote-core/src/monotime.rs
+++ b/crates/coyote-core/src/monotime.rs
@@ -60,6 +60,41 @@ impl Monotime {
         self.time.load(Ordering::Acquire)
     }
 
+    /// Sleeps for the given duration.
+    ///
+    /// In debug builds, polls with short real-time sleeps so that
+    /// [`Monotime::fast_forward`] causes the sleep to exit promptly.
+    /// In release builds, delegates to [`tokio::time::sleep`].
+    ///
+    /// IMPORTANT: You cannot call this within the raft layer, or you risk deadlocking.
+    #[cfg(debug_assertions)]
+    pub async fn sleep(&self, duration: std::time::Duration) {
+        use std::time::Instant;
+
+        /// Completely arbitrary, but used to make sure we don't inadvertently run forever in case you forget to fast forward time.
+        const MAX_SLEEP_REAL_TIME: std::time::Duration = std::time::Duration::from_secs(20);
+
+        let deadline = self.now() + duration;
+        let poll_interval = std::time::Duration::from_millis(10);
+        let t0 = Instant::now();
+        while t0.elapsed() < MAX_SLEEP_REAL_TIME {
+            tokio::time::sleep(poll_interval).await;
+            if self.now() >= deadline {
+                return;
+            }
+        }
+
+        panic!("Failed to fast forward time after {:?}", t0.elapsed())
+    }
+
+    /// Sleeps for the given duration.
+    ///
+    /// Delegates directly to [`tokio::time::sleep`].
+    #[cfg(not(debug_assertions))]
+    pub async fn sleep(&self, duration: std::time::Duration) {
+        tokio::time::sleep(duration).await;
+    }
+
     /// Advance time by the given amount. This should only be used in integration tests.
     #[cfg(debug_assertions)]
     pub fn fast_forward(&self, by: std::time::Duration) -> Timestamp {

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -1,13 +1,19 @@
-use coyote_error::Error;
+use coyote_error::{Error, Result};
+use coyote_id::NamespaceId;
 use coyote_namespace::{Namespace, entities::MsgsConfig};
 use fjall::{KeyspaceCreateOptions, KvSeparationOptions};
+use jiff::Timestamp;
+
+use entities::{ConsumerGroup, Partition, TopicName};
+use fjall_utils::{ReadableKeyspace, TableRow};
+use tables::{MsgRow, QueueLeaseRow, StreamLeaseRow, TopicRow};
 
 pub mod entities;
 pub mod operations;
 pub(crate) mod tables;
 
-const MSG_KEYSPACE: &str = "mod_msgs";
-const METADATA_KEYSPACE: &str = "mod_msgs_metadata";
+pub const MSG_KEYSPACE: &str = "mod_msgs";
+pub const METADATA_KEYSPACE: &str = "mod_msgs_metadata";
 
 pub type MsgsNamespace = Namespace<MsgsConfig>;
 
@@ -38,4 +44,91 @@ impl State {
             msg_table,
         })
     }
+}
+
+/// Counts available queue messages across all partitions.
+///
+/// For each partition, scans all `QueueLeaseRow` entries and counts messages that
+/// are available (no lease, or lease expired and not in DLQ).
+pub fn estimate_available_queue_messages(
+    metadata_tables: &impl ReadableKeyspace,
+    msg_table: &impl ReadableKeyspace,
+    namespace_id: NamespaceId,
+    topic: &TopicName,
+    consumer_group: &ConsumerGroup,
+    now: Timestamp,
+) -> Result<u64> {
+    let Some(topic_row) = TopicRow::fetch(metadata_tables, TopicRow::key_for(namespace_id, topic))?
+    else {
+        return Ok(0);
+    };
+
+    let mut total = 0u64;
+    for partition_idx in 0..topic_row.partitions {
+        let partition = Partition::new(partition_idx)?;
+
+        // SMH should probably rename StreamLeaseRow to CursorRow or something,
+        // the name is misleading here.
+        let cursor_offset = StreamLeaseRow::fetch(
+            metadata_tables,
+            StreamLeaseRow::key_for(topic_row.id, partition, consumer_group),
+        )?
+        .map(|c| c.offset)
+        .unwrap_or(0);
+
+        let next_offset = MsgRow::next_offset(msg_table, topic_row.id, partition)?;
+        let total_msgs = next_offset.saturating_sub(cursor_offset);
+
+        let leases = QueueLeaseRow::scan_partition(
+            metadata_tables,
+            topic_row.id,
+            partition,
+            consumer_group,
+        )?;
+        let unavailable = leases.iter().filter(|(_, l)| !l.is_available(now)).count() as u64;
+
+        total += total_msgs.saturating_sub(unavailable);
+    }
+
+    Ok(total)
+}
+
+// NOTE - I'm not thrilled about the location of this method, but I didn't want to expose the
+// tables module outside the msgs crate, and I wasn't sure where else to put this. 🤷
+/// Cheap offset-based estimate of available stream messages across all partitions.
+///
+/// Partitions with active leases are skipped — stream semantics lock at the partition level.
+pub fn estimate_available_stream_messages(
+    metadata_tables: &impl ReadableKeyspace,
+    msg_table: &impl ReadableKeyspace,
+    namespace_id: NamespaceId,
+    topic: &TopicName,
+    consumer_group: &ConsumerGroup,
+    now: Timestamp,
+) -> Result<u64> {
+    let Some(topic_row) = TopicRow::fetch(metadata_tables, TopicRow::key_for(namespace_id, topic))?
+    else {
+        return Ok(0);
+    };
+
+    let mut total = 0u64;
+    for partition_idx in 0..topic_row.partitions {
+        let partition = Partition::new(partition_idx)?;
+
+        let cursor = StreamLeaseRow::fetch(
+            metadata_tables,
+            StreamLeaseRow::key_for(topic_row.id, partition, consumer_group),
+        )?;
+
+        // Skip partitions with active leases
+        if cursor.as_ref().is_some_and(|c| c.expiry > now) {
+            continue;
+        }
+
+        let cursor_offset = cursor.map(|c| c.offset).unwrap_or(0);
+        let next_offset = MsgRow::next_offset(msg_table, topic_row.id, partition)?;
+        total += next_offset.saturating_sub(cursor_offset);
+    }
+
+    Ok(total)
 }

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -188,7 +188,7 @@ impl QueueLeaseRow {
     // with a proper range/prefix scan API on TableRow.
     /// Returns all lease rows for a given (topic, partition, consumer_group) via prefix scan.
     pub(crate) fn scan_partition(
-        keyspace: &fjall::Keyspace,
+        keyspace: &impl fjall_utils::ReadableKeyspace,
         topic_id: TopicId,
         partition: Partition,
         consumer_group: &ConsumerGroup,
@@ -276,7 +276,7 @@ impl MsgRow {
 
     #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn next_offset(
-        keyspace: &fjall::Keyspace,
+        keyspace: &impl fjall_utils::ReadableKeyspace,
         topic_id: TopicId,
         partition: Partition,
     ) -> Result<Offset> {

--- a/openapi.json
+++ b/openapi.json
@@ -5962,6 +5962,13 @@
             "type": "integer",
             "format": "uint64",
             "default": 30000
+          },
+          "batch_wait_ms": {
+            "description": "Maximum time (in milliseconds) to wait for messages before returning.",
+            "type": "integer",
+            "format": "uint64",
+            "default": null,
+            "nullable": true
           }
         },
         "required": [
@@ -6076,6 +6083,13 @@
           "default_starting_position": {
             "default": "latest",
             "$ref": "#/components/schemas/SeekPosition"
+          },
+          "batch_wait_ms": {
+            "description": "Maximum time (in milliseconds) to wait for messages before returning.",
+            "type": "integer",
+            "format": "uint64",
+            "default": null,
+            "nullable": true
           }
         },
         "required": [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,9 +91,6 @@ pub struct AppState {
 
     namespace_state: coyote_namespace::State,
 
-    // FIXME: do we need this?
-    // OTHERFIXME: yes, I think so.
-    #[allow(unused)]
     pub(crate) ro_dbs: ReadonlyDatabases,
 
     // FIXME: temporarily here until we make ro_dbs usable.
@@ -107,7 +104,6 @@ pub struct AppState {
 
     pub(crate) auth_token_cache: Arc<parking_lot::RwLock<core::auth::FifoCache<Permissions>>>,
 
-    #[allow(unused)]
     pub(crate) time: Monotime,
 }
 

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -23,6 +23,7 @@ use coyote_msgs::{
 };
 use coyote_namespace::entities::NamespaceName;
 use coyote_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
+use fjall_utils::{ReadableDatabase, ReadonlyConnection, StorageType};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -215,6 +216,9 @@ struct MsgStreamReceiveIn {
     pub lease_duration_ms: DurationMs,
     #[serde(default)]
     pub default_starting_position: SeekPosition,
+    /// Maximum time (in milliseconds) to wait for messages before returning.
+    #[serde(default)]
+    pub batch_wait_ms: Option<DurationMs>,
 }
 
 request_input!(MsgStreamReceiveIn, "Receive");
@@ -238,6 +242,41 @@ async fn stream_receive(
         .namespace_state
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
+
+    // FIXME(@svix-gabriel) - there's potentially optimizations we can do using fancy tokio
+    // Notifiers to avoid sleeping the max duration. But this is simplest for now.
+    if let Some(max_wait) = data.batch_wait_ms {
+        let ro_db = state.ro_dbs.db_for(StorageType::Persistent);
+        let metadata_ks = ro_db
+            .keyspace(coyote_msgs::METADATA_KEYSPACE)
+            .or_internal_error()?;
+        let msg_ks = ro_db
+            .keyspace(coyote_msgs::MSG_KEYSPACE)
+            .or_internal_error()?;
+
+        let ns_id = namespace.id;
+        let topic_name = data.topic.name().clone();
+        let cg = data.consumer_group.clone();
+        let now = state.time.now();
+        let batch_size = data.batch_size;
+
+        let estimated = coyote_core::task::spawn_blocking_in_current_span(move || {
+            coyote_msgs::estimate_available_stream_messages(
+                &metadata_ks,
+                &msg_ks,
+                ns_id,
+                &topic_name,
+                &cg,
+                now,
+            )
+        })
+        .await
+        .or_internal_error()??;
+
+        if (estimated as usize) < batch_size.get() as usize {
+            state.time.sleep(max_wait.into()).await;
+        }
+    }
 
     let operation = StreamReceiveOperation::new(
         namespace.id,
@@ -378,6 +417,9 @@ struct MsgQueueReceiveIn {
     pub batch_size: NonZeroU16,
     #[serde(default = "default_queue_lease_duration_ms")]
     pub lease_duration_ms: DurationMs,
+    /// Maximum time (in milliseconds) to wait for messages before returning.
+    #[serde(default)]
+    pub batch_wait_ms: Option<DurationMs>,
 }
 
 request_input!(MsgQueueReceiveIn, "Receive");
@@ -402,6 +444,41 @@ async fn queue_receive(
         .namespace_state
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
+
+    // FIXME(@svix-gabriel) - there's potentially optimizations we can do using fancy tokio
+    // Notifiers to avoid sleeping the max duration. But this is simplest for now.
+    if let Some(max_wait) = data.batch_wait_ms {
+        let ro_db = state.ro_dbs.db_for(StorageType::Persistent);
+        let metadata_ks = ro_db
+            .keyspace(coyote_msgs::METADATA_KEYSPACE)
+            .or_internal_error()?;
+        let msg_ks = ro_db
+            .keyspace(coyote_msgs::MSG_KEYSPACE)
+            .or_internal_error()?;
+
+        let ns_id = namespace.id;
+        let topic_name = data.topic.name().clone();
+        let cg = data.consumer_group.clone();
+        let now = state.time.now();
+        let batch_size = data.batch_size;
+
+        let estimated = coyote_core::task::spawn_blocking_in_current_span(move || {
+            coyote_msgs::estimate_available_queue_messages(
+                &metadata_ks,
+                &msg_ks,
+                ns_id,
+                &topic_name,
+                &cg,
+                now,
+            )
+        })
+        .await
+        .or_internal_error()??;
+
+        if (estimated as usize) < batch_size.get() as usize {
+            state.time.sleep(max_wait.into()).await;
+        }
+    }
 
     let operation = QueueReceiveOperation::new(
         namespace.id,

--- a/tests/it/msgs/queue.rs
+++ b/tests/it/msgs/queue.rs
@@ -5,6 +5,7 @@ use test_utils::{
     JsonFastAndLoose as _, StatusCode, TestResult,
     server::{TestContext, start_server},
 };
+use tokio::task::yield_now;
 
 #[tokio::test]
 async fn queue_receive_returns_published_messages() -> TestResult {
@@ -1190,6 +1191,239 @@ async fn nack_with_dlq_topic_forwards() -> TestResult {
     let dlq_msgs = r_dlq["msgs"].assert_array();
     assert_eq!(dlq_msgs.len(), 1, "message should appear in DLQ topic");
     assert_eq!(dlq_msgs[0]["value"], json!("a".as_bytes()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_receive_max_wait_returns_when_batch_filled() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-qwait-full" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish exactly 3 messages before receiving (queue starts from earliest)
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-qwait-full:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+                { "value": "c".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive with max_wait — batch is already full, should return immediately
+    let response = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-qwait-full:t1",
+            "consumer_group": "test-cg",
+            "batch_size": 3,
+            "batch_wait_ms": 5000,
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 3, "should return all 3 messages");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_receive_max_wait_returns_partial_batch_on_timeout() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-qwait-partial" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish only 2 messages — less than batch_size
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-qwait-partial:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Start a receive wanting batch_size=5 with a short wait
+    let recv_client = client.clone();
+    let recv_handle = tokio::spawn(async move {
+        recv_client
+            .post("v1.msgs.queue.receive")
+            .json(json!({
+                "topic": "ns-qwait-partial:t1",
+                "consumer_group": "test-cg",
+                "batch_size": 5,
+                "batch_wait_ms": 500,
+            }))
+            .await
+    });
+
+    // Let the receive request reach the server
+    yield_now().await;
+
+    // Advance past the max_wait deadline
+    time.fast_forward(Duration::from_millis(500));
+
+    let response = recv_handle.await??.expect(StatusCode::OK).json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(
+        msgs.len(),
+        2,
+        "should return the 2 available messages after timeout"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn queue_receive_max_wait_times_out_with_no_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-qtimeout" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive with a short max_wait — no messages will arrive
+    let recv_client = client.clone();
+    let recv_handle = tokio::spawn(async move {
+        recv_client
+            .post("v1.msgs.queue.receive")
+            .json(json!({
+                "topic": "ns-qtimeout:t1",
+                "consumer_group": "test-cg",
+                "batch_wait_ms": 500,
+            }))
+            .await
+    });
+
+    // Let the receive request reach the server
+    yield_now().await;
+
+    // Advance past the max_wait deadline
+    time.fast_forward(Duration::from_millis(500));
+
+    let response = recv_handle.await??.expect(StatusCode::OK).json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 0, "should return empty after timeout");
+
+    Ok(())
+}
+
+/// Queue partitions are not locked by active leases (unlike stream). The max_wait
+/// estimate must not skip partitions that have an existing cursor, otherwise consumers
+/// would unnecessarily wait even when messages are available.
+#[tokio::test]
+async fn queue_receive_max_wait_does_not_skip_partitions_with_existing_cursor() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-qwait-cursor" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish 3 messages
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-qwait-cursor:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+                { "value": "c".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Consumer A leases the first 2 messages, creating a cursor on the partition
+    let r1 = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-qwait-cursor:t1",
+            "consumer_group": "cg1",
+            "batch_size": 2,
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(r1["msgs"].assert_array().len(), 2);
+
+    // Publish 3 more messages
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-qwait-cursor:t1",
+            "msgs": [
+                { "value": "d".as_bytes(), "key": "k1" },
+                { "value": "e".as_bytes(), "key": "k1" },
+                { "value": "f".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Consumer B calls receive with max_wait. The partition already has a cursor from
+    // consumer A's receive, but queue partitions aren't locked — new messages should
+    // be available immediately without waiting.
+    let response = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "topic": "ns-qwait-cursor:t1",
+            "consumer_group": "cg1",
+            "batch_size": 3,
+            "batch_wait_ms": 5000,
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    // Should get the 1 unleased message from the first batch + 3 new messages = 4
+    // (or at least > 0 — the point is it didn't wait 5 seconds)
+    let msgs = response["msgs"].assert_array();
+    assert!(
+        !msgs.is_empty(),
+        "should return messages immediately, not wait for max_wait"
+    );
 
     Ok(())
 }

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -5,6 +5,7 @@ use test_utils::{
     JsonFastAndLoose as _, StatusCode, TestResult,
     server::{TestContext, start_server},
 };
+use tokio::task::yield_now;
 
 #[tokio::test]
 async fn stream_receive_returns_published_messages() -> TestResult {
@@ -1130,6 +1131,175 @@ async fn default_starting_position_earliest_gets_preexisting() -> TestResult {
         "earliest starting position should return all pre-existing messages"
     );
     assert_eq!(msgs[0]["offset"].assert_u64(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn stream_receive_max_wait_returns_when_batch_filled() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-wait-full" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group before publishing
+    client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "topic": "ns-wait-full:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish exactly 3 messages to fill the batch
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-wait-full:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+                { "value": "c".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive with max_wait — batch is already full, should return immediately
+    let response = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "topic": "ns-wait-full:t1",
+            "consumer_group": "cg1",
+            "batch_size": 3,
+            "batch_wait_ms": 5000,
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 3, "should return all 3 messages");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn stream_receive_max_wait_returns_partial_batch_on_timeout() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-wait-partial" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group before publishing
+    client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "topic": "ns-wait-partial:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish only 2 messages — less than batch_size
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-wait-partial:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Start a receive wanting batch_size=5 with a short wait
+    let recv_client = client.clone();
+    let recv_handle = tokio::spawn(async move {
+        recv_client
+            .post("v1.msgs.stream.receive")
+            .json(json!({
+                "topic": "ns-wait-partial:t1",
+                "consumer_group": "cg1",
+                "batch_size": 5,
+                "batch_wait_ms": 500,
+            }))
+            .await
+    });
+
+    // Let the receive request reach the server
+    yield_now().await;
+
+    // Advance past the max_wait deadline
+    time.fast_forward(Duration::from_millis(500));
+
+    let response = recv_handle.await??.expect(StatusCode::OK).json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(
+        msgs.len(),
+        2,
+        "should return the 2 available messages after timeout"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn stream_receive_max_wait_times_out_with_no_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-timeout" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive with a short max_wait — no messages will arrive
+    let recv_client = client.clone();
+    let recv_handle = tokio::spawn(async move {
+        recv_client
+            .post("v1.msgs.stream.receive")
+            .json(json!({
+                "topic": "ns-timeout:t1",
+                "consumer_group": "cg1",
+                "batch_wait_ms": 500,
+            }))
+            .await
+    });
+
+    // Let the receive request reach the server
+    yield_now().await;
+
+    // Advance past the max_wait deadline
+    time.fast_forward(Duration::from_millis(500));
+
+    let response = recv_handle.await??.expect(StatusCode::OK).json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 0, "should return empty after timeout");
 
     Ok(())
 }

--- a/z-clients/go/internal/apis/msgs_queue.go
+++ b/z-clients/go/internal/apis/msgs_queue.go
@@ -34,6 +34,7 @@ func (msgsQueue MsgsQueue) Receive(
 		ConsumerGroup:   consumerGroup,
 		BatchSize:       msgQueueReceiveIn.BatchSize,
 		LeaseDurationMs: msgQueueReceiveIn.LeaseDurationMs,
+		BatchWaitMs:     msgQueueReceiveIn.BatchWaitMs,
 	}
 
 	return coyote_proto.ExecuteRequest[coyote_models.MsgQueueReceiveIn_, coyote_models.MsgQueueReceiveOut](

--- a/z-clients/go/internal/apis/msgs_stream.go
+++ b/z-clients/go/internal/apis/msgs_stream.go
@@ -34,6 +34,7 @@ func (msgsStream MsgsStream) Receive(
 		BatchSize:               msgStreamReceiveIn.BatchSize,
 		LeaseDurationMs:         msgStreamReceiveIn.LeaseDurationMs,
 		DefaultStartingPosition: msgStreamReceiveIn.DefaultStartingPosition,
+		BatchWaitMs:             msgStreamReceiveIn.BatchWaitMs,
 	}
 
 	return coyote_proto.ExecuteRequest[coyote_models.MsgStreamReceiveIn_, coyote_models.MsgStreamReceiveOut](

--- a/z-clients/go/internal/models/msg_queue_receive_in.go
+++ b/z-clients/go/internal/models/msg_queue_receive_in.go
@@ -6,6 +6,7 @@ type MsgQueueReceiveIn struct {
 	Namespace       *string `msgpack:"namespace,omitempty"`
 	BatchSize       *uint16 `msgpack:"batch_size,omitempty"`
 	LeaseDurationMs *uint64 `msgpack:"lease_duration_ms,omitempty"`
+	BatchWaitMs     *uint64 `msgpack:"batch_wait_ms,omitempty"` // Maximum time (in milliseconds) to wait for messages before returning.
 }
 
 type MsgQueueReceiveIn_ struct {
@@ -14,4 +15,5 @@ type MsgQueueReceiveIn_ struct {
 	ConsumerGroup   string  `msgpack:"consumer_group"`
 	BatchSize       *uint16 `msgpack:"batch_size,omitempty"`
 	LeaseDurationMs *uint64 `msgpack:"lease_duration_ms,omitempty"`
+	BatchWaitMs     *uint64 `msgpack:"batch_wait_ms,omitempty"` // Maximum time (in milliseconds) to wait for messages before returning.
 }

--- a/z-clients/go/internal/models/msg_stream_receive_in.go
+++ b/z-clients/go/internal/models/msg_stream_receive_in.go
@@ -7,6 +7,7 @@ type MsgStreamReceiveIn struct {
 	BatchSize               *uint16       `msgpack:"batch_size,omitempty"`
 	LeaseDurationMs         *uint64       `msgpack:"lease_duration_ms,omitempty"`
 	DefaultStartingPosition *SeekPosition `msgpack:"default_starting_position,omitempty"`
+	BatchWaitMs             *uint64       `msgpack:"batch_wait_ms,omitempty"` // Maximum time (in milliseconds) to wait for messages before returning.
 }
 
 type MsgStreamReceiveIn_ struct {
@@ -16,4 +17,5 @@ type MsgStreamReceiveIn_ struct {
 	BatchSize               *uint16       `msgpack:"batch_size,omitempty"`
 	LeaseDurationMs         *uint64       `msgpack:"lease_duration_ms,omitempty"`
 	DefaultStartingPosition *SeekPosition `msgpack:"default_starting_position,omitempty"`
+	BatchWaitMs             *uint64       `msgpack:"batch_wait_ms,omitempty"` // Maximum time (in milliseconds) to wait for messages before returning.
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsQueue.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsQueue.java
@@ -54,7 +54,8 @@ public class MsgsQueue {
             topic,
             consumerGroup,
             msgQueueReceiveIn.getBatchSize(),
-            msgQueueReceiveIn.getLeaseDurationMs()
+            msgQueueReceiveIn.getLeaseDurationMs(),
+            msgQueueReceiveIn.getBatchWaitMs()
         );
 
         return this.client.executeRequest(

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/MsgsStream.java
@@ -48,7 +48,8 @@ public class MsgsStream {
             consumerGroup,
             msgStreamReceiveIn.getBatchSize(),
             msgStreamReceiveIn.getLeaseDurationMs(),
-            msgStreamReceiveIn.getDefaultStartingPosition()
+            msgStreamReceiveIn.getDefaultStartingPosition(),
+            msgStreamReceiveIn.getBatchWaitMs()
         );
 
         return this.client.executeRequest(

--- a/z-clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn.java
@@ -33,6 +33,7 @@ public class MsgQueueReceiveIn {
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty("batch_size") private Short batchSize;
     @JsonProperty("lease_duration_ms") private Long leaseDurationMs;
+    @JsonProperty("batch_wait_ms") private Long batchWaitMs;
     public MsgQueueReceiveIn() {}
 
     public MsgQueueReceiveIn namespace(String namespace) {
@@ -90,5 +91,24 @@ public class MsgQueueReceiveIn {
 
     public void setLeaseDurationMs(Long leaseDurationMs) {
         this.leaseDurationMs = leaseDurationMs;
+    }
+
+    public MsgQueueReceiveIn batchWaitMs(Long batchWaitMs) {
+        this.batchWaitMs = batchWaitMs;
+        return this;
+    }
+
+    /**
+    * Maximum time (in milliseconds) to wait for messages before returning.
+    *
+     * @return batchWaitMs
+     */
+    @javax.annotation.Nullable
+    public Long getBatchWaitMs() {
+        return batchWaitMs;
+    }
+
+    public void setBatchWaitMs(Long batchWaitMs) {
+        this.batchWaitMs = batchWaitMs;
     }
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn_.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/MsgQueueReceiveIn_.java
@@ -28,19 +28,22 @@ public class MsgQueueReceiveIn_ {
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty("batch_size") private Short batchSize;
     @JsonProperty("lease_duration_ms") private Long leaseDurationMs;
+    @JsonProperty("batch_wait_ms") private Long batchWaitMs;
 
     public MsgQueueReceiveIn_(
         String namespace,
         String topic,
         String consumerGroup,
         Short batchSize,
-        Long leaseDurationMs
+        Long leaseDurationMs,
+        Long batchWaitMs
     ) {
         this.namespace = namespace;
         this.topic = topic;
         this.consumerGroup = consumerGroup;
         this.batchSize = batchSize;
         this.leaseDurationMs = leaseDurationMs;
+        this.batchWaitMs = batchWaitMs;
     }
 
     /**

--- a/z-clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn.java
@@ -34,6 +34,7 @@ public class MsgStreamReceiveIn {
     @JsonProperty("batch_size") private Short batchSize;
     @JsonProperty("lease_duration_ms") private Long leaseDurationMs;
     @JsonProperty("default_starting_position") private SeekPosition defaultStartingPosition;
+    @JsonProperty("batch_wait_ms") private Long batchWaitMs;
     public MsgStreamReceiveIn() {}
 
     public MsgStreamReceiveIn namespace(String namespace) {
@@ -110,5 +111,24 @@ public class MsgStreamReceiveIn {
 
     public void setDefaultStartingPosition(SeekPosition defaultStartingPosition) {
         this.defaultStartingPosition = defaultStartingPosition;
+    }
+
+    public MsgStreamReceiveIn batchWaitMs(Long batchWaitMs) {
+        this.batchWaitMs = batchWaitMs;
+        return this;
+    }
+
+    /**
+    * Maximum time (in milliseconds) to wait for messages before returning.
+    *
+     * @return batchWaitMs
+     */
+    @javax.annotation.Nullable
+    public Long getBatchWaitMs() {
+        return batchWaitMs;
+    }
+
+    public void setBatchWaitMs(Long batchWaitMs) {
+        this.batchWaitMs = batchWaitMs;
     }
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn_.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/MsgStreamReceiveIn_.java
@@ -29,6 +29,7 @@ public class MsgStreamReceiveIn_ {
     @JsonProperty("batch_size") private Short batchSize;
     @JsonProperty("lease_duration_ms") private Long leaseDurationMs;
     @JsonProperty("default_starting_position") private SeekPosition defaultStartingPosition;
+    @JsonProperty("batch_wait_ms") private Long batchWaitMs;
 
     public MsgStreamReceiveIn_(
         String namespace,
@@ -36,7 +37,8 @@ public class MsgStreamReceiveIn_ {
         String consumerGroup,
         Short batchSize,
         Long leaseDurationMs,
-        SeekPosition defaultStartingPosition
+        SeekPosition defaultStartingPosition,
+        Long batchWaitMs
     ) {
         this.namespace = namespace;
         this.topic = topic;
@@ -44,6 +46,7 @@ public class MsgStreamReceiveIn_ {
         this.batchSize = batchSize;
         this.leaseDurationMs = leaseDurationMs;
         this.defaultStartingPosition = defaultStartingPosition;
+        this.batchWaitMs = batchWaitMs;
     }
 
     /**

--- a/z-clients/javascript/src/models/msgQueueReceiveIn.ts
+++ b/z-clients/javascript/src/models/msgQueueReceiveIn.ts
@@ -4,6 +4,8 @@ export interface MsgQueueReceiveIn {
     namespace?: string | null;
     batchSize?: number;
     leaseDurationMs?: number;
+    /** Maximum time (in milliseconds) to wait for messages before returning. */
+    batchWaitMs?: number | null;
 }
 
 export interface MsgQueueReceiveIn_ {
@@ -12,6 +14,8 @@ export interface MsgQueueReceiveIn_ {
     consumerGroup: string;
     batchSize?: number;
     leaseDurationMs?: number;
+    /** Maximum time (in milliseconds) to wait for messages before returning. */
+    batchWaitMs?: number | null;
 }
 
 export const MsgQueueReceiveInSerializer = {
@@ -23,6 +27,7 @@ export const MsgQueueReceiveInSerializer = {
             consumerGroup: object['consumer_group'],
             batchSize: object['batch_size'],
             leaseDurationMs: object['lease_duration_ms'],
+            batchWaitMs: object['batch_wait_ms'],
         };
     },
 
@@ -34,6 +39,7 @@ export const MsgQueueReceiveInSerializer = {
             'consumer_group': self.consumerGroup,
             'batch_size': self.batchSize,
             'lease_duration_ms': self.leaseDurationMs,
+            'batch_wait_ms': self.batchWaitMs,
         };
     }
 }

--- a/z-clients/javascript/src/models/msgStreamReceiveIn.ts
+++ b/z-clients/javascript/src/models/msgStreamReceiveIn.ts
@@ -9,6 +9,8 @@ export interface MsgStreamReceiveIn {
     batchSize?: number;
     leaseDurationMs?: number;
     defaultStartingPosition?: SeekPosition;
+    /** Maximum time (in milliseconds) to wait for messages before returning. */
+    batchWaitMs?: number | null;
 }
 
 export interface MsgStreamReceiveIn_ {
@@ -18,6 +20,8 @@ export interface MsgStreamReceiveIn_ {
     batchSize?: number;
     leaseDurationMs?: number;
     defaultStartingPosition?: SeekPosition;
+    /** Maximum time (in milliseconds) to wait for messages before returning. */
+    batchWaitMs?: number | null;
 }
 
 export const MsgStreamReceiveInSerializer = {
@@ -30,6 +34,7 @@ export const MsgStreamReceiveInSerializer = {
             batchSize: object['batch_size'],
             leaseDurationMs: object['lease_duration_ms'],
             defaultStartingPosition: object['default_starting_position'] != null ? SeekPositionSerializer._fromJsonObject(object['default_starting_position']): undefined,
+            batchWaitMs: object['batch_wait_ms'],
         };
     },
 
@@ -42,6 +47,7 @@ export const MsgStreamReceiveInSerializer = {
             'batch_size': self.batchSize,
             'lease_duration_ms': self.leaseDurationMs,
             'default_starting_position': self.defaultStartingPosition != null ? SeekPositionSerializer._toJsonObject(self.defaultStartingPosition) : undefined,
+            'batch_wait_ms': self.batchWaitMs,
         };
     }
 }

--- a/z-clients/python/coyote/apis/msgs_queue.py
+++ b/z-clients/python/coyote/apis/msgs_queue.py
@@ -39,6 +39,7 @@ class MsgsQueueAsync(ApiBase):
             consumer_group=consumer_group,
             batch_size=msg_queue_receive_in.batch_size,
             lease_duration_ms=msg_queue_receive_in.lease_duration_ms,
+            batch_wait_ms=msg_queue_receive_in.batch_wait_ms,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -159,6 +160,7 @@ class MsgsQueue(ApiBase):
             consumer_group=consumer_group,
             batch_size=msg_queue_receive_in.batch_size,
             lease_duration_ms=msg_queue_receive_in.lease_duration_ms,
+            batch_wait_ms=msg_queue_receive_in.batch_wait_ms,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/z-clients/python/coyote/apis/msgs_stream.py
+++ b/z-clients/python/coyote/apis/msgs_stream.py
@@ -33,6 +33,7 @@ class MsgsStreamAsync(ApiBase):
             batch_size=msg_stream_receive_in.batch_size,
             lease_duration_ms=msg_stream_receive_in.lease_duration_ms,
             default_starting_position=msg_stream_receive_in.default_starting_position,
+            batch_wait_ms=msg_stream_receive_in.batch_wait_ms,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -111,6 +112,7 @@ class MsgsStream(ApiBase):
             batch_size=msg_stream_receive_in.batch_size,
             lease_duration_ms=msg_stream_receive_in.lease_duration_ms,
             default_starting_position=msg_stream_receive_in.default_starting_position,
+            batch_wait_ms=msg_stream_receive_in.batch_wait_ms,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/z-clients/python/coyote/models/msg_queue_receive_in.py
+++ b/z-clients/python/coyote/models/msg_queue_receive_in.py
@@ -12,6 +12,9 @@ class MsgQueueReceiveIn(BaseModel):
 
     lease_duration_ms: t.Optional[int] = Field(default=None, alias="lease_duration_ms")
 
+    batch_wait_ms: t.Optional[int] = Field(default=None, alias="batch_wait_ms")
+    """Maximum time (in milliseconds) to wait for messages before returning."""
+
 
 class _MsgQueueReceiveIn(BaseModel):
     namespace: t.Optional[str] = None
@@ -23,3 +26,6 @@ class _MsgQueueReceiveIn(BaseModel):
     batch_size: t.Optional[int] = Field(default=None, alias="batch_size")
 
     lease_duration_ms: t.Optional[int] = Field(default=None, alias="lease_duration_ms")
+
+    batch_wait_ms: t.Optional[int] = Field(default=None, alias="batch_wait_ms")
+    """Maximum time (in milliseconds) to wait for messages before returning."""

--- a/z-clients/python/coyote/models/msg_stream_receive_in.py
+++ b/z-clients/python/coyote/models/msg_stream_receive_in.py
@@ -18,6 +18,9 @@ class MsgStreamReceiveIn(BaseModel):
         default=None, alias="default_starting_position"
     )
 
+    batch_wait_ms: t.Optional[int] = Field(default=None, alias="batch_wait_ms")
+    """Maximum time (in milliseconds) to wait for messages before returning."""
+
 
 class _MsgStreamReceiveIn(BaseModel):
     namespace: t.Optional[str] = None
@@ -33,3 +36,6 @@ class _MsgStreamReceiveIn(BaseModel):
     default_starting_position: t.Optional[SeekPosition] = Field(
         default=None, alias="default_starting_position"
     )
+
+    batch_wait_ms: t.Optional[int] = Field(default=None, alias="batch_wait_ms")
+    """Maximum time (in milliseconds) to wait for messages before returning."""

--- a/z-clients/rust/src/api/msgs_queue.rs
+++ b/z-clients/rust/src/api/msgs_queue.rs
@@ -27,6 +27,7 @@ impl<'a> MsgsQueue<'a> {
             consumer_group,
             batch_size: msg_queue_receive_in.batch_size,
             lease_duration_ms: msg_queue_receive_in.lease_duration_ms,
+            batch_wait_ms: msg_queue_receive_in.batch_wait_ms,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1.msgs.queue.receive")

--- a/z-clients/rust/src/api/msgs_stream.rs
+++ b/z-clients/rust/src/api/msgs_stream.rs
@@ -27,6 +27,7 @@ impl<'a> MsgsStream<'a> {
             batch_size: msg_stream_receive_in.batch_size,
             lease_duration_ms: msg_stream_receive_in.lease_duration_ms,
             default_starting_position: msg_stream_receive_in.default_starting_position,
+            batch_wait_ms: msg_stream_receive_in.batch_wait_ms,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1.msgs.stream.receive")

--- a/z-clients/rust/src/models/msg_queue_receive_in.rs
+++ b/z-clients/rust/src/models/msg_queue_receive_in.rs
@@ -11,6 +11,10 @@ pub struct MsgQueueReceiveIn {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lease_duration_ms: Option<u64>,
+
+    /// Maximum time (in milliseconds) to wait for messages before returning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch_wait_ms: Option<u64>,
 }
 
 impl MsgQueueReceiveIn {
@@ -19,6 +23,7 @@ impl MsgQueueReceiveIn {
             namespace: None,
             batch_size: None,
             lease_duration_ms: None,
+            batch_wait_ms: None,
         }
     }
 
@@ -34,6 +39,11 @@ impl MsgQueueReceiveIn {
 
     pub fn with_lease_duration_ms(mut self, value: impl Into<Option<u64>>) -> Self {
         self.lease_duration_ms = value.into();
+        self
+    }
+
+    pub fn with_batch_wait_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.batch_wait_ms = value.into();
         self
     }
 }
@@ -52,4 +62,8 @@ pub(crate) struct MsgQueueReceiveIn_ {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lease_duration_ms: Option<u64>,
+
+    /// Maximum time (in milliseconds) to wait for messages before returning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch_wait_ms: Option<u64>,
 }

--- a/z-clients/rust/src/models/msg_stream_receive_in.rs
+++ b/z-clients/rust/src/models/msg_stream_receive_in.rs
@@ -16,6 +16,10 @@ pub struct MsgStreamReceiveIn {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_starting_position: Option<SeekPosition>,
+
+    /// Maximum time (in milliseconds) to wait for messages before returning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch_wait_ms: Option<u64>,
 }
 
 impl MsgStreamReceiveIn {
@@ -25,6 +29,7 @@ impl MsgStreamReceiveIn {
             batch_size: None,
             lease_duration_ms: None,
             default_starting_position: None,
+            batch_wait_ms: None,
         }
     }
 
@@ -50,6 +55,11 @@ impl MsgStreamReceiveIn {
         self.default_starting_position = value.into();
         self
     }
+
+    pub fn with_batch_wait_ms(mut self, value: impl Into<Option<u64>>) -> Self {
+        self.batch_wait_ms = value.into();
+        self
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -69,4 +79,8 @@ pub(crate) struct MsgStreamReceiveIn_ {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_starting_position: Option<SeekPosition>,
+
+    /// Maximum time (in milliseconds) to wait for messages before returning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch_wait_ms: Option<u64>,
 }


### PR DESCRIPTION
This adds support for blocking receive calls for a certain duration until the batch size is reached.

The implementation is really rudimentary. The algorithm is essentially

```
if max_wait_millis is specified
    check if batch size messages are available using read_only db handles
    if batch size is not available, sleep
endif

do normal stream/queue receive raft operation
```

Since this is purely a read-only operation, none of the logic is in the raft layer, which I think makes sense.

There's definitely room for improving/optimizing this, potentially using a fancy tokio notification scheme so that when publish on a topic is called, we can potentially avoid sleeping for the entire max_wait_millis duration.