### PR TITLE
cluster: a smattering of performance improvements

### DIFF
--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -180,8 +180,9 @@ async fn handle_forwarded_write(
 
     // intentionally do not use state.client_write because we don't want an infinite recursion
     // of forwardings
+    let wrapped = Arc::new(req.request);
     let response =
-        state.raft.client_write(req.request).await.map_err(|e| {
+        state.raft.client_write(wrapped).await.map_err(|e| {
             crate::Error::internal(format!("Unable to execute forwarded write: {e:?}"))
         })?;
     let response = ForwardedWriteResponse {

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -1,15 +1,35 @@
+use std::sync::Arc;
+
 use super::{
     LogId,
     handle::{Request, RequestWithContext, Response},
-    state_machine::Store,
+    state_machine::{Store, Stores},
 };
+use crate::AppState;
 use opentelemetry::{Value, propagation::TextMapPropagator};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing::{Instrument, info_span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+/// The context for a single batch of apply operations.
+///
+/// Holds a (read) lock against the databases as long as it's live
+pub(super) struct ApplyContext {
+    pub stores: parking_lot::ArcRwLockReadGuard<parking_lot::RawRwLock, Stores>,
+    pub state: AppState,
+}
+
+impl ApplyContext {
+    pub(super) fn new(state: &Store) -> Self {
+        let stores = state.db_handle();
+        let state = state.state.clone();
+        Self { stores, state }
+    }
+}
+
 pub(super) async fn apply_request(
-    request: RequestWithContext,
+    state_context: &ApplyContext,
+    request: Arc<RequestWithContext>,
     state_machine: &mut Store,
     log_id: LogId,
 ) -> anyhow::Result<Response> {
@@ -41,54 +61,52 @@ pub(super) async fn apply_request(
         term: log_id.leader_id.term,
     };
 
-    apply_request_with_context(state_machine, context, request.inner)
+    let request = Arc::unwrap_or_clone(request);
+
+    apply_request_with_context(state_context, context, state_machine, request.inner)
         .instrument(child_span)
         .await
 }
 
 async fn apply_request_with_context(
-    state_machine: &mut Store,
+    state_context: &ApplyContext,
     context: coyote_operations::OpContext,
+    state_machine: &mut Store,
     request: Request,
 ) -> anyhow::Result<Response> {
     Ok(match request {
         Request::Kv(req) => {
-            let stores = state_machine.db_handle();
             let state = coyote_kv::operations::KvRaftState {
-                state: &stores.kv_state,
-                namespace: &state_machine.state.namespace_state,
+                state: &state_context.stores.kv_state,
+                namespace: &state_context.state.namespace_state,
             };
             Response::Kv(req.apply(state, &context).await)
         }
         Request::RateLimit(req) => {
-            let stores = state_machine.db_handle();
             let state = coyote_rate_limit::operations::RateLimitRaftState {
-                state: &stores.rate_limit_state,
-                namespace: &state_machine.state.namespace_state,
+                state: &state_context.stores.rate_limit_state,
+                namespace: &state_context.state.namespace_state,
             };
             Response::RateLimit(req.apply(state, &context).await)
         }
         Request::Idempotency(req) => {
-            let stores = state_machine.db_handle();
             let state = coyote_idempotency::operations::IdempotencyRaftState {
-                state: &stores.idempotency_state,
-                namespace: &state_machine.state.namespace_state,
+                state: &state_context.stores.idempotency_state,
+                namespace: &state_context.state.namespace_state,
             };
             Response::Idempotency(req.apply(state, &context).await)
         }
         Request::Cache(req) => {
-            let stores = state_machine.db_handle();
             let state = coyote_cache::operations::CacheRaftState {
-                state: &stores.cache_state,
-                namespace: &state_machine.state.namespace_state,
+                state: &state_context.stores.cache_state,
+                namespace: &state_context.state.namespace_state,
             };
             Response::Cache(req.apply(state, &context).await)
         }
         Request::Msgs(req) => {
-            let stores = state_machine.db_handle();
             let state = coyote_msgs::operations::MsgsRaftState {
-                msgs: &stores.msgs_state,
-                namespace: &state_machine.state.namespace_state,
+                msgs: &state_context.stores.msgs_state,
+                namespace: &state_context.state.namespace_state,
             };
             Response::Msgs(req.apply(state, &context).await)
         }
@@ -96,17 +114,15 @@ async fn apply_request_with_context(
             Response::ClusterInternal(req.apply(state_machine, &context).await)
         }
         Request::AuthToken(req) => {
-            let stores = state_machine.db_handle();
             let state = coyote_auth_token::operations::AuthTokenRaftState {
-                state: &stores.auth_token_state,
-                namespace: &state_machine.state.namespace_state,
+                state: &state_context.stores.auth_token_state,
+                namespace: &state_context.state.namespace_state,
             };
             Response::AuthToken(req.apply(state, &context).await)
         }
         Request::AdminAuth(req) => {
-            let stores = state_machine.db_handle();
             let state = coyote_admin_auth::operations::AdminAuthRaftState {
-                state: &stores.admin_auth_state,
+                state: &state_context.stores.admin_auth_state,
             };
             Response::AdminAuth(req.apply(state, &context).await)
         }

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -1,4 +1,4 @@
-use std::{fmt, time::Duration};
+use std::{fmt, sync::Arc, time::Duration};
 
 use super::{
     ClientWriteError, LogId, Node, NodeId, RaftError, discovery::Discovery,
@@ -354,8 +354,9 @@ impl RaftState {
         let now = self.time.update_now();
         let request =
             RequestWithContext::new(inner, now, Some(opentelemetry::Context::current().into()));
+        let request = Arc::new(request);
         let mut write_type = WriteType::Local;
-        let response = match self.raft.client_write(request.clone()).await {
+        let response = match self.raft.client_write(Arc::clone(&request)).await {
             Ok(resp) => {
                 tracing::trace!(log_id=?resp.log_id(), "request applied to log");
                 resp.data
@@ -373,7 +374,7 @@ impl RaftState {
                         client
                             .forward_request(super::proto::ForwardedWriteRequest {
                                 source_node_id: self.node_id,
-                                request,
+                                request: Arc::unwrap_or_clone(request),
                             })
                             .await
                             .map(|r| r.response)
@@ -711,6 +712,7 @@ impl coyote_operations::OperationWriterBase for RaftState {
         let now = self.state_machine.now();
         let request =
             RequestWithContext::new(request, now, Some(opentelemetry::Context::current().into()));
+        let request = Arc::new(request);
         match self.raft.client_write(request.clone()).await {
             Ok(resp) => {
                 tracing::trace!(log_id=?resp.log_id(), "request applied to log");

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -24,7 +24,7 @@ use crate::{
 
 openraft::declare_raft_types!(
     pub TypeConfig:
-        D = RequestWithContext,
+        D = Arc<RequestWithContext>,
         R = Response,
         Node = Node,
         NodeId = NodeId,
@@ -55,11 +55,11 @@ pub(crate) async fn initialize_cluster(
     let new_id = ClusterId::generate();
     tracing::info!(cluster_id=%new_id, "cluster initialized, setting cluster_id");
     #[allow(clippy::disallowed_methods)]
-    raft.client_write(RequestWithContext::new(
+    raft.client_write(Arc::new(RequestWithContext::new(
         Request::ClusterInternal(SetClusterUuidOperation(new_id).into()),
         jiff::Timestamp::now(),
         None,
-    ))
+    )))
     .await
     .tap_err(|err| tracing::error!(?err, "failed to set initial cluster id"))?;
     tracing::debug!(elapsed=?start.elapsed(), "initialization finished");

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -223,7 +223,7 @@ impl Store {
         self.cluster_id.as_ref()
     }
 
-    pub fn db_handle(&self) -> impl std::ops::Deref<Target = Stores> + Send {
+    pub fn db_handle(&self) -> parking_lot::ArcRwLockReadGuard<parking_lot::RawRwLock, Stores> {
         self.stores.read_arc()
     }
 
@@ -416,6 +416,7 @@ impl Store {
         let mut changed_membership = false;
         let mut num_entries = 0;
         let start = std::time::Instant::now();
+        let context = super::applier::ApplyContext::new(self);
         while let Some(entry) = entries.next().await {
             let (item, responder) = entry?;
 
@@ -430,7 +431,7 @@ impl Store {
                 EntryPayload::Normal(req) => {
                     tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
 
-                    super::applier::apply_request(req, self, item.log_id)
+                    super::applier::apply_request(&context, req, self, item.log_id)
                         .await
                         .map_err(|err| {
                             tracing::error!(?err, "failed to apply raft log");


### PR DESCRIPTION
Changes:

 - only acquire the read lock on the state once per apply batch and hold it instead of re-acquiring it everywhere
 - wrap the `Request` in an arc to make cloning cheaper (as suggested by @svix-jplatte [here](https://svixhq.slack.com/archives/C0A72988962/p1774962400055819))

Neither of these are huge: perhaps a 5% performance improvement under concurrent load.

I will be sticking more stuff in that `ApplyContext` in the future, I think.