### PR TITLE
Some time-duration improvements

### DIFF
--- a/crates/coyote-core/src/types/duration_ms.rs
+++ b/crates/coyote-core/src/types/duration_ms.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fmt,
-    ops::{Add, AddAssign},
+    ops::{Add, AddAssign, Mul},
     time::Duration,
 };
 
@@ -68,6 +68,12 @@ impl From<u64> for DurationMs {
     }
 }
 
+impl From<DurationMs> for jiff::TimestampArithmetic {
+    fn from(value: DurationMs) -> Self {
+        Duration::from(value).into()
+    }
+}
+
 impl fmt::Debug for DurationMs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
@@ -87,6 +93,22 @@ impl AddAssign<DurationMs> for jiff::Timestamp {
     #[inline]
     fn add_assign(&mut self, rhs: DurationMs) {
         *self += Duration::from(rhs);
+    }
+}
+
+impl Mul<DurationMs> for u64 {
+    type Output = DurationMs;
+
+    fn mul(self, rhs: DurationMs) -> DurationMs {
+        DurationMs(self * rhs.0)
+    }
+}
+
+impl Mul<u64> for DurationMs {
+    type Output = DurationMs;
+
+    fn mul(self, rhs: u64) -> DurationMs {
+        DurationMs(self.0 * rhs)
     }
 }
 

--- a/crates/coyote-core/src/types/duration_ms.rs
+++ b/crates/coyote-core/src/types/duration_ms.rs
@@ -100,7 +100,7 @@ impl Mul<DurationMs> for u64 {
     type Output = DurationMs;
 
     fn mul(self, rhs: DurationMs) -> DurationMs {
-        DurationMs(self * rhs.0)
+        DurationMs(self.saturating_mul(rhs.0))
     }
 }
 
@@ -108,7 +108,7 @@ impl Mul<u64> for DurationMs {
     type Output = DurationMs;
 
     fn mul(self, rhs: u64) -> DurationMs {
-        DurationMs(self.0 * rhs)
+        DurationMs(self.0.saturating_mul(rhs))
     }
 }
 

--- a/crates/coyote-core/src/types/duration_ms.rs
+++ b/crates/coyote-core/src/types/duration_ms.rs
@@ -140,6 +140,7 @@ impl JsonSchema for DurationMs {
         json_schema!({
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
         })
     }
 

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -12,7 +12,8 @@ pub struct CompleteOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,
     pub(crate) response: Vec<u8>,
-    pub(crate) ttl_ms: DurationMs,
+    #[serde(rename = "ttl_ms")]
+    pub(crate) ttl: DurationMs,
 }
 
 impl CompleteOperation {
@@ -20,13 +21,13 @@ impl CompleteOperation {
         namespace: IdempotencyNamespace,
         key: String,
         response: Vec<u8>,
-        ttl_ms: DurationMs,
+        ttl: DurationMs,
     ) -> Self {
         Self {
             namespace_id: namespace.id,
             key,
             response,
-            ttl_ms,
+            ttl,
         }
     }
 }
