### PR TITLE
state: serialize the KeyspaceCreateOptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
 name = "fjall-utils"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "byteorder",
  "coyote-error",
  "fjall",

--- a/crates/auth-token/src/controller.rs
+++ b/crates/auth-token/src/controller.rs
@@ -2,8 +2,7 @@ use crate::entities::TokenHashed;
 use coyote_core::{task::spawn_blocking_in_current_span, types::Metadata};
 use coyote_error::Result;
 use coyote_id::{AuthTokenId, NamespaceId};
-use fjall::KeyspaceCreateOptions;
-use fjall_utils::TableRow;
+use fjall_utils::{SerializableKeyspaceCreateOptions, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -79,10 +78,9 @@ pub struct AuthTokenController {
 
 impl AuthTokenController {
     pub fn new(db: fjall::Database, keyspace_name: &'static str) -> Self {
-        let keyspace = {
-            let opts = KeyspaceCreateOptions::default();
-            db.keyspace(keyspace_name, || opts).unwrap()
-        };
+        let keyspace = SerializableKeyspaceCreateOptions::default()
+            .create_and_record(&db, keyspace_name)
+            .expect("should be able to open keyspace");
 
         Self { db, keyspace }
     }

--- a/crates/coyote-admin-auth/src/controller.rs
+++ b/crates/coyote-admin-auth/src/controller.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 use coyote_authorization::{AccessPolicyId, AccessRule, RoleId};
 use coyote_core::task::spawn_blocking_in_current_span;
 use coyote_error::Result;
-use fjall::{KeyspaceCreateOptions, KvSeparationOptions};
-use fjall_utils::TableRow;
+use fjall_utils::{SerializableKeyspaceCreateOptions, TableRow};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -85,11 +84,10 @@ pub struct AdminAuthController {
 
 impl AdminAuthController {
     pub fn new(db: fjall::Database, keyspace_name: &'static str) -> Self {
-        let keyspace = {
-            let opts = KeyspaceCreateOptions::default()
-                .with_kv_separation(Some(KvSeparationOptions::default()));
-            db.keyspace(keyspace_name, || opts).unwrap()
-        };
+        let keyspace = SerializableKeyspaceCreateOptions::default()
+            .with_default_kv_separation()
+            .create_and_record(&db, keyspace_name)
+            .expect("should be able to open keyspace");
         Self { db, keyspace }
     }
 

--- a/crates/fjall-utils/Cargo.toml
+++ b/crates/fjall-utils/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 edition = "2024"
 
 [dependencies]
+anyhow.workspace = true
 byteorder.workspace = true
 coyote-error.workspace = true
 fjall.workspace = true

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -1,6 +1,7 @@
 mod db;
 pub mod duration_millis;
 mod fixed_key;
+mod options;
 mod readonly_db;
 mod table_row;
 pub mod table_row2;
@@ -8,6 +9,7 @@ pub mod table_row2;
 pub use self::{
     db::{Databases, ReadonlyConnection, ReadonlyDatabases, StorageType},
     fixed_key::FjallFixedKey,
+    options::{SchemaManifest, SerializableKeyspaceCreateOptions},
     readonly_db::{ReadableDatabase, ReadableKeyspace, ReadonlyDatabase, ReadonlyKeyspace},
     table_row::{TableKey, TableKeyFromFjall, TableKeyType, TableRow, WriteBatchExt},
 };

--- a/crates/fjall-utils/src/options.rs
+++ b/crates/fjall-utils/src/options.rs
@@ -1,0 +1,157 @@
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+// this is super-hacky but necessary until
+// https://github.com/fjall-rs/fjall/issues/262 is done. Rip it out at that point
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct SchemaManifest {
+    keyspaces: BTreeMap<String, SerializableKeyspaceCreateOptions>,
+}
+
+impl SchemaManifest {
+    pub fn load_from_db(database: &fjall::Database) -> anyhow::Result<Self> {
+        let mut keyspaces = BTreeMap::new();
+        let keyspace = database.keyspace("_schema", fjall::KeyspaceCreateOptions::default)?;
+        for row in keyspace.iter() {
+            let (key, value) = row.into_inner()?;
+            let keyspace_name = std::str::from_utf8(&key)?.to_owned();
+            let value = rmp_serde::from_slice(&value)?;
+            tracing::debug!(?keyspace_name, "loaded schema for keyspace from db");
+            keyspaces.insert(keyspace_name, value);
+        }
+        Ok(Self { keyspaces })
+    }
+
+    pub fn keyspace(
+        &self,
+        database: &fjall::Database,
+        keyspace_name: &str,
+    ) -> fjall::Result<fjall::Keyspace> {
+        database.keyspace(keyspace_name, || self.options_for_keyspace(keyspace_name))
+    }
+
+    pub fn contains(&self, keyspace_name: &str) -> bool {
+        self.keyspaces.contains_key(keyspace_name)
+    }
+
+    pub fn options_for_keyspace(&self, keyspace_name: &str) -> fjall::KeyspaceCreateOptions {
+        if let Some(schema) = self.keyspaces.get(keyspace_name) {
+            tracing::debug!(?keyspace_name, "found create options");
+            schema.clone().into()
+        } else {
+            fjall::KeyspaceCreateOptions::default()
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Copy, Clone)]
+pub enum SerializableCompressionType {
+    Lz4,
+    #[default]
+    None,
+}
+
+impl From<SerializableCompressionType> for fjall::CompressionType {
+    fn from(value: SerializableCompressionType) -> Self {
+        match value {
+            SerializableCompressionType::None => Self::None,
+            SerializableCompressionType::Lz4 => Self::Lz4,
+        }
+    }
+}
+
+impl From<fjall::CompressionType> for SerializableCompressionType {
+    fn from(value: fjall::CompressionType) -> Self {
+        match value {
+            fjall::CompressionType::None => Self::None,
+            fjall::CompressionType::Lz4 => Self::Lz4,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SerializableKvSeparationOptions {
+    compression: SerializableCompressionType,
+    file_target_size: u64,
+    separation_threshold: u32,
+    staleness_threshold: f32,
+    age_cutoff: f32,
+}
+
+impl Default for SerializableKvSeparationOptions {
+    fn default() -> Self {
+        fjall::KvSeparationOptions::default().into()
+    }
+}
+
+impl From<fjall::KvSeparationOptions> for SerializableKvSeparationOptions {
+    fn from(value: fjall::KvSeparationOptions) -> Self {
+        Self {
+            compression: value.compression.into(),
+            file_target_size: value.file_target_size,
+            separation_threshold: value.separation_threshold,
+            staleness_threshold: value.staleness_threshold,
+            age_cutoff: value.age_cutoff,
+        }
+    }
+}
+
+impl From<SerializableKvSeparationOptions> for fjall::KvSeparationOptions {
+    fn from(value: SerializableKvSeparationOptions) -> Self {
+        Self::default()
+            .compression(value.compression.into())
+            .file_target_size(value.file_target_size)
+            .separation_threshold(value.separation_threshold)
+            .staleness_threshold(value.staleness_threshold)
+            .age_cutoff(value.age_cutoff)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct SerializableKeyspaceCreateOptions {
+    kv_separation_options: Option<SerializableKvSeparationOptions>,
+    expect_point_read_hits: bool,
+}
+
+impl From<SerializableKeyspaceCreateOptions> for fjall::KeyspaceCreateOptions {
+    fn from(value: SerializableKeyspaceCreateOptions) -> Self {
+        Self::default()
+            .with_kv_separation(value.kv_separation_options.map(Into::into))
+            .expect_point_read_hits(value.expect_point_read_hits)
+    }
+}
+
+impl SerializableKeyspaceCreateOptions {
+    pub fn with_kv_separation(mut self, opts: Option<SerializableKvSeparationOptions>) -> Self {
+        self.kv_separation_options = opts;
+        self
+    }
+
+    pub fn with_default_kv_separation(mut self) -> Self {
+        self.kv_separation_options = Some(SerializableKvSeparationOptions::default());
+        self
+    }
+
+    pub fn expect_point_read_hits(mut self, expect: bool) -> Self {
+        self.expect_point_read_hits = expect;
+        self
+    }
+
+    /// Get or create the given keyspace name in the given database,
+    ///
+    /// recording the currente operations into the special _schema keyspace.
+    pub fn create_and_record(
+        self,
+        database: &fjall::Database,
+        keyspace_name: &str,
+    ) -> anyhow::Result<fjall::Keyspace> {
+        let schema = database.keyspace("_schema", fjall::KeyspaceCreateOptions::default)?;
+        let serialized = rmp_serde::to_vec_named(&self).context("serializing schema")?;
+        schema.insert(keyspace_name, serialized)?;
+        database
+            .keyspace(keyspace_name, || self.into())
+            .context("creating target keyspace")
+    }
+}

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -6,8 +6,8 @@ use coyote_core::{
 };
 use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
-use fjall::{Database, Keyspace, KeyspaceCreateOptions, KvSeparationOptions};
-use fjall_utils::{TableRow, WriteBatchExt};
+use fjall::{Database, Keyspace};
+use fjall_utils::{SerializableKeyspaceCreateOptions, TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -69,11 +69,10 @@ pub struct KvController {
 
 impl KvController {
     pub fn new(db: Database, keyspace_name: &'static str) -> Self {
-        let tables = {
-            let opts = KeyspaceCreateOptions::default()
-                .with_kv_separation(Some(KvSeparationOptions::default()));
-            db.keyspace(keyspace_name, || opts).unwrap()
-        };
+        let tables = SerializableKeyspaceCreateOptions::default()
+            .with_default_kv_separation()
+            .create_and_record(&db, keyspace_name)
+            .expect("should be able to open keyspace");
 
         Self {
             db: InstrumentedMutex::new(db),

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -1,12 +1,12 @@
-use coyote_error::{Error, Result};
+use coyote_error::{Error, Result, ResultExt};
 use coyote_id::NamespaceId;
 use coyote_namespace::{Namespace, entities::MsgsConfig};
 use coyote_operations::BackgroundResult;
-use fjall::{KeyspaceCreateOptions, KvSeparationOptions};
+use fjall::KeyspaceCreateOptions;
 use jiff::Timestamp;
 
 use entities::{ConsumerGroup, Partition, TopicName};
-use fjall_utils::{ReadableKeyspace, TableRow};
+use fjall_utils::{ReadableKeyspace, SerializableKeyspaceCreateOptions, TableRow};
 use tables::{MsgRow, QueueLeaseRow, StreamLeaseRow, TopicRow};
 
 use crate::metrics::{record_end_offsets, record_topic_lag_metrics};
@@ -38,17 +38,13 @@ impl State {
         db: fjall::Database,
         topic_publish_notifier: TopicPublishNotifier,
     ) -> Result<Self, Error> {
-        let metadata_tables = {
-            let opts = KeyspaceCreateOptions::default();
-            db.keyspace(METADATA_KEYSPACE, || opts)?
-        };
+        let metadata_tables = db.keyspace(METADATA_KEYSPACE, KeyspaceCreateOptions::default)?;
 
-        let msg_table = {
-            let opts = KeyspaceCreateOptions::default()
-                .expect_point_read_hits(true)
-                .with_kv_separation(Some(KvSeparationOptions::default()));
-            db.keyspace(MSG_KEYSPACE, || opts)?
-        };
+        let msg_table = SerializableKeyspaceCreateOptions::default()
+            .expect_point_read_hits(true)
+            .with_default_kv_separation()
+            .create_and_record(&db, MSG_KEYSPACE)
+            .or_internal_error()?;
 
         let meter = opentelemetry::global::meter("coyote.svix.com");
 

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -5,8 +5,8 @@ use std::{
 
 use anyhow::Context;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use fjall::{Database, Keyspace, KeyspaceCreateOptions, Readable};
-use fjall_utils::{Databases, StorageType};
+use fjall::{Database, Keyspace, Readable};
+use fjall_utils::{Databases, SchemaManifest, StorageType};
 use serde::{Deserialize, Serialize};
 use zip::{ZipArchive, write::SimpleFileOptions};
 
@@ -41,6 +41,8 @@ struct Chunk {
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct KeyspaceManifest {
     keyspaces: BTreeMap<String, Vec<Chunk>>,
+    #[serde(default)]
+    keyspace_schemas: SchemaManifest,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -113,7 +115,13 @@ impl<'a, B: Write + Seek> KeyspaceSerializer<'a, B> {
         snapshot: &R,
         keyspace: &Keyspace,
     ) -> anyhow::Result<Vec<Chunk>> {
-        tracing::trace!(storage_type = ?self.storage_type, keyspace_name = self.keyspace_name, "serializing keyspace");
+        tracing::debug!(
+            storage_type = ?self.storage_type,
+            keyspace_name = self.keyspace_name,
+            path = %keyspace.path().display(),
+            len = keyspace.len()?,
+            "serializing keyspace"
+        );
         for guard in snapshot.iter(keyspace) {
             let (k, v) = guard.into_inner()?;
             if self.current_buffer.len() > Self::MAX_BYTES_PER_CHUNK {
@@ -144,7 +152,11 @@ fn deserialize_keyspace<R: Read + Seek>(
     keyspace: &Keyspace,
     chunks: Vec<Chunk>,
 ) -> anyhow::Result<()> {
-    tracing::warn!(name=%keyspace.name(), "clearing keyspace");
+    tracing::info!(
+        name = %keyspace.name(),
+        path = %keyspace.path().display(),
+        len = keyspace.len()?,
+        "clearing and then deserializing keyspace");
     // TODO: remove this slow path after
     // https://github.com/fjall-rs/fjall/issues/277 is fixed
     if keyspace.is_kv_separated() {
@@ -203,12 +215,16 @@ pub(crate) fn serialize_to_file<F: Write + Seek>(
     let mut manifest = Manifest::default();
 
     for (db_name, db, snapshot, keyspaces) in targets {
-        let mut keyspace_manifests = KeyspaceManifest::default();
+        let mut keyspace_manifests = KeyspaceManifest {
+            keyspace_schemas: SchemaManifest::load_from_db(&db)?,
+            ..Default::default()
+        };
         for keyspace_name in keyspaces {
             tracing::debug!(keyspace=%keyspace_name, "serializing a keyspace");
-            // TODO: we should be copying keyspace create options from the source;
-            // see https://github.com/fjall-rs/fjall/issues/262
-            let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
+            let options = keyspace_manifests
+                .keyspace_schemas
+                .options_for_keyspace(&keyspace_name);
+            let keyspace = db.keyspace(&keyspace_name, || options)?;
             let serializer = KeyspaceSerializer::new(&mut zip, db_name, &keyspace_name)?;
             let chunks = serializer.serialize_keyspace(&snapshot, &keyspace)?;
             keyspace_manifests.keyspaces.insert(keyspace_name, chunks);
@@ -253,7 +269,10 @@ pub(crate) fn load_from_file<F: Read + Seek>(dbs: &Databases, f: &mut F) -> anyh
                 num_parts = chunks.len(),
                 "deserializing a keyspace"
             );
-            let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
+            let options = keyspaces
+                .keyspace_schemas
+                .options_for_keyspace(&keyspace_name);
+            let keyspace = db.keyspace(&keyspace_name, || options)?;
             deserialize_keyspace(&mut z, db, &keyspace, chunks)?;
             db.persist(fjall::PersistMode::SyncAll)?;
         }
@@ -267,7 +286,7 @@ mod tests {
     use std::io::Cursor;
 
     use fjall::{Database, KeyspaceCreateOptions, Slice};
-    use fjall_utils::Databases;
+    use fjall_utils::{Databases, SchemaManifest, SerializableKeyspaceCreateOptions};
 
     use super::{load_from_file, serialize_to_file};
     use fjall_utils::StorageType;
@@ -342,6 +361,70 @@ mod tests {
             keyspace2.get("key4")?.as_ref(),
             Some(&Slice::new(b"value4"))
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_custom_options() -> anyhow::Result<()> {
+        let workdir = tempfile::tempdir()?;
+        let mut db_path = workdir.path().to_path_buf();
+        db_path.push("db/");
+
+        let db = Database::builder(db_path).open()?;
+        let ks1 = SerializableKeyspaceCreateOptions::default()
+            .with_default_kv_separation()
+            .create_and_record(&db, "keyspace1")?;
+        assert!(ks1.is_kv_separated());
+        ks1.insert("foo", b"bar")?;
+        db.persist(fjall::PersistMode::Buffer)?;
+
+        let snapshot = db.snapshot();
+
+        let mut cursor = Cursor::new(vec![]);
+
+        let keyspaces = db
+            .list_keyspace_names()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let targets = vec![(StorageType::Persistent, db, snapshot, keyspaces)];
+
+        serialize_to_file(targets, &mut cursor)?;
+
+        let out = cursor.into_inner();
+
+        let mut db2_path = workdir.path().to_path_buf();
+        db2_path.push("db_loaded/");
+        let db2 = Database::builder(db2_path).open()?;
+
+        let mut db2e_path = workdir.path().to_path_buf();
+        db2e_path.push("db_loaded_ephem/");
+        let db2e = Database::builder(db2e_path).open()?;
+
+        let databases = Databases::new(db2.clone(), db2e);
+
+        let mut cursor = Cursor::new(out);
+
+        load_from_file(&databases, &mut cursor)?;
+
+        let schemas = SchemaManifest::load_from_db(&db2)?;
+        assert!(schemas.contains("keyspace1"));
+        assert!(!schemas.contains("_schema"));
+
+        let found_keyspaces = db2
+            .list_keyspace_names()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(&found_keyspaces, &["keyspace1", "_schema"]);
+
+        // even though we initialize it here with ::default, it should already have been
+        // initialized as kv-separated in the `load_from_file` call.
+        let keyspace1 = db2.keyspace("keyspace1", KeyspaceCreateOptions::default)?;
+        assert!(keyspace1.is_kv_separated());
+        assert_eq!(keyspace1.get("foo")?.as_ref(), Some(&Slice::new(b"bar")));
 
         Ok(())
     }


### PR DESCRIPTION
This fixes a longstanding TODO where the serialization step could lose the KeyspaceCreateOptions. It does this by writing the keyspace create options into a `_schema` keyspace in the database, and then copying them across the serialization step.

I don't like this code, but without https://github.com/fjall-rs/fjall/issues/262 I don't see any other option.