### PR TITLE
Optimize msgs.*.receive to avoid waiting longer than necessary for batch_wait

### DIFF
--- a/crates/coyote-id/src/marker.rs
+++ b/crates/coyote-id/src/marker.rs
@@ -18,6 +18,10 @@ macro_rules! id_marker {
 
         impl Eq for $name {}
 
+        impl ::std::hash::Hash for $name {
+            fn hash<H: ::std::hash::Hasher>(&self, _: &mut H) {}
+        }
+
         $(
             impl $crate::marker::PublicIdMarker for $name {
                 const PREFIX: &str = $prefix;

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -15,6 +15,9 @@ pub mod entities;
 pub mod metrics;
 pub mod operations;
 pub(crate) mod tables;
+mod topic_publish_notifier;
+
+pub use topic_publish_notifier::*;
 
 pub const MSG_KEYSPACE: &str = "mod_msgs";
 pub const METADATA_KEYSPACE: &str = "mod_msgs_metadata";
@@ -27,10 +30,14 @@ pub struct State {
     pub(crate) metadata_tables: fjall::Keyspace,
     pub(crate) msg_table: fjall::Keyspace,
     pub(crate) metrics: metrics::MsgMetrics,
+    pub(crate) topic_publish_notifier: TopicPublishNotifier,
 }
 
 impl State {
-    pub fn init(db: fjall::Database) -> Result<Self, Error> {
+    pub fn init(
+        db: fjall::Database,
+        topic_publish_notifier: TopicPublishNotifier,
+    ) -> Result<Self, Error> {
         let metadata_tables = {
             let opts = KeyspaceCreateOptions::default();
             db.keyspace(METADATA_KEYSPACE, || opts)?
@@ -50,6 +57,7 @@ impl State {
             metadata_tables,
             msg_table,
             metrics: metrics::MsgMetrics::new(&meter),
+            topic_publish_notifier,
         })
     }
 }
@@ -101,6 +109,15 @@ pub fn estimate_available_queue_messages(
     Ok(total)
 }
 
+/// Result of estimating available stream messages.
+#[derive(Default)]
+pub struct StreamEstimate {
+    /// Estimated number of available messages across all unlocked partitions.
+    pub count: u64,
+    /// Partitions that are not currently leased.
+    pub available_partitions: Vec<Partition>,
+}
+
 // NOTE - I'm not thrilled about the location of this method, but I didn't want to expose the
 // tables module outside the msgs crate, and I wasn't sure where else to put this. 🤷
 /// Cheap offset-based estimate of available stream messages across all partitions.
@@ -113,13 +130,14 @@ pub fn estimate_available_stream_messages(
     topic: &TopicName,
     consumer_group: &ConsumerGroup,
     now: Timestamp,
-) -> Result<u64> {
+) -> Result<StreamEstimate> {
     let Some(topic_row) = TopicRow::fetch(metadata_tables, TopicRow::key_for(namespace_id, topic))?
     else {
-        return Ok(0);
+        return Ok(StreamEstimate::default());
     };
 
     let mut total = 0u64;
+    let mut available_partitions = Vec::new();
     for partition_idx in 0..topic_row.partitions {
         let partition = Partition::new(partition_idx)?;
 
@@ -133,12 +151,17 @@ pub fn estimate_available_stream_messages(
             continue;
         }
 
+        available_partitions.push(partition);
+
         let cursor_offset = cursor.map(|c| c.offset).unwrap_or(0);
         let next_offset = MsgRow::next_offset(msg_table, topic_row.id, partition)?;
         total += next_offset.saturating_sub(cursor_offset);
     }
 
-    Ok(total)
+    Ok(StreamEstimate {
+        count: total,
+        available_partitions,
+    })
 }
 
 #[derive(Clone)]

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -107,6 +107,16 @@ impl PublishOperation {
                 .metrics
                 .record_published(&self.topic, msg_count, bytes);
 
+            for published in &results {
+                let count = published.offset.saturating_sub(published.start_offset);
+                state.topic_publish_notifier.notify_published(
+                    self.namespace_id,
+                    published.topic.topic.clone(),
+                    published.topic.partition,
+                    count,
+                );
+            }
+
             Ok::<_, Error>(results)
         })
         .await??;

--- a/crates/msgs/src/topic_publish_notifier.rs
+++ b/crates/msgs/src/topic_publish_notifier.rs
@@ -1,0 +1,142 @@
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+};
+
+use coyote_id::NamespaceId;
+use tokio::sync::Notify;
+
+use crate::entities::{Partition, TopicName};
+
+type Key = (NamespaceId, TopicName);
+
+struct WaiterState {
+    /// An empty vec is treated as "all partitions"
+    partitions: Vec<Partition>,
+    count: AtomicU64,
+    notify: Notify,
+}
+
+struct Inner {
+    waiters: Mutex<HashMap<Key, Vec<Arc<WaiterState>>>>,
+    closed: AtomicBool,
+    /// Notified on shutdown to wake all waiters.
+    shutdown: Notify,
+}
+
+/// Notifies when a topic has published messages to it.
+#[derive(Clone)]
+pub struct TopicPublishNotifier {
+    inner: Arc<Inner>,
+}
+
+/// Can be `await`ed to block until messages are published to a topic + partition.
+pub struct Notified {
+    state: Arc<WaiterState>,
+    inner: Arc<Inner>,
+    key: Key,
+}
+
+impl TopicPublishNotifier {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                waiters: Mutex::new(HashMap::new()),
+                closed: AtomicBool::new(false),
+                shutdown: Notify::new(),
+            }),
+        }
+    }
+
+    /// Sends a notification that messages were published to the topic + partition.
+    pub fn notify_published(
+        &self,
+        namespace: NamespaceId,
+        topic: TopicName,
+        partition: Partition,
+        count: u64,
+    ) {
+        let map = self.inner.waiters.lock().unwrap();
+        let Some(waiters) = map.get(&(namespace, topic)) else {
+            return;
+        };
+        for waiter in waiters {
+            if waiter.partitions.is_empty() || waiter.partitions.contains(&partition) {
+                waiter.count.fetch_add(count, Ordering::Release);
+                waiter.notify.notify_waiters();
+            }
+        }
+    }
+
+    /// Returns a Notified that can be `await`ed
+    pub fn register_notifier(
+        &self,
+        namespace: NamespaceId,
+        topic: TopicName,
+        partitions: Vec<Partition>,
+    ) -> Notified {
+        let state = Arc::new(WaiterState {
+            partitions,
+            count: AtomicU64::new(0),
+            notify: Notify::new(),
+        });
+        let key = (namespace, topic);
+
+        self.inner
+            .waiters
+            .lock()
+            .unwrap()
+            .entry(key.clone())
+            .or_default()
+            .push(Arc::clone(&state));
+
+        Notified {
+            state,
+            inner: Arc::clone(&self.inner),
+            key,
+        }
+    }
+}
+
+impl Notified {
+    /// Waits for the number of messages to be published to the registered topic + partitions.
+    /// Returns early if the notifier is shut down.
+    pub async fn wait(&mut self, count: u64) {
+        loop {
+            let notified = self.state.notify.notified();
+            let shutdown = self.inner.shutdown.notified();
+            if self.inner.closed.load(Ordering::Acquire) {
+                return;
+            }
+            if self.state.count.load(Ordering::Acquire) >= count {
+                return;
+            }
+            tokio::select! {
+                _ = notified => {},
+                _ = shutdown => return,
+            }
+        }
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        self.closed.store(true, Ordering::Release);
+        self.shutdown.notify_waiters();
+    }
+}
+
+impl Drop for Notified {
+    fn drop(&mut self) {
+        let mut map = self.inner.waiters.lock().unwrap();
+        if let Some(waiters) = map.get_mut(&self.key) {
+            waiters.retain(|w| !Arc::ptr_eq(w, &self.state));
+            if waiters.is_empty() {
+                map.remove(&self.key);
+            }
+        }
+    }
+}

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -170,8 +170,11 @@ impl Store {
 
         let stores = Stores {
             databases: databases.clone(),
-            msgs_state: coyote_msgs::State::init(persistent_db.clone())
-                .context("initializing msgs state")?,
+            msgs_state: coyote_msgs::State::init(
+                persistent_db.clone(),
+                app_state.topic_publish_notifier.clone(),
+            )
+            .context("initializing msgs state")?,
             kv_state: coyote_kv::State::init(databases.clone()).context("initializing kv state")?,
             cache_state: coyote_cache::State::init(databases.clone())
                 .context("initializing cache state")?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use axum::{
 use coyote_authorization::{Permissions, RoleId};
 use coyote_core::Monotime;
 use coyote_error::Error;
+use coyote_msgs::TopicPublishNotifier;
 use coyote_proto::{InternalClient, InternalRequest, InternalRequestError};
 use fjall_utils::{Databases, ReadonlyDatabases};
 use http::StatusCode;
@@ -104,6 +105,8 @@ pub struct AppState {
     pub(crate) auth_token_cache: Arc<parking_lot::RwLock<core::auth::FifoCache<Permissions>>>,
 
     pub(crate) time: Monotime,
+
+    pub(crate) topic_publish_notifier: TopicPublishNotifier,
 }
 
 #[derive(Debug, Serialize)]
@@ -267,6 +270,7 @@ impl AppState {
             internal_client,
             auth_token_cache,
             time,
+            topic_publish_notifier: TopicPublishNotifier::new(),
         }
     }
 

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -238,8 +238,6 @@ async fn stream_receive(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    // FIXME(@svix-gabriel) - there's potentially optimizations we can do using fancy tokio
-    // Notifiers to avoid sleeping the max duration. But this is simplest for now.
     if let Some(max_wait) = data.batch_wait_ms {
         let ro_db = state.ro_dbs.db_for(StorageType::Persistent);
         let metadata_ks = ro_db
@@ -255,7 +253,7 @@ async fn stream_receive(
         let now = state.time.now();
         let batch_size = data.batch_size;
 
-        let estimated = coyote_core::task::spawn_blocking_in_current_span(move || {
+        let estimate = coyote_core::task::spawn_blocking_in_current_span(move || {
             coyote_msgs::estimate_available_stream_messages(
                 &metadata_ks,
                 &msg_ks,
@@ -268,8 +266,17 @@ async fn stream_receive(
         .await
         .or_internal_error()??;
 
-        if (estimated as usize) < batch_size.get() as usize {
-            state.time.sleep(max_wait.into()).await;
+        if (estimate.count as usize) < batch_size.get() as usize {
+            let needed = batch_size.get() as u64 - estimate.count;
+            let mut notified = state.topic_publish_notifier.register_notifier(
+                namespace.id,
+                data.topic.name().clone(),
+                estimate.available_partitions,
+            );
+            tokio::select! {
+                _ = notified.wait(needed) => {},
+                _ = state.time.sleep(max_wait.into()) => {},
+            }
         }
     }
 
@@ -440,8 +447,6 @@ async fn queue_receive(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    // FIXME(@svix-gabriel) - there's potentially optimizations we can do using fancy tokio
-    // Notifiers to avoid sleeping the max duration. But this is simplest for now.
     if let Some(max_wait) = data.batch_wait_ms {
         let ro_db = state.ro_dbs.db_for(StorageType::Persistent);
         let metadata_ks = ro_db
@@ -471,7 +476,16 @@ async fn queue_receive(
         .or_internal_error()??;
 
         if (estimated as usize) < batch_size.get() as usize {
-            state.time.sleep(max_wait.into()).await;
+            let needed = batch_size.get() as u64 - estimated;
+            let mut notified = state.topic_publish_notifier.register_notifier(
+                namespace.id,
+                data.topic.name().clone(),
+                vec![],
+            );
+            tokio::select! {
+                _ = notified.wait(needed) => {},
+                _ = state.time.sleep(max_wait.into()) => {},
+            }
         }
     }
 

--- a/tests/it/msgs/queue.rs
+++ b/tests/it/msgs/queue.rs
@@ -1427,3 +1427,57 @@ async fn queue_receive_max_wait_does_not_skip_partitions_with_existing_cursor() 
 
     Ok(())
 }
+
+#[tokio::test]
+async fn queue_receive_wakes_on_publish_notification() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-qnotify" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Start a receive wanting 3 messages with a very long timeout.
+    // Uses mock time, so the timeout will never fire — the receive can only
+    // return if the publish notifier wakes it up.
+    let recv_client = client.clone();
+    let recv_handle = tokio::spawn(async move {
+        recv_client
+            .post("v1.msgs.queue.receive")
+            .json(json!({
+                "topic": "ns-qnotify:t1",
+                "consumer_group": "cg1",
+                "batch_size": 3,
+                "batch_wait_ms": 3_000_000,
+            }))
+            .await
+    });
+
+    yield_now().await;
+
+    // Publish 3 messages — should wake the waiting receive via the notifier
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-qnotify:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+                { "value": "c".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = recv_handle.await??.expect(StatusCode::OK).json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 3, "should receive all 3 published messages");
+
+    Ok(())
+}

--- a/tests/it/msgs/stream_receive.rs
+++ b/tests/it/msgs/stream_receive.rs
@@ -1303,3 +1303,67 @@ async fn stream_receive_max_wait_times_out_with_no_messages() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn stream_receive_wakes_on_publish_notification() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-notify" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group
+    client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "topic": "ns-notify:t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Start a receive wanting 3 messages with a very long timeout.
+    // Uses mock time, so the timeout will never fire — the receive can only
+    // return if the publish notifier wakes it up.
+    let recv_client = client.clone();
+    let recv_handle = tokio::spawn(async move {
+        recv_client
+            .post("v1.msgs.stream.receive")
+            .json(json!({
+                "topic": "ns-notify:t1",
+                "consumer_group": "cg1",
+                "batch_size": 3,
+                "batch_wait_ms": 3_000_000,
+            }))
+            .await
+    });
+
+    yield_now().await;
+
+    // Publish 3 messages — should wake the waiting receive via the notifier
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "topic": "ns-notify:t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+                { "value": "c".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = recv_handle.await??.expect(StatusCode::OK).json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 3, "should receive all 3 published messages");
+
+    Ok(())
+}


### PR DESCRIPTION
Currently, if there aren't enough messages to satisfy a batch, the receive method simply sleeps for the batch_wait specified by the user. This is simple, but means we risk waiting longer than necessary. For long batch_wait times, that can be killer.

Instead of reading from fjall in a loop, this adds a central way to register `tokio::*::Notify`ers so that publish calls will "Wake up" the appropriate receive calls. There's some synchronization/mutex overhead, but overall much less overhead than we'd expect from reading from `fjall`.

The `TopicNotifier` abstraction we use here is shared by both the Axum handlers (AppState) _and_ accessible by the State in the raft layer, so we can call `TopicNotifier` from within the `publish` operation. This is needed so the logic works across all nodes, not just if reads and writes on the same node.