### PR TITLE
cluster: improve more parts of snapshot handling

### DIFF
--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -313,6 +313,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
             log_sync_interval_duration: Duration::from_secs(30),
             log_ack_immediately: true,
             shut_down_on_go_away: true,
+            send_snapshot_timeout: Duration::from_secs(3),
         },
         bootstrap_cfg: None,
         bootstrap_cfg_path: None,

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -90,3 +90,7 @@ pub(super) fn cluster_log_sync_interval_commits() -> usize {
 pub(super) fn cluster_log_sync_interval_duration() -> Duration {
     Duration::from_secs(10)
 }
+
+pub(super) fn cluster_send_snapshot_timeout() -> Duration {
+    Duration::from_secs(30)
+}

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -286,6 +286,17 @@ pub struct ClusterConfiguration {
     )]
     pub election_timeout_max: Duration,
 
+    /// The minimum time to let an election run for.
+    ///
+    /// This should be set to at least 5x the RTT of your farthest-apart nodes
+    /// and must not be less than `cluster_election_timeout_max`.
+    #[serde(
+        rename = "send_snapshot_ms",
+        with = "crate::serde::duration::millis",
+        default = "defaults::cluster_send_snapshot_timeout"
+    )]
+    pub send_snapshot_timeout: Duration,
+
     /// Address that other nodes should use to communicate with this one.
     ///
     /// If not passed, we'll attempt to discover it at boot time.
@@ -660,6 +671,7 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
                 log_ack_immediately: cluster_log_ack_immediately,
                 snapshot_after_writes: cluster_snapshot_after_writes,
                 snapshot_after_time: cluster_snapshot_after_time,
+                send_snapshot_timeout: cluster_send_snapshot_timeout,
                 shut_down_on_go_away: _,
             },
     } = &mut config;
@@ -707,7 +719,8 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         cluster_discovery_timeout: "COYOTE_CLUSTER_DISCOVERY_TIMEOUT_MS",
         cluster_startup_discovery_delay: "COYOTE_CLUSTER_STARTUP_DISCOVERY_DELAY_MS",
         cluster_log_index_interval: "COYOTE_LOG_INDEX_INTERVAL_MS",
