### PR TITLE
Add basic metrics to `msgs` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
  "fjall",
  "fjall-utils",
  "jiff",
+ "opentelemetry",
  "rand 0.9.2",
  "rmp-serde",
  "schemars 1.2.1",

--- a/crates/msgs/Cargo.toml
+++ b/crates/msgs/Cargo.toml
@@ -14,6 +14,7 @@ coyote-operations.workspace = true
 fjall.workspace = true
 fjall-utils.workspace = true
 jiff.workspace = true
+opentelemetry.workspace = true
 rand.workspace = true
 rmp-serde.workspace = true
 schemars.workspace = true

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -9,6 +9,7 @@ use fjall_utils::{ReadableKeyspace, TableRow};
 use tables::{MsgRow, QueueLeaseRow, StreamLeaseRow, TopicRow};
 
 pub mod entities;
+pub mod metrics;
 pub mod operations;
 pub(crate) mod tables;
 
@@ -22,6 +23,7 @@ pub struct State {
     pub(crate) db: fjall::Database,
     pub(crate) metadata_tables: fjall::Keyspace,
     pub(crate) msg_table: fjall::Keyspace,
+    pub(crate) metrics: metrics::MsgMetrics,
 }
 
 impl State {
@@ -38,10 +40,13 @@ impl State {
             db.keyspace(MSG_KEYSPACE, || opts)?
         };
 
+        let meter = opentelemetry::global::meter("coyote.svix.com");
+
         Ok(Self {
             db,
             metadata_tables,
             msg_table,
+            metrics: metrics::MsgMetrics::new(&meter),
         })
     }
 }

