### PR TITLE
Stop creating non-deterministic uuid-v7 inside raft 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,7 @@ dependencies = [
  "data-encoding-macro",
  "itertools 0.14.0",
  "jiff",
+ "rand 0.9.2",
  "rmp-serde",
  "schemars 1.2.1",
  "serde",

--- a/crates/auth-token/src/controller.rs
+++ b/crates/auth-token/src/controller.rs
@@ -382,7 +382,7 @@ impl AuthTokenController {
 #[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 mod tests {
-    use coyote_id::NamespaceId;
+    use coyote_id::{NamespaceId, UuidV7RandomBytes, random_v7_bytes};
     use fjall::Database;
     use jiff::{Timestamp, ToSpan};
 
@@ -418,10 +418,11 @@ mod tests {
         name: &str,
         owner_id: &str,
         ts: Timestamp,
+        random_bytes: UuidV7RandomBytes,
     ) -> AuthTokenModel {
         let token = TokenPlaintext::generate("sk", None).unwrap();
         let input = CreateTokenInput {
-            id: AuthTokenId::new(ts),
+            id: AuthTokenId::new(ts, random_bytes),
             name: name.to_string(),
             token_hashed: token.hash(),
             expiry: None,
@@ -445,7 +446,8 @@ mod tests {
         let mut created = Vec::new();
         for i in 0..5i32 {
             let ts = base.checked_add((i + 1).seconds()).unwrap();
-            created.push(create_token(c, &format!("token-{i}"), owner, ts).await);
+            created
+                .push(create_token(c, &format!("token-{i}"), owner, ts, random_v7_bytes()).await);
         }
         created.sort_by_key(|t| *t.id.as_bytes());
 

--- a/crates/auth-token/src/controller.rs
+++ b/crates/auth-token/src/controller.rs
@@ -382,7 +382,7 @@ impl AuthTokenController {
 #[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 mod tests {
-    use coyote_id::{NamespaceId, UuidV7RandomBytes, random_v7_bytes};
+    use coyote_id::{NamespaceId, UuidV7RandomBytes};
     use fjall::Database;
     use jiff::{Timestamp, ToSpan};
 
@@ -446,8 +446,16 @@ mod tests {
         let mut created = Vec::new();
         for i in 0..5i32 {
             let ts = base.checked_add((i + 1).seconds()).unwrap();
-            created
-                .push(create_token(c, &format!("token-{i}"), owner, ts, random_v7_bytes()).await);
+            created.push(
+                create_token(
+                    c,
+                    &format!("token-{i}"),
+                    owner,
+                    ts,
+                    UuidV7RandomBytes::new_random(),
+                )
+                .await,
+            );
         }
         created.sort_by_key(|t| *t.id.as_bytes());
 

--- a/crates/auth-token/src/operations/create.rs
+++ b/crates/auth-token/src/operations/create.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use coyote_core::types::Metadata;
 use coyote_error::Result;
-use coyote_id::{AuthTokenId, NamespaceId};
+use coyote_id::{AuthTokenId, NamespaceId, UuidV7RandomBytes, random_v7_bytes};
 use coyote_operations::OpContext;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateResponseData {
@@ -19,7 +19,7 @@ pub struct CreateResponseData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateAuthTokenOperation {
     namespace_id: NamespaceId,
-    pub(crate) id: AuthTokenId,
+    id_random_bytes: UuidV7RandomBytes,
     name: String,
     token_hashed: TokenHashed,
     expiry: Option<Timestamp>,
@@ -42,12 +42,10 @@ impl CreateAuthTokenOperation {
         owner_id: String,
         scopes: Vec<String>,
         enabled: bool,
-        now: Timestamp,
     ) -> Self {
-        let id = AuthTokenId::new(now);
         Self {
             namespace_id: namespace.id,
-            id,
+            id_random_bytes: random_v7_bytes(),
             name,
             token_hashed,
             expiry,
@@ -59,12 +57,13 @@ impl CreateAuthTokenOperation {
     }
 
     async fn apply_real(self, state: &State, ctx: &OpContext) -> Result<CreateResponseData> {
+        let id = AuthTokenId::new(ctx.timestamp, self.id_random_bytes);
         let model = state
             .controller
             .create(
                 self.namespace_id,
                 CreateTokenInput {
-                    id: self.id,
+                    id,
                     name: self.name,
                     token_hashed: self.token_hashed,
                     expiry: self.expiry,

--- a/crates/auth-token/src/operations/create.rs
+++ b/crates/auth-token/src/operations/create.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use coyote_core::types::Metadata;
 use coyote_error::Result;
-use coyote_id::{AuthTokenId, NamespaceId, UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::{AuthTokenId, NamespaceId, UuidV7RandomBytes};
 use coyote_operations::OpContext;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateResponseData {
@@ -45,7 +45,7 @@ impl CreateAuthTokenOperation {
     ) -> Self {
         Self {
             namespace_id: namespace.id,
-            id_random_bytes: random_v7_bytes(),
+            id_random_bytes: UuidV7RandomBytes::new_random(),
             name,
             token_hashed,
             expiry,

--- a/crates/auth-token/src/operations/create_namespace.rs
+++ b/crates/auth-token/src/operations/create_namespace.rs
@@ -1,4 +1,5 @@
 use coyote_error::Result;
+use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
 use coyote_namespace::{
     entities::AuthTokenConfig,
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -11,17 +12,21 @@ use crate::operations::{AuthTokenRaftState, AuthTokenRequest, CreateNamespaceRes
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateAuthTokenNamespaceOperation {
     pub(crate) name: String,
+    id_random_bytes: UuidV7RandomBytes,
 }
 
 impl From<CreateAuthTokenNamespaceOperation> for CreateNamespace<AuthTokenConfig> {
     fn from(value: CreateAuthTokenNamespaceOperation) -> Self {
-        CreateNamespace::new(value.name, AuthTokenConfig {})
+        CreateNamespace::new(value.name, AuthTokenConfig {}, value.id_random_bytes)
     }
 }
 
 impl CreateAuthTokenNamespaceOperation {
     pub fn new(name: String) -> Self {
-        Self { name }
+        Self {
+            name,
+            id_random_bytes: random_v7_bytes(),
+        }
     }
 
     async fn apply_real(

--- a/crates/auth-token/src/operations/create_namespace.rs
+++ b/crates/auth-token/src/operations/create_namespace.rs
@@ -1,5 +1,5 @@
 use coyote_error::Result;
-use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::UuidV7RandomBytes;
 use coyote_namespace::{
     entities::AuthTokenConfig,
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -25,7 +25,7 @@ impl CreateAuthTokenNamespaceOperation {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            id_random_bytes: random_v7_bytes(),
+            id_random_bytes: UuidV7RandomBytes::new_random(),
         }
     }
 

--- a/crates/auth-token/src/operations/rotate.rs
+++ b/crates/auth-token/src/operations/rotate.rs
@@ -8,7 +8,7 @@ use crate::{
     operations::{AuthTokenRaftState, AuthTokenRequest, RotateResponse},
 };
 use coyote_error::Result;
-use coyote_id::{AuthTokenId, NamespaceId};
+use coyote_id::{AuthTokenId, NamespaceId, UuidV7RandomBytes, random_v7_bytes};
 use coyote_operations::OpContext;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RotateResponseData {
@@ -20,7 +20,7 @@ pub struct RotateResponseData {
 pub struct RotateAuthTokenOperation {
     namespace_id: NamespaceId,
     old_id: AuthTokenId,
-    new_id: AuthTokenId,
+    new_id_random_bytes: UuidV7RandomBytes,
     new_token_hashed: TokenHashed,
     /// When the old token expires. `None` means expire immediately (now).
     old_expiry: Option<Timestamp>,
@@ -32,13 +32,11 @@ impl RotateAuthTokenOperation {
         old_id: AuthTokenId,
         new_token_hashed: TokenHashed,
         old_expiry: Option<Timestamp>,
-        now: Timestamp,
     ) -> Self {
-        let new_id = AuthTokenId::new(now);
         Self {
             namespace_id: namespace.id,
             old_id,
-            new_id,
+            new_id_random_bytes: random_v7_bytes(),
             new_token_hashed,
             old_expiry,
         }
@@ -46,13 +44,14 @@ impl RotateAuthTokenOperation {
 
     async fn apply_real(self, state: &State, ctx: &OpContext) -> Result<RotateResponseData> {
         let old_expiry = self.old_expiry.unwrap_or(ctx.timestamp);
+        let new_id = AuthTokenId::new(ctx.timestamp, self.new_id_random_bytes);
         let model = state
             .controller
             .rotate(
                 self.namespace_id,
                 self.old_id,
                 RotateTokenInput {
-                    new_id: self.new_id,
+                    new_id,
                     new_token_hashed: self.new_token_hashed,
                     old_expiry,
                     now: ctx.timestamp,

--- a/crates/auth-token/src/operations/rotate.rs
+++ b/crates/auth-token/src/operations/rotate.rs
@@ -8,7 +8,7 @@ use crate::{
     operations::{AuthTokenRaftState, AuthTokenRequest, RotateResponse},
 };
 use coyote_error::Result;
-use coyote_id::{AuthTokenId, NamespaceId, UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::{AuthTokenId, NamespaceId, UuidV7RandomBytes};
 use coyote_operations::OpContext;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RotateResponseData {
@@ -36,7 +36,7 @@ impl RotateAuthTokenOperation {
         Self {
             namespace_id: namespace.id,
             old_id,
-            new_id_random_bytes: random_v7_bytes(),
+            new_id_random_bytes: UuidV7RandomBytes::new_random(),
             new_token_hashed,
             old_expiry,
         }

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -1,5 +1,5 @@
 use coyote_error::Result;
-use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::UuidV7RandomBytes;
 use coyote_namespace::{
     entities::{CacheConfig, EvictionPolicy},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -33,7 +33,7 @@ impl CreateCacheOperation {
         Self {
             name,
             eviction_policy,
-            id_random_bytes: random_v7_bytes(),
+            id_random_bytes: UuidV7RandomBytes::new_random(),
         }
     }
 

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -1,4 +1,5 @@
 use coyote_error::Result;
+use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
 use coyote_namespace::{
     entities::{CacheConfig, EvictionPolicy},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -12,6 +13,7 @@ use crate::operations::{CacheRaftState, CacheRequest, CreateCacheResponse};
 pub struct CreateCacheOperation {
     pub(crate) name: String,
     eviction_policy: EvictionPolicy,
+    id_random_bytes: UuidV7RandomBytes,
 }
 
 impl From<CreateCacheOperation> for CreateNamespace<CacheConfig> {
@@ -21,6 +23,7 @@ impl From<CreateCacheOperation> for CreateNamespace<CacheConfig> {
             CacheConfig {
                 eviction_policy: value.eviction_policy,
             },
+            value.id_random_bytes,
         )
     }
 }
@@ -30,6 +33,7 @@ impl CreateCacheOperation {
         Self {
             name,
             eviction_policy,
+            id_random_bytes: random_v7_bytes(),
         }
     }
 

--- a/crates/coyote-id/Cargo.toml
+++ b/crates/coyote-id/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 data-encoding = "2.10.0"
 data-encoding-macro = "0.1.19"
 jiff.workspace = true
+rand.workspace = true
 schemars.workspace = true
 serde.workspace = true
 uuid.workspace = true

--- a/crates/coyote-id/src/lib.rs
+++ b/crates/coyote-id/src/lib.rs
@@ -13,16 +13,20 @@ use self::marker::{IdMarker, PublicIdMarker};
 pub use self::{module::Module, public::Public};
 
 const V7_RANDOM_BYTES_LEN: usize = 10;
-pub type UuidV7RandomBytes = [u8; V7_RANDOM_BYTES_LEN];
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+#[serde(transparent)]
+pub struct UuidV7RandomBytes([u8; V7_RANDOM_BYTES_LEN]);
+
+impl UuidV7RandomBytes {
+    pub fn new_random() -> Self {
+        Self(rand::random())
+    }
+}
 
 pub type AuthTokenId = Id<m::AuthToken>;
 pub type NamespaceId = Id<m::Namespace>;
 pub type TopicId = Id<m::Topic>;
-
-pub fn random_v7_bytes() -> UuidV7RandomBytes {
-    // FIXME: maybe this should come from the raft state? it could also guarantee sub millisecond ordering.
-    rand::random()
-}
 
 // Don't want these types to be nameable,
 // so they're defined in a private submodule
@@ -51,7 +55,7 @@ impl<M: IdMarker> Id<M> {
 
     pub fn new(now: Timestamp, random_bytes: UuidV7RandomBytes) -> Self {
         let millis = now.as_millisecond() as u64;
-        Self::from_uuid(Builder::from_unix_timestamp_millis(millis, &random_bytes).into_uuid())
+        Self::from_uuid(Builder::from_unix_timestamp_millis(millis, &random_bytes.0).into_uuid())
     }
 
     pub fn nil() -> Self {
@@ -117,7 +121,7 @@ impl<'de, M: IdMarker> Deserialize<'de> for Id<M> {
 #[cfg(test)]
 #[allow(unreachable_pub)]
 mod tests {
-    use super::{Id, V7_RANDOM_BYTES_LEN};
+    use super::{Id, UuidV7RandomBytes};
 
     id_marker!(Private);
     id_marker!(Public, "pub_");
@@ -127,7 +131,7 @@ mod tests {
 
     #[test]
     fn private_id_serde() {
-        let id = PrivateId::new(jiff::Timestamp::UNIX_EPOCH, [0; V7_RANDOM_BYTES_LEN]);
+        let id = PrivateId::new(jiff::Timestamp::UNIX_EPOCH, UuidV7RandomBytes::new_random());
 
         assert_eq!(size_of_val(&id), 16); // 16 bytes, i.e. just a UUID
 
@@ -138,7 +142,7 @@ mod tests {
 
     #[test]
     fn public_id_serde() {
-        let id = PublicId::new(jiff::Timestamp::UNIX_EPOCH, [0; V7_RANDOM_BYTES_LEN]);
+        let id = PublicId::new(jiff::Timestamp::UNIX_EPOCH, UuidV7RandomBytes::new_random());
 
         assert_eq!(size_of_val(&id), 16); // 16 bytes, also just a UUID
 
@@ -154,7 +158,7 @@ mod tests {
     #[test]
     fn new_is_deterministic() {
         let now = jiff::Timestamp::UNIX_EPOCH;
-        let random_bytes = [7; V7_RANDOM_BYTES_LEN];
+        let random_bytes = UuidV7RandomBytes::new_random();
 
         assert_eq!(
             PrivateId::new(now, random_bytes),

--- a/crates/coyote-id/src/lib.rs
+++ b/crates/coyote-id/src/lib.rs
@@ -2,7 +2,7 @@ use std::{fmt, marker::PhantomData};
 
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+use uuid::{Builder, Uuid};
 
 mod public;
 #[macro_use]
@@ -12,9 +12,16 @@ mod module;
 use self::marker::{IdMarker, PublicIdMarker};
 pub use self::{module::Module, public::Public};
 
+const V7_RANDOM_BYTES_LEN: usize = 10;
+pub type UuidV7RandomBytes = [u8; V7_RANDOM_BYTES_LEN];
+
 pub type AuthTokenId = Id<m::AuthToken>;
 pub type NamespaceId = Id<m::Namespace>;
 pub type TopicId = Id<m::Topic>;
+
+pub fn random_v7_bytes() -> UuidV7RandomBytes {
+    rand::random()
+}
 
 // Don't want these types to be nameable,
 // so they're defined in a private submodule
@@ -41,12 +48,9 @@ impl<M: IdMarker> Id<M> {
         }
     }
 
-    pub fn new(now: Timestamp) -> Self {
-        Self::from_uuid(Uuid::new_v7(uuid::Timestamp::from_unix(
-            uuid::NoContext,
-            now.as_second() as u64,
-            now.subsec_nanosecond() as u32,
-        )))
+    pub fn new(now: Timestamp, random_bytes: UuidV7RandomBytes) -> Self {
+        let millis = now.as_millisecond() as u64;
+        Self::from_uuid(Builder::from_unix_timestamp_millis(millis, &random_bytes).into_uuid())
     }
 
     pub fn nil() -> Self {
@@ -112,7 +116,7 @@ impl<'de, M: IdMarker> Deserialize<'de> for Id<M> {
 #[cfg(test)]
 #[allow(unreachable_pub)]
 mod tests {
-    use super::Id;
+    use super::{Id, V7_RANDOM_BYTES_LEN};
 
     id_marker!(Private);
     id_marker!(Public, "pub_");
@@ -122,7 +126,7 @@ mod tests {
 
     #[test]
     fn private_id_serde() {
-        let id = PrivateId::new(jiff::Timestamp::UNIX_EPOCH);
+        let id = PrivateId::new(jiff::Timestamp::UNIX_EPOCH, [0; V7_RANDOM_BYTES_LEN]);
 
         assert_eq!(size_of_val(&id), 16); // 16 bytes, i.e. just a UUID
 
@@ -133,7 +137,7 @@ mod tests {
 
     #[test]
     fn public_id_serde() {
-        let id = PublicId::new(jiff::Timestamp::UNIX_EPOCH);
+        let id = PublicId::new(jiff::Timestamp::UNIX_EPOCH, [0; V7_RANDOM_BYTES_LEN]);
 
         assert_eq!(size_of_val(&id), 16); // 16 bytes, also just a UUID
 
@@ -144,5 +148,16 @@ mod tests {
         let serialized = rmp_serde::to_vec_named(&id.public()).unwrap();
         assert_eq!(serialized.len(), 31);
         assert_eq!(&serialized[1..][..4], b"pub_");
+    }
+
+    #[test]
+    fn new_is_deterministic() {
+        let now = jiff::Timestamp::UNIX_EPOCH;
+        let random_bytes = [7; V7_RANDOM_BYTES_LEN];
+
+        assert_eq!(
+            PrivateId::new(now, random_bytes),
+            PrivateId::new(now, random_bytes)
+        );
     }
 }

--- a/crates/coyote-id/src/lib.rs
+++ b/crates/coyote-id/src/lib.rs
@@ -20,6 +20,7 @@ pub type NamespaceId = Id<m::Namespace>;
 pub type TopicId = Id<m::Topic>;
 
 pub fn random_v7_bytes() -> UuidV7RandomBytes {
+    // FIXME: maybe this should come from the raft state? it could also guarantee sub millisecond ordering.
     rand::random()
 }
 

--- a/crates/coyote-namespace/src/operations/create_namespace.rs
+++ b/crates/coyote-namespace/src/operations/create_namespace.rs
@@ -1,5 +1,5 @@
 use coyote_error::Result;
-use coyote_id::NamespaceId;
+use coyote_id::{NamespaceId, UuidV7RandomBytes};
 
 use fjall_utils::WriteBatchExt;
 use jiff::Timestamp;
@@ -13,6 +13,7 @@ use crate::{State, entities::ModuleConfig, tables::Namespace};
 pub struct CreateNamespace<C: ModuleConfig> {
     name: String,
     config: C,
+    id_random_bytes: UuidV7RandomBytes,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -25,8 +26,12 @@ pub struct CreateNamespaceOutput<C: ModuleConfig> {
 }
 
 impl<C: ModuleConfig + 'static> CreateNamespace<C> {
-    pub fn new(name: String, config: C) -> Self {
-        Self { name, config }
+    pub fn new(name: String, config: C, id_random_bytes: UuidV7RandomBytes) -> Self {
+        Self {
+            name,
+            config,
+            id_random_bytes,
+        }
     }
 
     pub async fn apply_operation(
@@ -48,7 +53,7 @@ impl<C: ModuleConfig + 'static> CreateNamespace<C> {
                         namespace
                     }
                     None => {
-                        let id = NamespaceId::new(timestamp);
+                        let id = NamespaceId::new(timestamp, self.id_random_bytes);
                         Namespace {
                             id,
                             name: self.name,

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -1,5 +1,5 @@
 use coyote_error::Result;
-use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::UuidV7RandomBytes;
 use coyote_namespace::{
     entities::IdempotencyConfig,
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -25,7 +25,7 @@ impl CreateIdempotencyOperation {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            id_random_bytes: random_v7_bytes(),
+            id_random_bytes: UuidV7RandomBytes::new_random(),
         }
     }
 

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -1,4 +1,5 @@
 use coyote_error::Result;
+use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
 use coyote_namespace::{
     entities::IdempotencyConfig,
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -11,17 +12,21 @@ use crate::operations::{CreateIdempotencyResponse, IdempotencyRaftState, Idempot
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateIdempotencyOperation {
     pub(crate) name: String,
+    id_random_bytes: UuidV7RandomBytes,
 }
 
 impl From<CreateIdempotencyOperation> for CreateNamespace<IdempotencyConfig> {
     fn from(value: CreateIdempotencyOperation) -> Self {
-        CreateNamespace::new(value.name, IdempotencyConfig {})
+        CreateNamespace::new(value.name, IdempotencyConfig {}, value.id_random_bytes)
     }
 }
 
 impl CreateIdempotencyOperation {
     pub fn new(name: String) -> Self {
-        Self { name }
+        Self {
+            name,
+            id_random_bytes: random_v7_bytes(),
+        }
     }
 
     async fn apply_real(

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -1,5 +1,5 @@
 use coyote_error::Result;
-use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::UuidV7RandomBytes;
 use coyote_namespace::{
     entities::KeyValueConfig,
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -25,7 +25,7 @@ impl CreateKvOperation {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            id_random_bytes: random_v7_bytes(),
+            id_random_bytes: UuidV7RandomBytes::new_random(),
         }
     }
 

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -1,4 +1,5 @@
 use coyote_error::Result;
+use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
 use coyote_namespace::{
     entities::KeyValueConfig,
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -11,17 +12,21 @@ use crate::operations::{CreateKvResponse, KvRaftState, KvRequest};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateKvOperation {
     pub(crate) name: String,
+    id_random_bytes: UuidV7RandomBytes,
 }
 
 impl From<CreateKvOperation> for CreateNamespace<KeyValueConfig> {
     fn from(value: CreateKvOperation) -> Self {
-        CreateNamespace::new(value.name, KeyValueConfig {})
+        CreateNamespace::new(value.name, KeyValueConfig {}, value.id_random_bytes)
     }
 }
 
 impl CreateKvOperation {
     pub fn new(name: String) -> Self {
-        Self { name }
+        Self {
+            name,
+            id_random_bytes: random_v7_bytes(),
+        }
     }
 
     async fn apply_real(

--- a/crates/msgs/src/metrics.rs
+++ b/crates/msgs/src/metrics.rs
@@ -314,6 +314,7 @@ pub(crate) fn record_topic_lag_metrics(state: &State) -> Result<()> {
 mod tests {
     use std::collections::HashMap;
 
+    use coyote_id::UuidV7RandomBytes;
     use fjall_utils::WriteBatchExt as _;
     use jiff::Timestamp;
 
@@ -406,7 +407,11 @@ mod tests {
         let msgs = db.keyspace(crate::MSG_KEYSPACE, Default::default).unwrap();
 
         let topic_name = TopicName::new("test-topic".to_string()).unwrap();
-        let topic_row = TopicRow::new(topic_name, Timestamp::UNIX_EPOCH);
+        let topic_row = TopicRow::new(
+            topic_name,
+            Timestamp::UNIX_EPOCH,
+            UuidV7RandomBytes::new_random(),
+        );
         let cg = ConsumerGroup::try_from("my-group").unwrap();
         let partition = Partition::new(0).unwrap();
 

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -1,4 +1,5 @@
 use coyote_error::Result;
+use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
 use coyote_namespace::{
     entities::{MsgsConfig, NamespaceName},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -13,11 +14,16 @@ use crate::entities::Retention;
 pub struct CreateNamespaceOperation {
     pub name: NamespaceName,
     pub retention: Retention,
+    id_random_bytes: UuidV7RandomBytes,
 }
 
 impl CreateNamespaceOperation {
     pub fn new(name: NamespaceName, retention: Retention) -> Self {
-        Self { name, retention }
+        Self {
+            name,
+            retention,
+            id_random_bytes: random_v7_bytes(),
+        }
     }
 
     async fn apply_real(
@@ -31,6 +37,7 @@ impl CreateNamespaceOperation {
                 retention_period: self.retention.period,
                 retention_bytes: self.retention.size_bytes,
             },
+            self.id_random_bytes,
         );
         let out = op.apply_operation(namespace_state, now).await?;
         Ok(out.into())

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -1,5 +1,5 @@
 use coyote_error::Result;
-use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::UuidV7RandomBytes;
 use coyote_namespace::{
     entities::{MsgsConfig, NamespaceName},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -22,7 +22,7 @@ impl CreateNamespaceOperation {
         Self {
             name,
             retention,
-            id_random_bytes: random_v7_bytes(),
+            id_random_bytes: UuidV7RandomBytes::new_random(),
         }
     }
 

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use fjall::OwnedWriteBatch;
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
@@ -44,7 +44,7 @@ impl PublishOperation {
             topic,
             partition,
             msgs,
-            topic_id_random_bytes: random_v7_bytes(),
+            topic_id_random_bytes: UuidV7RandomBytes::new_random(),
         })
     }
 

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, TopicId};
+use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes, random_v7_bytes};
 use fjall::OwnedWriteBatch;
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
@@ -22,6 +22,7 @@ pub struct PublishOperation {
     pub(crate) topic: TopicName,
     partition: Option<Partition>,
     msgs: Vec<MsgIn>,
+    topic_id_random_bytes: UuidV7RandomBytes,
 }
 
 impl PublishOperation {
@@ -43,6 +44,7 @@ impl PublishOperation {
             topic,
             partition,
             msgs,
+            topic_id_random_bytes: random_v7_bytes(),
         })
     }
 
@@ -71,7 +73,7 @@ impl PublishOperation {
                     return Err(Error::invalid_user_input("topic does not exist"));
                 }
                 (None, None) => {
-                    let row = TopicRow::new(self.topic.clone(), now);
+                    let row = TopicRow::new(self.topic.clone(), now, self.topic_id_random_bytes);
                     batch.insert_row(
                         &state.metadata_tables,
                         TopicRow::key_for(self.namespace_id, &self.topic),

--- a/crates/msgs/src/operations/queue/configure.rs
+++ b/crates/msgs/src/operations/queue/configure.rs
@@ -1,6 +1,6 @@
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::{Error, Result};
-use coyote_id::NamespaceId;
+use coyote_id::{NamespaceId, UuidV7RandomBytes, random_v7_bytes};
 use fjall_utils::WriteBatchExt;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -20,6 +20,7 @@ pub struct QueueConfigureOperation {
     consumer_group: ConsumerGroup,
     retry_schedule: Vec<u64>,
     dlq_topic: Option<TopicName>,
+    topic_id_random_bytes: UuidV7RandomBytes,
 }
 
 impl QueueConfigureOperation {
@@ -36,6 +37,7 @@ impl QueueConfigureOperation {
             consumer_group,
             retry_schedule,
             dlq_topic,
+            topic_id_random_bytes: random_v7_bytes(),
         }
     }
 
@@ -51,6 +53,7 @@ impl QueueConfigureOperation {
                 self.namespace_id,
                 &self.topic,
                 now,
+                self.topic_id_random_bytes,
             )?;
 
             let config = QueueConfigRow {

--- a/crates/msgs/src/operations/queue/configure.rs
+++ b/crates/msgs/src/operations/queue/configure.rs
@@ -1,6 +1,6 @@
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::{NamespaceId, UuidV7RandomBytes};
 use fjall_utils::WriteBatchExt;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -37,7 +37,7 @@ impl QueueConfigureOperation {
             consumer_group,
             retry_schedule,
             dlq_topic,
-            topic_id_random_bytes: random_v7_bytes(),
+            topic_id_random_bytes: UuidV7RandomBytes::new_random(),
         }
     }
 

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, TopicId};
+use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes, random_v7_bytes};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -21,6 +21,7 @@ pub struct QueueNackOperation {
     pub(crate) topic: TopicName,
     consumer_group: ConsumerGroup,
     msg_ids: Vec<MsgId>,
+    dlq_topic_id_random_bytes: UuidV7RandomBytes,
 }
 
 impl QueueNackOperation {
@@ -35,6 +36,7 @@ impl QueueNackOperation {
             topic,
             consumer_group,
             msg_ids,
+            dlq_topic_id_random_bytes: random_v7_bytes(),
         }
     }
 
@@ -95,6 +97,7 @@ impl QueueNackOperation {
                         dlq_topic,
                         &self.consumer_group,
                         now,
+                        self.dlq_topic_id_random_bytes,
                     )?;
                     dlq_count += 1;
                 } else {
@@ -134,6 +137,7 @@ fn forward_to_dlq(
     dlq_topic: &TopicName,
     consumer_group: &ConsumerGroup,
     now: Timestamp,
+    dlq_topic_id_random_bytes: UuidV7RandomBytes,
 ) -> Result<()> {
     let original = MsgRow::fetch(
         &state.msg_table,
@@ -141,8 +145,14 @@ fn forward_to_dlq(
     )?
     .ok_or_else(|| Error::internal("nacked message not found"))?;
 
-    let dlq_topic_row =
-        TopicRow::fetch_or_create(&state.metadata_tables, batch, namespace_id, dlq_topic, now)?;
+    let dlq_topic_row = TopicRow::fetch_or_create(
+        &state.metadata_tables,
+        batch,
+        namespace_id,
+        dlq_topic,
+        now,
+        dlq_topic_id_random_bytes,
+    )?;
 
     // Route deterministically: use source partition clamped to DLQ partition count
     let dlq_partition = Partition::new(msg_id.partition.get() % dlq_topic_row.partitions)?;

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -36,7 +36,7 @@ impl QueueNackOperation {
             topic,
             consumer_group,
             msg_ids,
-            dlq_topic_id_random_bytes: random_v7_bytes(),
+            dlq_topic_id_random_bytes: UuidV7RandomBytes::new_random(),
         }
     }
 

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, num::NonZeroU16};
 
 use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -47,7 +47,7 @@ impl QueueReceiveOperation {
             consumer_group,
             batch_size,
             lease_duration,
-            topic_id_random_bytes: random_v7_bytes(),
+            topic_id_random_bytes: UuidV7RandomBytes::new_random(),
         })
     }
 

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, num::NonZeroU16};
 
 use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, TopicId};
+use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes, random_v7_bytes};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -25,6 +25,7 @@ pub struct QueueReceiveOperation {
     batch_size: NonZeroU16,
     #[serde(rename = "lease_duration_ms")]
     lease_duration: DurationMs,
+    topic_id_random_bytes: UuidV7RandomBytes,
 }
 
 impl QueueReceiveOperation {
@@ -46,6 +47,7 @@ impl QueueReceiveOperation {
             consumer_group,
             batch_size,
             lease_duration,
+            topic_id_random_bytes: random_v7_bytes(),
         })
     }
 
@@ -67,6 +69,7 @@ impl QueueReceiveOperation {
                 self.namespace_id,
                 &self.topic,
                 now,
+                self.topic_id_random_bytes,
             )?;
 
             Span::current().record("partition_count", topic_row.partitions);

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU16;
 
 use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::{NamespaceId, UuidV7RandomBytes};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -52,7 +52,7 @@ impl StreamReceiveOperation {
             batch_size,
             lease_duration,
             default_starting_position,
-            topic_id_random_bytes: random_v7_bytes(),
+            topic_id_random_bytes: UuidV7RandomBytes::new_random(),
         })
     }
 

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU16;
 
 use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
 use coyote_error::{Error, Result};
-use coyote_id::NamespaceId;
+use coyote_id::{NamespaceId, UuidV7RandomBytes, random_v7_bytes};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -28,6 +28,7 @@ pub struct StreamReceiveOperation {
     #[serde(rename = "lease_duration_ms")]
     lease_duration: DurationMs,
     default_starting_position: SeekPosition,
+    topic_id_random_bytes: UuidV7RandomBytes,
 }
 
 impl StreamReceiveOperation {
@@ -51,6 +52,7 @@ impl StreamReceiveOperation {
             batch_size,
             lease_duration,
             default_starting_position,
+            topic_id_random_bytes: random_v7_bytes(),
         })
     }
 
@@ -71,6 +73,7 @@ impl StreamReceiveOperation {
                 self.namespace_id,
                 &self.topic,
                 now,
+                self.topic_id_random_bytes,
             )?;
 
             Span::current().record("partition_count", topic_row.partitions);

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -1,6 +1,6 @@
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::{Error, Result};
-use coyote_id::{NamespaceId, UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::{NamespaceId, UuidV7RandomBytes};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -32,7 +32,7 @@ impl TopicConfigureOperation {
             namespace_id,
             topic,
             partitions,
-            topic_id_random_bytes: random_v7_bytes(),
+            topic_id_random_bytes: UuidV7RandomBytes::new_random(),
         })
     }
 

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -1,6 +1,6 @@
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::{Error, Result};
-use coyote_id::NamespaceId;
+use coyote_id::{NamespaceId, UuidV7RandomBytes, random_v7_bytes};
 use fjall_utils::{TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -18,6 +18,7 @@ pub struct TopicConfigureOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,
     partitions: u16,
+    topic_id_random_bytes: UuidV7RandomBytes,
 }
 
 impl TopicConfigureOperation {
@@ -31,6 +32,7 @@ impl TopicConfigureOperation {
             namespace_id,
             topic,
             partitions,
+            topic_id_random_bytes: random_v7_bytes(),
         })
     }
 
@@ -42,7 +44,7 @@ impl TopicConfigureOperation {
                 TopicRow::key_for(self.namespace_id, &self.topic),
             )? {
                 Some(topic_row) => topic_row,
-                None => TopicRow::new(self.topic.clone(), now),
+                None => TopicRow::new(self.topic.clone(), now, self.topic_id_random_bytes),
             };
 
             if self.partitions < topic_row.partitions {

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -351,7 +351,7 @@ mod tests {
     #[test]
     fn test_consumer_group_from_key() {
         use coyote_id::TopicId;
-        let topic_id = TopicId::new(Timestamp::UNIX_EPOCH);
+        let topic_id = TopicId::new(Timestamp::UNIX_EPOCH, UuidV7RandomBytes::new_random());
         let partition = Partition::new(0).unwrap();
         let cg = ConsumerGroup::try_from("my-group").unwrap();
         let key = StreamLeaseRow::key_for(topic_id, partition, &cg).into_fjall_key();

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -1,4 +1,4 @@
-use coyote_id::{NamespaceId, TopicId};
+use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use std::collections::HashMap;
 
 use coyote_error::{Result, ResultExt as _};
@@ -36,9 +36,9 @@ impl TopicRow {
         TableKey::init_key(Self::ROW_TYPE, &[namespace_id.as_bytes()], &[topic])
     }
 
-    pub(crate) fn new(name: TopicName, now: Timestamp) -> Self {
+    pub(crate) fn new(name: TopicName, now: Timestamp, id_random_bytes: UuidV7RandomBytes) -> Self {
         Self {
-            id: TopicId::new(now),
+            id: TopicId::new(now, id_random_bytes),
             name,
             partitions: 1,
         }
@@ -58,11 +58,12 @@ impl TopicRow {
         namespace_id: NamespaceId,
         topic: &TopicName,
         now: Timestamp,
+        id_random_bytes: UuidV7RandomBytes,
     ) -> Result<Self> {
         if let Some(row) = Self::fetch(metadata_tables, Self::key_for(namespace_id, topic))? {
             return Ok(row);
         }
-        let row = Self::new(topic.clone(), now);
+        let row = Self::new(topic.clone(), now, id_random_bytes);
         batch.insert_row(metadata_tables, Self::key_for(namespace_id, topic), &row)?;
         Ok(row)
     }

--- a/crates/rate-limit/src/operations/create_namespace.rs
+++ b/crates/rate-limit/src/operations/create_namespace.rs
@@ -1,5 +1,5 @@
 use coyote_error::Result;
-use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
+use coyote_id::UuidV7RandomBytes;
 use coyote_namespace::{
     entities::RateLimitConfig,
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -25,7 +25,7 @@ impl CreateRateLimitOperation {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            id_random_bytes: random_v7_bytes(),
+            id_random_bytes: UuidV7RandomBytes::new_random(),
         }
     }
 

--- a/crates/rate-limit/src/operations/create_namespace.rs
+++ b/crates/rate-limit/src/operations/create_namespace.rs
@@ -1,4 +1,5 @@
 use coyote_error::Result;
+use coyote_id::{UuidV7RandomBytes, random_v7_bytes};
 use coyote_namespace::{
     entities::RateLimitConfig,
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
@@ -11,17 +12,21 @@ use super::{CreateRateLimitResponse, RateLimitRaftState, RateLimitRequest};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateRateLimitOperation {
     pub(crate) name: String,
+    id_random_bytes: UuidV7RandomBytes,
 }
 
 impl From<CreateRateLimitOperation> for CreateNamespace<RateLimitConfig> {
     fn from(value: CreateRateLimitOperation) -> Self {
-        CreateNamespace::new(value.name, RateLimitConfig {})
+        CreateNamespace::new(value.name, RateLimitConfig {}, value.id_random_bytes)
     }
 }
 
 impl CreateRateLimitOperation {
     pub fn new(name: String) -> Self {
-        Self { name }
+        Self {
+            name,
+            id_random_bytes: random_v7_bytes(),
+        }
     }
 
     async fn apply_real(

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -147,7 +147,6 @@ async fn auth_token_create(
         data.owner_id,
         data.scopes,
         data.enabled,
-        repl.time.now(),
     );
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
 
@@ -393,13 +392,8 @@ async fn auth_token_rotate(
 
     let token = TokenPlaintext::generate(&data.prefix, data.suffix.as_deref())?;
     let old_expiry = data.expiry.map(|ms| repl.time.now() + ms);
-    let operation = RotateAuthTokenOperation::new(
-        namespace,
-        data.id.into_inner(),
-        token.hash(),
-        old_expiry,
-        repl.time.now(),
-    );
+    let operation =
+        RotateAuthTokenOperation::new(namespace, data.id.into_inner(), token.hash(), old_expiry);
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
     let model = resp.model.ok_or_not_found()?;
 


### PR DESCRIPTION
This
```
Self::from_uuid(Uuid::new_v7(uuid::Timestamp::from_unix(
    uuid::NoContext,
    now.as_second() as u64,
    now.subsec_nanosecond() as u32,
)))
```
adds random bits to the generated ID, so we can't use it as-is inside raft operations. They have to be completely deterministic. 

This updates the `Id::new` method to receive the timestamp and 10 random bytes to generate the uuidv7 id, which makes generation deterministic. The random bytes are then generated at the API level, when the operations are created. 

This makes me think that maybe the random bytes should come from the raft layer, instead of having to add the random bytes to each operation. Not sure though. In any case, it should be easy to refactor this version to get the random bytes from raft. 

Helps with https://github.com/svix/coyote-private/issues/738