### PR TITLE
metrics: switch all #[tracing::instrument] calls to skip_all and whitelist certain fields

### DIFF
--- a/crates/coyote-namespace/src/lib.rs
+++ b/crates/coyote-namespace/src/lib.rs
@@ -59,7 +59,7 @@ impl State {
         &self.keyspace
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(?namespace_name))]
     pub fn fetch_namespace<C: ModuleConfig>(
         &self,
         namespace_name: Option<&str>,
@@ -80,7 +80,7 @@ impl State {
     }
 
     /// Like `fetch_namespace` but allows passing `default` explicitly for admin purposes.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(?namespace_name))]
     pub fn fetch_namespace_admin<C: ModuleConfig>(
         &self,
         namespace_name: &str,
@@ -88,7 +88,7 @@ impl State {
         Namespace::fetch(&self.keyspace, namespace_name)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     pub fn fetch_all_namespaces<C: ModuleConfig>(
         &self,
     ) -> Result<impl Iterator<Item = Namespace<C>>> {

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -82,7 +82,7 @@ impl KvController {
         }
     }
 
-    #[tracing::instrument(skip(keyspace))]
+    #[tracing::instrument(skip_all)]
     fn fetch_inner(
         keyspace: &Keyspace,
         namespace_id: NamespaceId,
@@ -100,7 +100,7 @@ impl KvController {
         Ok(Some(data.into()))
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     pub async fn fetch<K: AsRef<str> + std::fmt::Debug + 'static + Send>(
         &self,
         namespace_id: NamespaceId,
@@ -148,7 +148,7 @@ impl KvController {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, model))]
+    #[tracing::instrument(skip_all, fields(?behavior))]
     pub async fn set<K: AsRef<str> + std::fmt::Debug + 'static + Send>(
         &self,
         namespace_id: NamespaceId,
@@ -240,7 +240,7 @@ impl KvController {
         .await?
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     pub async fn delete<T: AsRef<str> + std::fmt::Debug + 'static + Send>(
         &self,
         namespace_id: NamespaceId,
@@ -277,7 +277,7 @@ impl KvController {
         KvPairRow::values(&self.keyspace)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     pub async fn has_expired(&self, now: Timestamp) -> bool {
         let keyspace = self.keyspace.clone();
 
@@ -291,7 +291,7 @@ impl KvController {
             .unwrap_or(false)
     }
 
-    #[tracing::instrument(skip(self), fields(
+    #[tracing::instrument(skip_all, fields(
         keyspace_name = self.keyspace_name,
         cleared
     ))]

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -551,7 +551,7 @@ impl RaftState {
             .context("attempting to read last committed id from peer")
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     pub(crate) async fn handle_go_away(
         &self,
         cluster_id: ClusterId,

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -145,7 +145,7 @@ fn io_err(error: anyhow::Error) -> std::io::Error {
 }
 
 impl RaftLogReader<TypeConfig> for CoyoteLogs {
-    #[tracing::instrument(skip(self), fields(num_entries_found))]
+    #[tracing::instrument(skip_all, fields(num_entries_found))]
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
         &mut self,
         range: RB,
@@ -158,7 +158,7 @@ impl RaftLogReader<TypeConfig> for CoyoteLogs {
         Ok(output)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn read_vote(&mut self) -> std::io::Result<Option<Vote>> {
         self.read_vote_().await.map_err(io_err)
     }
@@ -171,12 +171,12 @@ impl RaftLogStorage<TypeConfig> for CoyoteLogs {
         self.clone()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn get_log_state(&mut self) -> std::io::Result<openraft::LogState<TypeConfig>> {
         self.get_log_state_().await.map_err(io_err)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn save_vote(&mut self, vote: &Vote) -> std::io::Result<()> {
         self.save_vote_(vote.to_owned()).await.map_err(io_err)?;
         Ok(())
@@ -201,22 +201,22 @@ impl RaftLogStorage<TypeConfig> for CoyoteLogs {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(log_id = ?log_id))]
     async fn truncate_after(&mut self, log_id: Option<LogId>) -> std::io::Result<()> {
         self.truncate_entries_(log_id).await.map_err(io_err)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(log_id = ?log_id))]
     async fn purge(&mut self, log_id: LogId) -> std::io::Result<()> {
         self.purge_entries_(log_id).await.map_err(io_err)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(log_id = ?committed))]
     async fn save_committed(&mut self, committed: Option<LogId>) -> std::io::Result<()> {
         self.save_committed_(committed).await.map_err(io_err)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn read_committed(&mut self) -> std::io::Result<Option<LogId>> {
         self.read_committed_().await.map_err(io_err)
     }
@@ -413,7 +413,7 @@ impl CoyoteLogs {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(timestamp = ?timestamp, log_index = ?log_index))]
     pub(crate) async fn record_log_timestamp(
         &self,
         timestamp: Timestamp,

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -201,12 +201,12 @@ impl RaftLogStorage<TypeConfig> for CoyoteLogs {
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, fields(log_id = ?log_id))]
+    #[tracing::instrument(skip_all, fields(?log_id))]
     async fn truncate_after(&mut self, log_id: Option<LogId>) -> std::io::Result<()> {
         self.truncate_entries_(log_id).await.map_err(io_err)
     }
 
-    #[tracing::instrument(skip_all, fields(log_id = ?log_id))]
+    #[tracing::instrument(skip_all, fields(?log_id))]
     async fn purge(&mut self, log_id: LogId) -> std::io::Result<()> {
         self.purge_entries_(log_id).await.map_err(io_err)
     }
@@ -413,7 +413,7 @@ impl CoyoteLogs {
         }
     }
 
-    #[tracing::instrument(skip_all, fields(timestamp = ?timestamp, log_index = ?log_index))]
+    #[tracing::instrument(skip_all, fields(?timestamp, ?log_index))]
     pub(crate) async fn record_log_timestamp(
         &self,
         timestamp: Timestamp,

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -243,7 +243,7 @@ impl RaftNetworkV2<TypeConfig> for NetworkClient {
             .await
     }
 
-    #[tracing::instrument(skip_all, fields(vote = ?vote))]
+    #[tracing::instrument(skip_all, fields(?vote))]
     async fn full_snapshot(
         &mut self,
         vote: openraft::type_config::alias::VoteOf<TypeConfig>,

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -208,7 +208,7 @@ impl NetworkClient {
         Ok(last_committed_log_id)
     }
 
-    #[tracing::instrument(skip(self, rpc))]
+    #[tracing::instrument(skip_all)]
     pub(super) async fn install_snapshot(
         &mut self,
         rpc: openraft::raft::InstallSnapshotRequest<TypeConfig>,
@@ -223,7 +223,7 @@ impl NetworkClient {
 }
 
 impl RaftNetworkV2<TypeConfig> for NetworkClient {
-    #[tracing::instrument(skip(self, rpc))]
+    #[tracing::instrument(skip_all)]
     async fn append_entries(
         &mut self,
         rpc: openraft::raft::AppendEntriesRequest<TypeConfig>,
@@ -233,7 +233,7 @@ impl RaftNetworkV2<TypeConfig> for NetworkClient {
             .await
     }
 
-    #[tracing::instrument(skip(self, rpc))]
+    #[tracing::instrument(skip_all)]
     async fn vote(
         &mut self,
         rpc: openraft::raft::VoteRequest<TypeConfig>,
@@ -243,7 +243,7 @@ impl RaftNetworkV2<TypeConfig> for NetworkClient {
             .await
     }
 
-    #[tracing::instrument(skip(self, vote, snapshot, cancel))]
+    #[tracing::instrument(skip_all, fields(vote = ?vote))]
     async fn full_snapshot(
         &mut self,
         vote: openraft::type_config::alias::VoteOf<TypeConfig>,

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -282,7 +282,7 @@ impl Store {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn load_information(&mut self) -> anyhow::Result<()> {
         let keyspace = self.readonly_meta_keyspace.clone();
 
@@ -487,7 +487,7 @@ impl Store {
         self.snapshot_idx += 1;
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn get_current_snapshot_(&mut self) -> anyhow::Result<Option<Snapshot>> {
         // clone to avoid holding a lock over an await point
         let last_snapshot = self.last_snapshot.read().clone();
@@ -759,7 +759,7 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
         self.clone()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn get_current_snapshot(&mut self) -> StorageResult<Option<Snapshot>> {
         self.inner
             .write()
@@ -769,7 +769,7 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
             .map_err(io_err)
     }
 
-    #[tracing::instrument(skip(self, meta))]
+    #[tracing::instrument(skip_all, fields(snapshot_id = meta.snapshot_id))]
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta,

--- a/src/core/cluster/streaming_snapshot.rs
+++ b/src/core/cluster/streaming_snapshot.rs
@@ -145,7 +145,7 @@ pub(super) trait ChunkedSnapshotReceiver {
 }
 
 impl<SM> ChunkedSnapshotReceiver for Raft<TypeConfig, SM> {
-    #[tracing::instrument(skip(self, req), fields(
+    #[tracing::instrument(skip_all, fields(
         snapshot_id = %req.meta.snapshot_id,
         offset = req.offset,
         done = req.done


### PR DESCRIPTION
as discussed in standup