### PR TITLE
feat(gha): add `COYOTE_ADMIN_TOKEN` as k8s secret

### DIFF
--- a/.github/workflows/svix-cloud-operator.yml
+++ b/.github/workflows/svix-cloud-operator.yml
@@ -14,6 +14,10 @@ on:
       namespace:
         description: "K8s namespace"
         type: string
+      coyote_admin_token:
+        description: "Coyote admin token"
+        type: string
+        default: "admin_abcdefghijlmnopqrstuvwxyz012345"
   workflow_call:
     inputs:
       image_tag:
@@ -26,6 +30,10 @@ on:
       namespace:
         description: "K8s namespace"
         type: string
+      coyote_admin_token:
+        description: "Coyote admin token"
+        type: string
+        default: "admin_abcdefghijlmnopqrstuvwxyz012345"
 
 env:
   REGISTRY: ghcr.io
@@ -69,6 +77,19 @@ jobs:
             --name ${{ vars.EKS_CLUSTER_NAME }} \
             --region ${{ vars.AWS_REGION }}
 
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Create COYOTE_ADMIN_TOKEN secret if not present
+        run: |
+          if kubectl get secret coyote-admin-token -n ${{ inputs.namespace }} > /dev/null 2>&1; then
+            echo "Secret coyote-admin-token is already present, skipping creation."
+          else
+            kubectl create secret generic coyote-admin-token \
+              --from-literal=COYOTE_ADMIN_TOKEN=${{ inputs.coyote_admin_token }} \
+              --namespace=${{ inputs.namespace }}
+          fi
+
       - name: Install Helm
         uses: azure/setup-helm@v4
 
@@ -86,9 +107,6 @@ jobs:
             --atomic \
             --timeout=120s \
             --namespace=${{ inputs.namespace }}
-
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v4
 
       - name: Verify rollout
         run: |

