### PR TITLE
Require RequestInput implementation for request input structs

### DIFF
--- a/crates/coyote-proto/src/msgpack_or_json.rs
+++ b/crates/coyote-proto/src/msgpack_or_json.rs
@@ -17,7 +17,9 @@ use http::{HeaderMap, HeaderValue, StatusCode, header};
 use serde::{Serialize, de::DeserializeOwned};
 use validator::Validate;
 
-use crate::{StandardErrorBody, ValidationErrorBody, ValidationErrorItem, validation_errors};
+use crate::{
+    RequestInput, StandardErrorBody, ValidationErrorBody, ValidationErrorItem, validation_errors,
+};
 
 tokio::task_local! {
     static RESPONSE_CONTENT_TYPE: SupportedContentType;
@@ -69,8 +71,7 @@ pub struct MsgPackOrJson<T>(pub T);
 
 impl<T, S> FromRequest<S> for MsgPackOrJson<T>
 where
-    // FIXME(@svix-jplatte): extra bound commented out to avoid merge issues
-    T: DeserializeOwned + Validate, // + RequestInput,
+    T: DeserializeOwned + Validate + RequestInput,
     S: Send + Sync,
 {
     type Rejection = MsgPackOrJsonRejection;

--- a/src/v1/endpoints/admin/cluster.rs
+++ b/src/v1/endpoints/admin/cluster.rs
@@ -243,6 +243,8 @@ async fn cluster_remove_node(
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, JsonSchema)]
 struct ClusterForceSnapshotIn {}
 
+admin_request_input!(ClusterForceSnapshotIn);
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 struct ClusterForceSnapshotOut {
     snapshot_time: jiff::Timestamp,


### PR DESCRIPTION
Follow-up to #618.
Part of #68.

Separate PR because this will conflict with any PR introducing a new API endpoint.