### PR TITLE
cfg: increase default timeouts

### DIFF
--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -40,11 +40,11 @@ pub(super) fn cluster_name() -> String {
 }
 
 pub(super) fn cluster_replication_request_timeout() -> Duration {
-    Duration::from_millis(100)
+    Duration::from_secs(10)
 }
 
 pub(super) fn cluster_discovery_request_timeout() -> Duration {
-    Duration::from_secs(3)
+    Duration::from_secs(10)
 }
 
 pub(super) fn cluster_discovery_timeout() -> Duration {

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -40,7 +40,7 @@ pub(super) fn cluster_name() -> String {
 }
 
 pub(super) fn cluster_replication_request_timeout() -> Duration {
-    Duration::from_secs(10)
+    Duration::from_secs(5)
 }
 
 pub(super) fn cluster_discovery_request_timeout() -> Duration {

--- a/src/cfg/validators.rs
+++ b/src/cfg/validators.rs
@@ -36,9 +36,9 @@ pub(super) fn validate_cluster_configuration(
         ));
     }
     if c.heartbeat_interval < c.replication_request_timeout {
-        return Err(ValidationError::new(
-            "heartbeat_interval must be >= replication_request_teimout",
-        ));
+        tracing::warn!(
+            "setting replication_request_timeout greater than heartbeat_interval may cause election timeouts"
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
100ms in particular isn't enough time to send the several-MB chunk of a snapshot