### PR TITLE
Don't use time.now() when creating raft ops, use it when applying the change

### DIFF
--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -1,5 +1,6 @@
 use super::{CacheRaftState, CacheRequest, SetResponse};
-use crate::{CacheModel, CacheNamespace};
+use crate::CacheNamespace;
+use coyote_core::types::DurationMs;
 use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
@@ -11,15 +12,22 @@ use serde::{Deserialize, Serialize};
 pub struct SetOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,
-    model: CacheModel,
+    ttl: Option<DurationMs>,
+    value: Vec<u8>,
 }
 
 impl SetOperation {
-    pub fn new(namespace: CacheNamespace, key: String, model: CacheModel) -> Self {
+    pub fn new(
+        namespace: CacheNamespace,
+        key: String,
+        ttl: Option<DurationMs>,
+        value: Vec<u8>,
+    ) -> Self {
         Self {
             namespace_id: namespace.id,
             key,
-            model,
+            ttl,
+            value,
         }
     }
 }
@@ -31,6 +39,12 @@ impl SetOperation {
         now: Timestamp,
         log_index: u64,
     ) -> Result<()> {
+        let expiry = self.ttl.map(|ttl| {
+            let expiry = now + ttl;
+            debug_assert!(expiry >= Timestamp::UNIX_EPOCH);
+            expiry
+        });
+
         state
             .state
             .controller()
@@ -38,8 +52,8 @@ impl SetOperation {
                 self.namespace_id,
                 self.key,
                 KvModelIn {
-                    value: self.model.value,
-                    expiry: self.model.expiry,
+                    value: self.value,
+                    expiry,
                     version: None,
                 },
                 OperationBehavior::Upsert,

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -23,7 +23,9 @@ pub struct SetResponseData {
 pub struct SetOperation {
     namespace_id: NamespaceId,
     pub(crate) key: EntityKey,
-    model: KvModelIn,
+    value: Vec<u8>,
+    version: Option<u64>,
+    ttl: Option<DurationMs>,
     behavior: OperationBehavior,
 }
 
@@ -35,19 +37,13 @@ impl SetOperation {
         ttl: Option<DurationMs>,
         behavior: OperationBehavior,
         version: Option<u64>,
-        now: Timestamp,
     ) -> Self {
-        let expiry = ttl
-            .map(|ttl| now + ttl)
-            .tap_some(|v| debug_assert!(*v >= Timestamp::UNIX_EPOCH));
         Self {
             namespace_id: namespace.id,
             key,
-            model: KvModelIn {
-                value,
-                expiry,
-                version,
-            },
+            value,
+            version,
+            ttl,
             behavior,
         }
     }
@@ -55,12 +51,24 @@ impl SetOperation {
 
 impl SetOperation {
     async fn apply_real(self, state: &State, ctx: &OpContext) -> Result<SetResponseData> {
+        let now = ctx.timestamp;
+        let expiry = self
+            .ttl
+            .map(|ttl| now + ttl)
+            .tap_some(|v| debug_assert!(*v >= Timestamp::UNIX_EPOCH));
+
+        let model = KvModelIn {
+            value: self.value,
+            expiry,
+            version: self.version,
+        };
+
         let result = state
             .controller()
             .set(
                 self.namespace_id,
                 self.key,
-                self.model,
+                model,
                 self.behavior,
                 ctx.timestamp,
                 ctx.log_index,

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -6,10 +6,7 @@ use std::num::NonZeroU64;
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_authorization::RequestedOperation;
-use coyote_cache::{
-    CacheModel,
-    operations::{CreateCacheOperation, DeleteOperation, SetOperation},
-};
+use coyote_cache::operations::{CreateCacheOperation, DeleteOperation, SetOperation};
 use coyote_core::types::{Consistency, DurationMs, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt, ResultExt};
@@ -67,18 +64,6 @@ pub struct CacheSetIn {
 }
 
 request_input!(CacheSetIn, "Set");
-
-impl CacheSetIn {
-    fn into_model(self, when: Timestamp) -> CacheModel {
-        let expiry = when + self.ttl_ms;
-        debug_assert!(expiry > Timestamp::UNIX_EPOCH);
-
-        CacheModel {
-            expiry: Some(expiry),
-            value: self.value,
-        }
-    }
-}
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 pub struct CacheSetOut {}
@@ -179,9 +164,12 @@ async fn cache_set(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let now = repl.time.now();
-
-    let operation = SetOperation::new(namespace, data.key.to_string(), data.into_model(now));
+    let operation = SetOperation::new(
+        namespace,
+        data.key.to_string(),
+        Some(data.ttl_ms),
+        data.value,
+    );
     repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(CacheSetOut {}))
 }

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -152,7 +152,6 @@ async fn kv_set(
         data.ttl_ms,
         data.behavior,
         data.version,
-        repl.time.now(),
     );
     let SetResponseData { version, success } =
         repl.client_write(operation).await.or_internal_error()?.0?;


### PR DESCRIPTION
For operations that use a `ttl`, the current timestamp should not be calculated in `operation::new()`, because we need raft to get the current timestamp when _applying_ the request. 

This was causing the following bug:

When setting a low TTL (<2s) in kv, it can appear as if keys immediately expire.

It happens because `repl.time.now()` can run behind the 'real' time which causes us to set an expiry in the past.
simplifying, but the sequence of logs looks like this

```
API SET / now: 2026-03-30T17:12:34.162Z 
Expiry set to Some(2026-03-30T17:12:37.162Z)
API GET / consistency: Strong, time: 2026-03-30T17:12:40.225Z
```

the clock time when this happened was 17:12:40, raft time was 6s behind so the SET created an already expired item (edited)