### PR TITLE
cluster: do not run background tasks (e.g., snapshots) until bootstrap finishes

### DIFF
--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -92,6 +92,10 @@ impl Error {
         })
     }
 
+    pub fn shutting_down() -> Self {
+        Self::new(ErrorType::ShuttingDown)
+    }
+
     /// Decompose into HTTP status, optional error code, and optional detail message.
     pub fn into_parts(self) -> (StatusCode, Option<String>, Option<String>) {
         match *self.0 {
@@ -122,6 +126,7 @@ impl Error {
                 detail,
             } => (status, error_code, detail),
             ErrorType::Internal { .. } => (StatusCode::INTERNAL_SERVER_ERROR, None, None),
+            ErrorType::ShuttingDown => (StatusCode::SERVICE_UNAVAILABLE, None, None),
         }
     }
 
@@ -192,6 +197,11 @@ impl IntoResponse for Error {
                 )
                     .into_response()
             }
+            ErrorType::ShuttingDown => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"error": "server shutting down"})),
+            )
+                .into_response(),
         }
     }
 }
@@ -264,6 +274,9 @@ pub enum ErrorType {
         error_code: Option<String>,
         detail: Option<String>,
     },
+
+    /// The operation cannot proceed because the server is shutting down
+    ShuttingDown,
 }
 
 impl fmt::Display for ErrorType {
@@ -275,6 +288,7 @@ impl fmt::Display for ErrorType {
             Self::Authentication(s) => write!(f, "authn {s}"),
             Self::Authorization(s) => write!(f, "authz {s}"),
             Self::Validation(s) => s.fmt(f),
+            Self::ShuttingDown => write!(f, "shutting_down"),
             Self::Operation { detail, status, .. } => {
                 if let Some(detail) = detail {
                     detail.fmt(f)

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -70,6 +70,7 @@ pub async fn initialize_raft(
     cfg: &Configuration,
     app_state: AppState,
     time: Monotime,
+    initialized: crate::Initialized,
 ) -> anyhow::Result<RaftState> {
     let mut logs = super::CoyoteLogs::new(
         cfg.cluster.log_path(cfg)?,
@@ -142,6 +143,9 @@ pub async fn initialize_raft(
         let handle = handle.clone();
         let cfg = cfg.clone();
         async move {
+            if initialized.wait().await.is_err() {
+                return;
+            }
             if let Err(err) = super::background::run_background_jobs_on_all_nodes(
                 cfg.clone(),
                 handle.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,36 @@ async fn fail_until_bootstrapped(
     next.run(request).await
 }
 
+#[derive(Debug, Clone)]
+pub struct Initialized {
+    inner: Arc<tokio::sync::SetOnce<()>>,
+}
+
+impl Initialized {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::SetOnce::new()),
+        }
+    }
+
+    fn set(&self) -> Result<(), tokio::sync::SetOnceError<()>> {
+        self.inner.set(())
+    }
+
+    // Wait until initialization is finished or the server shuts down
+    pub async fn wait(self) -> coyote_error::Result<()> {
+        let shutting_down_token = shutting_down_token();
+        if shutting_down_token
+            .run_until_cancelled(self.inner.wait())
+            .await
+            .is_none()
+        {
+            return Err(Error::shutting_down());
+        }
+        Ok(())
+    }
+}
+
 /// Run the server with the given configuration and initial state
 ///
 /// This is public for integration tests to use it, but should not be used
@@ -329,13 +359,16 @@ pub async fn run_with_listeners(
     // needed at router-construction time.
     let mut openapi = openapi::initialize_openapi();
 
+    let initialized = Initialized::new();
+
     let (internal_req_tx, internal_req_rx) = mpsc::channel(1);
     let internal_client = InternalClient::new(internal_req_tx);
     let app_state = AppState::new(cfg.clone(), time.clone(), internal_client);
 
-    let raft_state = core::cluster::initialize_raft(&cfg, app_state.clone(), time)
-        .await
-        .expect("failed to initialize cluster");
+    let raft_state =
+        core::cluster::initialize_raft(&cfg, app_state.clone(), time, initialized.clone())
+            .await
+            .expect("failed to initialize cluster");
     let node_id = raft_state.node_id;
 
     let v1_router = v1::router(Some(app_state.clone()))
@@ -409,12 +442,16 @@ pub async fn run_with_listeners(
     tokio::task::spawn({
         let cfg = cfg.clone();
         let raft_state = raft_state.clone();
+        let initialized = initialized.clone();
         async move {
             if let Err(err) = bootstrap::run(cfg, raft_state).await {
                 tracing::error!(?err, "bootstrap failed");
                 start_shut_down();
             }
             BOOTSTRAPPED.store(true, Ordering::SeqCst);
+            if initialized.set().is_err() {
+                tracing::error!("bootstrap ran twice???");
+            }
         }
     });
 
@@ -429,8 +466,18 @@ pub async fn run_with_listeners(
             .accepted(node_id, ConnectionType::External);
     });
 
-    let mut workers = Workers::new();
-    workers.spawn_all(raft_state).await;
+    let worker_handle = tokio::task::spawn({
+        let raft_state = raft_state.clone();
+        let shutting_down = shutting_down_token();
+        async move {
+            initialized.wait().await?;
+            let mut workers = Workers::new();
+            workers.spawn_all(raft_state).await;
+            shutting_down.cancelled().await;
+            workers.shutdown().await;
+            Ok::<(), Error>(())
+        }
+    });
 
     axum::serve(listener, make_svc)
         .with_graceful_shutdown(shutting_down_token().cancelled_owned())
@@ -439,8 +486,8 @@ pub async fn run_with_listeners(
 
     // Wait for workers to finish cleanup
     tracing::debug!("done serving; waiting for background tasks to finish");
+    let _ = worker_handle.await;
     let _ = interserver.await;
-    let _ = workers.shutdown().await;
     tracing::debug!("we're outta here!");
 }
 


### PR DESCRIPTION
fixes #661