### PR TITLE
cluster: load metadata when installing snapshot

### DIFF
--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -178,7 +178,10 @@ impl DatabaseConfig {
         fjall::Database::builder(path)
             .cache_size(Self::default_cache_size())
             .open()
-            .map_err(|e| e.into())
+            .map_err(|err| {
+                tracing::error!(?err, "error building database");
+                err.into()
+            })
     }
 
     pub fn persistent(db_config: &DatabaseConfig) -> Result<fjall::Database> {

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -375,6 +375,13 @@ impl Store {
     async fn delete_unused_snapshots(&self, keep_path: &Path) -> anyhow::Result<()> {
         tracing::debug!("cleaning up unused snapshots");
         let mut dents = tokio::fs::read_dir(&self.snapshot_directory).await?;
+        let last_file_name = {
+            let handle = self.last_snapshot.read();
+            handle
+                .as_ref()
+                .and_then(|s| s.path.file_name())
+                .map(|s| s.to_owned())
+        };
         while let Some(dent) = dents.next_entry().await? {
             if let Some(preserve_path) = keep_path.file_name() {
                 if dent.file_name() == preserve_path {
@@ -383,6 +390,12 @@ impl Store {
                 }
             } else {
                 tracing::warn!(path=?keep_path, "very weird snapshot path");
+            }
+            if let Some(preserve_name) = &last_file_name
+                && dent.file_name() == *preserve_name
+            {
+                tracing::trace!(filename=?dent.file_name(), "preserving last_snapshot");
+                continue;
             }
             tracing::debug!(filename=?dent.file_name(), "deleting unused snapshot");
             tokio::fs::remove_file(dent.path()).await?;
@@ -407,12 +420,16 @@ impl Store {
             serialized_state_machine::load_from_file(&stores.databases, &mut f)
         })
         .await??;
+        // load the embedded information from the metadata table in the snapshot
+        self.load_information().await?;
+        // overwrite any last_log_id and membership in the snapshot with the ones the leader told us
         self.last_applied_log_id = meta.last_log_id;
         self.last_membership = meta.last_membership.clone();
         self.record_ids_().await?;
-        self.delete_unused_snapshots(snapshot.path.as_path())
-            .await?;
+        // clean up the snapshot directory
         self.set_last_snapshot_(meta.clone(), snapshot.path.clone())
+            .await?;
+        self.delete_unused_snapshots(snapshot.path.as_path())
             .await?;
         Ok(())
     }


### PR DESCRIPTION
the first time a node started after loading a snapshot, the `cluster_id` would be blank because we only load it on bootup or when processing the relevant Raft log.