### PR TITLE
make the cli work by default inside the running server pod

### DIFF
--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -142,6 +142,12 @@ fn build_env(
             "COYOTE_LISTEN_ADDRESS",
             format!("0.0.0.0:{}", spec.api_port),
         ),
+        // This variable is only used by the CLI, but allows the CLI to talk to the local server
+        // without any special configuration
+        env_var(
+            "COYOTE_SERVER_URL",
+            format!("http://localhost:{}", spec.api_port),
+        ),
         env_var("COYOTE_PERSISTENT_DB_PATH", PERSISTENT_DATA_PATH),
     ];
 

--- a/z-clients/cli/src/main.rs
+++ b/z-clients/cli/src/main.rs
@@ -99,7 +99,13 @@ enum RootCommands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
+
+    if cli.auth_token.is_none()
+        && let Ok(token) = std::env::var("COYOTE_ADMIN_TOKEN")
+    {
+        cli.auth_token = Some(token);
+    }
 
     tracing_subscriber::fmt()
         .with_max_level(cli.log_level())


### PR DESCRIPTION
With these changes, you should be able to just use `coyote` with no configuration from inside a running pod.

Fixes #784.