### PR TITLE
Operator: Add default topology constraints

### DIFF
--- a/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
+++ b/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
@@ -1178,8 +1178,14 @@
                     "type": "array"
                   },
                   "topologySpreadConstraints": {
-                    "default": [],
-                    "description": "Topology spread constraints for pod scheduling.\nUse this to spread pods across availability zones or nodes.\nSee: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/",
+                    "default": [
+                      {
+                        "maxSkew": 1,
+                        "topologyKey": "topology.kubernetes.io/zone",
+                        "whenUnsatisfiable": "ScheduleAnyway"
+                      }
+                    ],
+                    "description": "Topology spread constraints for pod scheduling.\n\nDefaults to (topology.kubernetes.io/zone, ScheduleAnyway, maxSkew=1).\nThe operator automatically injects the cluster's pod labelSelector on any\nconstraint that omits it, so you don't need to specify it yourself.\nSet to `[]` to opt out of all spreading.\n\nSee: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/",
                     "items": {
                       "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
                       "properties": {

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -20,6 +20,15 @@ fn default_nodes() -> i32 {
     1
 }
 
+fn default_topology_spread_constraints() -> Vec<TopologySpreadConstraint> {
+    vec![TopologySpreadConstraint {
+        max_skew: 1,
+        topology_key: "topology.kubernetes.io/zone".into(),
+        when_unsatisfiable: "ScheduleAnyway".into(),
+        ..Default::default()
+    }]
+}
+
 /// A Coyote cluster deployment.
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -83,9 +92,14 @@ pub(crate) struct CoyoteClusterSpec {
     pub bootstrap: Option<String>,
 
     /// Topology spread constraints for pod scheduling.
-    /// Use this to spread pods across availability zones or nodes.
+    ///
+    /// Defaults to (topology.kubernetes.io/zone, ScheduleAnyway, maxSkew=1).
+    /// The operator automatically injects the cluster's pod labelSelector on any
+    /// constraint that omits it, so you don't need to specify it yourself.
+    /// Set to `[]` to opt out of all spreading.
+    ///
     /// See: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-    #[serde(default)]
+    #[serde(default = "default_topology_spread_constraints")]
     pub topology_spread_constraints: Vec<TopologySpreadConstraint>,
 
     /// Node selector for scheduling pods onto nodes with matching labels.

--- a/infra/operator/src/labels.rs
+++ b/infra/operator/src/labels.rs
@@ -1,23 +1,20 @@
 use std::collections::BTreeMap;
 
-/// Labels applied to all resources managed by the operator for a given cluster instance.
-pub(crate) fn common(cluster_name: &str) -> BTreeMap<String, String> {
-    BTreeMap::from([
-        ("app.kubernetes.io/name".into(), "coyote".into()),
-        ("app.kubernetes.io/instance".into(), cluster_name.into()),
-        (
-            "app.kubernetes.io/managed-by".into(),
-            "coyote-operator".into(),
-        ),
-    ])
-}
-
 /// Selector labels used to identify pods belonging to a cluster.
-/// Must be a stable subset of `common` — these are written into the StatefulSet selector
-/// and cannot be changed after creation.
+/// Must be stable — these are written into the StatefulSet selector and cannot be changed after creation.
 pub(crate) fn selector(cluster_name: &str) -> BTreeMap<String, String> {
     BTreeMap::from([
         ("app.kubernetes.io/name".into(), "coyote".into()),
         ("app.kubernetes.io/instance".into(), cluster_name.into()),
     ])
+}
+
+/// All labels applied to resources managed by the operator for a given cluster instance.
+pub(crate) fn general_labels(cluster_name: &str) -> BTreeMap<String, String> {
+    let mut l = selector(cluster_name);
+    l.insert(
+        "app.kubernetes.io/managed-by".into(),
+        "coyote-operator".into(),
+    );
+    l
 }

--- a/infra/operator/src/resources/pdb.rs
+++ b/infra/operator/src/resources/pdb.rs
@@ -17,7 +17,7 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<PodDisruptionBu
         metadata: ObjectMeta {
             name: Some(cluster_name.clone()),
             namespace: Some(ns.into()),
-            labels: Some(labels::common(&cluster_name)),
+            labels: Some(labels::general_labels(&cluster_name)),
             owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
             ..Default::default()
         },

--- a/infra/operator/src/resources/services.rs
+++ b/infra/operator/src/resources/services.rs
@@ -27,7 +27,7 @@ pub(crate) fn build_headless(cluster: &CoyoteCluster, ns: &str) -> Result<Servic
         metadata: ObjectMeta {
             name: Some(headless_name(&cluster_name)),
             namespace: Some(ns.into()),
-            labels: Some(labels::common(&cluster_name)),
+            labels: Some(labels::general_labels(&cluster_name)),
             owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
             ..Default::default()
         },
@@ -69,7 +69,7 @@ pub(crate) fn build_client(cluster: &CoyoteCluster, ns: &str) -> Result<Service>
     let mut metadata = ObjectMeta {
         name: Some(client_name(&cluster_name)),
         namespace: Some(ns.into()),
-        labels: Some(labels::common(&cluster_name)),
+        labels: Some(labels::general_labels(&cluster_name)),
         owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
         ..Default::default()
     };
@@ -83,6 +83,7 @@ pub(crate) fn build_client(cluster: &CoyoteCluster, ns: &str) -> Result<Service>
         spec: Some(ServiceSpec {
             type_: Some(svc_type),
             selector: Some(labels::selector(&cluster_name)),
+            traffic_distribution: Some("PreferSameZone".into()),
             ports: Some(vec![ServicePort {
                 name: Some("api".into()),
                 port: spec.api_port as i32,

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -46,12 +46,13 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<StatefulSet> {
     let volume_mounts = build_volume_mounts(spec);
     let container = build_container(spec, env, volume_mounts);
 
-    let mut pod_labels = labels::selector(&cluster_name);
-    pod_labels.extend(labels::common(&cluster_name));
+    let pod_labels = labels::general_labels(&cluster_name);
     let pod_annotations = spec.pod_annotations.clone();
 
-    let topology_spread_constraints: Vec<TopologySpreadConstraint> =
-        spec.topology_spread_constraints.clone();
+    let topology_spread_constraints = add_selector_labels(
+        &spec.topology_spread_constraints,
+        &labels::selector(&cluster_name),
+    );
 
     let node_selector: Option<BTreeMap<String, String>> = spec.node_selector.clone();
     let tolerations: Option<Vec<Toleration>> = spec.tolerations.clone();
@@ -66,11 +67,7 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<StatefulSet> {
             fs_group: Some(1000),
             ..Default::default()
         }),
-        topology_spread_constraints: if topology_spread_constraints.is_empty() {
-            None
-        } else {
-            Some(topology_spread_constraints)
-        },
+        topology_spread_constraints: Some(topology_spread_constraints),
         node_selector,
         tolerations,
         affinity,
@@ -81,7 +78,7 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<StatefulSet> {
         metadata: ObjectMeta {
             name: Some(cluster_name.clone()),
             namespace: Some(ns.into()),
-            labels: Some(labels::common(&cluster_name)),
+            labels: Some(labels::general_labels(&cluster_name)),
             owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
             ..Default::default()
         },
@@ -431,6 +428,28 @@ fn pvc_template(name: &str, size: &str, storage_class: Option<&str>) -> Persiste
         }),
         ..Default::default()
     }
+}
+
+// Add the label selectors to topology constraints,
+// including those supplied by user, which are managed
+// by the operator.
+fn add_selector_labels(
+    constraints: &[TopologySpreadConstraint],
+    pod_selector: &BTreeMap<String, String>,
+) -> Vec<TopologySpreadConstraint> {
+    let selector = LabelSelector {
+        match_labels: Some(pod_selector.clone()),
+        ..Default::default()
+    };
+
+    let mut constraints = constraints.to_vec();
+    for c in &mut constraints {
+        if c.label_selector.is_none() {
+            c.label_selector = Some(selector.clone());
+        }
+    }
+
+    constraints
 }
 
 fn seed_nodes_value(

--- a/justfile
+++ b/justfile
@@ -75,3 +75,8 @@ test-all: test test-sdks
 [working-directory('benchmarks')]
 bench:
     cargo bench
+
+# Regenerate the CRD JSON and write it into the Helm chart
+[working-directory('infra/operator')]
+generate-crd:
+    cargo run -- --print-crd-json > {{ HERE / "infra/helm-coyote/charts/crds/crds/coyoteclusters.json" }}


### PR DESCRIPTION
It seems like a reasonable default to try and spread pods across zones, so add this as the default spread constraint. User can override/add to them if needed.

Note: Also add the `PreferSameZone` annotation to the service, which won't have an effect on pre-1.35 versions of k8s, but should prefer to route requests to service endpoints in same-AZ in later versions.