### PR TITLE
rust: fix TTLs

### DIFF
--- a/codegen/templates/rust/types/macros.rs.jinja
+++ b/codegen/templates/rust/types/macros.rs.jinja
@@ -39,7 +39,7 @@
     {% if not field.required or field.nullable -%}
         skip_serializing_if = "Option::is_none",
     {% endif -%}
-    {% if field_name is endingwith "_ms" -%}
+    {% if (field.name | to_snake_case) is endingwith "_ms" -%}
         {% set serde_with = "crate::duration_ms_serde" -%}
         {% if not field.required or field.nullable -%}
             {% set serde_with = serde_with ~ "::optional" -%}

--- a/z-clients/rust/src/duration_ms_serde.rs
+++ b/z-clients/rust/src/duration_ms_serde.rs
@@ -2,28 +2,33 @@ use std::time::Duration;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-pub fn serialize<S: Serializer>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error> {
+pub(crate) fn serialize<S: Serializer>(
+    duration: &Duration,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
     (duration.as_millis() as u64).serialize(serializer)
 }
 
-pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
+pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Duration, D::Error> {
     let millis = u64::deserialize(deserializer)?;
     Ok(Duration::from_millis(millis))
 }
 
-mod optional {
+pub(crate) mod optional {
     use std::time::Duration;
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    pub fn serialize<S: Serializer>(
+    pub(crate) fn serialize<S: Serializer>(
         duration: &Option<Duration>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         duration.map(|d| d.as_millis() as u64).serialize(serializer)
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<Duration>, D::Error> {
         let millis = Option::<u64>::deserialize(deserializer)?;

--- a/z-clients/rust/src/lib.rs
+++ b/z-clients/rust/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 mod client;
 mod connector;
+mod duration_ms_serde;
 mod error;
 pub mod models;
 mod request;

--- a/z-clients/rust/src/models/admin_auth_token_create_in.rs
+++ b/z-clients/rust/src/models/admin_auth_token_create_in.rs
@@ -8,7 +8,11 @@ pub struct AdminAuthTokenCreateIn {
     pub role: String,
 
     /// Milliseconds from now until the token expires.
-    #[serde(rename = "expiry_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiry_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub expiry: Option<std::time::Duration>,
 
     /// Whether the token is enabled. Defaults to `true`.

--- a/z-clients/rust/src/models/admin_auth_token_expire_in.rs
+++ b/z-clients/rust/src/models/admin_auth_token_expire_in.rs
@@ -6,7 +6,11 @@ pub struct AdminAuthTokenExpireIn {
     pub id: String,
 
     /// Milliseconds from now until the token expires. `None` means expire immediately.
-    #[serde(rename = "expiry_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiry_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub expiry: Option<std::time::Duration>,
 }
 

--- a/z-clients/rust/src/models/admin_auth_token_update_in.rs
+++ b/z-clients/rust/src/models/admin_auth_token_update_in.rs
@@ -8,7 +8,11 @@ pub struct AdminAuthTokenUpdateIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    #[serde(rename = "expiry_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiry_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub expiry: Option<std::time::Duration>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/z-clients/rust/src/models/auth_token_create_in.rs
+++ b/z-clients/rust/src/models/auth_token_create_in.rs
@@ -15,7 +15,11 @@ pub struct AuthTokenCreateIn {
     pub suffix: Option<String>,
 
     /// Milliseconds from now until the token expires.
-    #[serde(rename = "expiry_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiry_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub expiry: Option<std::time::Duration>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/z-clients/rust/src/models/auth_token_expire_in.rs
+++ b/z-clients/rust/src/models/auth_token_expire_in.rs
@@ -9,7 +9,11 @@ pub struct AuthTokenExpireIn {
     pub id: String,
 
     /// Milliseconds from now until the token expires. `None` means expire immediately.
-    #[serde(rename = "expiry_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiry_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub expiry: Option<std::time::Duration>,
 }
 

--- a/z-clients/rust/src/models/auth_token_rotate_in.rs
+++ b/z-clients/rust/src/models/auth_token_rotate_in.rs
@@ -15,7 +15,11 @@ pub struct AuthTokenRotateIn {
     pub suffix: Option<String>,
 
     /// Milliseconds from now until the old token expires. `None` means expire immediately.
-    #[serde(rename = "expiry_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiry_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub expiry: Option<std::time::Duration>,
 }
 

--- a/z-clients/rust/src/models/auth_token_update_in.rs
+++ b/z-clients/rust/src/models/auth_token_update_in.rs
@@ -11,7 +11,11 @@ pub struct AuthTokenUpdateIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    #[serde(rename = "expiry_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiry_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub expiry: Option<std::time::Duration>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/z-clients/rust/src/models/cache_set_in.rs
+++ b/z-clients/rust/src/models/cache_set_in.rs
@@ -10,7 +10,7 @@ pub struct CacheSetIn {
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds
-    #[serde(rename = "ttl_ms")]
+    #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
 }
 
@@ -40,6 +40,6 @@ pub(crate) struct CacheSetIn_ {
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds
-    #[serde(rename = "ttl_ms")]
+    #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
 }

--- a/z-clients/rust/src/models/idempotency_complete_in.rs
+++ b/z-clients/rust/src/models/idempotency_complete_in.rs
@@ -11,7 +11,7 @@ pub struct IdempotencyCompleteIn {
     pub response: Vec<u8>,
 
     /// TTL in milliseconds for the cached response
-    #[serde(rename = "ttl_ms")]
+    #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
 }
 
@@ -42,6 +42,6 @@ pub(crate) struct IdempotencyCompleteIn_ {
     pub response: Vec<u8>,
 
     /// TTL in milliseconds for the cached response
-    #[serde(rename = "ttl_ms")]
+    #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
 }

--- a/z-clients/rust/src/models/idempotency_start_in.rs
+++ b/z-clients/rust/src/models/idempotency_start_in.rs
@@ -7,7 +7,7 @@ pub struct IdempotencyStartIn {
     pub namespace: Option<String>,
 
     /// TTL in milliseconds for the lock/response
-    #[serde(rename = "ttl_ms")]
+    #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
 }
 
@@ -33,6 +33,6 @@ pub(crate) struct IdempotencyStartIn_ {
     pub key: String,
 
     /// TTL in milliseconds for the lock/response
-    #[serde(rename = "ttl_ms")]
+    #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
 }

--- a/z-clients/rust/src/models/kv_set_in.rs
+++ b/z-clients/rust/src/models/kv_set_in.rs
@@ -12,7 +12,11 @@ pub struct KvSetIn {
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds
-    #[serde(rename = "ttl_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ttl_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub ttl: Option<std::time::Duration>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -67,7 +71,11 @@ pub(crate) struct KvSetIn_ {
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds
-    #[serde(rename = "ttl_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ttl_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub ttl: Option<std::time::Duration>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/z-clients/rust/src/models/msg_in.rs
+++ b/z-clients/rust/src/models/msg_in.rs
@@ -15,7 +15,11 @@ pub struct MsgIn {
 
     /// Optional delay in milliseconds. The message will not be delivered to queue consumers
     /// until `delay_ms` has elapsed from the time of publish.
-    #[serde(rename = "delay_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "delay_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub delay: Option<std::time::Duration>,
 }
 

--- a/z-clients/rust/src/models/msg_queue_receive_in.rs
+++ b/z-clients/rust/src/models/msg_queue_receive_in.rs
@@ -9,11 +9,19 @@ pub struct MsgQueueReceiveIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_size: Option<u16>,
 
-    #[serde(rename = "lease_duration_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "lease_duration_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub lease_duration: Option<std::time::Duration>,
 
     /// Maximum time (in milliseconds) to wait for messages before returning.
-    #[serde(rename = "batch_wait_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "batch_wait_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub batch_wait: Option<std::time::Duration>,
 }
 
@@ -60,10 +68,18 @@ pub(crate) struct MsgQueueReceiveIn_ {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_size: Option<u16>,
 
-    #[serde(rename = "lease_duration_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "lease_duration_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub lease_duration: Option<std::time::Duration>,
 
     /// Maximum time (in milliseconds) to wait for messages before returning.
-    #[serde(rename = "batch_wait_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "batch_wait_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub batch_wait: Option<std::time::Duration>,
 }

--- a/z-clients/rust/src/models/msg_stream_receive_in.rs
+++ b/z-clients/rust/src/models/msg_stream_receive_in.rs
@@ -11,14 +11,22 @@ pub struct MsgStreamReceiveIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_size: Option<u16>,
 
-    #[serde(rename = "lease_duration_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "lease_duration_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub lease_duration: Option<std::time::Duration>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_starting_position: Option<SeekPosition>,
 
     /// Maximum time (in milliseconds) to wait for messages before returning.
-    #[serde(rename = "batch_wait_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "batch_wait_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub batch_wait: Option<std::time::Duration>,
 }
 
@@ -74,13 +82,21 @@ pub(crate) struct MsgStreamReceiveIn_ {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_size: Option<u16>,
 
-    #[serde(rename = "lease_duration_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "lease_duration_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub lease_duration: Option<std::time::Duration>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_starting_position: Option<SeekPosition>,
 
     /// Maximum time (in milliseconds) to wait for messages before returning.
-    #[serde(rename = "batch_wait_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "batch_wait_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub batch_wait: Option<std::time::Duration>,
 }

--- a/z-clients/rust/src/models/rate_limit_check_out.rs
+++ b/z-clients/rust/src/models/rate_limit_check_out.rs
@@ -10,7 +10,11 @@ pub struct RateLimitCheckOut {
     pub remaining: u64,
 
     /// Milliseconds until enough tokens are available (only present when allowed is false)
-    #[serde(rename = "retry_after_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "retry_after_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub retry_after: Option<std::time::Duration>,
 }
 

--- a/z-clients/rust/src/models/rate_limit_get_remaining_out.rs
+++ b/z-clients/rust/src/models/rate_limit_get_remaining_out.rs
@@ -7,7 +7,11 @@ pub struct RateLimitGetRemainingOut {
     pub remaining: u64,
 
     /// Milliseconds until at least one token is available (only present when remaining is 0)
-    #[serde(rename = "retry_after_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "retry_after_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub retry_after: Option<std::time::Duration>,
 }
 

--- a/z-clients/rust/src/models/rate_limit_token_bucket_config.rs
+++ b/z-clients/rust/src/models/rate_limit_token_bucket_config.rs
@@ -10,7 +10,11 @@ pub struct RateLimitTokenBucketConfig {
     pub refill_amount: u64,
 
     /// Interval in milliseconds between refills (minimum 1 millisecond)
-    #[serde(rename = "refill_interval_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "refill_interval_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub refill_interval: Option<std::time::Duration>,
 }
 

--- a/z-clients/rust/src/models/retention.rs
+++ b/z-clients/rust/src/models/retention.rs
@@ -3,7 +3,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Retention {
-    #[serde(rename = "period_ms", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "period_ms",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::duration_ms_serde::optional"
+    )]
     pub period: Option<std::time::Duration>,
 
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
The Rust client library has been broken since #722 because it is passing the wrong type for TTLs. 

Before this change, the `cache.set` benchmark crashed with a msgpack decode error, and now it does not. 🎉 