### PR TITLE
cli: Change bytes representation to escaped JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,17 +826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "colored_json"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35980a1b846f8e3e359fd18099172a0857140ba9230affc4f71348081e039b6"
-dependencies = [
- "serde",
- "serde_json",
- "yansi",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,7 +1115,6 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
- "colored_json",
  "comfy-table",
  "concolor-clap",
  "config",
@@ -1147,6 +1135,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "yansi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf-min"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22d5698cf6842742ed64805705798f8b351fff53fa546fd45c52184bee58dc90"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1141,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "v_jsonescape",
  "yansi",
 ]
 
@@ -1154,6 +1161,7 @@ dependencies = [
  "rmp-serde",
  "rustls",
  "serde",
+ "serde_bytes",
  "serde_json",
  "tokio",
  "tower-service",
@@ -4725,6 +4733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5619,6 +5637,15 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "v_jsonescape"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8219cc464ba10c48c3231a6871f11d26d831c5c45a47467eea387ea7bb10e8"
+dependencies = [
+ "buf-min",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ rmpv = "1.3.1"
 rustls = "0.23.31"
 schemars = { version = "1.2.0", features = ["jiff02", "uuid1"] }
 serde = { version = "1.0.184", features = ["derive", "rc"] }
+serde_bytes = "0.11.19"
 serde_json = "1.0.74"
 serde_path_to_error = "0.1.7"
 sha2 = "0.10.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,6 @@ byteorder = "1.5.0"
 bytes = "1.11.1"
 clap = { version = "4.1.8", features = ["derive"] }
 clap_complete = "4.5.38"
-colored_json = "5.0.0"
 concolor-clap = "0.1.0"
 config = { version = "0.15.19", default-features = false, features = ["toml", "yaml"] }
 constant_time_eq = "0.4"
@@ -223,6 +222,7 @@ url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.19.0", features = ["v7", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 which = "8"
+yansi = "1.0.1"
 zip = "7"
 
 [workspace.lints.rust]

--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -53,11 +53,11 @@ pub enum {{ resource_type_name }}Commands {
 }
 
 impl {{ resource_type_name }}Commands {
-    pub async fn exec(self, client: &CoyoteClient, color_mode: colored_json::ColorMode) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             {% for name, _ in resource.subresources | items -%}
                 Self::{{ name | to_upper_camel_case }}(args) => {
-                    args.command.exec(client, color_mode).await?;
+                    args.command.exec(client).await?;
                 }
             {% endfor -%}
 
@@ -107,7 +107,7 @@ impl {{ resource_type_name }}Commands {
                         .await?;
 
                     {%- if op.response_body_schema_name is defined %}
-                        crate::json::print_json_output(&resp, color_mode)?;
+                        crate::json::print_json_output(&resp)?;
                     {%- endif %}
                 }
             {% endfor %}

--- a/codegen/templates/rust/types/macros.rs.jinja
+++ b/codegen/templates/rust/types/macros.rs.jinja
@@ -17,6 +17,13 @@
     {% if name != name | to_snake_case -%}
         rename = "{{ name }}",
     {% endif -%}
+    {% if field.type.is_bytes() -%}
+        {% if not field.required or field.nullable -%}
+            with = "crate::serde_bytes_opt",
+        {% else -%}
+            with = "serde_bytes",
+        {% endif -%}
+    {% endif -%}
     {% if not field.required or field.nullable -%}
         skip_serializing_if = "Option::is_none",
     {% endif -%}

--- a/z-clients/cli/Cargo.toml
+++ b/z-clients/cli/Cargo.toml
@@ -29,7 +29,6 @@ rustls-tls = ["coyote-client/rustls-tls"]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 clap_complete.workspace = true
-colored_json.workspace = true
 comfy-table = "7"
 concolor-clap.workspace = true
 config.workspace = true
@@ -50,3 +49,4 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+yansi.workspace = true

--- a/z-clients/cli/Cargo.toml
+++ b/z-clients/cli/Cargo.toml
@@ -49,4 +49,5 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+v_jsonescape = { version = "0.7.8", features = ["buf-min", "bytes-buf"] }
 yansi.workspace = true

--- a/z-clients/cli/src/cmds/api/admin.rs
+++ b/z-clients/cli/src/cmds/api/admin.rs
@@ -18,17 +18,13 @@ pub enum AdminCommands {
 }
 
 impl AdminCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::AuthToken(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Cluster(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/admin_auth_token.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_token.rs
@@ -49,11 +49,7 @@ pub enum AdminAuthTokenCommands {
 }
 
 impl AdminAuthTokenCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Create {
                 admin_auth_token_create_in,
@@ -63,7 +59,7 @@ impl AdminAuthTokenCommands {
                     .auth_token()
                     .create(admin_auth_token_create_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Expire {
                 admin_auth_token_expire_in,
@@ -73,7 +69,7 @@ impl AdminAuthTokenCommands {
                     .auth_token()
                     .expire(admin_auth_token_expire_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Rotate {
                 admin_auth_token_rotate_in,
@@ -83,7 +79,7 @@ impl AdminAuthTokenCommands {
                     .auth_token()
                     .rotate(admin_auth_token_rotate_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Delete {
                 admin_auth_token_delete_in,
@@ -93,7 +89,7 @@ impl AdminAuthTokenCommands {
                     .auth_token()
                     .delete(admin_auth_token_delete_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::List {
                 admin_auth_token_list_in,
@@ -103,7 +99,7 @@ impl AdminAuthTokenCommands {
                     .auth_token()
                     .list(admin_auth_token_list_in.unwrap_or_default().into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Update {
                 admin_auth_token_update_in,
@@ -113,7 +109,7 @@ impl AdminAuthTokenCommands {
                     .auth_token()
                     .update(admin_auth_token_update_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Whoami {
                 admin_auth_token_whoami_in,
@@ -123,7 +119,7 @@ impl AdminAuthTokenCommands {
                     .auth_token()
                     .whoami(admin_auth_token_whoami_in.unwrap_or_default().into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/admin_cluster.rs
+++ b/z-clients/cli/src/cmds/api/admin_cluster.rs
@@ -36,15 +36,11 @@ pub enum AdminClusterCommands {
 }
 
 impl AdminClusterCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Status {} => {
                 let resp = client.admin().cluster().status().await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Initialize {
                 cluster_initialize_in,
@@ -54,7 +50,7 @@ impl AdminClusterCommands {
                     .cluster()
                     .initialize(cluster_initialize_in.unwrap_or_default().into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::RemoveNode {
                 cluster_remove_node_in,
@@ -64,7 +60,7 @@ impl AdminClusterCommands {
                     .cluster()
                     .remove_node(cluster_remove_node_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::ForceSnapshot {
                 cluster_force_snapshot_in,
@@ -74,7 +70,7 @@ impl AdminClusterCommands {
                     .cluster()
                     .force_snapshot(cluster_force_snapshot_in.unwrap_or_default().into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/auth_token.rs
+++ b/z-clients/cli/src/cmds/api/auth_token.rs
@@ -45,14 +45,10 @@ pub enum AuthTokenCommands {
 }
 
 impl AuthTokenCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Namespace(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Create {
                 auth_token_create_in,
@@ -61,7 +57,7 @@ impl AuthTokenCommands {
                     .auth_token()
                     .create(auth_token_create_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Expire {
                 auth_token_expire_in,
@@ -70,7 +66,7 @@ impl AuthTokenCommands {
                     .auth_token()
                     .expire(auth_token_expire_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Delete {
                 auth_token_delete_in,
@@ -79,7 +75,7 @@ impl AuthTokenCommands {
                     .auth_token()
                     .delete(auth_token_delete_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Verify {
                 auth_token_verify_in,
@@ -88,14 +84,14 @@ impl AuthTokenCommands {
                     .auth_token()
                     .verify(auth_token_verify_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::List { auth_token_list_in } => {
                 let resp = client
                     .auth_token()
                     .list(auth_token_list_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Update {
                 auth_token_update_in,
@@ -104,7 +100,7 @@ impl AuthTokenCommands {
                     .auth_token()
                     .update(auth_token_update_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Rotate {
                 auth_token_rotate_in,
@@ -113,7 +109,7 @@ impl AuthTokenCommands {
                     .auth_token()
                     .rotate(auth_token_rotate_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/auth_token_namespace.rs
+++ b/z-clients/cli/src/cmds/api/auth_token_namespace.rs
@@ -24,11 +24,7 @@ pub enum AuthTokenNamespaceCommands {
 }
 
 impl AuthTokenNamespaceCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Create {
                 auth_token_create_namespace_in,
@@ -38,7 +34,7 @@ impl AuthTokenNamespaceCommands {
                     .namespace()
                     .create(auth_token_create_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Get {
                 auth_token_get_namespace_in,
@@ -48,7 +44,7 @@ impl AuthTokenNamespaceCommands {
                     .namespace()
                     .get(auth_token_get_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/cache.rs
+++ b/z-clients/cli/src/cmds/api/cache.rs
@@ -32,22 +32,18 @@ pub enum CacheCommands {
 }
 
 impl CacheCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Namespace(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Set { key, cache_set_in } => {
                 let resp = client.cache().set(key, cache_set_in.into_inner()).await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Get { key, cache_get_in } => {
                 let resp = client.cache().get(key, cache_get_in.into_inner()).await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Delete {
                 key,
@@ -57,7 +53,7 @@ impl CacheCommands {
                     .cache()
                     .delete(key, cache_delete_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/cache_namespace.rs
+++ b/z-clients/cli/src/cmds/api/cache_namespace.rs
@@ -23,11 +23,7 @@ pub enum CacheNamespaceCommands {
 }
 
 impl CacheNamespaceCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Create {
                 cache_create_namespace_in,
@@ -37,7 +33,7 @@ impl CacheNamespaceCommands {
                     .namespace()
                     .create(cache_create_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Get {
                 cache_get_namespace_in,
@@ -47,7 +43,7 @@ impl CacheNamespaceCommands {
                     .namespace()
                     .get(cache_get_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/health.rs
+++ b/z-clients/cli/src/cmds/api/health.rs
@@ -18,15 +18,11 @@ pub enum HealthCommands {
 }
 
 impl HealthCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Ping {} => {
                 let resp = client.health().ping().await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Error {} => {
                 client.health().error().await?;

--- a/z-clients/cli/src/cmds/api/idempotency.rs
+++ b/z-clients/cli/src/cmds/api/idempotency.rs
@@ -32,14 +32,10 @@ pub enum IdempotencyCommands {
 }
 
 impl IdempotencyCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Namespace(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Start {
                 key,
@@ -49,7 +45,7 @@ impl IdempotencyCommands {
                     .idempotency()
                     .start(key, idempotency_start_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Complete {
                 key,
@@ -59,7 +55,7 @@ impl IdempotencyCommands {
                     .idempotency()
                     .complete(key, idempotency_complete_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Abort {
                 key,
@@ -69,7 +65,7 @@ impl IdempotencyCommands {
                     .idempotency()
                     .abort(key, idempotency_abort_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/idempotency_namespace.rs
+++ b/z-clients/cli/src/cmds/api/idempotency_namespace.rs
@@ -24,11 +24,7 @@ pub enum IdempotencyNamespaceCommands {
 }
 
 impl IdempotencyNamespaceCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Create {
                 idempotency_create_namespace_in,
@@ -38,7 +34,7 @@ impl IdempotencyNamespaceCommands {
                     .namespace()
                     .create(idempotency_create_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Get {
                 idempotency_get_namespace_in,
@@ -48,7 +44,7 @@ impl IdempotencyNamespaceCommands {
                     .namespace()
                     .get(idempotency_get_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/kv.rs
+++ b/z-clients/cli/src/cmds/api/kv.rs
@@ -32,26 +32,22 @@ pub enum KvCommands {
 }
 
 impl KvCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Namespace(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Set { key, kv_set_in } => {
                 let resp = client.kv().set(key, kv_set_in.into_inner()).await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Get { key, kv_get_in } => {
                 let resp = client.kv().get(key, kv_get_in.into_inner()).await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Delete { key, kv_delete_in } => {
                 let resp = client.kv().delete(key, kv_delete_in.into_inner()).await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/kv_namespace.rs
+++ b/z-clients/cli/src/cmds/api/kv_namespace.rs
@@ -22,11 +22,7 @@ pub enum KvNamespaceCommands {
 }
 
 impl KvNamespaceCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Create {
                 kv_create_namespace_in,
@@ -36,7 +32,7 @@ impl KvNamespaceCommands {
                     .namespace()
                     .create(kv_create_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Get {
                 kv_get_namespace_in,
@@ -46,7 +42,7 @@ impl KvNamespaceCommands {
                     .namespace()
                     .get(kv_get_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/msgs.rs
+++ b/z-clients/cli/src/cmds/api/msgs.rs
@@ -25,23 +25,19 @@ pub enum MsgsCommands {
 }
 
 impl MsgsCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Namespace(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Queue(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Stream(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Topic(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Publish {
                 topic,
@@ -51,7 +47,7 @@ impl MsgsCommands {
                     .msgs()
                     .publish(topic, msg_publish_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/msgs_namespace.rs
+++ b/z-clients/cli/src/cmds/api/msgs_namespace.rs
@@ -24,11 +24,7 @@ pub enum MsgsNamespaceCommands {
 }
 
 impl MsgsNamespaceCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Create {
                 name,
@@ -39,7 +35,7 @@ impl MsgsNamespaceCommands {
                     .namespace()
                     .create(name, msg_namespace_create_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Get {
                 name,
@@ -50,7 +46,7 @@ impl MsgsNamespaceCommands {
                     .namespace()
                     .get(name, msg_namespace_get_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/msgs_queue.rs
+++ b/z-clients/cli/src/cmds/api/msgs_queue.rs
@@ -56,11 +56,7 @@ pub enum MsgsQueueCommands {
 }
 
 impl MsgsQueueCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Receive {
                 topic,
@@ -72,7 +68,7 @@ impl MsgsQueueCommands {
                     .queue()
                     .receive(topic, consumer_group, msg_queue_receive_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Ack {
                 topic,
@@ -84,7 +80,7 @@ impl MsgsQueueCommands {
                     .queue()
                     .ack(topic, consumer_group, msg_queue_ack_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Configure {
                 topic,
@@ -96,7 +92,7 @@ impl MsgsQueueCommands {
                     .queue()
                     .configure(topic, consumer_group, msg_queue_configure_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Nack {
                 topic,
@@ -108,7 +104,7 @@ impl MsgsQueueCommands {
                     .queue()
                     .nack(topic, consumer_group, msg_queue_nack_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::RedriveDlq {
                 topic,
@@ -120,7 +116,7 @@ impl MsgsQueueCommands {
                     .queue()
                     .redrive_dlq(topic, consumer_group, msg_queue_redrive_dlq_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/msgs_stream.rs
+++ b/z-clients/cli/src/cmds/api/msgs_stream.rs
@@ -42,11 +42,7 @@ pub enum MsgsStreamCommands {
 }
 
 impl MsgsStreamCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Receive {
                 topic,
@@ -58,7 +54,7 @@ impl MsgsStreamCommands {
                     .stream()
                     .receive(topic, consumer_group, msg_stream_receive_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Commit {
                 topic,
@@ -70,7 +66,7 @@ impl MsgsStreamCommands {
                     .stream()
                     .commit(topic, consumer_group, msg_stream_commit_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Seek {
                 topic,
@@ -82,7 +78,7 @@ impl MsgsStreamCommands {
                     .stream()
                     .seek(topic, consumer_group, msg_stream_seek_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/msgs_topic.rs
+++ b/z-clients/cli/src/cmds/api/msgs_topic.rs
@@ -21,11 +21,7 @@ pub enum MsgsTopicCommands {
 }
 
 impl MsgsTopicCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Configure {
                 topic,
@@ -36,7 +32,7 @@ impl MsgsTopicCommands {
                     .topic()
                     .configure(topic, msg_topic_configure_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/rate_limit.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit.rs
@@ -30,14 +30,10 @@ pub enum RateLimitCommands {
 }
 
 impl RateLimitCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Namespace(args) => {
-                args.command.exec(client, color_mode).await?;
+                args.command.exec(client).await?;
             }
             Self::Limit {
                 rate_limit_check_in,
@@ -46,7 +42,7 @@ impl RateLimitCommands {
                     .rate_limit()
                     .limit(rate_limit_check_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::GetRemaining {
                 rate_limit_get_remaining_in,
@@ -55,7 +51,7 @@ impl RateLimitCommands {
                     .rate_limit()
                     .get_remaining(rate_limit_get_remaining_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Reset {
                 rate_limit_reset_in,
@@ -64,7 +60,7 @@ impl RateLimitCommands {
                     .rate_limit()
                     .reset(rate_limit_reset_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
@@ -24,11 +24,7 @@ pub enum RateLimitNamespaceCommands {
 }
 
 impl RateLimitNamespaceCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
             Self::Create {
                 rate_limit_create_namespace_in,
@@ -38,7 +34,7 @@ impl RateLimitNamespaceCommands {
                     .namespace()
                     .create(rate_limit_create_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
             Self::Get {
                 rate_limit_get_namespace_in,
@@ -48,7 +44,7 @@ impl RateLimitNamespaceCommands {
                     .namespace()
                     .get(rate_limit_get_namespace_in.into_inner())
                     .await?;
-                crate::json::print_json_output(&resp, color_mode)?;
+                crate::json::print_json_output(&resp)?;
             }
         }
 

--- a/z-clients/cli/src/cmds/cluster.rs
+++ b/z-clients/cli/src/cmds/cluster.rs
@@ -1,11 +1,11 @@
 use clap::{Args, Subcommand};
-use colored_json::Paint;
 use comfy_table::{Attribute, Cell, Table};
 use coyote_client::{
     CoyoteClient,
     models::{ClusterInitializeIn, ClusterInitializeOut, ClusterRemoveNodeIn},
 };
 use itertools::Itertools;
+use yansi::Paint;
 
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
@@ -37,27 +37,19 @@ pub enum ClusterCommands {
 }
 
 impl ClusterCommands {
-    pub async fn exec(
-        self,
-        client: &CoyoteClient,
-        color_mode: colored_json::ColorMode,
-    ) -> anyhow::Result<()> {
+    pub async fn exec(self, client: &CoyoteClient) -> anyhow::Result<()> {
         match self {
-            Self::Status { json } => print_status(json, client, color_mode).await,
+            Self::Status { json } => print_status(json, client).await,
             Self::RemoveNode(args) => remove_node(args, client).await,
             Self::Initialize => initialize(client).await,
         }
     }
 }
 
-async fn print_status(
-    json: bool,
-    client: &CoyoteClient,
-    color_mode: colored_json::ColorMode,
-) -> anyhow::Result<()> {
+async fn print_status(json: bool, client: &CoyoteClient) -> anyhow::Result<()> {
     let raw_status = client.admin().cluster().status().await?;
     if json {
-        return crate::json::print_json_output(&raw_status, color_mode);
+        return crate::json::print_json_output(&raw_status);
     }
 
     let header = "Cluster Information".underline();

--- a/z-clients/cli/src/json.rs
+++ b/z-clients/cli/src/json.rs
@@ -1,7 +1,6 @@
 use std::{io::Read, str::FromStr};
 
 use anyhow::{Context, Error, Result};
-use colored_json::{Color, ColorMode, ToColoredJson};
 use serde::{Serialize, de::DeserializeOwned};
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -30,20 +29,11 @@ impl<T> JsonOf<T> {
     }
 }
 
-pub fn print_json_output<T>(val: &T, color_mode: ColorMode) -> Result<()>
+pub fn print_json_output<T>(val: &T) -> Result<()>
 where
     T: Serialize,
 {
-    let styler = colored_json::Styler {
-        integer_value: Color::Green.foreground(),
-        float_value: Color::Green.foreground(),
-        bool_value: Color::Yellow.foreground(),
-        nil_value: Color::Magenta.foreground(),
-        string_include_quotation: true,
-        ..Default::default()
-    };
-    let s = serde_json::to_string_pretty(val)?.to_colored_json_with_styler(color_mode, styler)?;
-
+    let s = serde_json::to_string_pretty(val)?;
     println!("{s}");
     Ok(())
 }

--- a/z-clients/cli/src/json/format.rs
+++ b/z-clients/cli/src/json/format.rs
@@ -1,0 +1,132 @@
+// Modified version of PrettyFormatter from serde_json.
+// https://github.com/serde-rs/json/blob/a42fa980f8556cda36d896fa3713544b2e5eaa2c/src/ser.rs
+
+use std::io;
+
+use serde_json::ser::Formatter;
+
+#[derive(Default)]
+pub(super) struct PrettyFormatter {
+    current_indent: usize,
+    has_value: bool,
+}
+
+const INDENT: &[u8] = b"    ";
+
+impl Formatter for PrettyFormatter {
+    #[inline]
+    fn begin_array<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.current_indent += 1;
+        self.has_value = false;
+        writer.write_all(b"[")
+    }
+
+    #[inline]
+    fn end_array<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.current_indent -= 1;
+
+        if self.has_value {
+            writer.write_all(b"\n")?;
+            indent(writer, self.current_indent, INDENT)?;
+        }
+
+        writer.write_all(b"]")
+    }
+
+    #[inline]
+    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        writer.write_all(if first { b"\n" } else { b",\n" })?;
+        indent(writer, self.current_indent, INDENT)
+    }
+
+    #[inline]
+    fn end_array_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.has_value = true;
+        Ok(())
+    }
+
+    #[inline]
+    fn begin_object<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.current_indent += 1;
+        self.has_value = false;
+        writer.write_all(b"{")
+    }
+
+    #[inline]
+    fn end_object<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.current_indent -= 1;
+
+        if self.has_value {
+            writer.write_all(b"\n")?;
+            indent(writer, self.current_indent, INDENT)?;
+        }
+
+        writer.write_all(b"}")
+    }
+
+    #[inline]
+    fn begin_object_key<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        writer.write_all(if first { b"\n" } else { b",\n" })?;
+        indent(writer, self.current_indent, INDENT)
+    }
+
+    #[inline]
+    fn begin_object_value<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        writer.write_all(b": ")
+    }
+
+    #[inline]
+    fn end_object_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.has_value = true;
+        Ok(())
+    }
+
+    fn write_byte_array<W>(&mut self, writer: &mut W, value: &[u8]) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.begin_string(writer)?;
+        let mut buf = Vec::new();
+        v_jsonescape::b_escape(value, &mut buf);
+        writer.write_all(&buf)?;
+        self.end_string(writer)
+    }
+}
+
+fn indent<W>(wr: &mut W, n: usize, s: &[u8]) -> io::Result<()>
+where
+    W: ?Sized + io::Write,
+{
+    for _ in 0..n {
+        wr.write_all(s)?;
+    }
+
+    Ok(())
+}

--- a/z-clients/cli/src/json/mod.rs
+++ b/z-clients/cli/src/json/mod.rs
@@ -3,6 +3,10 @@ use std::{io::Read, str::FromStr};
 use anyhow::{Context, Error, Result};
 use serde::{Serialize, de::DeserializeOwned};
 
+mod format;
+
+use self::format::PrettyFormatter;
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct JsonOf<T>(T);
 
@@ -33,7 +37,12 @@ pub fn print_json_output<T>(val: &T) -> Result<()>
 where
     T: Serialize,
 {
-    let s = serde_json::to_string_pretty(val)?;
+    let mut output = Vec::new();
+    let mut serializer =
+        serde_json::Serializer::with_formatter(&mut output, PrettyFormatter::default());
+    val.serialize(&mut serializer)?;
+    let s = String::from_utf8(output).expect("JSON is always valid utf-8");
+
     println!("{s}");
     Ok(())
 }

--- a/z-clients/cli/src/main.rs
+++ b/z-clients/cli/src/main.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
-use colored_json::{ColorMode, Output};
-use concolor_clap::{Color, ColorChoice};
+use concolor_clap::Color;
 use coyote_client::{CoyoteClient, CoyoteOptions, DEFAULT_URL};
 use mimalloc::MiMalloc;
 
@@ -62,18 +61,6 @@ struct Cli {
 }
 
 impl Cli {
-    /// Converts the selected `ColorChoice` from the CLI to a `ColorMode` as used by the JSON printer.
-    ///
-    /// When the color choice is "auto", this considers whether stdout is a tty or not so that
-    /// color codes are only produced when actually writing directly to a terminal.
-    fn color_mode(&self) -> ColorMode {
-        match self.color.color {
-            ColorChoice::Auto => ColorMode::Auto(Output::StdOut),
-            ColorChoice::Always => ColorMode::On,
-            ColorChoice::Never => ColorMode::Off,
-        }
-    }
-
     fn log_level(&self) -> tracing::Level {
         match self.verbose {
             3.. => tracing::Level::TRACE,
@@ -113,7 +100,6 @@ enum RootCommands {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    let color_mode = cli.color_mode();
 
     tracing_subscriber::fmt()
         .with_max_level(cli.log_level())
@@ -138,36 +124,36 @@ async fn main() -> Result<()> {
         // Remote API calls
         RootCommands::AuthToken(args) => {
             let client = get_client(&cfg?)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
         RootCommands::Cache(args) => {
             let client = get_client(&cfg?)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
         RootCommands::Idempotency(args) => {
             let client = get_client(&cfg?)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
         RootCommands::Kv(args) => {
             let cfg = cfg?;
             let client = get_client(&cfg)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
         RootCommands::Msgs(args) => {
             let client = get_client(&cfg?)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
         RootCommands::RateLimit(args) => {
             let client = get_client(&cfg?)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
         RootCommands::Health(args) => {
             let client = get_client(&cfg?)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
         RootCommands::RawAdmin(args) => {
             let client = get_client(&cfg?)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
         RootCommands::Benchmark(args) => {
             let cfg = cfg?;
@@ -180,7 +166,7 @@ async fn main() -> Result<()> {
         }
         RootCommands::ClusterAdmin(args) => {
             let client = get_client(&cfg?)?;
-            args.command.exec(&client, color_mode).await?;
+            args.command.exec(&client).await?;
         }
     }
 

--- a/z-clients/rust/Cargo.toml
+++ b/z-clients/rust/Cargo.toml
@@ -29,6 +29,7 @@ rand.workspace = true
 rmp-serde.workspace = true
 rustls = { workspace = true, optional = true }
 serde.workspace = true
+serde_bytes.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tower-service.workspace = true

--- a/z-clients/rust/src/lib.rs
+++ b/z-clients/rust/src/lib.rs
@@ -9,6 +9,7 @@ mod connector;
 mod error;
 pub mod models;
 mod request;
+mod serde_bytes_opt;
 
 use self::connector::Connector;
 pub use self::{

--- a/z-clients/rust/src/models/cache_get_out.rs
+++ b/z-clients/rust/src/models/cache_get_out.rs
@@ -7,7 +7,10 @@ pub struct CacheGetOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiry: Option<jiff::Timestamp>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        with = "crate::serde_bytes_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub value: Option<Vec<u8>>,
 }
 

--- a/z-clients/rust/src/models/cache_set_in.rs
+++ b/z-clients/rust/src/models/cache_set_in.rs
@@ -6,6 +6,7 @@ pub struct CacheSetIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 
+    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds
@@ -34,6 +35,7 @@ pub(crate) struct CacheSetIn_ {
 
     pub key: String,
 
+    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds

--- a/z-clients/rust/src/models/idempotency_complete_in.rs
+++ b/z-clients/rust/src/models/idempotency_complete_in.rs
@@ -7,6 +7,7 @@ pub struct IdempotencyCompleteIn {
     pub namespace: Option<String>,
 
     /// The response to cache
+    #[serde(with = "serde_bytes")]
     pub response: Vec<u8>,
 
     /// TTL in milliseconds for the cached response
@@ -36,6 +37,7 @@ pub(crate) struct IdempotencyCompleteIn_ {
     pub key: String,
 
     /// The response to cache
+    #[serde(with = "serde_bytes")]
     pub response: Vec<u8>,
 
     /// TTL in milliseconds for the cached response

--- a/z-clients/rust/src/models/idempotency_completed.rs
+++ b/z-clients/rust/src/models/idempotency_completed.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct IdempotencyCompleted {
+    #[serde(with = "serde_bytes")]
     pub response: Vec<u8>,
 }
 

--- a/z-clients/rust/src/models/kv_get_out.rs
+++ b/z-clients/rust/src/models/kv_get_out.rs
@@ -7,7 +7,10 @@ pub struct KvGetOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiry: Option<jiff::Timestamp>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        with = "crate::serde_bytes_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub value: Option<Vec<u8>>,
 
     /// Opaque version token for optimistic concurrency control.

--- a/z-clients/rust/src/models/kv_set_in.rs
+++ b/z-clients/rust/src/models/kv_set_in.rs
@@ -8,6 +8,7 @@ pub struct KvSetIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 
+    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds
@@ -62,6 +63,7 @@ pub(crate) struct KvSetIn_ {
 
     pub key: String,
 
+    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds

--- a/z-clients/rust/src/models/msg_in.rs
+++ b/z-clients/rust/src/models/msg_in.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MsgIn {
+    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/z-clients/rust/src/models/queue_msg_out.rs
+++ b/z-clients/rust/src/models/queue_msg_out.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct QueueMsgOut {
     pub msg_id: String,
 
+    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/z-clients/rust/src/models/stream_msg_out.rs
+++ b/z-clients/rust/src/models/stream_msg_out.rs
@@ -7,6 +7,7 @@ pub struct StreamMsgOut {
 
     pub topic: String,
 
+    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/z-clients/rust/src/serde_bytes_opt.rs
+++ b/z-clients/rust/src/serde_bytes_opt.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_bytes::{ByteBuf, Bytes};
+
+pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let buf = Option::<ByteBuf>::deserialize(deserializer)?;
+    Ok(buf.map(ByteBuf::into_vec))
+}
+
+pub(crate) fn serialize<S>(bytes: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    bytes.as_deref().map(Bytes::new).serialize(serializer)
+}


### PR DESCRIPTION
Arrays of integers (bytes) are still supported as input.

```
$ coyote kv set keyy '{"value": "\u0024value\u0000"}'                                                  
{
    "success": true,
    "version": 2485
}
$ coyote kv get keyy '{}'                                                
{
    "value": "$value\u0000",
    "version": 2485
}
```

Part of https://github.com/svix/coyote-private/issues/373.