### PR TITLE
cluster: make default config crash-safe

### DIFF
--- a/config.bench.toml
+++ b/config.bench.toml
@@ -10,5 +10,5 @@ opentelemetry_sample_ratio=0.1
 
 [cluster]
 log_sync_interval_commits = 0
-log_sync_interval_ms = 100
-log_ack_immediately = true
+log_sync_interval_ms = 10
+log_ack_immediately = false

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -5,6 +5,10 @@ use std::{
 
 use super::DatabaseConfig;
 
+pub(super) fn default_false() -> bool {
+    false
+}
+
 pub(super) fn default_true() -> bool {
     true
 }
@@ -88,7 +92,7 @@ pub(super) fn cluster_log_sync_interval_commits() -> usize {
 }
 
 pub(super) fn cluster_log_sync_interval_duration() -> Duration {
-    Duration::from_secs(10)
+    Duration::from_millis(10)
 }
 
 pub(super) fn cluster_send_snapshot_timeout() -> Duration {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -374,7 +374,7 @@ pub struct ClusterConfiguration {
     /// This should be set to `false` for full ACID compliance, but can be set to `true` to enable
     /// higher throughput than your fsync rate. Note that we always flush to the OS buffers before
     /// acking, so data will only be lost of the OS crashes.
-    #[serde(default = "defaults::default_true")]
+    #[serde(default = "defaults::default_false")]
     pub log_ack_immediately: bool,
 
     /// Trigger a background snapshot after this many writes

--- a/z-clients/cli/src/cmds/benchmark.rs
+++ b/z-clients/cli/src/cmds/benchmark.rs
@@ -392,7 +392,7 @@ fn print_table(all_stats: &[Stats]) {
 fn new_bar(prefix: impl Into<String>, iterations: u64) -> ProgressBar {
     let pb = ProgressBar::new(iterations);
     pb.set_style(
-        ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] {prefix:20.bold} [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}")
+        ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] {prefix:48.bold} [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}")
             .unwrap()
             .progress_chars("#>-"),
     );


### PR DESCRIPTION
This changes the default config (and the benchmarking config) to be crash-safe by refusing to acknowledge until data has been synced out, which by default happens every 10ms.

This subtantially increases latency (making the mean latency for writes 5ms, for obvious reasons), but means that the log is guaranteed to be flushed to persistent storage if a crash occurs.

The throughput impact is less-stark; for very-low concurrency benchmarking (e.g., 1 writer) it's obviously awful and drops throughput to ~100 ops; however, there's essentially no impact for concurrent benchmarks (e.g., at 500 concurrent clients, `msgs.stream.receive` goes from 10936 ops to 9093 ops (about a 15% decrease) and `msgs.queue.receive (batch=1) - receive` goes from 9484 ops to 11032 ops -- mostly just showing that there's a ton of variance between otherwise-identical test runs!

Fixes #732 