### PR TITLE
Cache role rules

### DIFF
--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -23,6 +23,7 @@ use coyote_admin_auth::State as AdminAuthState;
 use coyote_error::{Error, ResultExt};
 
 const AUTH_TOKEN_CACHE_TTL: Duration = Duration::from_secs(1);
+const RULES_CACHE_TTL: Duration = Duration::from_secs(5);
 
 pub(crate) use coyote_core::fifo_cache::FifoCache;
 
@@ -139,6 +140,15 @@ async fn authorization_inner(
 }
 
 async fn resolve_access_rules(state: &AppState, role_id: &RoleId) -> Result<Arc<[AccessRule]>> {
+    if let Some(cached) = state
+        .rules_cache
+        .read()
+        .get(role_id.as_str(), RULES_CACHE_TTL)
+        .cloned()
+    {
+        return Ok(cached);
+    }
+
     let admin_auth = AdminAuthState::init(state.do_not_use_dbs.clone()).or_internal_error()?;
 
     let Some(role) = admin_auth
@@ -162,5 +172,10 @@ async fn resolve_access_rules(state: &AppState, role_id: &RoleId) -> Result<Arc<
         }
     }
 
-    Ok(rules.into())
+    let rules: Arc<[AccessRule]> = rules.into();
+    state
+        .rules_cache
+        .write()
+        .put(role_id.to_string(), rules.clone());
+    Ok(rules)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use axum::{
     response::IntoResponse as _,
     serve::{Listener, ListenerExt as _},
 };
-use coyote_authorization::Permissions;
+use coyote_authorization::{AccessRule, Permissions};
 use coyote_core::Monotime;
 use coyote_error::Error;
 use coyote_msgs::TopicPublishNotifier;
@@ -103,6 +103,7 @@ pub struct AppState {
     internal_client: InternalClient,
 
     pub(crate) auth_token_cache: Arc<parking_lot::RwLock<core::auth::FifoCache<Permissions>>>,
+    pub(crate) rules_cache: Arc<parking_lot::RwLock<core::auth::FifoCache<Arc<[AccessRule]>>>>,
 
     pub(crate) time: Monotime,
 
@@ -256,6 +257,7 @@ impl AppState {
 
         let auth_token_cache =
             Arc::new(parking_lot::RwLock::new(core::auth::FifoCache::new(10_000)));
+        let rules_cache = Arc::new(parking_lot::RwLock::new(core::auth::FifoCache::new(1_000)));
 
         AppState {
             cfg,
@@ -265,6 +267,7 @@ impl AppState {
             meter,
             internal_client,
             auth_token_cache,
+            rules_cache,
             time,
             topic_publish_notifier: TopicPublishNotifier::new(),
         }


### PR DESCRIPTION
That's about it. Seems easier than caching both roles and policies separately.

RE #776