### PR TITLE
server: clean up metrics a bit

### DIFF
--- a/src/core/cluster/node.rs
+++ b/src/core/cluster/node.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use opentelemetry::{KeyValue, Value};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -124,5 +125,20 @@ impl From<u64> for NodeId {
     fn from(value: u64) -> Self {
         let inner = Uuid::from_u64_pair(value, value);
         Self { inner }
+    }
+}
+
+impl From<NodeId> for Value {
+    fn from(value: NodeId) -> Self {
+        // we want to make this cheaply cloneable since we use it in
+        // metrics all the time, and it's low-cardinality
+        let value: std::sync::Arc<str> = value.to_string().into();
+        Self::String(value.into())
+    }
+}
+
+impl From<NodeId> for KeyValue {
+    fn from(value: NodeId) -> Self {
+        KeyValue::new("node_id", value)
     }
 }

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -1,5 +1,3 @@
-use std::fmt::{self, Display, Formatter};
-
 use http::StatusCode;
 use opentelemetry::{
     KeyValue,
@@ -22,12 +20,18 @@ impl From<DbType> for opentelemetry::Value {
     }
 }
 
+impl From<DbType> for KeyValue {
+    fn from(db_type: DbType) -> Self {
+        KeyValue::new("db_type", db_type)
+    }
+}
+
 #[derive(Clone)]
 pub struct DbMetrics {
     bytes_used: Gauge<u64>,
     apply_operations: Gauge<u64>,
     apply_batch_size: Histogram<u64>,
-    node_id: NodeId,
+    node_id_kv: KeyValue,
 }
 
 impl DbMetrics {
@@ -46,27 +50,20 @@ impl DbMetrics {
                 .u64_histogram("coyote.raft.apply_batch_size")
                 .with_description("Raft apply operation batch sizes")
                 .build(),
-            node_id,
+            node_id_kv: node_id.into(),
         }
     }
 
     pub fn record_apply(&self, batch_size: usize) {
         self.apply_operations
-            .record(1, &[KeyValue::new("node_id", self.node_id.to_string())]);
-        self.apply_batch_size.record(
-            batch_size as u64,
-            &[KeyValue::new("node_id", self.node_id.to_string())],
-        );
+            .record(1, std::slice::from_ref(&self.node_id_kv));
+        self.apply_batch_size
+            .record(batch_size as u64, std::slice::from_ref(&self.node_id_kv));
     }
 
     pub fn bytes_used(&self, bytes: u64, db_type: DbType) {
-        self.bytes_used.record(
-            bytes,
-            &[
-                KeyValue::new("node_id", self.node_id.to_string()),
-                KeyValue::new("db_type", db_type),
-            ],
-        );
+        self.bytes_used
+            .record(bytes, &[self.node_id_kv.clone(), db_type.into()]);
     }
 }
 
