### PR TITLE
server: add short flag for config-path and add doc

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -26,7 +26,8 @@ mod tracing_panic_hook;
 #[derive(Parser)]
 #[clap(author, version, about = env!("CARGO_PKG_DESCRIPTION"), long_about = None)]
 struct Args {
-    #[clap(long)]
+    /// Path to a TOML configuration file
+    #[clap(short = 'C', long)]
     config_path: Option<PathBuf>,
 
     #[clap(subcommand)]


### PR DESCRIPTION
I type it enough that i don't really want to do `--config-path` every time.