### PR TITLE
refactor(clusterspec): use k8s-native EnvVar for extraEnv

### DIFF
--- a/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
+++ b/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
@@ -143,24 +143,11 @@
                     },
                     "type": "object"
                   },
-                  "extraEnv": {
-                    "default": [],
-                    "description": "Additional environment variables to inject into pods.",
+                  "envVar": {
+                    "description": "Additional environment variables to inject into pods.\nFollows the Kubernetes EnvVar API spec (v1.EnvVar): supports plain `value`\nand `valueFrom` (secretKeyRef, configMapKeyRef, fieldRef, resourceFieldRef)",
                     "items": {
-                      "description": "An environment variable to inject into pods.",
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "value": {
-                          "nullable": true,
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object"
+                      "type": "object",
+                      "x-kubernetes-preserve-unknown-fields": true
                     },
                     "type": "array"
                   },

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use k8s_openapi::api::core::v1::{Affinity, Toleration, TopologySpreadConstraint};
+use k8s_openapi::api::core::v1::{Affinity, EnvVar, Toleration, TopologySpreadConstraint};
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -65,8 +65,11 @@ pub(crate) struct CoyoteClusterSpec {
     pub api_port: u16,
 
     /// Additional environment variables to inject into pods.
-    #[serde(default)]
-    pub extra_env: Vec<EnvVar>,
+    /// Follows the Kubernetes EnvVar API spec (v1.EnvVar): supports plain `value`
+    /// and `valueFrom` (secretKeyRef, configMapKeyRef, fieldRef, resourceFieldRef)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(schema_with = "env_var_schema")]
+    pub env_var: Vec<EnvVar>,
 
     /// CPU and memory resource requests and limits for the coyote container.
     #[serde(default)]
@@ -196,14 +199,6 @@ pub(crate) struct ServiceSpec {
     pub annotations: BTreeMap<String, String>,
 }
 
-/// An environment variable to inject into pods.
-#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
-pub(crate) struct EnvVar {
-    pub name: String,
-    #[serde(default)]
-    pub value: Option<String>,
-}
-
 /// Status of a CoyoteCluster.
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -250,6 +245,13 @@ fn nodes_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
         "default": 1,
         "minimum": 1.0,
         "description": "Number of Coyote nodes. Should be odd for quorum (1, 3, 5...)."
+    })
+}
+
+fn env_var_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "array",
+        "items": { "type": "object", "x-kubernetes-preserve-unknown-fields": true }
     })
 }
 

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -221,7 +221,7 @@ fn build_env(
     }
 
     // Extra user-provided env vars.
-    for extra in &spec.extra_env {
+    for extra in &spec.env_var {
         env.push(EnvVar {
             name: extra.name.clone(),
             value: extra.value.clone(),

--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -27,7 +27,7 @@ cluster:
       persistent:
         size: 64Gi
         storageClass: gp3-encrypted
-    extraEnv:
+    envVar:
       - name: COYOTE_OPENTELEMETRY_METRICS_ADDRESS
         value: "http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090/api/v1/otlp/v1/metrics"
       - name: COYOTE_OPENTELEMETRY_METRICS_USE_HTTP


### PR DESCRIPTION
This PR ensures we use k8s-native EnvVar for extraEnv

First and foremost, this renames `spec.extraEnv` to `spec.envVar` 
This then adds  support for the fields `spec.envVar` to  extract
data from configmap or secrets (e.g. `valueFrom.secretRef`)
i.e. uses k8s_openapi native `EnvVar` type for `spec.envVar`.