### PR TITLE
Fix codegen bug in JS client

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run lint
+      - run: npm run build

--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -50,7 +50,7 @@ export class {{ resource_type_name }} {
             {
                 ...{{ req_body_schema_name }},
             {%- for field in positional_fields %}
-                {{ field.name | to_snake_case }},
+                {{ field.name | to_lower_camel_case }}: {{ field.name | to_snake_case }},
             {%- endfor %}
             }
         {%- endset -%}

--- a/z-clients/javascript/src/apis/cache.ts
+++ b/z-clients/javascript/src/apis/cache.ts
@@ -44,7 +44,7 @@ export class Cache {
         request.setBody(
             CacheSetInSerializer._toJsonObject({
                 ...cacheSetIn,
-                key,
+                key: key,
             })
         );
         
@@ -62,7 +62,7 @@ export class Cache {
         request.setBody(
             CacheGetInSerializer._toJsonObject({
                 ...cacheGetIn,
-                key,
+                key: key,
             })
         );
         
@@ -80,7 +80,7 @@ export class Cache {
         request.setBody(
             CacheDeleteInSerializer._toJsonObject({
                 ...cacheDeleteIn,
-                key,
+                key: key,
             })
         );
         

--- a/z-clients/javascript/src/apis/idempotency.ts
+++ b/z-clients/javascript/src/apis/idempotency.ts
@@ -44,7 +44,7 @@ export class Idempotency {
         request.setBody(
             IdempotencyStartInSerializer._toJsonObject({
                 ...idempotencyStartIn,
-                key,
+                key: key,
             })
         );
         
@@ -62,7 +62,7 @@ export class Idempotency {
         request.setBody(
             IdempotencyCompleteInSerializer._toJsonObject({
                 ...idempotencyCompleteIn,
-                key,
+                key: key,
             })
         );
         
@@ -80,7 +80,7 @@ export class Idempotency {
         request.setBody(
             IdempotencyAbortInSerializer._toJsonObject({
                 ...idempotencyAbortIn,
-                key,
+                key: key,
             })
         );
         

--- a/z-clients/javascript/src/apis/kv.ts
+++ b/z-clients/javascript/src/apis/kv.ts
@@ -44,7 +44,7 @@ export class Kv {
         request.setBody(
             KvSetInSerializer._toJsonObject({
                 ...kvSetIn,
-                key,
+                key: key,
             })
         );
         
@@ -62,7 +62,7 @@ export class Kv {
         request.setBody(
             KvGetInSerializer._toJsonObject({
                 ...kvGetIn,
-                key,
+                key: key,
             })
         );
         
@@ -80,7 +80,7 @@ export class Kv {
         request.setBody(
             KvDeleteInSerializer._toJsonObject({
                 ...kvDeleteIn,
-                key,
+                key: key,
             })
         );
         

--- a/z-clients/javascript/src/apis/msgs.ts
+++ b/z-clients/javascript/src/apis/msgs.ts
@@ -43,7 +43,7 @@ export class Msgs {
         request.setBody(
             MsgPublishInSerializer._toJsonObject({
                 ...msgPublishIn,
-                topic,
+                topic: topic,
             })
         );
         

--- a/z-clients/javascript/src/apis/msgsNamespace.ts
+++ b/z-clients/javascript/src/apis/msgsNamespace.ts
@@ -31,7 +31,7 @@ export class MsgsNamespace {
         request.setBody(
             MsgNamespaceCreateInSerializer._toJsonObject({
                 ...msgNamespaceCreateIn,
-                name,
+                name: name,
             })
         );
         
@@ -49,7 +49,7 @@ export class MsgsNamespace {
         request.setBody(
             MsgNamespaceGetInSerializer._toJsonObject({
                 ...msgNamespaceGetIn,
-                name,
+                name: name,
             })
         );
         

--- a/z-clients/javascript/src/apis/msgsQueue.ts
+++ b/z-clients/javascript/src/apis/msgsQueue.ts
@@ -62,8 +62,8 @@ export class MsgsQueue {
         request.setBody(
             MsgQueueReceiveInSerializer._toJsonObject({
                 ...msgQueueReceiveIn,
-                topic,
-                consumer_group,
+                topic: topic,
+                consumerGroup: consumer_group,
             })
         );
         
@@ -86,8 +86,8 @@ export class MsgsQueue {
         request.setBody(
             MsgQueueAckInSerializer._toJsonObject({
                 ...msgQueueAckIn,
-                topic,
-                consumer_group,
+                topic: topic,
+                consumerGroup: consumer_group,
             })
         );
         
@@ -111,8 +111,8 @@ export class MsgsQueue {
         request.setBody(
             MsgQueueConfigureInSerializer._toJsonObject({
                 ...msgQueueConfigureIn,
-                topic,
-                consumer_group,
+                topic: topic,
+                consumerGroup: consumer_group,
             })
         );
         
@@ -136,8 +136,8 @@ export class MsgsQueue {
         request.setBody(
             MsgQueueNackInSerializer._toJsonObject({
                 ...msgQueueNackIn,
-                topic,
-                consumer_group,
+                topic: topic,
+                consumerGroup: consumer_group,
             })
         );
         
@@ -156,8 +156,8 @@ export class MsgsQueue {
         request.setBody(
             MsgQueueRedriveDlqInSerializer._toJsonObject({
                 ...msgQueueRedriveDlqIn,
-                topic,
-                consumer_group,
+                topic: topic,
+                consumerGroup: consumer_group,
             })
         );
         

--- a/z-clients/javascript/src/apis/msgsStream.ts
+++ b/z-clients/javascript/src/apis/msgsStream.ts
@@ -45,8 +45,8 @@ export class MsgsStream {
         request.setBody(
             MsgStreamReceiveInSerializer._toJsonObject({
                 ...msgStreamReceiveIn,
-                topic,
-                consumer_group,
+                topic: topic,
+                consumerGroup: consumer_group,
             })
         );
         
@@ -70,8 +70,8 @@ export class MsgsStream {
         request.setBody(
             MsgStreamCommitInSerializer._toJsonObject({
                 ...msgStreamCommitIn,
-                topic,
-                consumer_group,
+                topic: topic,
+                consumerGroup: consumer_group,
             })
         );
         
@@ -96,8 +96,8 @@ export class MsgsStream {
         request.setBody(
             MsgStreamSeekInSerializer._toJsonObject({
                 ...msgStreamSeekIn,
-                topic,
-                consumer_group,
+                topic: topic,
+                consumerGroup: consumer_group,
             })
         );
         

--- a/z-clients/javascript/src/apis/msgsTopic.ts
+++ b/z-clients/javascript/src/apis/msgsTopic.ts
@@ -27,7 +27,7 @@ export class MsgsTopic {
         request.setBody(
             MsgTopicConfigureInSerializer._toJsonObject({
                 ...msgTopicConfigureIn,
-                topic,
+                topic: topic,
             })
         );
         


### PR DESCRIPTION
Fix a bug in the template that generated code that didn't compile because of differences in expected casing.

Also update the github workflow to actually run `npm build` in CI. That's why this never came up 😛 