@@ -86,7 +83,7 @@ pub struct LogMetrics {
 
 impl LogMetrics {
     pub fn new(meter: &Meter, node_id: NodeId) -> Self {
-        let context = vec![KeyValue::new("node_id", node_id.to_string())];
+        let context = vec![node_id.into()];
         Self {
             bytes_used: meter
                 .u64_gauge("coyote.raft.log.bytes_used")
@@ -140,53 +137,64 @@ impl LogMetrics {
 
 pub enum ConnectionType {
     Internal,
+    Interserver,
     External,
+    Unknown,
 }
 
-impl Display for ConnectionType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let value = match self {
+impl From<ConnectionType> for opentelemetry::Value {
+    fn from(value: ConnectionType) -> Self {
+        match value {
             ConnectionType::Internal => "internal",
+            ConnectionType::Interserver => "interserver",
             ConnectionType::External => "external",
-        };
-        write!(f, "{value}")
+            ConnectionType::Unknown => "unknown",
+        }
+        .into()
     }
 }
+
+impl From<ConnectionType> for KeyValue {
+    fn from(value: ConnectionType) -> Self {
+        KeyValue::new("connection_type", value)
+    }
+}
+
+#[derive(Clone)]
 pub struct ConnectionMetrics {
     pub total: Counter<u64>,
+    node_id_kv: KeyValue,
 }
 
 impl ConnectionMetrics {
-    pub fn new(meter: &Meter) -> Self {
+    pub fn new(meter: &Meter, node_id: NodeId) -> Self {
         Self {
             total: meter
                 .u64_counter("coyote.connections.total")
                 .with_description("Total number of accepted connections")
                 .build(),
+            node_id_kv: node_id.into(),
         }
     }
 
-    pub fn accepted(&self, node_id: NodeId, t: ConnectionType) {
-        self.total.add(
-            1,
-            &[
-                KeyValue::new("node_id", node_id.to_string()),
-                KeyValue::new("connection_type", t.to_string()),
-            ],
-        );
+    pub fn accepted(&self, t: ConnectionType) {
+        self.total.add(1, &[self.node_id_kv.clone(), t.into()]);
     }
 }
 
+#[derive(Clone)]
 pub struct RequestMetrics {
     success: Counter<u64>,
     client_error: Counter<u64>,
     server_error: Counter<u64>,
     latency: Histogram<u64>,
     content_length: Histogram<u64>,
+    node_id_kv: KeyValue,
+    connection_type_kv: KeyValue,
 }
 
 impl RequestMetrics {
-    pub fn new(meter: &Meter) -> Self {
+    pub fn new(meter: &Meter, node_id: NodeId) -> Self {
         Self {
             success: meter
                 .u64_counter("coyote.request.success")
@@ -210,20 +218,29 @@ impl RequestMetrics {
                 .with_description("Content length")
                 .with_unit("By")
                 .build(),
+            node_id_kv: node_id.into(),
+            connection_type_kv: ConnectionType::Unknown.into(),
         }
+    }
+
+    /// Make a clone of this RequestMetrics (sharing the same meters) with the given
+    /// ConnectionType as context
+    pub fn with_connection_type(&self, connection_type: ConnectionType) -> Self {
+        let mut cloned = self.clone();
+        cloned.connection_type_kv = connection_type.into();
+        cloned
     }
 
     pub fn record(
         &self,
         route: &str,
-        node_id: NodeId,
         status: StatusCode,
         duration: u64,
         content_length: Option<u64>,
     ) {
         let attrs = &[
             KeyValue::new("route", route.to_owned()),
-            KeyValue::new("node_id", node_id.to_string()),
+            self.node_id_kv.clone(),
         ];
 
         if status.is_success() {

--- a/src/core/otel_spans.rs
+++ b/src/core/otel_spans.rs
@@ -6,7 +6,6 @@
 use std::{net::SocketAddr, time::Instant};
 
 use axum::{
-    Extension,
     extract::{ConnectInfo, MatchedPath, Request, State},
     middleware::Next,
     response::Response,
@@ -22,15 +21,15 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 pub(crate) async fn request_metrics_middleware(
-    State(state): State<crate::AppState>,
-    Extension(raft_state): Extension<super::cluster::RaftState>,
+    State(request_metrics): State<super::metrics::RequestMetrics>,
     matched_path: Option<MatchedPath>,
     req: Request,
     next: Next,
 ) -> Response {
     let route = matched_path
-        .map(|p| p.as_str().to_owned())
-        .unwrap_or_else(|| "unknown".to_owned());
+        .as_ref()
+        .map(|p| p.as_str())
+        .unwrap_or_else(|| "unknown");
     let content_length = req
         .headers()
         .get(header::CONTENT_LENGTH)
@@ -40,13 +39,7 @@ pub(crate) async fn request_metrics_middleware(
     let response = next.run(req).await;
     let duration = start.elapsed().as_millis() as _;
 
-    state.request_metrics.record(
-        &route,
-        raft_state.node_id,
-        response.status(),
-        duration,
-        content_length,
-    );
+    request_metrics.record(route, response.status(), duration, content_length);
     response
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,9 +96,6 @@ pub struct AppState {
     pub(crate) do_not_use_dbs: Databases,
 
     pub meter: Meter,
-    pub request_metrics: Arc<RequestMetrics>,
-    pub conn_metrics: Arc<ConnectionMetrics>,
-
     internal_client: InternalClient,
 
     pub(crate) auth_token_cache: Arc<parking_lot::RwLock<core::auth::FifoCache<Permissions>>>,
@@ -134,6 +131,8 @@ async fn run_interserver(
     raft: RaftState,
     listener: Option<TcpListener>,
     bind_barrier: Arc<Barrier>,
+    conn_metrics: ConnectionMetrics,
+    request_metrics: RequestMetrics,
 ) {
     let listen_address = cfg.cluster.listen_address(&cfg);
     let listener = match listener {
@@ -150,34 +149,31 @@ async fn run_interserver(
 
     let app = core::cluster::router(&cfg)
         .with_state(state.clone())
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            core::otel_spans::request_metrics_middleware,
-        ))
-        .layer(Extension(raft.clone()))
         .layer(DefaultBodyLimit::disable())
         .layer(middleware::from_fn(coyote_proto::capture_accept_hdr))
-        .layer(CatchPanicLayer::custom(handle_panic))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(AxumOtelSpanCreator)
                 .on_response(AxumOtelOnResponse)
                 .on_failure(AxumOtelOnFailure),
-        );
+        )
+        .layer(middleware::from_fn_with_state(
+            request_metrics,
+            core::otel_spans::request_metrics_middleware,
+        ))
+        .layer(CatchPanicLayer::custom(handle_panic))
+        .layer(Extension(raft.clone()));
     let svc = tower::make::Shared::new(
         // It is important that this service wraps the router instead of being
         // applied via `Router::layer`, as it would run after routing then.
         NormalizePath::trim_trailing_slash(app),
     );
 
-    let node_id = raft.node_id;
     let listener = listener.tap_io(move |tcp_stream| {
         if let Err(err) = tcp_stream.set_nodelay(true) {
             tracing::warn!("failed to set TCP_NODELAY on incoming connection: {err:#}");
         }
-        state
-            .conn_metrics
-            .accepted(node_id, ConnectionType::Internal);
+        conn_metrics.accepted(ConnectionType::Internal);
     });
 
     axum::serve(listener, svc)
@@ -191,6 +187,7 @@ async fn run_interserver(
 async fn run_internal(
     api_router: axum::Router,
     mut internal_req_rx: mpsc::Receiver<InternalRequest>,
+    request_metrics: RequestMetrics,
 ) {
     let svc = api_router
         .layer((
@@ -198,6 +195,10 @@ async fn run_internal(
                 .make_span_with(AxumOtelSpanCreator)
                 .on_response(AxumOtelOnResponse)
                 .on_failure(AxumOtelOnFailure),
+            middleware::from_fn_with_state(
+                request_metrics,
+                core::otel_spans::request_metrics_middleware,
+            ),
             middleware::from_fn(coyote_proto::capture_accept_hdr),
             CatchPanicLayer::custom(handle_panic),
         ))
@@ -246,9 +247,6 @@ impl AppState {
 
         let meter = opentelemetry::global::meter("coyote.svix.com");
 
-        let request_metrics = Arc::new(RequestMetrics::new(&meter));
-        let conn_metrics = Arc::new(ConnectionMetrics::new(&meter));
-
         let mut listen_addr = cfg.listen_address;
         if listen_addr.ip().is_unspecified() {
             listen_addr.set_ip(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
@@ -263,8 +261,6 @@ impl AppState {
             ro_dbs,
             do_not_use_dbs: dbs,
             meter,
-            request_metrics,
-            conn_metrics,
             internal_client,
             auth_token_cache,
             time,
@@ -369,10 +365,12 @@ pub async fn run_with_listeners(
             .expect("failed to initialize cluster");
     let node_id = raft_state.node_id;
 
+    let request_metrics = RequestMetrics::new(&app_state.meter, node_id);
+
     let v1_router = v1::router(Some(app_state.clone()))
         .with_state::<()>(app_state.clone())
         .layer(middleware::from_fn_with_state(
-            app_state.clone(),
+            request_metrics.with_connection_type(ConnectionType::External),
             core::otel_spans::request_metrics_middleware,
         ))
         .layer(Extension(raft_state.clone()))
@@ -382,12 +380,16 @@ pub async fn run_with_listeners(
 
     tokio::spawn(graceful_shutdown_handler());
 
+    let connection_metrics = ConnectionMetrics::new(&app_state.meter, node_id);
+
     let interserver = tokio::spawn(run_interserver(
         cfg.clone(),
         app_state.clone(),
         raft_state.clone(),
         interserver_listener,
         Arc::clone(&interserver_started_barrier),
+        connection_metrics.clone(),
+        request_metrics.with_connection_type(ConnectionType::Interserver),
     ));
 
     tokio::spawn({
@@ -406,7 +408,11 @@ pub async fn run_with_listeners(
         .nest_api_service("/api", v1_router)
         .finish_api(&mut openapi);
 
-    tokio::spawn(run_internal(api_router.clone(), internal_req_rx));
+    tokio::spawn(run_internal(
+        api_router.clone(),
+        internal_req_rx,
+        request_metrics.with_connection_type(ConnectionType::Internal),
+    ));
 
     openapi::postprocess_spec(&mut openapi);
     let docs_router = docs::router(openapi);
@@ -459,9 +465,7 @@ pub async fn run_with_listeners(
         if let Err(err) = tcp_stream.set_nodelay(true) {
             tracing::warn!("failed to set TCP_NODELAY on incoming connection: {err:#}");
         }
-        app_state
-            .conn_metrics
-            .accepted(node_id, ConnectionType::External);
+        connection_metrics.accepted(ConnectionType::External);
     });
 
     let worker_handle = tokio::task::spawn({


### PR DESCRIPTION
This is branched off of #672.

It refactors metrics so that we aren't cloning strings constantly. Specific changes:

 - Implements `From<NodeId>` for `opentelemetry::KeyValue` using an `Arc<str>` so that the clones are cheapish
 - When possible, shares the state (like the Connection Type and the Node ID) between the whole metrics instance instead of recreating it on every metric emission
 - Adds request metrics to the interserver port