--- a/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
+++ b/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
@@ -43,6 +43,24 @@
               "spec": {
                 "description": "A Coyote cluster deployment.",
                 "properties": {
+                  "adminToken": {
+                    "description": "Admin token for privileged API access.\nMust reference a Secret key containing the plaintext token.",
+                    "properties": {
+                      "key": {
+                        "description": "Key within the Secret.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the Secret.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
                   "affinity": {
                     "description": "Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity).",
                     "type": "object",
@@ -108,12 +126,10 @@
                         "type": "integer"
                       },
                       "secretRef": {
-                        "description": "Reference to a Secret containing the inter-node authentication token.\nThe referenced key (default: \"secret\") must contain a plaintext secret string.",
-                        "nullable": true,
+                        "description": "Reference to a Secret containing the inter-node authentication token.",
                         "properties": {
                           "key": {
-                            "default": "secret",
-                            "description": "Key within the Secret containing the value.",
+                            "description": "Key within the Secret.",
                             "type": "string"
                           },
                           "name": {
@@ -122,6 +138,7 @@
                           }
                         },
                         "required": [
+                          "key",
                           "name"
                         ],
                         "type": "object"

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -3,7 +3,9 @@
 
 use std::collections::BTreeMap;
 
-use k8s_openapi::api::core::v1::{Affinity, EnvVar, Toleration, TopologySpreadConstraint};
+use k8s_openapi::api::core::v1::{
+    Affinity, EnvVar, SecretKeySelector, Toleration, TopologySpreadConstraint,
+};
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -16,10 +18,6 @@ fn default_api_port() -> u16 {
 
 fn default_nodes() -> i32 {
     1
-}
-
-fn default_secret_key() -> String {
-    "secret".into()
 }
 
 /// A Coyote cluster deployment.
@@ -105,6 +103,12 @@ pub(crate) struct CoyoteClusterSpec {
     #[serde(default)]
     #[schemars(schema_with = "affinity_schema")]
     pub affinity: Option<Affinity>,
+
+    /// Admin token for privileged API access.
+    /// Must reference a Secret key containing the plaintext token.
+    #[serde(default)]
+    #[schemars(schema_with = "secret_key_selector_schema")]
+    pub admin_token: Option<SecretKeySelector>,
 }
 
 /// Storage configuration for a Coyote cluster.
@@ -144,8 +148,8 @@ pub(crate) struct VolumeSpec {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ClusterSpec {
     /// Reference to a Secret containing the inter-node authentication token.
-    /// The referenced key (default: "secret") must contain a plaintext secret string.
     #[serde(default)]
+    #[schemars(schema_with = "secret_key_selector_schema")]
     pub secret_ref: Option<SecretKeySelector>,
 
     /// Heartbeat interval in milliseconds.
@@ -175,16 +179,6 @@ pub(crate) struct ClusterSpec {
     /// Log level (info, debug, trace). Defaults to info.
     #[serde(default)]
     pub log_level: Option<String>,
-}
-
-/// Reference to a key within a Kubernetes Secret.
-#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
-pub(crate) struct SecretKeySelector {
-    /// Name of the Secret.
-    pub name: String,
-    /// Key within the Secret containing the value.
-    #[serde(default = "default_secret_key")]
-    pub key: String,
 }
 
 /// Configuration for the client-facing Service.
@@ -271,4 +265,15 @@ fn tolerations_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema 
 
 fn affinity_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({ "type": "object", "x-kubernetes-preserve-unknown-fields": true })
+}
+
+fn secret_key_selector_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "object",
+        "required": ["name", "key"],
+        "properties": {
+            "name": { "type": "string", "description": "Name of the Secret." },
+            "key": { "type": "string", "description": "Key within the Secret." }
+        }
+    })
 }

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -150,11 +150,7 @@ fn build_env(
         env.push(EnvVar {
             name: "COYOTE_CLUSTER_SECRET".into(),
             value_from: Some(EnvVarSource {
-                secret_key_ref: Some(k8s_openapi::api::core::v1::SecretKeySelector {
-                    name: secret_ref.name.clone(),
-                    key: secret_ref.key.clone(),
-                    ..Default::default()
-                }),
+                secret_key_ref: Some(secret_ref.clone()),
                 ..Default::default()
             }),
             ..Default::default()
@@ -221,10 +217,16 @@ fn build_env(
     }
 
     // Extra user-provided env vars.
-    for extra in &spec.env_var {
+    env.extend(spec.env_var.iter().cloned());
+
+    // Admin token — appended last so it overwrites any COYOTE_ADMIN_TOKEN set via env_var.
+    if let Some(admin_token) = &spec.admin_token {
         env.push(EnvVar {
-            name: extra.name.clone(),
-            value: extra.value.clone(),
+            name: "COYOTE_ADMIN_TOKEN".into(),
+            value_from: Some(EnvVarSource {
+                secret_key_ref: Some(admin_token.clone()),
+                ..Default::default()
+            }),
             ..Default::default()
         });
     }

--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -42,8 +42,6 @@ cluster:
         value: "json"
       - name: COYOTE_OPENTELEMETRY_ADDRESS
         value: grpc://datadog-agent.datadog.svc.cluster.local:4317
-      - name: COYOTE_ADMIN_TOKEN
-        value: "admin_abcdefghijlmnopqrstuvwxyz012345"
     nodeSelector:
       db-name: coyote
     tolerations:
@@ -51,3 +49,8 @@ cluster:
         operator: Equal
         value: coyote
         effect: NoSchedule
+    adminToken:
+        valueFrom:
+          secretKeyRef:
+            name: coyote-admin-token
+            key: COYOTE_ADMIN_TOKEN


### PR DESCRIPTION
This PR adds  `COYOTE_ADMIN_TOKEN` as a k8s secret

The secret is fed to the `adminToken` in the coyoteclusterspec CR
which then sets the  `COYOTE_ADMIN_TOKEN`  env var.