--- a/crates/msgs/src/metrics.rs
+++ b/crates/msgs/src/metrics.rs
@@ -1,0 +1,167 @@
+use opentelemetry::metrics::{Counter, Meter};
+
+#[derive(Clone)]
+pub struct MsgMetrics {
+    pub(crate) published: Counter<u64>,
+    pub(crate) published_bytes: Counter<u64>,
+
+    pub(crate) queue_received: Counter<u64>,
+    pub(crate) queue_acked: Counter<u64>,
+    pub(crate) queue_nacked: Counter<u64>,
+    pub(crate) queue_nack_retried: Counter<u64>,
+    pub(crate) queue_nack_dlq: Counter<u64>,
+    pub(crate) queue_redrive: Counter<u64>,
+
+    pub(crate) stream_received: Counter<u64>,
+    pub(crate) stream_committed: Counter<u64>,
+    pub(crate) stream_no_lease: Counter<u64>,
+    pub(crate) stream_seeks: Counter<u64>,
+}
+
+impl MsgMetrics {
+    pub fn new(meter: &Meter) -> Self {
+        Self {
+            published: meter
+                .u64_counter("coyote.msgs.published")
+                .with_description("Messages published")
+                .with_unit("{message}")
+                .build(),
+            published_bytes: meter
+                .u64_counter("coyote.msgs.published.bytes")
+                .with_description("Total bytes published")
+                .with_unit("By")
+                .build(),
+            queue_received: meter
+                .u64_counter("coyote.msgs.queue.received")
+                .with_description("Messages delivered")
+                .with_unit("{message}")
+                .build(),
+            queue_acked: meter
+                .u64_counter("coyote.msgs.queue.acked")
+                .with_description("Messages acknowledged in queue")
+                .with_unit("{message}")
+                .build(),
+            queue_nacked: meter
+                .u64_counter("coyote.msgs.queue.nacked")
+                .with_description("Messages nacked")
+                .with_unit("{message}")
+                .build(),
+            queue_nack_retried: meter
+                .u64_counter("coyote.msgs.queue.retried")
+                .with_description("Messages scheduled for retry")
+                .with_unit("{message}")
+                .build(),
+            queue_nack_dlq: meter
+                .u64_counter("coyote.msgs.queue.nack.dlq")
+                .with_description("Messages sent to dead-letter queue")
+                .with_unit("{message}")
+                .build(),
+            queue_redrive: meter
+                .u64_counter("coyote.msgs.queue.redrive")
+                .with_description("Messages redriven from dead-letter queue")
+                .with_unit("{message}")
+                .build(),
+            stream_received: meter
+                .u64_counter("coyote.msgs.stream.received")
+                .with_description("Messages delivered")
+                .with_unit("{message}")
+                .build(),
+            stream_committed: meter
+                .u64_counter("coyote.msgs.stream.committed")
+                .with_description("Stream offset commits")
+                .with_unit("{event}")
+                .build(),
+            stream_no_lease: meter
+                .u64_counter("coyote.msgs.stream.no_lease")
+                .with_description("Times stream receive failed because all partitions were leased")
+                .with_unit("{event}")
+                .build(),
+            stream_seeks: meter
+                .u64_counter("coyote.msgs.stream.seek")
+                .with_description("Stream seek operations")
+                .with_unit("{event}")
+                .build(),
+        }
+    }
+}
+
+impl MsgMetrics {
+    pub(crate) fn record_published(&self, topic: &str, msg_count: u64, bytes: u64) {
+        let attrs = &[opentelemetry::KeyValue::new("topic", topic.to_owned())];
+        self.published.add(msg_count, attrs);
+        self.published_bytes.add(bytes, attrs);
+    }
+
+    pub(crate) fn record_queue_received(&self, topic: &str, consumer_group: &str, count: u64) {
+        let attrs = &[
+            opentelemetry::KeyValue::new("topic", topic.to_owned()),
+            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
+        ];
+        self.queue_received.add(count, attrs);
+    }
+
+    pub(crate) fn record_queue_acked(&self, topic: &str, consumer_group: &str, count: u64) {
+        let attrs = &[
+            opentelemetry::KeyValue::new("topic", topic.to_owned()),
+            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
+        ];
+        self.queue_acked.add(count, attrs);
+    }
+
+    pub(crate) fn record_queue_nacked(
+        &self,
+        topic: &str,
+        consumer_group: &str,
+        nacked: u64,
+        retried: u64,
+        dlq: u64,
+    ) {
+        let attrs = &[
+            opentelemetry::KeyValue::new("topic", topic.to_owned()),
+            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
+        ];
+        self.queue_nacked.add(nacked, attrs);
+        self.queue_nack_retried.add(retried, attrs);
+        self.queue_nack_dlq.add(dlq, attrs);
+    }
+
+    pub(crate) fn record_queue_redrive(&self, topic: &str, consumer_group: &str, count: u64) {
+        let attrs = &[
+            opentelemetry::KeyValue::new("topic", topic.to_owned()),
+            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
+        ];
+        self.queue_redrive.add(count, attrs);
+    }
+
+    pub(crate) fn record_stream_received(&self, topic: &str, consumer_group: &str, count: u64) {
+        let attrs = &[
+            opentelemetry::KeyValue::new("topic", topic.to_owned()),
+            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
+        ];
+        self.stream_received.add(count, attrs);
+    }
+
+    pub(crate) fn record_stream_no_lease(&self, topic: &str, consumer_group: &str) {
+        let attrs = &[
+            opentelemetry::KeyValue::new("topic", topic.to_owned()),
+            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
+        ];
+        self.stream_no_lease.add(1, attrs);
+    }
+
+    pub(crate) fn record_stream_committed(&self, topic: &str, consumer_group: &str) {
+        let attrs = &[
+            opentelemetry::KeyValue::new("topic", topic.to_owned()),
+            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
+        ];
+        self.stream_committed.add(1, attrs);
+    }
+
+    pub(crate) fn record_stream_seek(&self, topic: &str, consumer_group: &str) {
+        let attrs = &[
+            opentelemetry::KeyValue::new("topic", topic.to_owned()),
+            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
+        ];
+        self.stream_seeks.add(1, attrs);
+    }
+}

--- a/crates/msgs/src/metrics.rs
+++ b/crates/msgs/src/metrics.rs
@@ -1,5 +1,19 @@
 use opentelemetry::metrics::{Counter, Meter};
 
