### PR TITLE
tf: allow conflicts on deploy

### DIFF
--- a/.github/workflows/svix-cloud-operator.yml
+++ b/.github/workflows/svix-cloud-operator.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Deploy operator via Helm
         run: |
           helm upgrade --install coyote-operator ./${{ env.OPERATOR_DIR }}/../helm-coyote \
+            --force-conflicts \
             --values ./${{ env.OPERATOR_DIR }}/../svix-values.yaml \
             --set-string operator.image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
             --set-string operator.image.tag=${{ inputs.image_tag }} \


### PR DESCRIPTION
I was trying to debug the weird state of cac1 yesterday and manually edited something, and now helm refuses to run due to conflicts. Ignore them for the time being.