### PR TITLE
Eviction policy: remove eviction policy from namespace configs.

### DIFF
--- a/crates/coyote-namespace/src/entities.rs
+++ b/crates/coyote-namespace/src/entities.rs
@@ -11,17 +11,12 @@ pub type NamespaceName = String;
 pub enum EvictionPolicy {
     #[default]
     NoEviction,
-    LeastRecentlyUsed,
 }
 
 pub trait ModuleConfig:
     Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync
 {
     fn module() -> Module;
-
-    fn eviction_policy(&self) -> EvictionPolicy {
-        EvictionPolicy::NoEviction
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
@@ -44,10 +39,6 @@ pub struct CacheConfig {
 
 impl CacheConfig {
     pub const NAMESPACE: &'static str = "cache_store";
-
-    pub fn eviction_policy(&self) -> EvictionPolicy {
-        self.eviction_policy
-    }
 }
 
 impl ModuleConfig for CacheConfig {
@@ -88,10 +79,6 @@ impl ModuleConfig for IdempotencyConfig {
 
 impl IdempotencyConfig {
     pub const NAMESPACE: &'static str = "idempotency_store";
-
-    pub fn eviction_policy(&self) -> EvictionPolicy {
-        EvictionPolicy::NoEviction
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]

--- a/openapi.json
+++ b/openapi.json
@@ -5081,8 +5081,7 @@
       "EvictionPolicy": {
         "type": "string",
         "enum": [
-          "NoEviction",
-          "LeastRecentlyUsed"
+          "NoEviction"
         ]
       },
       "IdempotencyAbortIn": {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -302,18 +302,6 @@ mod tests {
     }
 
     #[test]
-    fn cache_with_options() {
-        let cmd: BootstrapCommand =
-            r#"cache namespace create {"name":"myns","eviction_policy":"LeastRecentlyUsed"}"#
-                .parse()
-                .unwrap();
-        let BootstrapCommand::Cache(v) = cmd else {
-            panic!()
-        };
-        assert_eq!(v.eviction_policy, EvictionPolicy::LeastRecentlyUsed);
-    }
-
-    #[test]
     fn idempotency() {
         let cmd: BootstrapCommand =
             r#"idempotency namespace create {"name":"myns"}"#.parse().unwrap();

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -51,7 +51,7 @@ async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert_eq!(cache1["name"], "cache1");
-    assert_eq!(cache1["eviction_policy"], "LeastRecentlyUsed");
+    assert_eq!(cache1["eviction_policy"], "NoEviction");
 
     let msgs2 = client
         .post("v1.msgs.namespace.get")

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -135,39 +135,6 @@ async fn create_namespace_with_defaults() -> TestResult {
 }
 
 #[tokio::test]
-async fn create_namespace_with_custom_config() -> TestResult {
-    let TestContext {
-        client,
-        handle: _handle,
-        ..
-    } = start_server().await;
-
-    let response = client
-        .post("v1.cache.namespace.create")
-        .json(json!({
-            "name": "custom-ns",
-            "eviction_policy": "LeastRecentlyUsed",
-        }))
-        .await?
-        .expect(StatusCode::OK)
-        .json();
-
-    let ts = &response["created"];
-
-    assert_eq!(
-        response,
-        json!({
-            "name": "custom-ns",
-            "eviction_policy": "LeastRecentlyUsed",
-            "created": ts,
-            "updated": ts,
-        })
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn create_namespace_upserts() -> TestResult {
     let TestContext {
         client,

--- a/tests/it/static/bootstrap.test
+++ b/tests/it/static/bootstrap.test
@@ -1,5 +1,5 @@
 kv namespace create {"name":"default"}
 kv namespace create {"name":"kv1"}
 kv namespace create {"name":"kv2"}
-cache namespace create {"name":"cache1","eviction_policy":"LeastRecentlyUsed"}
+cache namespace create {"name":"cache1"}
 msgs namespace create {"name":"msgs2"}

--- a/z-clients/go/internal/models/eviction_policy.go
+++ b/z-clients/go/internal/models/eviction_policy.go
@@ -12,13 +12,11 @@ import (
 type EvictionPolicy string
 
 const (
-	EVICTIONPOLICY_NO_EVICTION         EvictionPolicy = "NoEviction"
-	EVICTIONPOLICY_LEAST_RECENTLY_USED EvictionPolicy = "LeastRecentlyUsed"
+	EVICTIONPOLICY_NO_EVICTION EvictionPolicy = "NoEviction"
 )
 
 var allowedEvictionPolicy = []EvictionPolicy{
 	"NoEviction",
-	"LeastRecentlyUsed",
 }
 
 func (v *EvictionPolicy) UnmarshalMsgpack(src []byte) error {
@@ -37,6 +35,5 @@ func (v *EvictionPolicy) UnmarshalMsgpack(src []byte) error {
 }
 
 var EvictionPolicyFromString = map[string]EvictionPolicy{
-	"NoEviction":        EVICTIONPOLICY_NO_EVICTION,
-	"LeastRecentlyUsed": EVICTIONPOLICY_LEAST_RECENTLY_USED,
+	"NoEviction": EVICTIONPOLICY_NO_EVICTION,
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/models/EvictionPolicy.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/EvictionPolicy.java
@@ -4,8 +4,7 @@ package com.svix.coyote.models;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum EvictionPolicy {
-    NO_EVICTION("NoEviction"),
-    LEAST_RECENTLY_USED("LeastRecentlyUsed");
+    NO_EVICTION("NoEviction");
     private final String value;
 
     EvictionPolicy(String value) {

--- a/z-clients/javascript/src/models/evictionPolicy.ts
+++ b/z-clients/javascript/src/models/evictionPolicy.ts
@@ -2,7 +2,6 @@
 
 export enum EvictionPolicy {
     NoEviction = 'NoEviction',
-    LeastRecentlyUsed = 'LeastRecentlyUsed',
     }
 
 export const EvictionPolicySerializer = {

--- a/z-clients/python/coyote/models/eviction_policy.py
+++ b/z-clients/python/coyote/models/eviction_policy.py
@@ -4,7 +4,6 @@ from enum import Enum
 
 class EvictionPolicy(str, Enum):
     NO_EVICTION = "NoEviction"
-    LEAST_RECENTLY_USED = "LeastRecentlyUsed"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/z-clients/rust/src/models/eviction_policy.rs
+++ b/z-clients/rust/src/models/eviction_policy.rs
@@ -7,15 +7,12 @@ use serde::{Deserialize, Serialize};
 pub enum EvictionPolicy {
     #[serde(rename = "NoEviction")]
     NoEviction,
-    #[serde(rename = "LeastRecentlyUsed")]
-    LeastRecentlyUsed,
 }
 
 impl fmt::Display for EvictionPolicy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let value = match self {
             Self::NoEviction => "NoEviction",
-            Self::LeastRecentlyUsed => "LeastRecentlyUsed",
         };
         f.write_str(value)
     }


### PR DESCRIPTION
Technically I left it on cache, but only allowed value is NoEviction. Maybe I should remove it altogether?

We'll fix it properly as part of #81.