+use crate::entities::{ConsumerGroup, TopicName};
+
+impl From<&TopicName> for opentelemetry::KeyValue {
+    fn from(topic: &TopicName) -> Self {
+        opentelemetry::KeyValue::new("topic", topic.to_string())
+    }
+}
+
+impl From<&ConsumerGroup> for opentelemetry::KeyValue {
+    fn from(group: &ConsumerGroup) -> Self {
+        opentelemetry::KeyValue::new("consumer_group", group.to_string())
+    }
+}
+
 #[derive(Clone)]
 pub struct MsgMetrics {
     pub(crate) published: Counter<u64>,
@@ -86,82 +100,82 @@ impl MsgMetrics {
 }
 
 impl MsgMetrics {
-    pub(crate) fn record_published(&self, topic: &str, msg_count: u64, bytes: u64) {
-        let attrs = &[opentelemetry::KeyValue::new("topic", topic.to_owned())];
+    pub(crate) fn record_published(&self, topic: &TopicName, msg_count: u64, bytes: u64) {
+        let attrs = &[opentelemetry::KeyValue::from(topic)];
         self.published.add(msg_count, attrs);
         self.published_bytes.add(bytes, attrs);
     }
 
-    pub(crate) fn record_queue_received(&self, topic: &str, consumer_group: &str, count: u64) {
-        let attrs = &[
-            opentelemetry::KeyValue::new("topic", topic.to_owned()),
-            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
-        ];
+    pub(crate) fn record_queue_received(
+        &self,
+        topic: &TopicName,
+        consumer_group: &ConsumerGroup,
+        count: u64,
+    ) {
+        let attrs = &[topic.into(), consumer_group.into()];
         self.queue_received.add(count, attrs);
     }
 
-    pub(crate) fn record_queue_acked(&self, topic: &str, consumer_group: &str, count: u64) {
-        let attrs = &[
-            opentelemetry::KeyValue::new("topic", topic.to_owned()),
-            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
-        ];
+    pub(crate) fn record_queue_acked(
+        &self,
+        topic: &TopicName,
+        consumer_group: &ConsumerGroup,
+        count: u64,
+    ) {
+        let attrs = &[topic.into(), consumer_group.into()];
         self.queue_acked.add(count, attrs);
     }
 
     pub(crate) fn record_queue_nacked(
         &self,
-        topic: &str,
-        consumer_group: &str,
+        topic: &TopicName,
+        consumer_group: &ConsumerGroup,
         nacked: u64,
         retried: u64,
         dlq: u64,
     ) {
-        let attrs = &[
-            opentelemetry::KeyValue::new("topic", topic.to_owned()),
-            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
-        ];
+        let attrs = &[topic.into(), consumer_group.into()];
         self.queue_nacked.add(nacked, attrs);
         self.queue_nack_retried.add(retried, attrs);
         self.queue_nack_dlq.add(dlq, attrs);
     }
 
-    pub(crate) fn record_queue_redrive(&self, topic: &str, consumer_group: &str, count: u64) {
-        let attrs = &[
-            opentelemetry::KeyValue::new("topic", topic.to_owned()),
-            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
-        ];
+    pub(crate) fn record_queue_redrive(
+        &self,
+        topic: &TopicName,
+        consumer_group: &ConsumerGroup,
+        count: u64,
+    ) {
+        let attrs = &[topic.into(), consumer_group.into()];
         self.queue_redrive.add(count, attrs);
     }
 
-    pub(crate) fn record_stream_received(&self, topic: &str, consumer_group: &str, count: u64) {
-        let attrs = &[
-            opentelemetry::KeyValue::new("topic", topic.to_owned()),
-            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
-        ];
+    pub(crate) fn record_stream_received(
+        &self,
+        topic: &TopicName,
+        consumer_group: &ConsumerGroup,
+        count: u64,
+    ) {
+        let attrs = &[topic.into(), consumer_group.into()];
         self.stream_received.add(count, attrs);
     }
 
-    pub(crate) fn record_stream_no_lease(&self, topic: &str, consumer_group: &str) {
-        let attrs = &[
-            opentelemetry::KeyValue::new("topic", topic.to_owned()),
-            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
-        ];
+    pub(crate) fn record_stream_no_lease(&self, topic: &TopicName, consumer_group: &ConsumerGroup) {
+        let attrs = &[topic.into(), consumer_group.into()];
         self.stream_no_lease.add(1, attrs);
     }
 
-    pub(crate) fn record_stream_committed(&self, topic: &str, consumer_group: &str) {
-        let attrs = &[
-            opentelemetry::KeyValue::new("topic", topic.to_owned()),
-            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
-        ];
+    pub(crate) fn record_stream_committed(
+        &self,
+        topic: &TopicName,
+        consumer_group: &ConsumerGroup,
+    ) {
+        let attrs = &[topic.into(), consumer_group.into()];
         self.stream_committed.add(1, attrs);
     }
 
-    pub(crate) fn record_stream_seek(&self, topic: &str, consumer_group: &str) {
-        let attrs = &[
-            opentelemetry::KeyValue::new("topic", topic.to_owned()),
-            opentelemetry::KeyValue::new("consumer_group", consumer_group.to_owned()),
-        ];
+    pub(crate) fn record_stream_seek(&self, topic: &TopicName, consumer_group: &ConsumerGroup) {
+        let attrs = &[topic.into(), consumer_group.into()];
         self.stream_seeks.add(1, attrs);
     }
 }

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -53,6 +53,9 @@ impl PublishOperation {
         let state = state.clone();
 
         let results = spawn_blocking_in_current_span(move || {
+            let bytes: u64 = self.msgs.iter().map(|m| m.value.len() as u64).sum();
+            let topic = self.topic.to_string();
+
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
                 TopicRow::key_for(self.namespace_id, &self.topic),
@@ -96,6 +99,13 @@ impl PublishOperation {
             )?;
 
             batch.commit().map_err(Error::from)?;
+
+            let msg_count: u64 = results
+                .iter()
+                .map(|r| r.offset.saturating_sub(r.start_offset))
+                .sum();
+            state.metrics.record_published(&topic, msg_count, bytes);
+
             Ok::<_, Error>(results)
         })
         .await??;

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -54,7 +54,6 @@ impl PublishOperation {
 
         let results = spawn_blocking_in_current_span(move || {
             let bytes: u64 = self.msgs.iter().map(|m| m.value.len() as u64).sum();
-            let topic = self.topic.to_string();
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
@@ -104,7 +103,9 @@ impl PublishOperation {
                 .iter()
                 .map(|r| r.offset.saturating_sub(r.start_offset))
                 .sum();
-            state.metrics.record_published(&topic, msg_count, bytes);
+            state
+                .metrics
+                .record_published(&self.topic, msg_count, bytes);
 
             Ok::<_, Error>(results)
         })

--- a/crates/msgs/src/operations/queue/ack.rs
+++ b/crates/msgs/src/operations/queue/ack.rs
@@ -43,6 +43,10 @@ impl QueueAckOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
+            let topic = self.topic.to_string();
+            let consumer_group = self.consumer_group.to_string();
+            let ack_count = self.msg_ids.len() as u64;
+
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
                 TopicRow::key_for(self.namespace_id, &self.topic),
@@ -93,6 +97,9 @@ impl QueueAckOperation {
 
             batch.commit().map_err(Error::from)?;
 
+            state
+                .metrics
+                .record_queue_acked(&topic, &consumer_group, ack_count);
             Ok(QueueAckResponseData {})
         })
         .await?

--- a/crates/msgs/src/operations/queue/ack.rs
+++ b/crates/msgs/src/operations/queue/ack.rs
@@ -43,8 +43,6 @@ impl QueueAckOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
-            let topic = self.topic.to_string();
-            let consumer_group = self.consumer_group.to_string();
             let ack_count = self.msg_ids.len() as u64;
 
             let topic_row = TopicRow::fetch(
@@ -99,7 +97,7 @@ impl QueueAckOperation {
 
             state
                 .metrics
-                .record_queue_acked(&topic, &consumer_group, ack_count);
+                .record_queue_acked(&self.topic, &self.consumer_group, ack_count);
             Ok(QueueAckResponseData {})
         })
         .await?

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -41,7 +41,11 @@ impl QueueNackOperation {
     #[tracing::instrument(skip_all, level = "debug")]
     async fn apply_real(self, state: &State, now: Timestamp) -> Result<QueueNackResponseData> {
         let state = state.clone();
+
         spawn_blocking_in_current_span(move || {
+            let topic = self.topic.to_string();
+            let consumer_group = self.consumer_group.to_string();
+            let nack_count = self.msg_ids.len() as u64;
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
                 TopicRow::key_for(self.namespace_id, &self.topic),
@@ -59,6 +63,8 @@ impl QueueNackOperation {
                 .unwrap_or_default();
 
             let mut batch = state.db.batch();
+            let mut retried_count: u64 = 0;
+            let mut dlq_count: u64 = 0;
 
             for msg_id in &self.msg_ids {
                 let existing = QueueLeaseRow::fetch(
@@ -79,6 +85,7 @@ impl QueueNackOperation {
                             attempt_count: attempt_count + 1,
                         },
                     )?;
+                    retried_count += 1;
                 } else if let Some(dlq_topic) = config.as_ref().and_then(|c| c.dlq_topic.as_ref()) {
                     // Retries exhausted, forward to DLQ topic
                     forward_to_dlq(
@@ -91,6 +98,7 @@ impl QueueNackOperation {
                         &self.consumer_group,
                         now,
                     )?;
+                    dlq_count += 1;
                 } else {
                     // No config or no DLQ topic — immediate DLQ
                     batch.insert_row(
@@ -98,11 +106,19 @@ impl QueueNackOperation {
                         QueueLeaseRow::key_for(topic_row.id, msg_id, &self.consumer_group),
                         &QueueLeaseRow::dlq_marker(attempt_count),
                     )?;
+                    dlq_count += 1;
                 }
             }
 
             batch.commit().map_err(Error::from)?;
 
+            state.metrics.record_queue_nacked(
+                &topic,
+                &consumer_group,
+                nack_count,
+                retried_count,
+                dlq_count,
+            );
             Ok(QueueNackResponseData {})
         })
         .await?

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -43,8 +43,6 @@ impl QueueNackOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
-            let topic = self.topic.to_string();
-            let consumer_group = self.consumer_group.to_string();
             let nack_count = self.msg_ids.len() as u64;
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
@@ -113,8 +111,8 @@ impl QueueNackOperation {
             batch.commit().map_err(Error::from)?;
 
             state.metrics.record_queue_nacked(
-                &topic,
-                &consumer_group,
+                &self.topic,
+                &self.consumer_group,
                 nack_count,
                 retried_count,
                 dlq_count,

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -53,8 +53,6 @@ impl QueueReceiveOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
-            let topic = self.topic.to_string();
-            let consumer_group = self.consumer_group.to_string();
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<QueueReceiveMsg> = Vec::with_capacity(remaining.into());
 
@@ -153,9 +151,11 @@ impl QueueReceiveOperation {
             batch.commit().map_err(Error::from)?;
 
             Span::current().record("msgs_returned", all_msgs.len());
-            state
-                .metrics
-                .record_queue_received(&topic, &consumer_group, all_msgs.len() as u64);
+            state.metrics.record_queue_received(
+                &self.topic,
+                &self.consumer_group,
+                all_msgs.len() as u64,
+            );
             Ok(QueueReceiveResponseData { msgs: all_msgs })
         })
         .await?

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -53,6 +53,8 @@ impl QueueReceiveOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
+            let topic = self.topic.to_string();
+            let consumer_group = self.consumer_group.to_string();
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<QueueReceiveMsg> = Vec::with_capacity(remaining.into());
 
@@ -151,7 +153,9 @@ impl QueueReceiveOperation {
             batch.commit().map_err(Error::from)?;
 
             Span::current().record("msgs_returned", all_msgs.len());
-
+            state
+                .metrics
+                .record_queue_received(&topic, &consumer_group, all_msgs.len() as u64);
             Ok(QueueReceiveResponseData { msgs: all_msgs })
         })
         .await?

--- a/crates/msgs/src/operations/queue/redrive_dlq.rs
+++ b/crates/msgs/src/operations/queue/redrive_dlq.rs
@@ -31,7 +31,10 @@ impl QueueRedriveDlqOperation {
     #[tracing::instrument(skip_all, level = "debug")]
     async fn apply_real(self, state: &State) -> Result<QueueRedriveDlqResponseData> {
         let state = state.clone();
+
         spawn_blocking_in_current_span(move || {
+            let topic = self.topic.to_string();
+            let consumer_group = self.consumer_group.to_string();
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
                 TopicRow::key_for(self.namespace_id, &self.topic),
@@ -39,6 +42,7 @@ impl QueueRedriveDlqOperation {
             .ok_or_else(|| Error::invalid_user_input("topic must exist"))?;
 
             let mut batch = state.db.batch();
+            let mut total_redriven: u64 = 0;
 
             for partition_idx in 0..topic_row.partitions {
                 let partition = Partition::new(partition_idx)?;
@@ -59,6 +63,7 @@ impl QueueRedriveDlqOperation {
                 )?;
 
                 let mut min_redriven: Option<u64> = None;
+                let mut partition_redriven: u64 = 0;
                 for (msg_id, lease) in &leases {
                     if lease.is_dlq() {
                         batch.remove(
@@ -68,6 +73,7 @@ impl QueueRedriveDlqOperation {
                         );
                         min_redriven =
                             Some(min_redriven.map_or(msg_id.offset, |m| m.min(msg_id.offset)));
+                        partition_redriven += 1;
                     }
                 }
 
@@ -80,10 +86,15 @@ impl QueueRedriveDlqOperation {
                         &cursor,
                     )?;
                 }
+
+                total_redriven += partition_redriven;
             }
 
             batch.commit().map_err(Error::from)?;
 
+            state
+                .metrics
+                .record_queue_redrive(&topic, &consumer_group, total_redriven);
             Ok(QueueRedriveDlqResponseData {})
         })
         .await?

--- a/crates/msgs/src/operations/queue/redrive_dlq.rs
+++ b/crates/msgs/src/operations/queue/redrive_dlq.rs
@@ -33,8 +33,6 @@ impl QueueRedriveDlqOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
-            let topic = self.topic.to_string();
-            let consumer_group = self.consumer_group.to_string();
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
                 TopicRow::key_for(self.namespace_id, &self.topic),
@@ -94,7 +92,7 @@ impl QueueRedriveDlqOperation {
 
             state
                 .metrics
-                .record_queue_redrive(&topic, &consumer_group, total_redriven);
+                .record_queue_redrive(&self.topic, &self.consumer_group, total_redriven);
             Ok(QueueRedriveDlqResponseData {})
         })
         .await?

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -40,10 +40,8 @@ impl StreamCommitOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
-            let consumer_group = self.consumer_group.to_string();
             let mut batch = state.db.batch();
             let topic = self.topic;
-            let topic_name = topic.topic.to_string();
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
@@ -72,7 +70,7 @@ impl StreamCommitOperation {
 
             state
                 .metrics
-                .record_stream_committed(&topic_name, &consumer_group);
+                .record_stream_committed(&topic.topic, &self.consumer_group);
             Ok(StreamCommitResponseData {})
         })
         .await?

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -38,9 +38,12 @@ impl StreamCommitOperation {
     #[tracing::instrument(skip_all, level = "debug")]
     async fn apply_real(self, state: &State) -> Result<StreamCommitResponseData> {
         let state = state.clone();
+
         spawn_blocking_in_current_span(move || {
+            let consumer_group = self.consumer_group.to_string();
             let mut batch = state.db.batch();
             let topic = self.topic;
+            let topic_name = topic.topic.to_string();
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
@@ -67,6 +70,9 @@ impl StreamCommitOperation {
 
             batch.commit().map_err(Error::from)?;
 
+            state
+                .metrics
+                .record_stream_committed(&topic_name, &consumer_group);
             Ok(StreamCommitResponseData {})
         })
         .await?

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -56,7 +56,11 @@ impl StreamReceiveOperation {
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size = self.batch_size))]
     async fn apply_real(self, state: &State, now: Timestamp) -> Result<StreamReceiveResponseData> {
         let state = state.clone();
+
         spawn_blocking_in_current_span(move || {
+            let topic = self.topic.to_string();
+            let consumer_group = self.consumer_group.to_string();
+
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<StreamReceiveMsg> = Vec::with_capacity(remaining as usize);
             let expiry = now + self.lease_duration_ms;
@@ -161,6 +165,9 @@ impl StreamReceiveOperation {
             }
 
             if no_lease_available {
+                state
+                    .metrics
+                    .record_stream_no_lease(&topic, &consumer_group);
                 return Err(Error::bad_request(
                     "no_available_leases",
                     "no available leases",
@@ -170,7 +177,9 @@ impl StreamReceiveOperation {
             batch.commit().map_err(Error::from)?;
 
             Span::current().record("msgs_returned", all_msgs.len());
-
+            state
+                .metrics
+                .record_stream_received(&topic, &consumer_group, all_msgs.len() as u64);
             Ok(StreamReceiveResponseData { msgs: all_msgs })
         })
         .await?

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -58,9 +58,6 @@ impl StreamReceiveOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
-            let topic = self.topic.to_string();
-            let consumer_group = self.consumer_group.to_string();
-
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<StreamReceiveMsg> = Vec::with_capacity(remaining as usize);
             let expiry = now + self.lease_duration_ms;
@@ -167,7 +164,7 @@ impl StreamReceiveOperation {
             if no_lease_available {
                 state
                     .metrics
-                    .record_stream_no_lease(&topic, &consumer_group);
+                    .record_stream_no_lease(&self.topic, &self.consumer_group);
                 return Err(Error::bad_request(
                     "no_available_leases",
                     "no available leases",
@@ -177,9 +174,11 @@ impl StreamReceiveOperation {
             batch.commit().map_err(Error::from)?;
 
             Span::current().record("msgs_returned", all_msgs.len());
-            state
-                .metrics
-                .record_stream_received(&topic, &consumer_group, all_msgs.len() as u64);
+            state.metrics.record_stream_received(
+                &self.topic,
+                &self.consumer_group,
+                all_msgs.len() as u64,
+            );
             Ok(StreamReceiveResponseData { msgs: all_msgs })
         })
         .await?

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -60,8 +60,6 @@ impl StreamSeekOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
-            let topic = self.topic.to_string();
-            let consumer_group = self.consumer_group.to_string();
             let mut batch = state.db.batch();
 
             let topic_row = TopicRow::fetch(
@@ -101,7 +99,9 @@ impl StreamSeekOperation {
 
             batch.commit().map_err(Error::from)?;
 
-            state.metrics.record_stream_seek(&topic, &consumer_group);
+            state
+                .metrics
+                .record_stream_seek(&self.topic, &self.consumer_group);
             Ok(StreamSeekResponseData {})
         })
         .await?

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -58,7 +58,10 @@ impl StreamSeekOperation {
     #[tracing::instrument(skip_all, level = "debug")]
     async fn apply_real(self, state: &State) -> Result<StreamSeekResponseData> {
         let state = state.clone();
+
         spawn_blocking_in_current_span(move || {
+            let topic = self.topic.to_string();
+            let consumer_group = self.consumer_group.to_string();
             let mut batch = state.db.batch();
 
             let topic_row = TopicRow::fetch(
@@ -98,6 +101,7 @@ impl StreamSeekOperation {
 
             batch.commit().map_err(Error::from)?;
 
+            state.metrics.record_stream_seek(&topic, &consumer_group);
             Ok(StreamSeekResponseData {})
         })
         .await?


### PR DESCRIPTION
Basic metrics added to the different operations. For now I've avoided the probably more useful metrics like queue depth/topic lag because I'm not yet sure how to do it efficiently. We'll get them in the next PR.