### PR TITLE
cluster: manually persist journal once per batch

### DIFF
--- a/config.bench.toml
+++ b/config.bench.toml
@@ -1,3 +1,5 @@
+# This is a configuration used for benchmarking, not for general use
+
 listen_address = "0.0.0.0:8050"
 log_level="info"
 environment = "dev"
@@ -6,9 +8,13 @@ opentelemetry_metrics_use_http=true
 opentelemetry_service_name="coyote"
 opentelemetry_address="http://localhost:4317"
 opentelemetry_metrics_address="http://localhost:9090/api/v1/otlp/v1/metrics"
-opentelemetry_sample_ratio=0.1
+opentelemetry_sample_ratio=0.001
+# for the primary data, write to the OS but do not fsync
+sync_mode = "buffer"
 
 [cluster]
+# fsync very infrequently
 log_sync_interval_commits = 0
-log_sync_interval_ms = 10
+log_sync_interval_ms = 10000
+# acknowledge commits before we fsync
 log_ack_immediately = false

--- a/config.bench.toml
+++ b/config.bench.toml
@@ -17,4 +17,4 @@ sync_mode = "buffer"
 log_sync_interval_commits = 0
 log_sync_interval_ms = 10000
 # acknowledge commits before we fsync
-log_ack_immediately = false
+log_ack_immediately = true

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -319,6 +319,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         background_cleanup_interval: Duration::from_secs(10),
         bootstrap_cfg: None,
         bootstrap_cfg_path: None,
+        sync_mode: coyote::cfg::SyncMode::Buffer,
         admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
         jwt: None,
     }

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -5,6 +5,7 @@ use coyote::{
     Initialized,
     cfg::{
         ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, LogFormat, LogLevel,
+        SyncMode,
     },
     core::cluster::{ClusterId, NodeId, proto::HealthResponse},
     run_with_listeners,
@@ -319,7 +320,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         background_cleanup_interval: Duration::from_secs(10),
         bootstrap_cfg: None,
         bootstrap_cfg_path: None,
-        sync_mode: coyote::cfg::SyncMode::Buffer,
+        sync_mode: SyncMode::Buffer,
         admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
         jwt: None,
     }

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -101,6 +101,15 @@ impl Serialize for PeerAddr {
     }
 }
 
