### PR TITLE
Change wildcard patterns to use a single asterisk

### DIFF
--- a/crates/coyote-authorization/src/pattern.rs
+++ b/crates/coyote-authorization/src/pattern.rs
@@ -143,9 +143,9 @@ impl fmt::Display for KeyPattern {
             Self::Exactly(s) => f.write_str(s),
             Self::Prefix(s) => {
                 f.write_str(s)?;
-                f.write_str("**")
+                f.write_str("*")
             }
-            Self::Any => f.write_str("**"),
+            Self::Any => f.write_str("*"),
         }
     }
 }
@@ -154,21 +154,17 @@ impl FromStr for KeyPattern {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "**" {
+        if s == "*" {
             return Ok(Self::Any);
         }
 
-        if s.ends_with("/**") {
-            let prefix = &s[..s.len() - 2]; // keep the /
-            if prefix.contains("*") {
-                return Err("single-asterisk key patterns not yet supported");
-            }
-
+        if s.ends_with("/*") {
+            let prefix = &s[..s.len() - 1]; // keep the /
             return Ok(Self::Prefix(prefix.to_owned()));
         }
 
         if s.contains("*") {
-            return Err("single-asterisk key patterns not yet supported");
+            return Err("wildcard in key pattern mut be at the end");
         }
 
         // FIXME: Could forbid special characters other than `*`

--- a/crates/coyote-authorization/tests/it/pattern_matching.rs
+++ b/crates/coyote-authorization/tests/it/pattern_matching.rs
@@ -22,20 +22,20 @@ fn test_any_namespace_exact_key_match() {
 
 #[test]
 fn test_default_namespace_any_key_match() {
-    let pat = "kv::**".parse::<ResourcePattern>().unwrap();
+    let pat = "kv::*".parse::<ResourcePattern>().unwrap();
     assert!(pat.matches(&EXAMPLE_OP_KV));
 }
 
 #[test]
 fn test_any_namespace_any_key_match() {
-    let pat = "kv:*:**".parse::<ResourcePattern>().unwrap();
+    let pat = "kv:*:*".parse::<ResourcePattern>().unwrap();
     assert!(pat.matches(&EXAMPLE_OP_KV));
 }
 
 #[test]
 fn test_any_namespace_wrong_module() {
     for wrong_module in ["auth_token", "cache", "idempotency", "msgs"] {
-        let pat_s = &format!("{wrong_module}::**");
+        let pat_s = &format!("{wrong_module}::*");
         let pat = pat_s.parse::<ResourcePattern>().unwrap();
         assert!(!pat.matches(&EXAMPLE_OP_KV), "{pat_s}");
     }
@@ -59,20 +59,20 @@ static EXAMPLE_OP_AUTH_TOKEN: RequestedOperation<'static> = RequestedOperation {
 
 #[test]
 fn test_explicit_namespace_any_key_match() {
-    let pat = "auth_token:my-ns:**".parse::<ResourcePattern>().unwrap();
+    let pat = "auth_token:my-ns:*".parse::<ResourcePattern>().unwrap();
     assert!(pat.matches(&EXAMPLE_OP_AUTH_TOKEN));
 }
 
 #[test]
 fn test_any_namespace_any_key_match_2() {
-    let pat = "auth_token:*:**".parse::<ResourcePattern>().unwrap();
+    let pat = "auth_token:*:*".parse::<ResourcePattern>().unwrap();
     assert!(pat.matches(&EXAMPLE_OP_AUTH_TOKEN));
 }
 
 #[test]
 fn test_wrong_namespace() {
     for wrong_ns in ["myns", "my-", "-ns", "m", "my-ns-"] {
-        let pat_s = format!("auth_token:{wrong_ns}:**");
+        let pat_s = format!("auth_token:{wrong_ns}:*");
         let pat = pat_s.parse::<ResourcePattern>().unwrap();
         assert!(!pat.matches(&EXAMPLE_OP_AUTH_TOKEN), "{pat_s}");
     }

--- a/crates/coyote-authorization/tests/it/serde.rs
+++ b/crates/coyote-authorization/tests/it/serde.rs
@@ -45,7 +45,7 @@ fn example_rules_serialized() -> serde_json::Value {
     json!([
         {
             "effect": "allow",
-            "resource": "cache::foo/**",
+            "resource": "cache::foo/*",
             "actions": [
                 "Read",
                 "List"
@@ -60,7 +60,7 @@ fn example_rules_serialized() -> serde_json::Value {
         },
         {
             "effect": "allow",
-            "resource": "kv::some-data/**",
+            "resource": "kv::some-data/*",
             "actions": [
                 "Read",
                 "List"

--- a/crates/coyote-authorization/tests/it/verification.rs
+++ b/crates/coyote-authorization/tests/it/verification.rs
@@ -6,7 +6,7 @@ fn example_rules() -> Vec<AccessRule> {
     serde_json::from_value(json!([
         {
             "effect": "allow",
-            "resource": "cache::foo/**",
+            "resource": "cache::foo/*",
             "actions": [
                 "Read",
                 "List"
@@ -21,14 +21,14 @@ fn example_rules() -> Vec<AccessRule> {
         },
         {
             "effect": "allow",
-            "resource": "kv:xyz:some-data/**",
+            "resource": "kv:xyz:some-data/*",
             "actions": [
                 "Create"
             ],
         },
         {
             "effect": "allow",
-            "resource": "kv:*:some-data/**",
+            "resource": "kv:*:some-data/*",
             "actions": [
                 "Read",
                 "List"


### PR DESCRIPTION
Probably more obvious, definitely simpler because we don't intend to support `*/x` as a key anymore.

From discussion with Tom end of last week. Part of #68.