### PR TITLE
cluster: fix database corruption on serialization

### DIFF
--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -254,7 +254,7 @@ pub(crate) fn load_from_file<F: Read + Seek>(dbs: &Databases, f: &mut F) -> anyh
                 "deserializing a keyspace"
             );
             let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
-            deserialize_keyspace(&mut z, &db, &keyspace, chunks)?;
+            deserialize_keyspace(&mut z, db, &keyspace, chunks)?;
             db.persist(fjall::PersistMode::SyncAll)?;
         }
     }

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -136,13 +136,36 @@ impl<'a, B: Write + Seek> KeyspaceSerializer<'a, B> {
     }
 }
 
+const CLEAR_CHUNK_SIZE: usize = 10_000;
+
 fn deserialize_keyspace<R: Read + Seek>(
     z: &mut ZipArchive<R>,
+    db: &Database,
     keyspace: &Keyspace,
     chunks: Vec<Chunk>,
 ) -> anyhow::Result<()> {
     tracing::warn!(name=%keyspace.name(), "clearing keyspace");
-    keyspace.clear()?;
+    // TODO: remove this slow path after
+    // https://github.com/fjall-rs/fjall/issues/277 is fixed
+    if keyspace.is_kv_separated() {
+        if !keyspace.is_empty()? {
+            tracing::warn!("falling back to slow path to clear k-v separated database");
+            while !keyspace.is_empty()? {
+                let some_keys = keyspace
+                    .iter()
+                    .take(CLEAR_CHUNK_SIZE)
+                    .map(|k| k.key())
+                    .collect::<fjall::Result<Vec<_>>>()?;
+                let mut batch = db.batch().durability(Some(fjall::PersistMode::Buffer));
+                for key in some_keys {
+                    batch.remove(keyspace, key);
+                }
+                batch.commit()?;
+            }
+        }
+    } else {
+        keyspace.clear()?;
+    }
     let mut key_buf = vec![];
     let mut value_buf = vec![];
 
@@ -231,7 +254,7 @@ pub(crate) fn load_from_file<F: Read + Seek>(dbs: &Databases, f: &mut F) -> anyh
                 "deserializing a keyspace"
             );
             let keyspace = db.keyspace(&keyspace_name, KeyspaceCreateOptions::default)?;
-            deserialize_keyspace(&mut z, &keyspace, chunks)?;
+            deserialize_keyspace(&mut z, &db, &keyspace, chunks)?;
             db.persist(fjall::PersistMode::SyncAll)?;
         }
     }


### PR DESCRIPTION
This works around https://github.com/fjall-rs/lsm-tree/issues/286

fjall has a bug where if you call `.clear()` on a key-value separated keyspace, it leaves the whole DB in a broken state (which is only detectable on the *next* boot). This works around it by not calling `.clear()` on k-v separated databases.