+impl From<SyncMode> for fjall::PersistMode {
+    fn from(value: SyncMode) -> Self {
+        match value {
+            SyncMode::Buffer => fjall::PersistMode::Buffer,
+            SyncMode::Sync => fjall::PersistMode::SyncAll,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, EnvOverridable, Serialize)]
 pub struct DatabaseConfig {
     /// Directory in which this database is stored
@@ -177,6 +186,7 @@ impl DatabaseConfig {
         // FIXME: we should probably make the cache size a config.
         fjall::Database::builder(path)
             .cache_size(Self::default_cache_size())
+            .manual_journal_persist(true)
             .open()
             .map_err(|err| {
                 tracing::error!(?err, "error building database");
@@ -540,6 +550,14 @@ pub struct ConfigurationInner {
     )]
     pub background_cleanup_interval: Duration,
 
+    /// How to persist data to the actual underlying database
+    ///
+    /// This is similar to the `cluster.log_sync` options, but applies to the actual
+    /// primary data as opposed to the log, and is applied at every batch commit from the
+    /// underlying replication system.
+    #[serde(default)]
+    pub sync_mode: SyncMode,
+
     /// An auth token for admin access to Coyote
     ///
     /// It's useful for bootstrapping a new Coyote cluster, or using it in CI pipelines or other
@@ -634,7 +652,7 @@ macro_rules! from_str_via_serde {
     };
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     #[default]
@@ -645,7 +663,17 @@ pub enum LogLevel {
 
 from_str_via_serde!(LogLevel);
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+impl From<LogLevel> for Level {
+    fn from(value: LogLevel) -> Self {
+        match value {
+            LogLevel::Info => Level::INFO,
+            LogLevel::Debug => Level::DEBUG,
+            LogLevel::Trace => Level::TRACE,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogFormat {
     #[default]
@@ -655,7 +683,7 @@ pub enum LogFormat {
 
 from_str_via_serde!(LogFormat);
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Environment {
     #[default]
@@ -682,14 +710,22 @@ impl fmt::Display for Environment {
 
 impl fmt::Display for LogLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Info => Level::INFO,
-            Self::Debug => Level::DEBUG,
-            Self::Trace => Level::TRACE,
-        }
-        .fmt(f)
+        Level::from(*self).fmt(f)
     }
 }
+
+/// How data is synchronized to the underlying database
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SyncMode {
+    /// Write data to the OS, but do not fsync
+    #[default]
+    Buffer,
+    /// fsync the data on every batch apply
+    Sync,
+}
+
+from_str_via_serde!(SyncMode);
 
 pub fn load(config_path: Option<&Path>) -> anyhow::Result<Arc<ConfigurationInner>> {
     let config_toml = match config_path {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -653,7 +653,7 @@ macro_rules! from_str_via_serde {
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum LogLevel {
     #[default]
     Info,
@@ -674,7 +674,7 @@ impl From<LogLevel> for Level {
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum LogFormat {
     #[default]
     Default,
@@ -684,7 +684,7 @@ pub enum LogFormat {
 from_str_via_serde!(LogFormat);
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum Environment {
     #[default]
     Dev,
@@ -716,7 +716,7 @@ impl fmt::Display for LogLevel {
 
 /// How data is synchronized to the underlying database
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum SyncMode {
     /// Write data to the OS, but do not fsync
     #[default]

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -57,6 +57,24 @@ pub enum Request {
     AdminAuth(coyote_admin_auth::operations::AdminAuthOperation),
 }
 
+impl Request {
+    pub fn affects_persistent(&self) -> bool {
+        matches!(
+            self,
+            Self::ClusterInternal(_)
+                | Self::Kv(_)
+                | Self::Idempotency(_)
+                | Self::Msgs(_)
+                | Self::AuthToken(_)
+                | Self::AdminAuth(_)
+        )
+    }
+
+    pub fn affects_ephemeral(&self) -> bool {
+        matches!(self, Self::Cache(_) | Self::RateLimit(_))
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RequestWithContext {
     pub inner: Request,

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -16,6 +16,7 @@ use anyhow::Context;
 use coyote_core::Monotime;
 use coyote_error::ResultExt;
 use coyote_operations::{OperationRequest, OperationRequestMetadata, OperationResponse};
+use fjall_utils::StorageType;
 use itertools::Itertools;
 use jiff::Timestamp;
 use maplit::btreeset;
@@ -58,20 +59,24 @@ pub enum Request {
 }
 
 impl Request {
-    pub fn affects_persistent(&self) -> bool {
-        matches!(
-            self,
+    fn db_type(&self) -> StorageType {
+        match self {
             Self::ClusterInternal(_)
-                | Self::Kv(_)
-                | Self::Idempotency(_)
-                | Self::Msgs(_)
-                | Self::AuthToken(_)
-                | Self::AdminAuth(_)
-        )
+            | Self::Kv(_)
+            | Self::Idempotency(_)
+            | Self::Msgs(_)
+            | Self::AuthToken(_)
+            | Self::AdminAuth(_) => StorageType::Persistent,
+            Self::Cache(_) | Self::RateLimit(_) => StorageType::Ephemeral,
+        }
     }
 
-    pub fn affects_ephemeral(&self) -> bool {
-        matches!(self, Self::Cache(_) | Self::RateLimit(_))
+    pub(crate) fn affects_persistent(&self) -> bool {
+        self.db_type() == StorageType::Persistent
+    }
+
+    pub(crate) fn affects_ephemeral(&self) -> bool {
+        self.db_type() == StorageType::Ephemeral
     }
 }
 

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -455,6 +455,7 @@ impl Store {
         let mut changed_log_id = false;
         let mut changed_membership = false;
         let mut num_entries = 0;
+        let mut num_normal_entries = 0;
         let start = std::time::Instant::now();
         let context = super::applier::ApplyContext::new(self);
         while let Some(entry) = entries.next().await {
@@ -470,6 +471,8 @@ impl Store {
                 }
                 EntryPayload::Normal(req) => {
                     tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
+
+                    num_normal_entries += 1;
 
                     super::applier::apply_request(&context, req, self, item.log_id)
                         .await
@@ -495,6 +498,16 @@ impl Store {
         tracing::trace!(num_entries, "applied some entries");
         if changed_log_id || changed_membership {
             self.record_ids_().await.context("recording updated IDs")?;
+        }
+        if num_normal_entries > 0 {
+            // TODO: this should handle ephemeral if we ever bring ephemeral back.
+            // Would probably be nice to make each module report back which store(s) it wrote
+            // to so we can only flush those that have changed.
+            context
+                .stores
+                .databases
+                .persistent
+                .persist(self.state.cfg.sync_mode.into())?;
         }
         self.metrics.record_apply(num_entries, start.elapsed());
         Ok(())

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -455,9 +455,12 @@ impl Store {
         let mut changed_log_id = false;
         let mut changed_membership = false;
         let mut num_entries = 0;
-        let mut num_normal_entries = 0;
         let start = std::time::Instant::now();
         let context = super::applier::ApplyContext::new(self);
+
+        let mut touched_ephemeral = false;
+        let mut touched_persistent = false;
+
         while let Some(entry) = entries.next().await {
             let (item, responder) = entry?;
 
@@ -472,7 +475,12 @@ impl Store {
                 EntryPayload::Normal(req) => {
                     tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
 
-                    num_normal_entries += 1;
+                    if req.inner.affects_persistent() {
+                        touched_persistent = true;
+                    }
+                    if req.inner.affects_ephemeral() {
+                        touched_ephemeral = true;
+                    }
 
                     super::applier::apply_request(&context, req, self, item.log_id)
                         .await
@@ -499,14 +507,18 @@ impl Store {
         if changed_log_id || changed_membership {
             self.record_ids_().await.context("recording updated IDs")?;
         }
-        if num_normal_entries > 0 {
-            // TODO: this should handle ephemeral if we ever bring ephemeral back.
-            // Would probably be nice to make each module report back which store(s) it wrote
-            // to so we can only flush those that have changed.
+        if touched_persistent {
             context
                 .stores
                 .databases
                 .persistent
+                .persist(self.state.cfg.sync_mode.into())?;
+        }
+        if touched_ephemeral {
+            context
+                .stores
+                .databases
+                .ephemeral
                 .persist(self.state.cfg.sync_mode.into())?;
         }
         self.metrics.record_apply(num_entries, start.elapsed());


### PR DESCRIPTION
The main change in here is to change it so that instead of writing the journal on every operation, we do it at most once per batch.

This also adds the option (disabled by default) to fsync the primary data, which we've never supported before.

Branched off of and depends on #769.