### PR TITLE
Auth token: remove kv-separation in storage.

### DIFF
--- a/crates/auth-token/src/controller.rs
+++ b/crates/auth-token/src/controller.rs
@@ -2,7 +2,7 @@ use crate::entities::TokenHashed;
 use coyote_core::{task::spawn_blocking_in_current_span, types::Metadata};
 use coyote_error::Result;
 use coyote_id::{AuthTokenId, NamespaceId};
-use fjall::{KeyspaceCreateOptions, KvSeparationOptions};
+use fjall::KeyspaceCreateOptions;
 use fjall_utils::TableRow;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -80,8 +80,7 @@ pub struct AuthTokenController {
 impl AuthTokenController {
     pub fn new(db: fjall::Database, keyspace_name: &'static str) -> Self {
         let keyspace = {
-            let opts = KeyspaceCreateOptions::default()
-                .with_kv_separation(Some(KvSeparationOptions::default()));
+            let opts = KeyspaceCreateOptions::default();
             db.keyspace(keyspace_name, || opts).unwrap()
         };
 


### PR DESCRIPTION
It was a bad copy-paste. We don't actually need that because values are always small. So this is actually the opposite of what we need.