### PR TITLE
refactor(clusterspec): use k8s_openapi `ResourceRequirements`

### DIFF
--- a/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
+++ b/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
@@ -1032,26 +1032,44 @@
                     "type": "object"
                   },
                   "resources": {
-                    "default": {
-                      "limits": null,
-                      "requests": null
-                    },
+                    "default": {},
                     "description": "CPU and memory resource requests and limits for the coyote container.",
                     "properties": {
+                      "claims": {
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                        "items": {
+                          "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                          "properties": {
+                            "name": {
+                              "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
                       "limits": {
                         "additionalProperties": {
-                          "type": "string"
+                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                          "x-kubernetes-int-or-string": true
                         },
-                        "description": "Resource limits — the maximum resources the container may use.",
-                        "nullable": true,
+                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       },
                       "requests": {
                         "additionalProperties": {
-                          "type": "string"
+                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                          "x-kubernetes-int-or-string": true
                         },
-                        "description": "Resource requests — the minimum guaranteed resources for the container.",
-                        "nullable": true,
+                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       }
                     },

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -2,7 +2,10 @@
 #![allow(unused_qualifications)]
 
 use k8s_openapi::{
-    api::core::v1::{Affinity, EnvVar, SecretKeySelector, Toleration, TopologySpreadConstraint},
+    api::core::v1::{
+        Affinity, EnvVar, ResourceRequirements, SecretKeySelector, Toleration,
+        TopologySpreadConstraint,
+    },
     apimachinery::pkg::api::resource::Quantity,
 };
 use kube::CustomResource;
@@ -70,7 +73,7 @@ pub(crate) struct CoyoteClusterSpec {
 
     /// CPU and memory resource requests and limits for the coyote container.
     #[serde(default)]
-    pub resources: ResourcesSpec,
+    pub resources: ResourceRequirements,
 
     /// Additional annotations to add to pods.
     #[serde(default)]
@@ -221,20 +224,6 @@ pub(crate) enum AdminTokenSource {
         #[serde(rename = "valueFrom")]
         value_from: SecretKeySelector,
     },
-}
-
-/// CPU and memory resource requests/limits for the coyote container.
-/// Values are in standard Kubernetes quantity format, e.g. "500m", "1", "512Mi", "2Gi".
-#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct ResourcesSpec {
-    /// Resource requests — the minimum guaranteed resources for the container.
-    #[serde(default)]
-    pub requests: Option<BTreeMap<String, String>>,
-
-    /// Resource limits — the maximum resources the container may use.
-    #[serde(default)]
-    pub limits: Option<BTreeMap<String, String>>,
 }
 
 impl CoyoteClusterSpec {

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -6,7 +6,7 @@ use k8s_openapi::{
         core::v1::{
             Affinity, Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction,
             ObjectFieldSelector, PersistentVolumeClaim, PersistentVolumeClaimSpec,
-            PodSecurityContext, PodSpec, PodTemplateSpec, Probe, ResourceRequirements, Toleration,
+            PodSecurityContext, PodSpec, PodTemplateSpec, Probe, Toleration,
             TopologySpreadConstraint, VolumeMount, VolumeResourceRequirements,
         },
     },
@@ -271,19 +271,7 @@ fn build_container(
             },
         ]),
         volume_mounts: Some(volume_mounts),
-        resources: Some(ResourceRequirements {
-            requests: spec.resources.requests.as_ref().map(|r| {
-                r.iter()
-                    .map(|(k, v)| (k.clone(), Quantity(v.clone())))
-                    .collect()
-            }),
-            limits: spec.resources.limits.as_ref().map(|l| {
-                l.iter()
-                    .map(|(k, v)| (k.clone(), Quantity(v.clone())))
-                    .collect()
-            }),
-            ..Default::default()
-        }),
+        resources: Some(spec.resources.clone()),
         liveness_probe: Some(Probe {
             http_get: Some(HTTPGetAction {
                 path: Some(API_HEALTH_ENDPOINT.into()),


### PR DESCRIPTION
This replaces handrolled  `ResourcesSpec` with k8s_openapi `ResourceRequirements`