### PR TITLE
Enable NLB zonal affinity

### DIFF
--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -23,6 +23,7 @@ cluster:
         service.beta.kubernetes.io/aws-load-balancer-type: "external"
         service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+        service.beta.kubernetes.io/aws-load-balancer-attributes: dns_record.client_routing_policy=availability_zone_affinity
         external-dns.alpha.kubernetes.io/hostname: "coyote.svix.local"
     storage:
       persistent:


### PR DESCRIPTION
I'm not positive this will work, but it's supposed to enable zone affinity, which means internal DNS lookups of the main NLB address should return an IP in the same AZ as the requester.