### PR TITLE
Add stream lag metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,8 @@ dependencies = [
  "rmp-serde",
  "schemars 1.2.1",
  "serde",
+ "tempfile",
+ "tokio",
  "tracing",
  "validator",
 ]

--- a/crates/msgs/Cargo.toml
+++ b/crates/msgs/Cargo.toml
@@ -19,8 +19,12 @@ rand.workspace = true
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 validator.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -1,12 +1,15 @@
 use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
 use coyote_namespace::{Namespace, entities::MsgsConfig};
+use coyote_operations::BackgroundResult;
 use fjall::{KeyspaceCreateOptions, KvSeparationOptions};
 use jiff::Timestamp;
 
 use entities::{ConsumerGroup, Partition, TopicName};
 use fjall_utils::{ReadableKeyspace, TableRow};
 use tables::{MsgRow, QueueLeaseRow, StreamLeaseRow, TopicRow};
+
+use crate::metrics::record_stream_lag_metrics;
 
 pub mod entities;
 pub mod metrics;
@@ -136,4 +139,46 @@ pub fn estimate_available_stream_messages(
     }
 
     Ok(total)
+}
+
+#[derive(Clone)]
+pub struct AllNodesWorker {
+    state: State,
+}
+
+impl AllNodesWorker {
+    pub fn new(state: State) -> Self {
+        Self { state }
+    }
+
+    async fn worker_loop(&self) -> BackgroundResult<()> {
+        let state = self.state.clone();
+        match coyote_core::task::spawn_blocking_in_current_span(move || {
+            record_stream_lag_metrics(&state)
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => tracing::warn!(?err, "failed to collect stream lag metrics"),
+            Err(err) => tracing::warn!(?err, "stream lag metrics task panicked"),
+        }
+        Ok(())
+    }
+}
+
+impl coyote_operations::workers::BackgroundWorker for AllNodesWorker {
+    const NAME: &'static str = "bg-worker:msgs";
+
+    async fn run(self) -> BackgroundResult<()> {
+        let mut timer = tokio::time::interval(std::time::Duration::from_secs(60));
+        let shutting_down = coyote_core::shutdown::shutting_down_token();
+        while shutting_down
+            .run_until_cancelled(timer.tick())
+            .await
+            .is_some()
+        {
+            self.worker_loop().await?;
+        }
+        Ok(())
+    }
 }

--- a/crates/msgs/src/metrics.rs
+++ b/crates/msgs/src/metrics.rs
@@ -1,6 +1,11 @@
-use opentelemetry::metrics::{Counter, Meter};
+use opentelemetry::metrics::{Counter, Gauge, Meter};
 
-use crate::entities::{ConsumerGroup, TopicName};
+use crate::{
+    State,
+    entities::{ConsumerGroup, Partition, TopicName},
+    tables::{MsgRow, StreamLeaseRow, TopicRow},
+};
+use coyote_error::{Result, ResultExt as _};
 
 impl From<&TopicName> for opentelemetry::KeyValue {
     fn from(topic: &TopicName) -> Self {
@@ -30,6 +35,7 @@ pub struct MsgMetrics {
     pub(crate) stream_committed: Counter<u64>,
     pub(crate) stream_no_lease: Counter<u64>,
     pub(crate) stream_seeks: Counter<u64>,
+    pub(crate) stream_topic_lag: Gauge<u64>,
 }
 
 impl MsgMetrics {
@@ -94,6 +100,11 @@ impl MsgMetrics {
                 .u64_counter("coyote.msgs.stream.seek")
                 .with_description("Stream seek operations")
                 .with_unit("{event}")
+                .build(),
+            stream_topic_lag: meter
+                .u64_gauge("coyote.msgs.stream.lag")
+                .with_description("Estimated stream lag")
+                .with_unit("{message}")
                 .build(),
         }
     }
@@ -177,5 +188,210 @@ impl MsgMetrics {
     pub(crate) fn record_stream_seek(&self, topic: &TopicName, consumer_group: &ConsumerGroup) {
         let attrs = &[topic.into(), consumer_group.into()];
         self.stream_seeks.add(1, attrs);
+    }
+
+    pub(crate) fn record_stream_topic_lag(
+        &self,
+        topic: &TopicName,
+        consumer_group: &ConsumerGroup,
+        partition: Partition,
+        lag: u64,
+    ) {
+        let attrs = &[
+            topic.into(),
+            consumer_group.into(),
+            opentelemetry::KeyValue::new("partition", partition.get() as i64),
+        ];
+        self.stream_topic_lag.record(lag, attrs);
+    }
+}
+
+pub(crate) struct PartitionLag {
+    pub topic_name: TopicName,
+    pub consumer_group: ConsumerGroup,
+    pub partition: Partition,
+    pub lag: u64,
+}
+
+fn compute_stream_lag(
+    metadata_tables: &impl fjall_utils::ReadableKeyspace,
+    msg_table: &impl fjall_utils::ReadableKeyspace,
+) -> Result<Vec<PartitionLag>> {
+    use fjall_utils::TableRow as _;
+    use std::collections::HashSet;
+
+    let mut results = Vec::new();
+    for guard in metadata_tables.prefix([TopicRow::ROW_TYPE]) {
+        let (_, val) = guard.into_inner()?;
+        let topic_row: TopicRow = rmp_serde::from_slice(&val).or_internal_error()?;
+
+        let prefix = StreamLeaseRow::topic_scan_prefix(topic_row.id);
+
+        let mut consumer_groups = HashSet::new();
+        for guard in metadata_tables.prefix(&prefix) {
+            let (key, _) = guard.into_inner()?;
+            if let Some(cg_str) = StreamLeaseRow::consumer_group_from_key(&key)
+                && let Ok(consumer_group) = ConsumerGroup::try_from(cg_str)
+            {
+                consumer_groups.insert(consumer_group);
+            }
+        }
+
+        for cg in consumer_groups {
+            for partition_idx in 0..topic_row.partitions {
+                let Ok(partition) = Partition::new(partition_idx) else {
+                    continue;
+                };
+                let cursor_offset = StreamLeaseRow::fetch(
+                    metadata_tables,
+                    StreamLeaseRow::key_for(topic_row.id, partition, &cg),
+                )?
+                .map(|c| c.offset)
+                .unwrap_or(0);
+                let tail = MsgRow::next_offset(msg_table, topic_row.id, partition)?;
+                results.push(PartitionLag {
+                    topic_name: topic_row.name.clone(),
+                    consumer_group: cg.clone(),
+                    partition,
+                    lag: tail.saturating_sub(cursor_offset),
+                });
+            }
+        }
+    }
+    Ok(results)
+}
+
+pub(crate) fn record_stream_lag_metrics(state: &State) -> Result<()> {
+    for entry in compute_stream_lag(&state.metadata_tables, &state.msg_table)? {
+        state.metrics.record_stream_topic_lag(
+            &entry.topic_name,
+            &entry.consumer_group,
+            entry.partition,
+            entry.lag,
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use fjall_utils::WriteBatchExt as _;
+    use jiff::Timestamp;
+
+    use super::*;
+    use crate::tables::{MsgRow, StreamLeaseRow, TopicRow};
+
+    fn make_db() -> (fjall::Database, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = fjall::Database::builder(dir.path())
+            .temporary(true)
+            .open()
+            .unwrap();
+        (db, dir)
+    }
+
+    fn insert_topic(db: &fjall::Database, meta: &fjall::Keyspace, topic_row: &TopicRow) {
+        use coyote_id::NamespaceId;
+        let mut batch = db.batch();
+        batch
+            .insert_row(
+                meta,
+                TopicRow::key_for(NamespaceId::nil(), &topic_row.name),
+                topic_row,
+            )
+            .unwrap();
+        batch.commit().unwrap();
+    }
+
+    fn insert_msg(
+        db: &fjall::Database,
+        msgs: &fjall::Keyspace,
+        topic_row: &TopicRow,
+        partition: Partition,
+        offset: u64,
+    ) {
+        let mut batch = db.batch();
+        let row = MsgRow {
+            value: vec![],
+            headers: HashMap::new(),
+            timestamp: Timestamp::UNIX_EPOCH,
+            scheduled_at: None,
+        };
+        batch
+            .insert_row(msgs, MsgRow::key_for(topic_row.id, partition, offset), &row)
+            .unwrap();
+        batch.commit().unwrap();
+    }
+
+    fn insert_cursor(
+        db: &fjall::Database,
+        meta: &fjall::Keyspace,
+        topic_row: &TopicRow,
+        partition: Partition,
+        cg: &ConsumerGroup,
+        offset: u64,
+    ) {
+        let mut batch = db.batch();
+        let row = StreamLeaseRow {
+            offset,
+            expiry: Timestamp::UNIX_EPOCH,
+            end_offset: offset,
+        };
+        batch
+            .insert_row(
+                meta,
+                StreamLeaseRow::key_for(topic_row.id, partition, cg),
+                &row,
+            )
+            .unwrap();
+        batch.commit().unwrap();
+    }
+
+    #[test]
+    fn no_topics_returns_empty() {
+        let (db, _dir) = make_db();
+        let meta = db
+            .keyspace(crate::METADATA_KEYSPACE, Default::default)
+            .unwrap();
+        let msgs = db.keyspace(crate::MSG_KEYSPACE, Default::default).unwrap();
+        let results = compute_stream_lag(&meta, &msgs).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn lag_is_tail_minus_cursor() {
+        let (db, _dir) = make_db();
+        let meta = db
+            .keyspace(crate::METADATA_KEYSPACE, Default::default)
+            .unwrap();
+        let msgs = db.keyspace(crate::MSG_KEYSPACE, Default::default).unwrap();
+
+        let topic_name = TopicName::new("test-topic".to_string()).unwrap();
+        let topic_row = TopicRow::new(topic_name, Timestamp::UNIX_EPOCH);
+        let cg = ConsumerGroup::try_from("my-group").unwrap();
+        let partition = Partition::new(0).unwrap();
+
+        insert_topic(&db, &meta, &topic_row);
+
+        let results = compute_stream_lag(&meta, &msgs).unwrap();
+        assert!(results.is_empty());
+
+        // 5 messages, cursor at 0
+        for offset in 0..5 {
+            insert_msg(&db, &msgs, &topic_row, partition, offset);
+        }
+        insert_cursor(&db, &meta, &topic_row, partition, &cg, 0);
+
+        let results = compute_stream_lag(&meta, &msgs).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].lag, 5);
+
+        // Advance cursor to 2
+        insert_cursor(&db, &meta, &topic_row, partition, &cg, 2);
+
+        let results = compute_stream_lag(&meta, &msgs).unwrap();
+        assert_eq!(results[0].lag, 3);
     }
 }

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -78,6 +78,22 @@ pub(crate) struct StreamLeaseRow {
 }
 
 impl StreamLeaseRow {
+    const CONSUMER_GROUP_OFFSET: usize =
+        size_of::<fjall_utils::TableKeyType>() + size_of::<TopicId>() + size_of::<Partition>();
+
+    pub(crate) fn consumer_group_from_key(key: &[u8]) -> Option<&str> {
+        std::str::from_utf8(key.get(Self::CONSUMER_GROUP_OFFSET..)?).ok()
+    }
+
+    /// Returns the key prefix for scanning all `StreamLeaseRow`s for a given topic.
+    pub(crate) fn topic_scan_prefix(topic_id: TopicId) -> Vec<u8> {
+        let mut prefix =
+            Vec::with_capacity(size_of::<fjall_utils::TableKeyType>() + size_of::<TopicId>());
+        prefix.push(Self::ROW_TYPE);
+        prefix.extend_from_slice(topic_id.as_bytes());
+        prefix
+    }
+
     pub(crate) fn key_for(
         topic_id: TopicId,
         partition: Partition,
@@ -322,4 +338,25 @@ impl MsgRow {
 
 impl TableRow for MsgRow {
     const ROW_TYPE: u8 = RowType::Msg as u8;
+}
+
+#[cfg(test)]
+mod tests {
+    use jiff::Timestamp;
+
+    use super::*;
+    use crate::entities::{ConsumerGroup, Partition};
+
+    #[test]
+    fn test_consumer_group_from_key() {
+        use coyote_id::TopicId;
+        let topic_id = TopicId::new(Timestamp::UNIX_EPOCH);
+        let partition = Partition::new(0).unwrap();
+        let cg = ConsumerGroup::try_from("my-group").unwrap();
+        let key = StreamLeaseRow::key_for(topic_id, partition, &cg).into_fjall_key();
+        assert_eq!(
+            StreamLeaseRow::consumer_group_from_key(&key),
+            Some("my-group")
+        );
+    }
 }

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -778,6 +778,10 @@ impl StoreHandle {
         self.time.update_now()
     }
 
+    pub(crate) async fn msgs_store(&self) -> coyote_msgs::State {
+        self.inner.read().await.stores.read().msgs_state.clone()
+    }
+
     pub(crate) async fn kv_store(&self) -> coyote_kv::State {
         self.inner.read().await.stores.read().kv_state.clone()
     }

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -17,6 +17,11 @@ impl Workers {
         tracing::debug!("spawning background workers");
         let time = state.state_machine.time.clone();
         {
+            tracing::debug!("spawning msgs module worker");
+            let state = state.state_machine.msgs_store().await;
+            self.spawn(coyote_msgs::AllNodesWorker::new(state));
+        }
+        {
             tracing::debug!("spawning KV module worker");
             let state = state.state_machine.kv_store().await;
             let time = time.clone();


### PR DESCRIPTION
Record topic/partition/consumer group lag on an interval, report them to OpenTelemetry.