@@ -38,7 +39,7 @@ impl CompleteOperation {
         now: Timestamp,
         log_index: u64,
     ) -> Result<()> {
-        let expiry = now + self.ttl_ms;
+        let expiry = now + self.ttl;
         state
             .state
             .controller()

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -11,15 +11,16 @@ use serde::{Deserialize, Serialize};
 pub struct TryStartOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,
-    pub(crate) ttl_ms: DurationMs,
+    #[serde(rename = "ttl_ms")]
+    pub(crate) ttl: DurationMs,
 }
 
 impl TryStartOperation {
-    pub fn new(namespace: IdempotencyNamespace, key: String, ttl_ms: DurationMs) -> Self {
+    pub fn new(namespace: IdempotencyNamespace, key: String, ttl: DurationMs) -> Self {
         Self {
             namespace_id: namespace.id,
             key,
-            ttl_ms,
+            ttl,
         }
     }
 }
@@ -36,7 +37,7 @@ impl TryStartOperation {
         now: Timestamp,
         log_index: u64,
     ) -> Result<TryStartResponseData> {
-        let expiry = now + self.ttl_ms;
+        let expiry = now + self.ttl;
 
         let controller = state.state.controller();
 

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -343,9 +343,9 @@ pub struct MsgIn {
     /// Optional delay in milliseconds.
     ///
     /// The message will not be delivered to queue consumers
-    /// until `delay_ms` has elapsed from the time of publish.
-    #[serde(default)]
-    pub delay_ms: Option<u64>,
+    /// until the delay has elapsed from the time of publish.
+    #[serde(default, rename = "delay_ms")]
+    pub delay: Option<DurationMs>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -460,6 +460,7 @@ impl JsonSchema for ConsumerGroup {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize, JsonSchema)]
 pub struct Retention {
-    pub period_ms: Option<DurationMs>,
+    #[serde(rename = "period_ms")]
+    pub period: Option<DurationMs>,
     pub size_bytes: Option<NonZeroU64>,
 }

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -336,9 +336,13 @@ pub struct MsgIn {
     pub value: Vec<u8>,
     #[serde(default)]
     pub headers: HashMap<String, String>,
-    /// Optional partition key. Messages with the same key are routed to the same partition.
+    /// Optional partition key.
+    ///
+    /// Messages with the same key are routed to the same partition.
     pub key: Option<String>,
-    /// Optional delay in milliseconds. The message will not be delivered to queue consumers
+    /// Optional delay in milliseconds.
+    ///
+    /// The message will not be delivered to queue consumers
     /// until `delay_ms` has elapsed from the time of publish.
     #[serde(default)]
     pub delay_ms: Option<u64>,

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -28,7 +28,7 @@ impl CreateNamespaceOperation {
         let op = CreateNamespace::new(
             self.name,
             MsgsConfig {
-                retention_period: self.retention.period_ms,
+                retention_period: self.retention.period,
                 retention_bytes: self.retention.size_bytes,
             },
         );
@@ -50,7 +50,7 @@ impl From<CreateNamespaceOutput<MsgsConfig>> for CreateNamespaceResponseData {
         Self {
             name: value.name,
             retention: Retention {
-                period_ms: value.config.retention_period,
+                period: value.config.retention_period,
                 size_bytes: value.config.retention_bytes,
             },
             created: value.created,

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -16,8 +16,6 @@ use crate::{
     tables::{MsgRow, TopicRow},
 };
 
-use jiff::SignedDuration;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublishOperation {
     namespace_id: NamespaceId,
@@ -181,10 +179,9 @@ fn write_msg_batch(
         let start_offset = offset;
 
         for msg in msgs {
-            let scheduled_at = msg.delay_ms.map(|ms| {
-                now.checked_add(SignedDuration::from_millis(ms as i64))
-                    .expect("scheduled_at overflow")
-            });
+            let scheduled_at = msg
+                .delay
+                .map(|ms| now.checked_add(ms).expect("scheduled_at overflow"));
             let msg = MsgRow {
                 value: msg.value,
                 headers: msg.headers,

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -23,7 +23,8 @@ pub struct QueueReceiveOperation {
     partition: Option<Partition>,
     consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
-    lease_duration_ms: DurationMs,
+    #[serde(rename = "lease_duration_ms")]
+    lease_duration: DurationMs,
 }
 
 impl QueueReceiveOperation {
@@ -32,7 +33,7 @@ impl QueueReceiveOperation {
         topic: TopicIn,
         consumer_group: ConsumerGroup,
         batch_size: NonZeroU16,
-        lease_duration_ms: DurationMs,
+        lease_duration: DurationMs,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => (tp.topic, Some(tp.partition)),
@@ -44,7 +45,7 @@ impl QueueReceiveOperation {
             partition,
             consumer_group,
             batch_size,
-            lease_duration_ms,
+            lease_duration,
         })
     }
 
@@ -56,7 +57,7 @@ impl QueueReceiveOperation {
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<QueueReceiveMsg> = Vec::with_capacity(remaining.into());
 
-            let expiry = now + self.lease_duration_ms;
+            let expiry = now + self.lease_duration;
 
             let mut batch = state.db.batch();
 

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -25,7 +25,8 @@ pub struct StreamReceiveOperation {
     partition: Option<Partition>,
     consumer_group: ConsumerGroup,
     batch_size: NonZeroU16,
-    lease_duration_ms: DurationMs,
+    #[serde(rename = "lease_duration_ms")]
+    lease_duration: DurationMs,
     default_starting_position: SeekPosition,
 }
 
@@ -35,7 +36,7 @@ impl StreamReceiveOperation {
         topic: TopicIn,
         consumer_group: ConsumerGroup,
         batch_size: NonZeroU16,
-        lease_duration_ms: DurationMs,
+        lease_duration: DurationMs,
         default_starting_position: SeekPosition,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
@@ -48,7 +49,7 @@ impl StreamReceiveOperation {
             partition,
             consumer_group,
             batch_size,
-            lease_duration_ms,
+            lease_duration,
             default_starting_position,
         })
     }
@@ -60,7 +61,7 @@ impl StreamReceiveOperation {
         spawn_blocking_in_current_span(move || {
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<StreamReceiveMsg> = Vec::with_capacity(remaining as usize);
-            let expiry = now + self.lease_duration_ms;
+            let expiry = now + self.lease_duration;
 
             let mut batch = state.db.batch();
 

--- a/crates/rate-limit/src/algorithms.rs
+++ b/crates/rate-limit/src/algorithms.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use coyote_core::types::DurationMs;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -42,9 +40,9 @@ impl TokenBucket {
         (capacity, new_last_refill)
     }
 
-    pub(crate) fn calculate_retry_after(&self, current: u64, wanted: u64) -> Duration {
+    pub(crate) fn calculate_retry_after(&self, current: u64, wanted: u64) -> DurationMs {
         let wanted = wanted.saturating_sub(current);
         let intervals = wanted.div_ceil(self.refill_rate);
-        Duration::from_millis(intervals * self.refill_interval.as_millis())
+        intervals * self.refill_interval
     }
 }

--- a/crates/rate-limit/src/controller.rs
+++ b/crates/rate-limit/src/controller.rs
@@ -1,6 +1,4 @@
-use std::time::Duration;
-
-use coyote_core::task::spawn_blocking_in_current_span;
+use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
 use coyote_error::{Result, ResultExt as _};
 use coyote_id::NamespaceId;
 use fjall::KeyspaceCreateOptions;
@@ -47,7 +45,7 @@ impl RateLimitController {
         identifier: I,
         wanted: u64,
         config: TokenBucket,
-    ) -> Result<(bool, u64, Option<Duration>)> {
+    ) -> Result<(bool, u64, Option<DurationMs>)> {
         let tables = self.tables.clone();
 
         spawn_blocking_in_current_span(move || {
@@ -82,7 +80,7 @@ impl RateLimitController {
         namespace_id: NamespaceId,
         identifier: I,
         config: TokenBucket,
-    ) -> Result<(u64, Option<Duration>)> {
+    ) -> Result<(u64, Option<DurationMs>)> {
         let tables = self.tables.clone();
         spawn_blocking_in_current_span(move || {
             let identifier = identifier.as_ref();
@@ -179,7 +177,7 @@ mod tests {
             limiter.limit(clock, ns(), id, 1, config()).await.unwrap();
         assert!(!result);
         assert_eq!(remaining, 0);
-        assert_eq!(retry_after, Some(Duration::from_millis(100)));
+        assert_eq!(retry_after, Some(DurationMs::from(100)));
     }
 
     #[tokio::test]

--- a/crates/rate-limit/src/operations/limit.rs
+++ b/crates/rate-limit/src/operations/limit.rs
@@ -1,7 +1,6 @@
-use std::time::Duration;
-
 use super::{LimitResponse, RateLimitRaftState, RateLimitRequest};
 use crate::{RateLimitNamespace, TokenBucket};
+use coyote_core::types::DurationMs;
 use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_operations::OpContext;
@@ -36,7 +35,8 @@ impl LimitOperation {
 pub struct LimitResponseData {
     pub allowed: bool,
     pub remaining: u64,
-    pub retry_after: Option<Duration>,
+    #[serde(rename = "retry_after_ms")]
+    pub retry_after: Option<DurationMs>,
 }
 
 impl LimitOperation {

--- a/openapi.json
+++ b/openapi.json
@@ -6586,12 +6586,12 @@
             }
           },
           "key": {
-            "description": "Optional partition key. Messages with the same key are routed to the same partition.",
+            "description": "Optional partition key.\n\nMessages with the same key are routed to the same partition.",
             "type": "string",
             "nullable": true
           },
           "delay_ms": {
-            "description": "Optional delay in milliseconds. The message will not be delivered to queue consumers\nuntil `delay_ms` has elapsed from the time of publish.",
+            "description": "Optional delay in milliseconds.\n\nThe message will not be delivered to queue consumers\nuntil `delay_ms` has elapsed from the time of publish.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0,

--- a/openapi.json
+++ b/openapi.json
@@ -6591,10 +6591,9 @@
             "nullable": true
           },
           "delay_ms": {
-            "description": "Optional delay in milliseconds.\n\nThe message will not be delivered to queue consumers\nuntil `delay_ms` has elapsed from the time of publish.",
+            "description": "Optional delay in milliseconds.\n\nThe message will not be delivered to queue consumers\nuntil the delay has elapsed from the time of publish.",
             "type": "integer",
             "format": "uint64",
-            "minimum": 0,
             "default": null,
             "nullable": true
           }
@@ -7272,7 +7271,6 @@
             "description": "Milliseconds until enough tokens are available (only present when allowed is false)",
             "type": "integer",
             "format": "uint64",
-            "minimum": 0,
             "nullable": true
           }
         },
@@ -7382,7 +7380,6 @@
             "description": "Milliseconds until at least one token is available (only present when remaining is 0)",
             "type": "integer",
             "format": "uint64",
-            "minimum": 0,
             "nullable": true
           }
         },

--- a/openapi.json
+++ b/openapi.json
@@ -4925,6 +4925,7 @@
             "description": "Milliseconds from now until the token expires.",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           },
           "enabled": {
@@ -4995,6 +4996,7 @@
             "description": "Milliseconds from now until the token expires. `None` means expire immediately.",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           }
         },
@@ -5111,6 +5113,7 @@
           "expiry_ms": {
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           },
           "enabled": {
@@ -5315,6 +5318,7 @@
             "description": "Milliseconds from now until the token expires.",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           },
           "metadata": {
@@ -5442,6 +5446,7 @@
             "description": "Milliseconds from now until the token expires. `None` means expire immediately.",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           }
         },
@@ -5587,6 +5592,7 @@
             "description": "Milliseconds from now until the old token expires. `None` means expire immediately.",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           }
         },
@@ -5636,6 +5642,7 @@
           "expiry_ms": {
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           },
           "metadata": {
@@ -5870,7 +5877,8 @@
           "ttl_ms": {
             "description": "Time to live in milliseconds",
             "type": "integer",
-            "format": "uint64"
+            "format": "uint64",
+            "minimum": 0
           }
         },
         "required": [
@@ -6594,6 +6602,7 @@
             "description": "Optional delay in milliseconds.\n\nThe message will not be delivered to queue consumers\nuntil the delay has elapsed from the time of publish.",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "default": null,
             "nullable": true
           }
@@ -6899,12 +6908,14 @@
           "lease_duration_ms": {
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "default": 30000
           },
           "batch_wait_ms": {
             "description": "Maximum time (in milliseconds) to wait for messages before returning.",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "default": null,
             "nullable": true
           }
@@ -7016,6 +7027,7 @@
           "lease_duration_ms": {
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "default": 300000
           },
           "default_starting_position": {
@@ -7026,6 +7038,7 @@
             "description": "Maximum time (in milliseconds) to wait for messages before returning.",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "default": null,
             "nullable": true
           }
@@ -7271,6 +7284,7 @@
             "description": "Milliseconds until enough tokens are available (only present when allowed is false)",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           }
         },
@@ -7380,6 +7394,7 @@
             "description": "Milliseconds until at least one token is available (only present when remaining is 0)",
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           }
         },
@@ -7448,6 +7463,7 @@
           "period_ms": {
             "type": "integer",
             "format": "uint64",
+            "minimum": 0,
             "nullable": true
           },
           "size_bytes": {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -337,7 +337,7 @@ mod tests {
         let BootstrapCommand::Msgs(v) = cmd else {
             panic!()
         };
-        assert_eq!(v.retention.period_ms.unwrap().as_millis(), 60000);
+        assert_eq!(v.retention.period.unwrap().as_millis(), 60000);
         assert_eq!(v.retention.size_bytes.unwrap().get(), 500);
     }
 

--- a/src/v1/endpoints/admin/auth/token.rs
+++ b/src/v1/endpoints/admin/auth/token.rs
@@ -51,7 +51,8 @@ pub struct AdminAuthTokenCreateIn {
     pub name: String,
     pub role: String,
     /// Milliseconds from now until the token expires.
-    pub expiry_ms: Option<DurationMs>,
+    #[serde(rename = "expiry_ms")]
+    pub expiry: Option<DurationMs>,
     /// Whether the token is enabled. Defaults to `true`.
     #[serde(default = "default_true")]
     pub enabled: bool,
@@ -88,7 +89,7 @@ async fn auth_token_create(
                 name: data.name,
                 prefix: default_prefix(),
                 suffix: None,
-                expiry_ms: data.expiry_ms,
+                expiry: data.expiry,
                 metadata: Metadata(metadata),
                 owner_id: RoleId::operator().0,
                 scopes: vec![],
@@ -112,7 +113,8 @@ async fn auth_token_create(
 pub struct AdminAuthTokenExpireIn {
     pub id: Public<AuthTokenId>,
     /// Milliseconds from now until the token expires. `None` means expire immediately.
-    pub expiry_ms: Option<DurationMs>,
+    #[serde(rename = "expiry_ms")]
+    pub expiry: Option<DurationMs>,
 }
 
 admin_request_input!(AdminAuthTokenExpireIn);
@@ -132,7 +134,7 @@ async fn auth_token_expire(
             &AuthTokenExpireIn {
                 id: data.id,
                 namespace: Some(INTERNAL_NAMESPACE.to_owned()),
-                expiry_ms: data.expiry_ms,
+                expiry: data.expiry,
             },
         )
         .await
@@ -172,7 +174,7 @@ async fn auth_token_rotate(
                 id: data.id,
                 prefix: default_prefix(),
                 suffix: None,
-                expiry_ms: None,
+                expiry: None,
             },
         )
         .await
@@ -287,7 +289,8 @@ async fn auth_token_list(
 pub struct AdminAuthTokenUpdateIn {
     pub id: Public<AuthTokenId>,
     pub name: Option<String>,
-    pub expiry_ms: Option<DurationMs>,
+    #[serde(rename = "expiry_ms")]
+    pub expiry: Option<DurationMs>,
     pub enabled: Option<bool>,
 }
 
@@ -309,7 +312,7 @@ async fn auth_token_update(
                 namespace: Some(INTERNAL_NAMESPACE.to_owned()),
                 id: data.id,
                 name: data.name,
-                expiry_ms: data.expiry_ms,
+                expiry: data.expiry,
                 metadata: None,
                 scopes: None,
                 enabled: data.enabled,

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -95,7 +95,8 @@ pub struct AuthTokenCreateIn {
     pub prefix: String,
     pub suffix: Option<String>,
     /// Milliseconds from now until the token expires.
-    pub expiry_ms: Option<DurationMs>,
+    #[serde(rename = "expiry_ms")]
+    pub expiry: Option<DurationMs>,
     #[serde(default)]
     pub metadata: Metadata,
     pub owner_id: String,
@@ -141,7 +142,7 @@ async fn auth_token_create(
         namespace,
         data.name,
         token.hash(),
-        data.expiry_ms.map(|ms| repl.time.now() + ms),
+        data.expiry.map(|ms| repl.time.now() + ms),
         data.metadata,
         data.owner_id,
         data.scopes,
@@ -164,7 +165,8 @@ pub struct AuthTokenExpireIn {
     pub namespace: Option<String>,
     pub id: Public<AuthTokenId>,
     /// Milliseconds from now until the token expires. `None` means expire immediately.
-    pub expiry_ms: Option<DurationMs>,
+    #[serde(rename = "expiry_ms")]
+    pub expiry: Option<DurationMs>,
 }
 
 request_input!(AuthTokenExpireIn, "Expire");
@@ -184,7 +186,7 @@ async fn auth_token_expire(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let expiry = data.expiry_ms.map(|ms| repl.time.now() + ms);
+    let expiry = data.expiry.map(|ms| repl.time.now() + ms);
     let operation = ExpireAuthTokenOperation::new(namespace, data.id.into_inner(), expiry);
     let _ = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(AuthTokenExpireOut {}))
@@ -318,7 +320,8 @@ pub struct AuthTokenUpdateIn {
     pub namespace: Option<String>,
     pub id: Public<AuthTokenId>,
     pub name: Option<String>,
-    pub expiry_ms: Option<DurationMs>,
+    #[serde(rename = "expiry_ms")]
+    pub expiry: Option<DurationMs>,
     pub metadata: Option<Metadata>,
     pub scopes: Option<Vec<String>>,
     pub enabled: Option<bool>,
@@ -345,7 +348,7 @@ async fn auth_token_update(
         namespace,
         data.id.into_inner(),
         data.name,
-        data.expiry_ms.map(|ms| repl.time.now() + ms),
+        data.expiry.map(|ms| repl.time.now() + ms),
         data.metadata,
         data.scopes,
         data.enabled,
@@ -362,7 +365,8 @@ pub struct AuthTokenRotateIn {
     pub prefix: String,
     pub suffix: Option<String>,
     /// Milliseconds from now until the old token expires. `None` means expire immediately.
-    pub expiry_ms: Option<DurationMs>,
+    #[serde(rename = "expiry_ms")]
+    pub expiry: Option<DurationMs>,
 }
 
 request_input!(AuthTokenRotateIn, "Rotate");
@@ -388,7 +392,7 @@ async fn auth_token_rotate(
         .ok_or_not_found()?;
 
     let token = TokenPlaintext::generate(&data.prefix, data.suffix.as_deref())?;
-    let old_expiry = data.expiry_ms.map(|ms| repl.time.now() + ms);
+    let old_expiry = data.expiry.map(|ms| repl.time.now() + ms);
     let operation = RotateAuthTokenOperation::new(
         namespace,
         data.id.into_inner(),

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -58,7 +58,8 @@ pub struct CacheSetIn {
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds
-    pub ttl_ms: DurationMs,
+    #[serde(rename = "ttl_ms")]
+    pub ttl: DurationMs,
 }
 
 request_input!(CacheSetIn, "Set");
@@ -157,12 +158,7 @@ async fn cache_set(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let operation = SetOperation::new(
-        namespace,
-        data.key.to_string(),
-        Some(data.ttl_ms),
-        data.value,
-    );
+    let operation = SetOperation::new(namespace, data.key.to_string(), Some(data.ttl), data.value);
     repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(CacheSetOut {}))
 }

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -65,8 +65,9 @@ pub struct IdempotencyStartIn {
     pub key: EntityKey,
 
     /// TTL in milliseconds for the lock/response
+    #[serde(rename = "ttl_ms")]
     #[validate(range(min = 1))]
-    pub ttl_ms: DurationMs,
+    pub ttl: DurationMs,
 }
 
 request_input!(IdempotencyStartIn, "Start");
@@ -112,8 +113,9 @@ pub struct IdempotencyCompleteIn {
     pub response: Vec<u8>,
 
     /// TTL in milliseconds for the cached response
+    #[serde(rename = "ttl_ms")]
     #[validate(range(min = 1))]
-    pub ttl_ms: DurationMs,
+    pub ttl: DurationMs,
 }
 
 request_input!(IdempotencyCompleteIn, "Complete");
@@ -152,7 +154,7 @@ async fn idempotency_start(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let operation = TryStartOperation::new(namespace, data.key.to_string(), data.ttl_ms);
+    let operation = TryStartOperation::new(namespace, data.key.to_string(), data.ttl);
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 
     Ok(MsgPackOrJson(response.result.into()))
@@ -171,7 +173,7 @@ async fn idempotency_complete(
         .ok_or_not_found()?;
 
     let operation =
-        CompleteOperation::new(namespace, data.key.to_string(), data.response, data.ttl_ms);
+        CompleteOperation::new(namespace, data.key.to_string(), data.response, data.ttl);
     repl.client_write(operation).await.or_internal_error()?.0?;
 
     Ok(MsgPackOrJson(IdempotencyCompleteOut {}))

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -57,8 +57,9 @@ pub struct KvSetIn {
     pub value: Vec<u8>,
 
     /// Time to live in milliseconds
+    #[serde(rename = "ttl_ms")]
     #[validate(range(min = 1))]
-    pub ttl_ms: Option<DurationMs>,
+    pub ttl: Option<DurationMs>,
 
     #[serde(default)]
     pub behavior: OperationBehavior,
@@ -147,7 +148,7 @@ async fn kv_set(
         namespace,
         data.key,
         data.value,
-        data.ttl_ms,
+        data.ttl,
         data.behavior,
         data.version,
     );

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -127,7 +127,7 @@ async fn get_namespace(
     Ok(MsgPackOrJson(MsgNamespaceGetOut {
         name: namespace.name,
         retention: Retention {
-            period_ms: namespace.config.retention_period,
+            period: namespace.config.retention_period,
             size_bytes: namespace.config.retention_bytes,
         },
         created: namespace.created,
@@ -207,13 +207,13 @@ struct MsgStreamReceiveIn {
     pub consumer_group: ConsumerGroup,
     #[serde(default = "default_batch_size")]
     pub batch_size: NonZeroU16,
-    #[serde(default = "default_lease_duration_ms")]
-    pub lease_duration_ms: DurationMs,
+    #[serde(rename = "lease_duration_ms", default = "default_lease_duration_ms")]
+    pub lease_duration: DurationMs,
     #[serde(default)]
     pub default_starting_position: SeekPosition,
     /// Maximum time (in milliseconds) to wait for messages before returning.
-    #[serde(default)]
-    pub batch_wait_ms: Option<DurationMs>,
+    #[serde(rename = "batch_wait_ms", default)]
+    pub batch_wait: Option<DurationMs>,
 }
 
 request_input!(MsgStreamReceiveIn, "Receive");
@@ -238,7 +238,7 @@ async fn stream_receive(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    if let Some(max_wait) = data.batch_wait_ms {
+    if let Some(max_wait) = data.batch_wait {
         let ro_db = state.ro_dbs.db_for(StorageType::Persistent);
         let metadata_ks = ro_db
             .keyspace(coyote_msgs::METADATA_KEYSPACE)
@@ -285,7 +285,7 @@ async fn stream_receive(
         data.topic,
         data.consumer_group,
         data.batch_size,
-        data.lease_duration_ms,
+        data.lease_duration,
         data.default_starting_position,
     )?;
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
@@ -404,7 +404,7 @@ async fn stream_seek(
 // queue/receive
 // ---------------------------------------------------------------------------
 
-fn default_queue_lease_duration_ms() -> DurationMs {
+fn default_queue_lease_duration() -> DurationMs {
     DurationMs::from_secs(30)
 }
 
@@ -417,11 +417,11 @@ struct MsgQueueReceiveIn {
     pub consumer_group: ConsumerGroup,
     #[serde(default = "default_batch_size")]
     pub batch_size: NonZeroU16,
-    #[serde(default = "default_queue_lease_duration_ms")]
-    pub lease_duration_ms: DurationMs,
+    #[serde(rename = "lease_duration_ms", default = "default_queue_lease_duration")]
+    pub lease_duration: DurationMs,
     /// Maximum time (in milliseconds) to wait for messages before returning.
-    #[serde(default)]
-    pub batch_wait_ms: Option<DurationMs>,
+    #[serde(rename = "batch_wait_ms", default)]
+    pub batch_wait: Option<DurationMs>,
 }
 
 request_input!(MsgQueueReceiveIn, "Receive");
@@ -447,7 +447,7 @@ async fn queue_receive(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    if let Some(max_wait) = data.batch_wait_ms {
+    if let Some(max_wait) = data.batch_wait {
         let ro_db = state.ro_dbs.db_for(StorageType::Persistent);
         let metadata_ks = ro_db
             .keyspace(coyote_msgs::METADATA_KEYSPACE)
@@ -494,7 +494,7 @@ async fn queue_receive(
         data.topic,
         data.consumer_group,
         data.batch_size,
-        data.lease_duration_ms,
+        data.lease_duration,
     )?;
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -108,8 +108,8 @@ pub struct RateLimitCheckOut {
     pub remaining: u64,
 
     /// Milliseconds until enough tokens are available (only present when allowed is false)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_after_ms: Option<u64>,
+    #[serde(rename = "retry_after_ms", skip_serializing_if = "Option::is_none")]
+    pub retry_after: Option<DurationMs>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -133,8 +133,8 @@ pub struct RateLimitGetRemainingOut {
     pub remaining: u64,
 
     /// Milliseconds until at least one token is available (only present when remaining is 0)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_after_ms: Option<u64>,
+    #[serde(rename = "retry_after_ms", skip_serializing_if = "Option::is_none")]
+    pub retry_after: Option<DurationMs>,
 }
 
 /// Rate Limiter Check and Consume
@@ -159,9 +159,7 @@ async fn rate_limit_limit(
     Ok(MsgPackOrJson(RateLimitCheckOut {
         allowed: response.allowed,
         remaining: response.remaining,
-        retry_after_ms: response
-            .retry_after
-            .map(|t: std::time::Duration| t.as_millis() as u64),
+        retry_after: response.retry_after,
     }))
 }
 
@@ -189,7 +187,7 @@ async fn rate_limit_get_remaining(
 
     Ok(MsgPackOrJson(RateLimitGetRemainingOut {
         remaining,
-        retry_after_ms: retry_after.map(|t| t.as_millis() as u64),
+        retry_after,
     }))
 }
 

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -51,7 +51,7 @@ impl From<RateLimitTokenBucketConfig> for TokenBucket {
         TokenBucket {
             bucket_size: val.capacity,
             refill_rate: val.refill_amount,
-            refill_interval: val.refill_interval_ms,
+            refill_interval: val.refill_interval,
         }
     }
 }
@@ -67,9 +67,9 @@ pub struct RateLimitTokenBucketConfig {
     pub refill_amount: u64,
 
     /// Interval in milliseconds between refills (minimum 1 millisecond)
+    #[serde(rename = "refill_interval_ms", default = "default_interval_ms")]
     #[validate(range(min = 1))]
-    #[serde(default = "default_interval_ms")]
-    pub refill_interval_ms: DurationMs,
+    pub refill_interval: DurationMs,
 }
 
 fn default_interval_ms() -> DurationMs {

--- a/z-clients/go/internal/models/msg_in.go
+++ b/z-clients/go/internal/models/msg_in.go
@@ -12,6 +12,6 @@ type MsgIn struct {
 	// Optional delay in milliseconds.
 	//
 	// The message will not be delivered to queue consumers
-	// until `delay_ms` has elapsed from the time of publish.
+	// until the delay has elapsed from the time of publish.
 	DelayMs *uint64 `msgpack:"delay_ms,omitempty"`
 }

--- a/z-clients/go/internal/models/msg_in.go
+++ b/z-clients/go/internal/models/msg_in.go
@@ -5,8 +5,13 @@ package coyote_models
 type MsgIn struct {
 	Value   []uint8            `msgpack:"value"`
 	Headers *map[string]string `msgpack:"headers,omitempty"`
-	Key     *string            `msgpack:"key,omitempty"` // Optional partition key. Messages with the same key are routed to the same partition.
-	// Optional delay in milliseconds. The message will not be delivered to queue consumers
+	// Optional partition key.
+	//
+	// Messages with the same key are routed to the same partition.
+	Key *string `msgpack:"key,omitempty"`
+	// Optional delay in milliseconds.
+	//
+	// The message will not be delivered to queue consumers
 	// until `delay_ms` has elapsed from the time of publish.
 	DelayMs *uint64 `msgpack:"delay_ms,omitempty"`
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/models/MsgIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/MsgIn.java
@@ -116,7 +116,7 @@ Messages with the same key are routed to the same partition.
     * Optional delay in milliseconds.
 
 The message will not be delivered to queue consumers
-until `delay_ms` has elapsed from the time of publish.
+until the delay has elapsed from the time of publish.
     *
      * @return delayMs
      */

--- a/z-clients/java/src/main/java/com/svix/coyote/models/MsgIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/MsgIn.java
@@ -92,7 +92,9 @@ public class MsgIn {
     }
 
     /**
-    * Optional partition key. Messages with the same key are routed to the same partition.
+    * Optional partition key.
+
+Messages with the same key are routed to the same partition.
     *
      * @return key
      */
@@ -111,7 +113,9 @@ public class MsgIn {
     }
 
     /**
-    * Optional delay in milliseconds. The message will not be delivered to queue consumers
+    * Optional delay in milliseconds.
+
+The message will not be delivered to queue consumers
 until `delay_ms` has elapsed from the time of publish.
     *
      * @return delayMs

--- a/z-clients/javascript/src/models/msgIn.ts
+++ b/z-clients/javascript/src/models/msgIn.ts
@@ -3,10 +3,16 @@
 export interface MsgIn {
     value: number[];
     headers?: { [key: string]: string };
-    /** Optional partition key. Messages with the same key are routed to the same partition. */
+    /**
+     * Optional partition key.
+     * 
+     * Messages with the same key are routed to the same partition.
+     */
     key?: string | null;
     /**
-     * Optional delay in milliseconds. The message will not be delivered to queue consumers
+     * Optional delay in milliseconds.
+     * 
+     * The message will not be delivered to queue consumers
      * until `delay_ms` has elapsed from the time of publish.
      */
     delayMs?: number | null;

--- a/z-clients/javascript/src/models/msgIn.ts
+++ b/z-clients/javascript/src/models/msgIn.ts
@@ -13,7 +13,7 @@ export interface MsgIn {
      * Optional delay in milliseconds.
      * 
      * The message will not be delivered to queue consumers
-     * until `delay_ms` has elapsed from the time of publish.
+     * until the delay has elapsed from the time of publish.
      */
     delayMs?: number | null;
 }

--- a/z-clients/python/coyote/models/msg_in.py
+++ b/z-clients/python/coyote/models/msg_in.py
@@ -19,4 +19,4 @@ class MsgIn(BaseModel):
     """Optional delay in milliseconds.
 
     The message will not be delivered to queue consumers
-    until `delay_ms` has elapsed from the time of publish."""
+    until the delay has elapsed from the time of publish."""

--- a/z-clients/python/coyote/models/msg_in.py
+++ b/z-clients/python/coyote/models/msg_in.py
@@ -11,8 +11,12 @@ class MsgIn(BaseModel):
     headers: t.Optional[t.Dict[str, str]] = None
 
     key: t.Optional[str] = None
-    """Optional partition key. Messages with the same key are routed to the same partition."""
+    """Optional partition key.
+
+    Messages with the same key are routed to the same partition."""
 
     delay_ms: t.Optional[int] = Field(default=None, alias="delay_ms")
-    """Optional delay in milliseconds. The message will not be delivered to queue consumers
+    """Optional delay in milliseconds.
+
+    The message will not be delivered to queue consumers
     until `delay_ms` has elapsed from the time of publish."""

--- a/z-clients/rust/src/models/msg_in.rs
+++ b/z-clients/rust/src/models/msg_in.rs
@@ -9,11 +9,15 @@ pub struct MsgIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<std::collections::HashMap<String, String>>,
 
-    /// Optional partition key. Messages with the same key are routed to the same partition.
+    /// Optional partition key.
+    ///
+    /// Messages with the same key are routed to the same partition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
-    /// Optional delay in milliseconds. The message will not be delivered to queue consumers
+    /// Optional delay in milliseconds.
+    ///
+    /// The message will not be delivered to queue consumers
     /// until `delay_ms` has elapsed from the time of publish.
     #[serde(
         rename = "delay_ms",

--- a/z-clients/rust/src/models/msg_in.rs
+++ b/z-clients/rust/src/models/msg_in.rs
@@ -18,7 +18,7 @@ pub struct MsgIn {
     /// Optional delay in milliseconds.
     ///
     /// The message will not be delivered to queue consumers
-    /// until `delay_ms` has elapsed from the time of publish.
+    /// until the delay has elapsed from the time of publish.
     #[serde(
         rename = "delay_ms",
         skip_serializing_if = "Option::is_none",


### PR DESCRIPTION
I went to review whether all the durations were `_ms`-suffixed in serialized form for https://github.com/svix/coyote-private/issues/156, and found that they already were, but there were a couple other improvements to be made.

Last commit is a **breaking change** for raft because the rate-limit's `LimitResponseData` field `retry_after` which I think is serialized as an object is removed, and instead we get `retry_after_ms` which is just an integer. It's an optional property though, so I don't think we have to kill any instances over this.