### PR TITLE
CI: Publish Helm chart to GHCR on push to main

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,40 @@
+name: Helm Publish
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      image_tag:
+        required: true
+        type: string
+
+jobs:
+  helm-publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image tags
+        run: |
+          sed -i 's/tag: ""/tag: "${{ inputs.image_tag }}"/g' infra/helm-coyote/values.yaml
+
+      - name: Package and push chart
+        run: |
+          helm package ./infra/helm-coyote --version ${{ inputs.version }}
+          helm push coyote-${{ inputs.version }}.tgz oci://ghcr.io/svix/charts

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -64,6 +64,14 @@ jobs:
       packages: write
       security-events: write
 
+  helm-publish:
+    needs: ci
+    uses: ./.github/workflows/helm-publish.yml
+    secrets: inherit
+    with:
+      version: 0.0.0-${{ github.sha }}
+      image_tag: sha-${{ github.sha }}
+
   svix-cloud-deploy:
     needs:
       - docker_publish_server


### PR DESCRIPTION
That's about it. The Helm version has to be semver-compliant, so hacked around that for now. But we definitely will need a real solution there soon.