### PR TITLE
feat(helm): add coyote nodeselector for operator

### DIFF
--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -4,6 +4,15 @@ crds:
     enabled: true
     forceConflicts: true
 
+operator:
+  nodeSelector:
+    db-name: coyote
+  tolerations:
+    - key: db-name
+      operator: Equal
+      value: coyote
+      effect: NoSchedule
+
 cluster:
   image:
     tag: ""


### PR DESCRIPTION
This PR adds coyote nodeSelector for operator

This would ensure that the operator.nodeSelector uses 
`db-name=coyote ` node label in order to deploy the operator
on the coyote nodes in svix cloud CH eks.