### PR TITLE
logging: set up LogTracer and get fjall logs flowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ tower = "0.5.1"
 tower-http = { version = "0.6.1", features = ["catch-panic", "compression-full", "cors", "request-id", "trace"] }
 tower-service = "0.3.3"
 tracing = { version = "0.1.35", features = ["release_max_level_debug"] }
+tracing-log = "0.2.0"
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "local-time", "fmt", "registry", "std"] }
 tracing-test = "0.2"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,6 +21,7 @@ reqwest.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
+tracing-log.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -107,6 +107,7 @@ async fn main() -> anyhow::Result<()> {
 
     let cfg = cfg::load(args.config_path.as_deref())?;
 
+    tracing_log::LogTracer::init()?;
     let (tracing_subscriber, otel_tracer_provider) =
         otel::setup_tracing(&cfg, /* for_test = */ false);
     tracing_subscriber.init();

--- a/server/src/otel.rs
+++ b/server/src/otel.rs
@@ -26,6 +26,7 @@ pub(crate) fn setup_tracing(
         let level = cfg.log_level.to_string();
         let var = [
             format!("coyote={level}"),
+            format!("fjall={level}"),
             format!("fjall_utils={level}"),
             format!("tower_http={level}"),
             "opentelemetry_sdk=ERROR".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,7 +502,7 @@ pub fn setup_tracing_for_tests() {
                 // Output is only printed for failing tests, but still we shouldn't overload
                 // the output with unnecessary info. When debugging a specific test, it's easy
                 // to override this default by setting the `RUST_LOG` environment variable.
-                "coyote=debug,it=debug,test_utils=debug".into()
+                "coyote=debug,fjall=info,it=debug,test_utils=debug".into()
             }),
         )
         .with(tracing_subscriber::fmt::layer().with_test_writer())


### PR DESCRIPTION
fjall uses `log` instead of `tracing`, so we aren't getting any of its logs. 😠 

This fixes that by using [tracing_log](https://docs.rs/tracing-log/latest/tracing_log/).

Note that I can't set it up in tests; if I do, I get an error that there's already a global log subscriber set up (presumably from nextest itself?)