-        cluster_log_sync_interval_duration: "COYOTE_CLUSTER_LOG_SYNC_INTERVAL_MS"
+        cluster_log_sync_interval_duration: "COYOTE_CLUSTER_LOG_SYNC_INTERVAL_MS",
+        cluster_send_snapshot_timeout: "COYOTE_CLUSTER_SEND_SNAPSHOT_TIMEOUT_MS",
     );
 
     // Fields that require different parsing

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -69,6 +69,7 @@ pub(super) struct NetworkClient {
     node: Node,
     client: reqwest::Client,
     cfg: Configuration,
+    default_timeout: Duration,
 }
 
 impl NetworkClient {
@@ -79,7 +80,7 @@ impl NetworkClient {
         Resp: DeserializeOwned + Sized,
         Err: std::error::Error + DeserializeOwned + Sized,
     {
-        self.send_request_with_timeout(path, req, self.cfg.cluster.replication_request_timeout)
+        self.send_request_with_timeout(path, req, self.default_timeout)
             .await
     }
 
@@ -207,6 +208,7 @@ impl NetworkClient {
         Ok(last_committed_log_id)
     }
 
+    #[tracing::instrument(skip(self, rpc))]
     pub(super) async fn install_snapshot(
         &mut self,
         rpc: openraft::raft::InstallSnapshotRequest<TypeConfig>,
@@ -221,6 +223,7 @@ impl NetworkClient {
 }
 
 impl RaftNetworkV2<TypeConfig> for NetworkClient {
+    #[tracing::instrument(skip(self, rpc))]
     async fn append_entries(
         &mut self,
         rpc: openraft::raft::AppendEntriesRequest<TypeConfig>,
@@ -230,6 +233,7 @@ impl RaftNetworkV2<TypeConfig> for NetworkClient {
             .await
     }
 
+    #[tracing::instrument(skip(self, rpc))]
     async fn vote(
         &mut self,
         rpc: openraft::raft::VoteRequest<TypeConfig>,
@@ -239,6 +243,7 @@ impl RaftNetworkV2<TypeConfig> for NetworkClient {
             .await
     }
 
+    #[tracing::instrument(skip(self, vote, snapshot, cancel))]
     async fn full_snapshot(
         &mut self,
         vote: openraft::type_config::alias::VoteOf<TypeConfig>,
@@ -271,6 +276,7 @@ impl NetworkFactory {
             node: node.clone(),
             client: self.client.clone(),
             cfg: self.cfg.clone(),
+            default_timeout: Duration::from_secs(60),
         }
     }
 }

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -90,6 +90,10 @@ pub async fn initialize_raft(
         election_timeout_max: cfg.cluster.election_timeout_max.as_millis() as u64,
         cluster_name: cfg.cluster.name.clone(),
         snapshot_policy: openraft::SnapshotPolicy::Never,
+        // we're using the v1 version of snapshot sending for now
+        #[allow(deprecated)]
+        send_snapshot_timeout: cfg.cluster.send_snapshot_timeout.as_millis() as u64,
+        install_snapshot_timeout: cfg.cluster.send_snapshot_timeout.as_millis() as u64,
         ..Default::default()
     };
     let config = Arc::new(config.validate().context("configuring openraft")?);

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -182,7 +182,7 @@ pub(crate) fn serialize_to_file<F: Write + Seek>(
     for (db_name, db, snapshot, keyspaces) in targets {
         let mut keyspace_manifests = KeyspaceManifest::default();
         for keyspace_name in keyspaces {
-            tracing::debug!(keyspace=%keyspace_name, "serializing a keyspce");
+            tracing::debug!(keyspace=%keyspace_name, "serializing a keyspace");
             // TODO: we should be copying keyspace create options from the source;
             // see https://github.com/fjall-rs/fjall/issues/262
             let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -377,10 +377,14 @@ impl Store {
     async fn install_snapshot_(
         &mut self,
         meta: &SnapshotMeta,
-        snapshot: StoredSnapshot,
+        mut snapshot: StoredSnapshot,
     ) -> anyhow::Result<()> {
         tracing::debug!("starting snapshot installation");
-        let mut f = snapshot.file.into_std().await;
+        if !snapshot.is_final {
+            snapshot.persist(meta, &self.snapshot_directory)?;
+        }
+        let mut f = snapshot.file.try_clone().await?.into_std().await;
+        f.seek(SeekFrom::Start(0))?;
         let handle = self.stores.clone();
         spawn_blocking_in_current_span(move || {
             let stores = handle.write();
@@ -392,7 +396,8 @@ impl Store {
         self.record_ids_().await?;
         self.delete_unused_snapshots(snapshot.path.as_path())
             .await?;
-        self.set_last_snapshot_(meta.clone(), snapshot.path).await?;
+        self.set_last_snapshot_(meta.clone(), snapshot.path.clone())
+            .await?;
         Ok(())
     }
 
@@ -448,14 +453,17 @@ impl Store {
     }
 
     async fn begin_receiving_snapshot_(&mut self) -> anyhow::Result<SnapshotData> {
-        let path = self
-            .snapshot_directory
-            .with_file_name(format!("coyote-incoming-snapshot-{}", self.snapshot_idx));
+        let tempfile = tempfile::Builder::new()
+            .permissions(std::fs::Permissions::from_mode(0o600))
+            .tempfile_in(&self.snapshot_directory)?;
+        let (f, path) = tempfile.keep()?;
         self.snapshot_idx += 1;
-        let f = tokio::fs::File::create_new(path.clone())
-            .await
-            .context("failed to create snapshot")?;
-        Ok(StoredSnapshot { path, file: f })
+        let f = tokio::fs::File::from_std(f);
+        Ok(StoredSnapshot {
+            path,
+            file: f,
+            is_final: false,
+        })
     }
 
     fn prep_snapshot_builder_(&mut self) {
@@ -476,6 +484,7 @@ impl Store {
                 snapshot: StoredSnapshot {
                     file: f,
                     path: last_snapshot.path.clone(),
+                    is_final: true,
                 },
             }))
         } else {
@@ -549,11 +558,26 @@ impl Store {
 pub struct StoredSnapshot {
     file: tokio::fs::File,
     path: PathBuf,
+    is_final: bool,
+}
+
+impl Drop for StoredSnapshot {
+    fn drop(&mut self) {
+        if !self.is_final
+            && let Err(err) = std::fs::remove_file(&self.path)
+        {
+            tracing::warn!(?err, "error unlinking in-progress snapshot");
+        }
+    }
 }
 
 impl std::fmt::Debug for StoredSnapshot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "StoredSnapshot {{ path: {:?} }}", self.path)
+        write!(
+            f,
+            "StoredSnapshot {{ path: {:?}, final: {:?} }}",
+            self.path, self.is_final
+        )
     }
 }
 
@@ -639,7 +663,28 @@ impl StoredSnapshot {
         })
         .await??;
         let file = tokio::fs::File::from_std(file);
-        Ok(Self { file, path })
+        Ok(Self {
+            file,
+            path,
+            is_final: true,
+        })
+    }
+
+    fn persist(&mut self, metadata: &SnapshotMeta, directory: &Path) -> anyhow::Result<()> {
+        if self.is_final {
+            anyhow::bail!("cannot persist a final snapshot");
+        }
+        let file_name = format!("coyote-{}", metadata.snapshot_id);
+        let path = directory.join(file_name);
+        tracing::debug!(
+            current_path = %self.path.display(),
+            target_path = %path.display(),
+            "persisting incoming snapshot"
+        );
+        std::fs::rename(&self.path, &path).context("renaming snapshot into place")?;
+        self.path = path;
+        self.is_final = true;
+        Ok(())
     }
 }
 
@@ -704,12 +749,8 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
         meta: &SnapshotMeta,
         snapshot: StoredSnapshot,
     ) -> StorageResult<()> {
-        self.inner
-            .write()
-            .await
-            .install_snapshot_(meta, snapshot)
-            .await
-            .map_err(io_err)
+        let mut this = self.inner.write().await;
+        this.install_snapshot_(meta, snapshot).await.map_err(io_err)
     }
 }
 

--- a/src/core/cluster/streaming_snapshot.rs
+++ b/src/core/cluster/streaming_snapshot.rs
@@ -145,6 +145,11 @@ pub(super) trait ChunkedSnapshotReceiver {
 }
 
 impl<SM> ChunkedSnapshotReceiver for Raft<TypeConfig, SM> {
+    #[tracing::instrument(skip(self, req), fields(
+        snapshot_id = %req.meta.snapshot_id,
+        offset = req.offset,
+        done = req.done
+    ))]
     async fn install_snapshot(
         &self,
         req: InstallSnapshotRequest<TypeConfig>,
@@ -154,13 +159,6 @@ impl<SM> ChunkedSnapshotReceiver for Raft<TypeConfig, SM> {
         let snapshot_id = &req.meta.snapshot_id;
         let snapshot_meta = req.meta.clone();
         let done = req.done;
-
-        tracing::info!(
-            snapshot_id = display(snapshot_id),
-            offset = req.offset,
-            done,
-            "ChunkedSnapshotReceiver::install_snapshot"
-        );
 
         // Get or create streaming state via extension()
         let state: StreamingState = self.extension();
@@ -194,10 +192,12 @@ impl<SM> ChunkedSnapshotReceiver for Raft<TypeConfig, SM> {
             *streaming = Some(Streaming::new(snapshot_id.clone(), snapshot_data));
         }
 
+        let chunk_size = req.data.len();
+
         // Write the chunk
         streaming.as_mut().unwrap().receive_chunk(&req).await?;
 
-        tracing::info!("Received snapshot chunk");
+        tracing::debug!(?snapshot_id, chunk_size, "Received snapshot chunk");
 
         // If done, finalize the snapshot
         if done {
@@ -211,7 +211,7 @@ impl<SM> ChunkedSnapshotReceiver for Raft<TypeConfig, SM> {
                 )))
             })?;
 
-            tracing::info!(
+            tracing::debug!(
                 snapshot_meta = debug(&snapshot_meta),
                 "Finished streaming snapshot"
             );


### PR DESCRIPTION
Changes:

 - write the incoming snapshot to a temp file so that if we die half-way through receiving, it gets dropped
 - increase the snapshot send timeout
 - make the network client use a much larger timeout for requests without a TTL option (which is to say, requests that we are making instead of that openraft is making)