### PR TITLE
cfg: load environment variables with a derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "comfy-table",
  "coyote",
  "coyote-core",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ byteorder = "1.5.0"
 bytes = "1.11.1"
 clap = { version = "4.1.8", features = ["derive"] }
 clap_complete = "4.5.38"
+comfy-table = "7"
 concolor-clap = "0.1.0"
 config = { version = "0.15.19", default-features = false, features = ["toml", "yaml"] }
 constant_time_eq = "0.4"

--- a/crates/coyote-derive/src/lib.rs
+++ b/crates/coyote-derive/src/lib.rs
@@ -1,5 +1,8 @@
 use quote::quote;
-use syn::{DeriveInput, GenericParam, Generics, ItemFn, parse_macro_input, parse_quote};
+use syn::{
+    DeriveInput, GenericParam, Generics, Ident, ItemFn, LitStr, parenthesized, parse_macro_input,
+    parse_quote, spanned::Spanned,
+};
 
 mod aide;
 
@@ -76,4 +79,286 @@ fn add_trait_bounds(mut generics: Generics) -> Generics {
         }
     }
     generics
+}
+
+fn ungroup(mut ty: &syn::Type) -> &syn::Type {
+    while let syn::Type::Group(group) = ty {
+        ty = &group.elem;
+    }
+    ty
+}
+
+fn is_ty_option(ty: &syn::Type) -> Option<&syn::Type> {
+    let path = match ungroup(ty) {
+        syn::Type::Path(ty) => &ty.path,
+        _ => {
+            return None;
+        }
+    };
+    let seg = path.segments.last()?;
+    let args = match &seg.arguments {
+        syn::PathArguments::AngleBracketed(bracketed) => &bracketed.args,
+        _ => {
+            return None;
+        }
+    };
+    if seg.ident == "Option" && args.len() == 1 {
+        let Some(syn::GenericArgument::Type(arg)) = args.get(0) else {
+            return None;
+        };
+        Some(arg)
+    } else {
+        None
+    }
+}
+
+fn is_ty_vec(ty: &syn::Type) -> bool {
+    let path = match ungroup(ty) {
+        syn::Type::Path(ty) => &ty.path,
+        _ => {
+            return false;
+        }
+    };
+    let Some(seg) = path.segments.last() else {
+        return false;
+    };
+    let args = match &seg.arguments {
+        syn::PathArguments::AngleBracketed(bracketed) => &bracketed.args,
+        _ => {
+            return false;
+        }
+    };
+    seg.ident == "Vec" && args.len() == 1
+}
+
+fn is_ty_duration(ty: &syn::Type) -> bool {
+    let path = match ungroup(ty) {
+        syn::Type::Path(ty) => &ty.path,
+        _ => {
+            return false;
+        }
+    };
+    let Some(seg) = path.segments.last() else {
+        return false;
+    };
+    seg.ident == "Duration"
+}
+
+struct EOField {
+    variable: String,
+    field: Ident,
+    is_optional: bool,
+    is_vec: bool,
+    is_duration: bool,
+    docstring: Vec<String>,
+    nest: Option<(String, syn::Type)>,
+}
+
+impl EOField {
+    fn parse(field: &syn::Field) -> Result<Option<Self>, syn::Error> {
+        let mut render = true;
+        let Some(ident) = &field.ident else {
+            return Ok(None);
+        };
+        let mut nest = None;
+
+        let is_vec;
+        let is_duration;
+        let is_optional;
+        let mut docstring = vec![];
+
+        if let Some(option_inner) = is_ty_option(&field.ty) {
+            is_optional = true;
+            is_duration = is_ty_duration(option_inner);
+            is_vec = is_ty_vec(option_inner);
+        } else {
+            is_optional = false;
+            is_duration = is_ty_duration(&field.ty);
+            is_vec = is_ty_vec(&field.ty);
+        }
+
+        let mut variable = ident.to_string().to_uppercase();
+        if is_duration {
+            variable.push_str("_MS");
+        }
+
+        for attr in &field.attrs {
+            if attr.path().is_ident("doc") {
+                if let syn::Meta::NameValue(nv) = &attr.meta
+                    && let syn::Expr::Lit(lit) = &nv.value
+                    && let syn::Lit::Str(lit) = &lit.lit
+                {
+                    let value = lit.value();
+                    docstring.push(value.trim_start().to_string())
+                }
+            } else if attr.path().is_ident("env_overridable") {
+                attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("skip") {
+                        render = false;
+                        Ok(())
+                    } else if meta.path.is_ident("var") {
+                        let content;
+                        parenthesized!(content in meta.input);
+                        let lit: LitStr = content.parse()?;
+                        variable = lit.value();
+                        Ok(())
+                    } else if meta.path.is_ident("nest_with_prefix") {
+                        let content;
+                        parenthesized!(content in meta.input);
+                        let lit: LitStr = content.parse()?;
+                        let recursive_prefix = lit.value();
+                        let ty = field.ty.clone();
+                        nest = Some((recursive_prefix, ty));
+                        Ok(())
+                    } else {
+                        Err(meta.error("unrecognized repr"))
+                    }
+                })?;
+            }
+        }
+        if !render {
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            field: ident.clone(),
+            variable,
+            nest,
+            is_optional,
+            is_vec,
+            is_duration,
+            docstring,
+        }))
+    }
+}
+
+#[proc_macro_derive(EnvOverridable, attributes(env_overridable))]
+pub fn derive_env_overridable(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    // Parse the input tokens into a syntax tree.
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let syn::Data::Struct(obj) = input.data else {
+        return proc_macro::TokenStream::from(
+            syn::Error::new(
+                input.ident.span(),
+                "This macro may only be applied to structs".to_string(),
+            )
+            .to_compile_error(),
+        );
+    };
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut fields = Vec::with_capacity(obj.fields.len());
+    let mut lists = Vec::with_capacity(obj.fields.len());
+    for field in obj.fields.iter() {
+        let parsed = match EOField::parse(field) {
+            Ok(Some(field)) => field,
+            Ok(None) => continue,
+            Err(e) => {
+                return proc_macro::TokenStream::from(
+                    syn::Error::new(
+                        field.span(),
+                        format!("Invalid field while parsing structure: {e}"),
+                    )
+                    .to_compile_error(),
+                );
+            }
+        };
+        let variable = parsed.variable;
+        let field = parsed.field;
+
+        let setter = if parsed.is_optional {
+            quote! { self.#field = Some(value) }
+        } else {
+            quote! { self.#field = value }
+        };
+
+        let loader = if parsed.is_vec {
+            quote! { crate::cfg::env_overridable::env_var_comma_separated }
+        } else if parsed.is_duration {
+            quote! { crate::cfg::env_overridable::env_var_ms }
+        } else {
+            quote! { crate::cfg::env_overridable::env_var }
+        };
+
+        let field_parser = if let Some((recurse_name, _recurse_ty)) = &parsed.nest {
+            quote! {
+                let name = if prefix.is_empty() {
+                    std::borrow::Cow::Borrowed(#recurse_name)
+                } else {
+                    std::borrow::Cow::Owned(format!("{}_{}", prefix, #recurse_name))
+                };
+
+                self.#field.load_environment_with_prefix(name)?;
+            }
+        } else {
+            quote! {
+                let name = if prefix.is_empty() {
+                    std::borrow::Cow::Borrowed(#variable)
+                } else {
+                    std::borrow::Cow::Owned(format!("{}_{}", prefix, #variable))
+                };
+
+                if let Some(value) = #loader(name)? {
+                    #setter;
+                }
+            }
+        };
+        fields.push(field_parser);
+
+        let lister = if let Some((recurse_name, recurse_ty)) = &parsed.nest {
+            quote! {
+                let name = if prefix.is_empty() {
+                    std::borrow::Cow::Borrowed(#recurse_name)
+                } else {
+                    std::borrow::Cow::Owned(format!("{}_{}", prefix, #recurse_name))
+                };
+
+                variables.extend(#recurse_ty::list_environment_variables_with_prefix(name));
+            }
+        } else {
+            let docstring = if parsed.docstring.is_empty() {
+                quote! { None }
+            } else {
+                let ds = parsed.docstring.join("\n");
+                let ds = ds.trim();
+                quote! { Some(#ds) }
+            };
+            quote! {
+                let name = if prefix.is_empty() {
+                    #variable.to_string()
+                } else {
+                    format!("{}_{}", prefix, #variable)
+                };
+                let v = crate::cfg::env_overridable::Variable {
+                    env_var: name,
+                    docstring: #docstring
+                };
+                variables.push(v);
+            }
+        };
+        lists.push(lister);
+    }
+
+    // Used in the quasi-quotation below as `#name`.
+    let name = input.ident;
+
+    let expanded = quote! {
+        impl #impl_generics crate::cfg::env_overridable::EnvOverridable for #name #ty_generics #where_clause {
+            fn load_environment_with_prefix(&mut self, prefix: std::borrow::Cow<'_, str>) -> anyhow::Result<()> {
+                #(#fields)*;
+                Ok(())
+            }
+
+            fn list_environment_variables_with_prefix(prefix: std::borrow::Cow<'_, str>) -> Vec<crate::cfg::env_overridable::Variable> {
+                let mut variables = vec![];
+                #(#lists)*;
+                variables
+            }
+        }
+    };
+
+    // Hand the output tokens back to the compiler.
+    proc_macro::TokenStream::from(expanded)
 }

--- a/crates/coyote-derive/src/lib.rs
+++ b/crates/coyote-derive/src/lib.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use syn::{
     DeriveInput, GenericParam, Generics, Ident, ItemFn, LitStr, parenthesized, parse_macro_input,
-    parse_quote, spanned::Spanned,
+    parse_quote,
 };
 
 mod aide;
@@ -88,63 +88,37 @@ fn ungroup(mut ty: &syn::Type) -> &syn::Type {
     ty
 }
 
-fn is_ty_option(ty: &syn::Type) -> Option<&syn::Type> {
-    let path = match ungroup(ty) {
-        syn::Type::Path(ty) => &ty.path,
-        _ => {
-            return None;
-        }
+/// Determine if the given type is an option and, if so, extract its inner type name
+fn as_ty_option(ty: &syn::Type) -> Option<&syn::Type> {
+    let syn::Type::Path(ty) = ungroup(ty) else {
+        return None;
     };
-    let seg = path.segments.last()?;
-    let args = match &seg.arguments {
-        syn::PathArguments::AngleBracketed(bracketed) => &bracketed.args,
-        _ => {
-            return None;
-        }
+    let seg = ty.path.segments.last()?;
+    let syn::PathArguments::AngleBracketed(bracketed) = &seg.arguments else {
+        return None;
     };
-    if seg.ident == "Option" && args.len() == 1 {
-        let Some(syn::GenericArgument::Type(arg)) = args.get(0) else {
-            return None;
-        };
-        Some(arg)
-    } else {
-        None
+    if seg.ident != "Option" || bracketed.args.len() != 1 {
+        return None;
     }
+    let Some(syn::GenericArgument::Type(arg)) = bracketed.args.get(0) else {
+        return None;
+    };
+    Some(arg)
 }
 
-fn is_ty_vec(ty: &syn::Type) -> bool {
-    let path = match ungroup(ty) {
-        syn::Type::Path(ty) => &ty.path,
-        _ => {
-            return false;
-        }
-    };
-    let Some(seg) = path.segments.last() else {
+/// Determine whether the final segment of the given type has the given name
+fn is_ty_name(name: &str, ty: &syn::Type) -> bool {
+    let syn::Type::Path(ty) = ungroup(ty) else {
         return false;
     };
-    let args = match &seg.arguments {
-        syn::PathArguments::AngleBracketed(bracketed) => &bracketed.args,
-        _ => {
-            return false;
-        }
-    };
-    seg.ident == "Vec" && args.len() == 1
+    ty.path
+        .segments
+        .last()
+        .map(|s| s.ident == name)
+        .unwrap_or(false)
 }
 
-fn is_ty_duration(ty: &syn::Type) -> bool {
-    let path = match ungroup(ty) {
-        syn::Type::Path(ty) => &ty.path,
-        _ => {
-            return false;
-        }
-    };
-    let Some(seg) = path.segments.last() else {
-        return false;
-    };
-    seg.ident == "Duration"
-}
-
-struct EOField {
+struct EoField {
     variable: String,
     field: Ident,
     is_optional: bool,
@@ -154,7 +128,7 @@ struct EOField {
     nest: Option<(String, syn::Type)>,
 }
 
-impl EOField {
+impl EoField {
     fn parse(field: &syn::Field) -> Result<Option<Self>, syn::Error> {
         let mut render = true;
         let Some(ident) = &field.ident else {
@@ -167,14 +141,14 @@ impl EOField {
         let is_optional;
         let mut docstring = vec![];
 
-        if let Some(option_inner) = is_ty_option(&field.ty) {
+        if let Some(option_inner) = as_ty_option(&field.ty) {
             is_optional = true;
-            is_duration = is_ty_duration(option_inner);
-            is_vec = is_ty_vec(option_inner);
+            is_duration = is_ty_name("Duration", option_inner);
+            is_vec = is_ty_name("Vec", option_inner);
         } else {
             is_optional = false;
-            is_duration = is_ty_duration(&field.ty);
-            is_vec = is_ty_vec(&field.ty);
+            is_duration = is_ty_name("Duration", &field.ty);
+            is_vec = is_ty_name("Vec", &field.ty);
         }
 
         let mut variable = ident.to_string().to_uppercase();
@@ -238,13 +212,7 @@ pub fn derive_env_overridable(input: proc_macro::TokenStream) -> proc_macro::Tok
     let input = parse_macro_input!(input as DeriveInput);
 
     let syn::Data::Struct(obj) = input.data else {
-        return proc_macro::TokenStream::from(
-            syn::Error::new(
-                input.ident.span(),
-                "This macro may only be applied to structs".to_string(),
-            )
-            .to_compile_error(),
-        );
+        return quote! { compile_error!("This macro may only be applied to structs") }.into();
     };
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -252,26 +220,18 @@ pub fn derive_env_overridable(input: proc_macro::TokenStream) -> proc_macro::Tok
     let mut fields = Vec::with_capacity(obj.fields.len());
     let mut lists = Vec::with_capacity(obj.fields.len());
     for field in obj.fields.iter() {
-        let parsed = match EOField::parse(field) {
+        let parsed = match EoField::parse(field) {
             Ok(Some(field)) => field,
             Ok(None) => continue,
-            Err(e) => {
-                return proc_macro::TokenStream::from(
-                    syn::Error::new(
-                        field.span(),
-                        format!("Invalid field while parsing structure: {e}"),
-                    )
-                    .to_compile_error(),
-                );
-            }
+            Err(e) => return e.to_compile_error().into(),
         };
         let variable = parsed.variable;
         let field = parsed.field;
 
         let setter = if parsed.is_optional {
-            quote! { self.#field = Some(value) }
+            quote! { Some(value) }
         } else {
-            quote! { self.#field = value }
+            quote! { value }
         };
 
         let loader = if parsed.is_vec {
@@ -284,24 +244,15 @@ pub fn derive_env_overridable(input: proc_macro::TokenStream) -> proc_macro::Tok
 
         let field_parser = if let Some((recurse_name, _recurse_ty)) = &parsed.nest {
             quote! {
-                let name = if prefix.is_empty() {
-                    std::borrow::Cow::Borrowed(#recurse_name)
-                } else {
-                    std::borrow::Cow::Owned(format!("{}_{}", prefix, #recurse_name))
-                };
-
+                let name = format!("{}_{}", prefix, #recurse_name);
                 self.#field.load_environment_with_prefix(name)?;
             }
         } else {
             quote! {
-                let name = if prefix.is_empty() {
-                    std::borrow::Cow::Borrowed(#variable)
-                } else {
-                    std::borrow::Cow::Owned(format!("{}_{}", prefix, #variable))
-                };
+                let name = format!("{}_{}", prefix, #variable);
 
                 if let Some(value) = #loader(name)? {
-                    #setter;
+                    self.#field = #setter;
                 }
             }
         };
@@ -309,11 +260,7 @@ pub fn derive_env_overridable(input: proc_macro::TokenStream) -> proc_macro::Tok
 
         let lister = if let Some((recurse_name, recurse_ty)) = &parsed.nest {
             quote! {
-                let name = if prefix.is_empty() {
-                    std::borrow::Cow::Borrowed(#recurse_name)
-                } else {
-                    std::borrow::Cow::Owned(format!("{}_{}", prefix, #recurse_name))
-                };
+                let name = format!("{}_{}", prefix, #recurse_name);
 
                 variables.extend(#recurse_ty::list_environment_variables_with_prefix(name));
             }
@@ -346,12 +293,12 @@ pub fn derive_env_overridable(input: proc_macro::TokenStream) -> proc_macro::Tok
 
     let expanded = quote! {
         impl #impl_generics crate::cfg::env_overridable::EnvOverridable for #name #ty_generics #where_clause {
-            fn load_environment_with_prefix(&mut self, prefix: std::borrow::Cow<'_, str>) -> anyhow::Result<()> {
+            fn load_environment_with_prefix(&mut self, prefix: String) -> anyhow::Result<()> {
                 #(#fields)*;
                 Ok(())
             }
 
-            fn list_environment_variables_with_prefix(prefix: std::borrow::Cow<'_, str>) -> Vec<crate::cfg::env_overridable::Variable> {
+            fn list_environment_variables_with_prefix(prefix: String) -> Vec<crate::cfg::env_overridable::Variable> {
                 let mut variables = vec![];
                 #(#lists)*;
                 variables

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+comfy-table.workspace = true
 coyote.workspace = true
 coyote-core.workspace = true
 dotenvy.workspace = true

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,6 +5,7 @@
 #![forbid(unsafe_code)]
 
 use clap::{Parser, Subcommand};
+use comfy_table::{Cell, Table};
 use coyote::{
     cfg::{self, Configuration},
     run,
@@ -51,6 +52,8 @@ enum Commands {
         /// Path to write to; if not specified, writes to stdout
         path: Option<PathBuf>,
     },
+    /// Describe environment variables honored by this service
+    DescribeEnvironmentVariables,
 }
 
 fn dump_config(cfg: Configuration, path: Option<PathBuf>) -> anyhow::Result<()> {
@@ -113,6 +116,24 @@ async fn main() -> anyhow::Result<()> {
     match args.command {
         Some(Commands::Healthcheck { .. }) => {
             unreachable!("Healthcheck command should be handled before config loading")
+        }
+        Some(Commands::DescribeEnvironmentVariables) => {
+            let mut table = Table::new();
+            let rows = cfg::describe_environment()
+                .into_iter()
+                .map(|var| {
+                    [
+                        Cell::new(var.env_var),
+                        Cell::new(var.docstring.unwrap_or_default()),
+                    ]
+                })
+                .collect::<Vec<_>>();
+            table
+                .load_preset(comfy_table::presets::UTF8_FULL)
+                .set_header(["Environment Variable", "Description"])
+                .add_rows(rows);
+            println!("{table}");
+            cfg::describe_environment();
         }
         Some(Commands::Server) | None => {
             otel::setup_metrics(&cfg);

--- a/src/cfg/env_overridable.rs
+++ b/src/cfg/env_overridable.rs
@@ -1,0 +1,71 @@
+use std::{borrow::Cow, fmt, str::FromStr, time::Duration};
+use tap::Pipe;
+
+pub(super) fn env_var<T, S>(name: S) -> anyhow::Result<Option<T>>
+where
+    S: AsRef<str>,
+    T: FromStr<Err: fmt::Display>,
+{
+    env_var_parse(name, FromStr::from_str)
+}
+
+pub(super) fn env_var_ms<S>(name: S) -> anyhow::Result<Option<Duration>>
+where
+    S: AsRef<str>,
+{
+    env_var::<u64, S>(name)?.map(Duration::from_millis).pipe(Ok)
+}
+
+pub(super) fn env_var_comma_separated<T, S>(name: S) -> anyhow::Result<Option<Vec<T>>>
+where
+    T: FromStr<Err: fmt::Display>,
+    S: AsRef<str>,
+{
+    env_var_parse(name.as_ref(), |value| {
+        value
+            .split(',')
+            .map(str::trim_ascii)
+            .map(FromStr::from_str)
+            .collect()
+    })
+}
+
+pub(super) fn env_var_parse<S, T, E>(
+    name: S,
+    parse: impl FnOnce(&str) -> Result<T, E>,
+) -> anyhow::Result<Option<T>>
+where
+    S: AsRef<str>,
+    E: fmt::Display,
+{
+    let name = name.as_ref();
+    match std::env::var(name) {
+        Ok(value) => parse(&value)
+            .map_err(|e| anyhow::anyhow!("invalid format for `{name}`: {e}"))
+            .map(Some),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(anyhow::anyhow!(
+            "invalid format for `{name}`: invalid UTF-8"
+        )),
+    }
+}
+
+#[derive(Debug)]
+pub struct Variable {
+    pub env_var: String,
+    pub docstring: Option<&'static str>,
+}
+
+pub(crate) trait EnvOverridable {
+    fn load_environment_with_prefix(&mut self, prefix: Cow<'_, str>) -> anyhow::Result<()>;
+
+    fn load_environment(&mut self) -> anyhow::Result<()> {
+        self.load_environment_with_prefix(Cow::Borrowed("COYOTE"))
+    }
+
+    fn list_environment_variables_with_prefix(prefix: Cow<'_, str>) -> Vec<Variable>;
+
+    fn list_environment_variables() -> Vec<Variable> {
+        Self::list_environment_variables_with_prefix(Cow::Borrowed("COYOTE"))
+    }
+}

--- a/src/cfg/env_overridable.rs
+++ b/src/cfg/env_overridable.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt, str::FromStr, time::Duration};
+use std::{fmt, str::FromStr, time::Duration};
 use tap::Pipe;
 
 pub(super) fn env_var<T, S>(name: S) -> anyhow::Result<Option<T>>
@@ -56,16 +56,18 @@ pub struct Variable {
     pub docstring: Option<&'static str>,
 }
 
+const ENV_VAR_PREFIX: &str = "COYOTE";
+
 pub(crate) trait EnvOverridable {
-    fn load_environment_with_prefix(&mut self, prefix: Cow<'_, str>) -> anyhow::Result<()>;
+    fn load_environment_with_prefix(&mut self, prefix: String) -> anyhow::Result<()>;
 
     fn load_environment(&mut self) -> anyhow::Result<()> {
-        self.load_environment_with_prefix(Cow::Borrowed("COYOTE"))
+        self.load_environment_with_prefix(ENV_VAR_PREFIX.to_owned())
     }
 
-    fn list_environment_variables_with_prefix(prefix: Cow<'_, str>) -> Vec<Variable>;
+    fn list_environment_variables_with_prefix(prefix: String) -> Vec<Variable>;
 
     fn list_environment_variables() -> Vec<Variable> {
-        Self::list_environment_variables_with_prefix(Cow::Borrowed("COYOTE"))
+        Self::list_environment_variables_with_prefix(ENV_VAR_PREFIX.to_string())
     }
 }

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -11,17 +11,21 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, anyhow};
+use anyhow::Context;
+use coyote_derive::EnvOverridable;
 use fs_err as fs;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use tap::Pipe;
 use tracing::Level;
 use validator::Validate;
 
 use crate::error::{Error, Result};
 
 mod defaults;
+pub(crate) mod env_overridable;
 mod validators;
+
+use env_overridable::EnvOverridable as _;
+pub use env_overridable::Variable;
 
 pub type Configuration = Arc<ConfigurationInner>;
 
@@ -97,9 +101,11 @@ impl Serialize for PeerAddr {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, EnvOverridable, Serialize)]
 pub struct DatabaseConfig {
+    /// Directory in which this database is stored
     pub path: PathBuf,
+    /// Filename under the directory specified in `path`
     pub filename: Option<String>,
 }
 
@@ -190,7 +196,7 @@ impl DatabaseConfig {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, EnvOverridable)]
 #[validate(schema(
     function = "validators::validate_cluster_configuration",
     skip_on_field_errors = true
@@ -201,6 +207,9 @@ pub struct ClusterConfiguration {
     #[serde(default)]
     pub listen_address: Option<SocketAddr>,
 
+    /// Human-facing name for this cluster.
+    ///
+    /// Only used in discovery and debugging.
     #[serde(default = "defaults::cluster_name")]
     pub name: String,
 
@@ -218,6 +227,9 @@ pub struct ClusterConfiguration {
     #[serde(default)]
     pub log_path: Option<PathBuf>,
 
+    /// Shared secret for intra-cluster communications
+    ///
+    /// This must be the same on all nodes.
     #[serde(default)]
     pub secret: Option<String>,
 
@@ -380,6 +392,7 @@ pub struct ClusterConfiguration {
     ///
     /// This should be true unless you are testing internal details of the replication system
     #[serde(default = "defaults::default_true")]
+    #[env_overridable(skip)]
     pub shut_down_on_go_away: bool,
 }
 
@@ -420,15 +433,17 @@ fn default_from_serde<T: DeserializeOwned>() -> Result<T, serde::de::value::Erro
     T::deserialize(serde::de::value::MapDeserializer::new(empty.into_iter()))
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Validate)]
+#[derive(Clone, Debug, Serialize, Deserialize, Validate, EnvOverridable)]
 pub struct ConfigurationInner {
     /// The address to listen on
     #[serde(default = "defaults::listen_address")]
     pub listen_address: SocketAddr,
 
     #[serde(default = "defaults::persistent_db")]
+    #[env_overridable(nest_with_prefix("PERSISTENT_DB"))]
     pub persistent_db: DatabaseConfig,
     #[serde(default = "defaults::ephemeral_db")]
+    #[env_overridable(nest_with_prefix("EPHEMERAL_DB"))]
     pub ephemeral_db: DatabaseConfig,
 
     /// The log level to run the service with. Supported: info, debug, trace
@@ -473,6 +488,7 @@ pub struct ConfigurationInner {
 
     #[validate(nested)]
     #[serde(default)]
+    #[env_overridable(nest_with_prefix("CLUSTER"))]
     pub cluster: ClusterConfiguration,
 
     /// The path to a YAML bootstrap file
@@ -592,193 +608,15 @@ fn load_toml(config_toml: Option<&str>) -> anyhow::Result<Arc<ConfigurationInner
         None => ConfigurationInner::default(),
     };
 
-    macro_rules! env_overrides {
-        ( $( $field:ident: $env_var:literal ),* $(,)? ) => {
-            $(
-                if let Some(value) = env_var($env_var)? {
-                    *$field = value;
-                }
-            )*
-        };
-    }
-
-    macro_rules! opt_env_overrides {
-        ( $( $field:ident: $env_var:literal ),* $(,)? ) => {
-            $(
-                if let Some(value) = env_var($env_var)? {
-                    *$field = Some(value);
-                }
-            )*
-        };
-    }
-
-    macro_rules! env_ms_overrides {
-        ( $( $field:ident: $env_var:literal ),* $(,)? ) => {
-            $(
-                if let Some(value) = env_var_ms($env_var)? {
-                    *$field = value;
-                }
-            )*
-        };
-    }
-
-    let ConfigurationInner {
-        listen_address,
-        persistent_db:
-            DatabaseConfig {
-                path: persistent_db_path,
-                filename: persistent_db_filename,
-            },
-        ephemeral_db:
-            DatabaseConfig {
-                path: ephemeral_db_path,
-                filename: ephemeral_db_filename,
-            },
-        log_level,
-        log_format,
-        opentelemetry_address,
-        opentelemetry_metrics_address,
-        opentelemetry_metrics_use_http,
-        opentelemetry_metrics_period_seconds,
-        opentelemetry_sample_ratio,
-        opentelemetry_service_name,
-        environment,
-        bootstrap_cfg_path,
-        bootstrap_cfg,
-        bootstrap_max_wait_time,
-        admin_token,
-        cluster:
-            ClusterConfiguration {
-                advertised_address: cluster_advertised_address,
-                listen_address: cluster_listen_address,
-                name: cluster_name,
-                snapshot_path: cluster_snapshot_path,
-                log_path: cluster_log_path,
-                secret: cluster_secret,
-                replication_request_timeout: cluster_replication_request_timeout,
-                discovery_request_timeout: cluster_discovery_request_timeout,
-                connection_timeout: cluster_connection_timeout,
-                heartbeat_interval: cluster_heartbeat_interval,
-                election_timeout_min: cluster_election_timeout_min,
-                election_timeout_max: cluster_election_timeout_max,
-                seed_nodes: cluster_seed_nodes,
-                auto_initialize: cluster_auto_initialize,
-                discovery_timeout: cluster_discovery_timeout,
-                startup_discovery_delay: cluster_startup_discovery_delay,
-                log_index_interval: cluster_log_index_interval,
-                log_sync_interval_commits: cluster_log_sync_interval_commits,
-                log_sync_interval_duration: cluster_log_sync_interval_duration,
-                log_ack_immediately: cluster_log_ack_immediately,
-                snapshot_after_writes: cluster_snapshot_after_writes,
-                snapshot_after_time: cluster_snapshot_after_time,
-                send_snapshot_timeout: cluster_send_snapshot_timeout,
-                shut_down_on_go_away: _,
-            },
-    } = &mut config;
-
-    env_overrides!(
-        listen_address: "COYOTE_LISTEN_ADDRESS",
-        persistent_db_path: "COYOTE_PERSISTENT_DB_PATH",
-        ephemeral_db_path: "COYOTE_EPHEMERAL_DB_PATH",
-        log_level: "COYOTE_LOG_LEVEL",
-        log_format: "COYOTE_LOG_FORMAT",
-        opentelemetry_metrics_use_http: "COYOTE_OPENTELEMETRY_METRICS_USE_HTTP",
-        opentelemetry_metrics_period_seconds: "COYOTE_OPENTELEMETRY_METRICS_PERIOD_SECONDS",
-        opentelemetry_service_name: "COYOTE_OPENTELEMETRY_SERVICE_NAME",
-        environment: "COYOTE_ENVIRONMENT",
-        cluster_name: "COYOTE_CLUSTER_NAME",
-        cluster_auto_initialize: "COYOTE_CLUSTER_AUTO_INITIALIZE",
-        cluster_log_sync_interval_commits: "COYOTE_CLUSTER_LOG_SYNC_INTERVAL_COMMITS",
-        cluster_log_ack_immediately: "COYOTE_CLUSTER_LOG_ACK_IMMEDIATELY"
-    );
-
-    opt_env_overrides!(
-        persistent_db_filename: "COYOTE_PERSISTENT_DB_FILENAME",
-        ephemeral_db_filename: "COYOTE_EPHEMERAL_DB_FILENAME",
-        opentelemetry_address: "COYOTE_OPENTELEMETRY_ADDRESS",
-        opentelemetry_metrics_address: "COYOTE_OPENTELEMETRY_METRICS_ADDRESS",
-        opentelemetry_sample_ratio: "COYOTE_OPENTELEMETRY_SAMPLE_RATIO",
-        bootstrap_cfg_path: "COYOTE_BOOTSTRAP_CFG_PATH",
-        bootstrap_cfg: "COYOTE_BOOTSTRAP_CFG",
-        admin_token: "COYOTE_ADMIN_TOKEN",
-        cluster_listen_address: "COYOTE_CLUSTER_LISTEN_ADDRESS",
-        cluster_advertised_address: "COYOTE_CLUSTER_ADVERTISED_ADDRESS",
-        cluster_snapshot_path: "COYOTE_CLUSTER_SNAPSHOT_PATH",
-        cluster_log_path: "COYOTE_CLUSTER_LOG_PATH",
-        cluster_secret: "COYOTE_CLUSTER_SECRET",
-        cluster_snapshot_after_writes: "COYOTE_SNAPSHOT_AFTER_WRITES"
-    );
-
-    env_ms_overrides!(
-        cluster_heartbeat_interval: "COYOTE_CLUSTER_HEARTBEAT_INTERVAL_MS",
-        cluster_election_timeout_min: "COYOTE_CLUSTER_ELECTION_TIMEOUT_MIN_MS",
-        cluster_election_timeout_max: "COYOTE_CLUSTER_ELECTION_TIMEOUT_MAX_MS",
-        cluster_replication_request_timeout: "COYOTE_CLUSTER_REPLICATION_REQUEST_TIMEOUT_MS",
-        cluster_discovery_request_timeout: "COYOTE_CLUSTER_DISCOVERY_REQUEST_TIMEOUT_MS",
-        cluster_connection_timeout: "COYOTE_CLUSTER_CONNECTION_TIMEOUT_MS",
-        cluster_discovery_timeout: "COYOTE_CLUSTER_DISCOVERY_TIMEOUT_MS",
-        cluster_startup_discovery_delay: "COYOTE_CLUSTER_STARTUP_DISCOVERY_DELAY_MS",
-        cluster_log_index_interval: "COYOTE_LOG_INDEX_INTERVAL_MS",
-        cluster_log_sync_interval_duration: "COYOTE_CLUSTER_LOG_SYNC_INTERVAL_MS",
-        cluster_send_snapshot_timeout: "COYOTE_CLUSTER_SEND_SNAPSHOT_TIMEOUT_MS",
-    );
-
-    // Fields that require different parsing
-    if let Some(value) = env_var_comma_separated("COYOTE_CLUSTER_SEED_NODES")? {
-        *cluster_seed_nodes = value;
-    }
-    if let Some(value) = env_var_ms("COYOTE_CLUSTER_SNAPSHOT_AFTER_MS")? {
-        *cluster_snapshot_after_time = Some(value);
-    }
-    if let Some(value) = env_var_ms("COYOTE_BOOTSTRAP_MAX_WAIT_MS")? {
-        *bootstrap_max_wait_time = Some(value);
-    }
+    config.load_environment()?;
 
     config.validate()?;
 
     Ok(Arc::from(config))
 }
 
-fn env_var<T>(name: &'static str) -> anyhow::Result<Option<T>>
-where
-    T: FromStr<Err: fmt::Display>,
-{
-    env_var_parse(name, FromStr::from_str)
-}
-
-fn env_var_ms(name: &'static str) -> anyhow::Result<Option<Duration>> {
-    env_var::<u64>(name)?.map(Duration::from_millis).pipe(Ok)
-}
-
-fn env_var_comma_separated<T>(name: &'static str) -> anyhow::Result<Option<Vec<T>>>
-where
-    T: FromStr<Err: fmt::Display>,
-{
-    env_var_parse(name, |value| {
-        value
-            .split(',')
-            .map(str::trim_ascii)
-            .map(FromStr::from_str)
-            .collect()
-    })
-}
-
-fn env_var_parse<T, E>(
-    name: &'static str,
-    parse: impl FnOnce(&str) -> Result<T, E>,
-) -> anyhow::Result<Option<T>>
-where
-    E: fmt::Display,
-{
-    match std::env::var(name) {
-        Ok(value) => parse(&value)
-            .map_err(|e| anyhow!("invalid format for `{name}`: {e}"))
-            .map(Some),
-        Err(std::env::VarError::NotPresent) => Ok(None),
-        Err(std::env::VarError::NotUnicode(_)) => {
-            Err(anyhow!("invalid format for `{name}`: invalid UTF-8"))
-        }
-    }
+pub fn describe_environment() -> Vec<Variable> {
+    ConfigurationInner::list_environment_variables()
 }
 
 #[cfg(test)]

--- a/z-clients/cli/Cargo.toml
+++ b/z-clients/cli/Cargo.toml
@@ -29,7 +29,7 @@ rustls-tls = ["coyote-client/rustls-tls"]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 clap_complete.workspace = true
-comfy-table = "7"
+comfy-table.workspace = true
 concolor-clap.workspace = true
 config.workspace = true
 coyote-client.workspace = true


### PR DESCRIPTION
This is something else I wanted for #659 

It changes the environment variable parsing to be done via custom derive macro, and adds a new subcommand to dump out all the supported environment variable names.

There are two big advantages here:

 1. There's no longer the big hand-coded list of environment variable name -> field mappings
 2. We get the automated documentation for which env vars we support

The big downside is that it's a proc-macro written by me.

<details>

<summary>example</summary>

```
┌───────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────┐
│ Environment Variable                          ┆ Description                                                                                 │
╞═══════════════════════════════════════════════╪═════════════════════════════════════════════════════════════════════════════════════════════╡
│ COYOTE_LISTEN_ADDRESS                         ┆ The address to listen on                                                                    │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_PERSISTENT_DB_PATH                     ┆ Directory in which this database is stored                                                  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_PERSISTENT_DB_FILENAME                 ┆ Filename under the directory specified in `path`                                            │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_EPHEMERAL_DB_PATH                      ┆ Directory in which this database is stored                                                  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_EPHEMERAL_DB_FILENAME                  ┆ Filename under the directory specified in `path`                                            │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_LOG_LEVEL                              ┆ The log level to run the service with. Supported: info, debug, trace                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_LOG_FORMAT                             ┆ The log format that all output will follow. Supported: default, json                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_OPENTELEMETRY_ADDRESS                  ┆ The OpenTelemetry address to send events to if given.                                       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_OPENTELEMETRY_METRICS_ADDRESS          ┆ The OpenTelemetry address to send metrics to if given.                                      │
│                                               ┆                                                                                             │
│                                               ┆ If not specified, the server will attempt to fall back                                      │
│                                               ┆ to `opentelemetry_address`                                                                  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_OPENTELEMETRY_METRICS_USE_HTTP         ┆ By default, `opentelemetry_address` is expected to be a GRPC server.                        │
│                                               ┆                                                                                             │
│                                               ┆ When this is set to true, HTTP is used instead.                                             │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_OPENTELEMETRY_METRICS_PERIOD_SECONDS   ┆                                                                                             │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_OPENTELEMETRY_SAMPLE_RATIO             ┆ The ratio at which to sample spans when sending to OpenTelemetry.                           │
│                                               ┆                                                                                             │
│                                               ┆ When not given it defaults to always sending.                                               │
│                                               ┆ If the OpenTelemetry address is not set, this will do nothing.                              │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_OPENTELEMETRY_SERVICE_NAME             ┆ The service name to use for OpenTelemetry. If not provided, it defaults to "coyote".        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_ENVIRONMENT                            ┆ The environment (dev, staging, or prod) that the server is running in.                      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_LISTEN_ADDRESS                 ┆ The address to listen on for replication. Defaults to the main listen address,              │
│                                               ┆ but with the port incremented by 10000                                                      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_NAME                           ┆ Human-facing name for this cluster.                                                         │
│                                               ┆                                                                                             │
│                                               ┆ Only used in discovery and debugging.                                                       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_SNAPSHOT_PATH                  ┆ Location to store snapshots.                                                                │
│                                               ┆                                                                                             │
│                                               ┆ This volume must have at least as much space as the persistent DB path                      │
│                                               ┆ and ephemeral DB path combined. Defaults to a subdirectory under the                        │
│                                               ┆ persistent DB path if not passed.                                                           │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_LOG_PATH                       ┆ Location to store logs. For high-throughput systems, this should be a separate volume.      │
│                                               ┆                                                                                             │
│                                               ┆ Defaults to a subdirectory under the persistent DB path if not passed.                      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_SECRET                         ┆ Shared secret for intra-cluster communications                                              │
│                                               ┆                                                                                             │
│                                               ┆ This must be the same on all nodes.                                                         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_REPLICATION_REQUEST_TIMEOUT_MS ┆ Timeout for replication requests.                                                           │
│                                               ┆                                                                                             │
│                                               ┆ This should be set to approximately 2X the RTT of your farthest-apart nodes.                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_DISCOVERY_REQUEST_TIMEOUT_MS   ┆ Timeout for discovery requests.                                                             │
│                                               ┆                                                                                             │
│                                               ┆ This should be set to approximately 2X the RTT of your farthest-apart nodes.                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_CONNECTION_TIMEOUT_MS          ┆ Timeout for new connections.                                                                │
│                                               ┆                                                                                             │
│                                               ┆ If you want to be tolerant of dropped packets, this should be set to at least TO + ε,       │
│                                               ┆ where TO is the initial TCP retransmission timer (typically either 1s or 3s,                │
│                                               ┆ depending on your operating system).                                                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_HEARTBEAT_INTERVAL_MS          ┆ How often to send heartbeats.                                                               │
│                                               ┆                                                                                             │
│                                               ┆ This controls how fast lost leaders can be detected.                                        │
│                                               ┆ Must not be less than `replication_request_timeout`.                                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_ELECTION_TIMEOUT_MIN_MS        ┆ The minimum time to let an election run for.                                                │
│                                               ┆                                                                                             │
│                                               ┆ This should be set to at least 4x the RTT of your farthest-apart nodes,                     │
│                                               ┆ and must not be less than `heartbeat_interval_ms`.                                          │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_ELECTION_TIMEOUT_MAX_MS        ┆ The minimum time to let an election run for.                                                │
│                                               ┆                                                                                             │
│                                               ┆ This should be set to at least 5x the RTT of your farthest-apart nodes                      │
│                                               ┆ and must not be less than `cluster_election_timeout_max`.                                   │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_SEND_SNAPSHOT_TIMEOUT_MS       ┆ The minimum time to let an election run for.                                                │
│                                               ┆                                                                                             │
│                                               ┆ This should be set to at least 5x the RTT of your farthest-apart nodes                      │
│                                               ┆ and must not be less than `cluster_election_timeout_max`.                                   │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_ADVERTISED_ADDRESS             ┆ Address that other nodes should use to communicate with this one.                           │
│                                               ┆                                                                                             │
│                                               ┆ If not passed, we'll attempt to discover it at boot time.                                   │
│                                               ┆ This cannot currently be changed after cluster initialization.                              │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_SEED_NODES                     ┆ Other nodes that we should attempt to join a cluster with at boot time.                     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_AUTO_INITIALIZE                ┆ Automatically initialize the cluster on bootup if we can't discover any                     │
│                                               ┆ peers and we don't have any existing state.                                                 │
│                                               ┆                                                                                             │
│                                               ┆ If you initialize all peers at exactly the same time, this can potentially cause errors.    │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_DISCOVERY_TIMEOUT_MS           ┆                                                                                             │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_STARTUP_DISCOVERY_DELAY_MS     ┆                                                                                             │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_LOG_INDEX_INTERVAL_MS          ┆                                                                                             │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_LOG_SYNC_INTERVAL_COMMITS      ┆ Interval (in transactions) between fsyncing the commit log.                                 │
│                                               ┆                                                                                             │
│                                               ┆ This should be set to 1 for full ACID compliance; at any other value,                       │
│                                               ┆ data may be lost in the event of catastrophic hardware failure.                             │
│                                               ┆ If you are using a multi-node cluster and set this to a value other than                    │
│                                               ┆ 1, if a node experiences catastrophic failure and the OS shuts down uncleanly, that node    │
│                                               ┆ should be removed from the cluster and rebuilt. If set to 0, logs will only be fsynced on a │
│                                               ┆ timer                                                                                       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_LOG_SYNC_INTERVAL_DURATION_MS  ┆ Interval (in milliseconds) between fsyncing the commit log.                                 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_LOG_ACK_IMMEDIATELY            ┆ Commit logs to the cluster immediately, before fsyncing them to persistent storage.         │
│                                               ┆                                                                                             │
│                                               ┆ This should be set to `false` for full ACID compliance, but can be set to `true` to enable  │
│                                               ┆ higher throughput than your fsync rate. Note that we always flush to the OS buffers before  │
│                                               ┆ acking, so data will only be lost of the OS crashes.                                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_SNAPSHOT_AFTER_WRITES          ┆ Trigger a background snapshot after this many writes                                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_CLUSTER_SNAPSHOT_AFTER_TIME_MS         ┆ Trigger a background snapshot after this many milliseconds                                  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_BOOTSTRAP_CFG_PATH                     ┆ The path to a YAML bootstrap file                                                           │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_BOOTSTRAP_CFG                          ┆ YAML bootstrap data. Takes precedence over `bootstrap_cfg_path`                             │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_BOOTSTRAP_MAX_WAIT_TIME_MS             ┆ Maximum time to wait for cluster initialization at startup                                  │
│                                               ┆                                                                                             │
│                                               ┆ If this is unset, we will wait indefinitely.                                                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ COYOTE_ADMIN_TOKEN                            ┆ A pre-set admin token to use instead of having coyote generate one automatically.           │
│                                               ┆                                                                                             │
│                                               ┆ Under normal circumstances you should not set this, and instead let coyote generate the     │
│                                               ┆ admin token on first boot and use that to create any additional tokens you need. Setting    │
│                                               ┆ this directly is useful in CI pipelines and other automated environments where you need a   │
│                                               ┆ stable, well-known token for testing or scripted setup.                                     │
└───────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘

```

</details>