### PR TITLE
cfg: make opentelemetry_metrics_period a Duration

### DIFF
--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -284,7 +284,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         opentelemetry_address: None,
         opentelemetry_metrics_address: None,
         opentelemetry_metrics_use_http: false,
-        opentelemetry_metrics_period_seconds: 60,
+        opentelemetry_metrics_period: Duration::from_secs(10),
         opentelemetry_sample_ratio: None,
         opentelemetry_service_name: "coyote-test".to_string(),
         environment: Environment::Dev,

--- a/server/src/otel.rs
+++ b/server/src/otel.rs
@@ -146,9 +146,7 @@ pub(crate) fn setup_metrics(cfg: &ConfigurationInner) {
         };
 
         let reader = PeriodicReader::builder(exporter, runtime::Tokio)
-            .with_interval(Duration::from_secs(
-                cfg.opentelemetry_metrics_period_seconds,
-            ))
+            .with_interval(cfg.opentelemetry_metrics_period)
             .build();
 
         let provider = SdkMeterProvider::builder()

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -31,8 +31,8 @@ pub(super) fn opentelemetry_service_name() -> String {
     "coyote".into()
 }
 
-pub(super) fn opentelemetry_metrics_period() -> u64 {
-    60
+pub(super) fn opentelemetry_metrics_period() -> Duration {
+    Duration::from_secs(60)
 }
 
 pub(super) fn cluster_name() -> String {

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -32,7 +32,7 @@ pub(super) fn opentelemetry_service_name() -> String {
 }
 
 pub(super) fn opentelemetry_metrics_period() -> Duration {
-    Duration::from_secs(60)
+    Duration::from_secs(10)
 }
 
 pub(super) fn cluster_name() -> String {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -469,8 +469,12 @@ pub struct ConfigurationInner {
     #[serde(default)]
     pub opentelemetry_metrics_use_http: bool,
 
-    #[serde(default = "defaults::opentelemetry_metrics_period")]
-    pub opentelemetry_metrics_period_seconds: u64,
+    #[serde(
+        rename = "opentelemetry_metrics_period_ms",
+        with = "crate::serde::duration::millis",
+        default = "defaults::opentelemetry_metrics_period"
+    )]
+    pub opentelemetry_metrics_period: Duration,
 
     /// The ratio at which to sample spans when sending to OpenTelemetry.
     ///


### PR DESCRIPTION
also changes the default to 10s because 60s-resolution-metrics is... not very useful...