### PR TITLE
Refactor Operator/CRD and add Helm README

### DIFF
--- a/infra/helm-coyote/README.md
+++ b/infra/helm-coyote/README.md
@@ -1,51 +1,106 @@
 # Coyote Helm chart
+Coyote is the backend survival toolkit. It’s a set of well integrated infrastructure primitives for backend and data engineers such as caching, kv-store, rate-limiting, idempotency, queue, and stream. Please see the [Coyote documentation](https://coyote.svix.io/) for more details.
 
-Installs the Coyote CRD, operator and cluster.
+This chart installs components required for running Coyote as a standalone instance or as a cluster, including a CRD, an operator, and a CoyoteCluster resource.
 
 ## Usage
+The chart is distributed as an OCI artfact.
+
+### Installation
+```console
+helm install [RELEASE_NAME] oci://ghcr.io/svix/charts/coyote
+```
+
+## Parameters
+
+### Configuring CRD Installation
+The CRD is enabled by default. The chart will attempt to manage upgrades of the CRD, if enabled, using Helm hooks to manually apply CRD updates.
+
+| Parameter | Description | Default |
+|---|---|---|
+| `crds.enabled` | Install the `CoyoteCluster` CRD. Set to `false` to manage the CRD yourself. | `true` |
+| `crds.upgrade.enabled` | If enabled, the Helm chart will attempt to apply updates to the CRD. | `false` |
+| `crds.upgrade.forceConflicts` | Passes `--force-conflicts` to `kubectl apply` to resolve CRD conflicts. | `false` |
+
+### Configuring the Operator
+
+| Parameter | Description | Default |
+|---|---|---|
+| `operator.image.repository` | Operator image repository. | `ghcr.io/svix/coyote-operator` |
+| `operator.image.tag` | Operator image tag. | Chart pre-populates current tag. |
+| `operator.image.pullPolicy` | Operator image pull policy. | `IfNotPresent` |
+| `operator.imagePullSecrets` | Operator image pull secrets. | `[]` |
+| `operator.serviceAccount.create` | Create a ServiceAccount for the operator. | `true` |
+| `operator.serviceAccount.name` | ServiceAccount name. Defaults to the release fullname. | `""` |
+| `operator.serviceAccount.annotations` | Annotations for the ServiceAccount. | `{}` |
+| `operator.rbac.create` | Create ClusterRole and ClusterRoleBinding for the operator. | `true` |
+| `operator.logLevel` | Operator log level (`info`, `debug`, `trace`). | `info` |
+| `operator.podAnnotations` | Annotations to add to the operator pod. | `{}` |
+| `operator.resources` | Resource requests/limits for the operator pod. | request cpu: 100m, memory: 128Mi, no limits |
+| `operator.nodeSelector` | Node selector for the operator pod. | `{}` |
+| `operator.tolerations` | Tolerations for the operator pod. | `[]` |
+| `operator.affinity` | Affinity rules for the operator pod. | `{}` |
+
+### Configuring the Cluster
+
+Example configuration for a 3-node cluster:
 
 ```yaml
-# values.yaml
-operator:
-  image:
-    tag: "0.1.0"
-
 cluster:
-  enabled: true
-  image:
-    tag: "0.1.0"
   spec:
     nodes: 3
     storage:
       persistent:
-        size: 64Gi
-        storageClass: gp3-encrypted
+        size: 10Gi
+    adminToken:
+      valueFrom:
+        name: coyote-secrets
+        key: admin-token
+    internodeSecret:
+      valueFrom:
+        name: coyote-secrets
+        key: internode-secret
+    logLevel: info
+    logFormat: json
+    opentelemetryAddress: grpc://otel-collector.monitoring.svc.cluster.local:4317
 ```
 
-```sh
-helm install coyote ./helm-coyote
-```
+| Parameter | Description | Default |
+|---|---|---|
+| `cluster.enabled` | Create a `CoyoteCluster` resource. Set to `false` to manage the cluster separately. | `true` |
+| `cluster.name` | Name of the `CoyoteCluster` resource. Defaults to the release name. | `coyote` |
+| `cluster.image.repository` | Coyote server image repository. | `ghcr.io/svix/coyote-server` |
+| `cluster.image.tag` | Coyote server image tag. | Chart pre-populates current tag. |
+| `cluster.spec.nodes` | Number of Coyote nodes. Should be an odd number. | `1` |
+| `cluster.spec.apiPort` | Port for the external API and service. | `8080` |
+| `cluster.spec.envVar` | Additional environment variables to inject into pods (list of `{name, value}`). | `[]` |
+| `cluster.spec.bootstrap` | Newline-delimited bootstrap script to run on cluster startup. | `""` |
+| `cluster.spec.logLevel` | The log level to run the service with. Supported: info, debug, trace. | `""` |
+| `cluster.spec.logFormat` | Log level for the Coyote server (`info`, `debug`, `trace`). | `""` |
+| `cluster.spec.opentelemetryAddress` | OpenTelemetry tracing endpoint address (GRPC). | `""` |
+| `cluster.spec.opentelemetryMetricsAddress` | OpenTelemetry metrics endpoint address, if different from tracing opentelemetryAddress. | `""` |
+| `cluster.spec.opentelemetryMetricsUseHttp` | Use HTTP instead of GRPC for OpenTelemetry metrics export. | `false` |
+| `cluster.spec.adminToken.value` | Plaintext token for privileged API access, as a plain string. Only recommended for testing. | `""` |
+| `cluster.spec.adminToken.valueFrom.name` | Name of the Kubernetes Secret containing the admin token. | `""` |
+| `cluster.spec.adminToken.valueFrom.key` | Key within the Secret to use as the admin token. | `""` |
+| `cluster.spec.internodeSecret.value` | Plaintext inter-node authentication secret. Only recommended for testing. | `""` |
+| `cluster.spec.internodeSecret.valueFrom.name` | Name of the Kubernetes Secret containing the inter-node secret. | `""` |
+| `cluster.spec.internodeSecret.valueFrom.key` | Key within the Secret to use as the inter-node secret. | `""` |
+| `cluster.spec.storage.persistent.size` | Size of the persistent database volume **Required**. | `""` |
+| `cluster.spec.storage.persistent.storageClass` | Storage class for the persistent volume. Uses the cluster default if unset. | `""` |
+| `cluster.spec.storage.logs.size` | Size of the separate Raft commit log volume. | `""` |
+| `cluster.spec.storage.logs.storageClass` | Storage class for the logs volume. | `""` |
+| `cluster.spec.storage.snapshots.size` | Size of the separate Raft snapshot volume. Should be at least as large as the persistent volume. | `""` |
+| `cluster.spec.storage.snapshots.storageClass` | Storage class for the snapshots volume. | `""` |
+| `cluster.spec.imagePullPolicy` | Image pull policy (`Always`, `IfNotPresent`, `Never`). | `""` |
+| `cluster.spec.podAnnotations` | Additional annotations to add to pods. | `{}` |
+| `cluster.spec.nodeSelector` | Node selector labels for pod scheduling. | `{}` |
+| `cluster.spec.tolerations` | Pod tolerations. | `[]` |
+| `cluster.spec.affinity` | Pod affinity rules. | `{}` |
+| `cluster.spec.topologySpreadConstraints` | Topology spread constraints. | `[]` |
+| `cluster.spec.resources` | CPU and memory resource requests and limits for the coyote pods. | `{}` |
+| `cluster.spec.service` | Configuration for the externally-facing Service. | `{type: ClusterIP}` |
 
-## CRD installation
-
-The `Cluster` CRD is installed by default (`crds.enabled: true`). Set it
-to `false` if you want to manage it separately.
-
-### Upgrades
-
-The CRD is bundled in the chart's `crds/` sub-chart and is installed
-automatically on `helm install`, but **is not upgraded on `helm upgrade` because Helm**.
-When the CRD schema changes across chart versions, you have to apply it manually before upgrading the chart:
-
-```sh
-kubectl apply -f {path to crd.json}
-```
 
 ### Uninstall
-
-Helm will **not** delete the CRD on `helm uninstall`. To fully remove the CRD:
-
-```sh
-helm delete coyote
-kubectl delete crd clusters.coyote.svix.com
-```
+Note that Helm will not delete the CRD or any persistent volumes associated with removed installations.

--- a/infra/helm-coyote/README.md
+++ b/infra/helm-coyote/README.md
@@ -71,7 +71,7 @@ cluster:
 | `cluster.name` | Name of the `CoyoteCluster` resource. Defaults to the release name. | `coyote` |
 | `cluster.image.repository` | Coyote server image repository. | `ghcr.io/svix/coyote-server` |
 | `cluster.image.tag` | Coyote server image tag. | Chart pre-populates current tag. |
-| `cluster.spec.nodes` | Number of Coyote nodes. Should be an odd number. | `1` |
+| `cluster.spec.nodes` | Number of Coyote nodes. Should be an odd number. Recommended value is 3 for a cluster, or 1 for a single node. | `1` |
 | `cluster.spec.apiPort` | Port for the external API and service. | `8080` |
 | `cluster.spec.envVar` | Additional environment variables to inject into pods (list of `{name, value}`). | `[]` |
 | `cluster.spec.bootstrap` | Newline-delimited bootstrap script to run on cluster startup. | `""` |

--- a/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
+++ b/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
@@ -56,7 +56,7 @@
                         ]
                       }
                     ],
-                    "description": "Admin token for privileged API access.\nSet either `value` for a plain string or `valueFrom` to pull from a Kubernetes Secret.\nUsing a plain string value is only recommended for testing. Use `valueFrom` in all other cases.",
+                    "description": "Admin token for privileged API access.\n\nSet either `value` for a plain string or `valueFrom` to pull from a Kubernetes Secret.\nUsing a plain string value is only recommended for testing. Use `valueFrom` in all other cases.",
                     "nullable": true,
                     "properties": {
                       "value": {
@@ -792,102 +792,16 @@
                   },
                   "apiPort": {
                     "default": 8080,
-                    "description": "Port for the external API. The inter-node port is this value + 10000.",
+                    "description": "Port for the external API and service.",
                     "format": "uint16",
                     "maximum": 65535.0,
                     "minimum": 0.0,
                     "type": "integer"
                   },
                   "bootstrap": {
-                    "description": "Bootstrap script to run on cluster startup.\nCurrently a YAML file defining namespaces to pre-create; may become a shell script in future.\nMounted into pods and passed to the server via COYOTE_BOOTSTRAP_CFG_PATH.",
+                    "description": "Newline-delimited bootstrap script to run on cluster startup.",
                     "nullable": true,
                     "type": "string"
-                  },
-                  "cluster": {
-                    "default": {
-                      "electionTimeoutMaxMs": null,
-                      "electionTimeoutMinMs": null,
-                      "heartbeatIntervalMs": null,
-                      "logLevel": null,
-                      "replicationRequestTimeoutMs": null,
-                      "secretRef": null,
-                      "snapshotAfterMs": null,
-                      "snapshotAfterWrites": null
-                    },
-                    "description": "Cluster/replication configuration.",
-                    "properties": {
-                      "electionTimeoutMaxMs": {
-                        "description": "Maximum election timeout in milliseconds.",
-                        "format": "uint64",
-                        "minimum": 0.0,
-                        "nullable": true,
-                        "type": "integer"
-                      },
-                      "electionTimeoutMinMs": {
-                        "description": "Minimum election timeout in milliseconds.",
-                        "format": "uint64",
-                        "minimum": 0.0,
-                        "nullable": true,
-                        "type": "integer"
-                      },
-                      "heartbeatIntervalMs": {
-                        "description": "Heartbeat interval in milliseconds.",
-                        "format": "uint64",
-                        "minimum": 0.0,
-                        "nullable": true,
-                        "type": "integer"
-                      },
-                      "logLevel": {
-                        "description": "Log level (info, debug, trace). Defaults to info.",
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "replicationRequestTimeoutMs": {
-                        "description": "Replication request timeout in milliseconds.",
-                        "format": "uint64",
-                        "minimum": 0.0,
-                        "nullable": true,
-                        "type": "integer"
-                      },
-                      "secretRef": {
-                        "description": "Reference to a Secret containing the inter-node authentication token.\n`name` is the name of the Kubernetes Secret.\n`key` is the key within the Secret whose value is the token.",
-                        "nullable": true,
-                        "properties": {
-                          "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                            "type": "string"
-                          },
-                          "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
-                            "type": "boolean"
-                          }
-                        },
-                        "required": [
-                          "key",
-                          "name"
-                        ],
-                        "type": "object"
-                      },
-                      "snapshotAfterMs": {
-                        "description": "Trigger a background snapshot after this many milliseconds.",
-                        "format": "uint64",
-                        "minimum": 0.0,
-                        "nullable": true,
-                        "type": "integer"
-                      },
-                      "snapshotAfterWrites": {
-                        "description": "Trigger a background snapshot after this many writes.",
-                        "format": "uint32",
-                        "minimum": 0.0,
-                        "nullable": true,
-                        "type": "integer"
-                      }
-                    },
-                    "type": "object"
                   },
                   "envVar": {
                     "description": "Additional environment variables to inject into pods.\nFollows the Kubernetes EnvVar API spec (v1.EnvVar): supports plain `value`\nand `valueFrom` (secretKeyRef, configMapKeyRef, fieldRef, resourceFieldRef)",
@@ -1008,6 +922,60 @@
                     "nullable": true,
                     "type": "string"
                   },
+                  "internodeSecret": {
+                    "anyOf": [
+                      {
+                        "required": [
+                          "value"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "valueFrom"
+                        ]
+                      }
+                    ],
+                    "description": "Inter-node authentication token.\n\nSet either `value` for a plain string or `valueFrom` to pull from a Kubernetes Secret.\nUsing a plain string value is only recommended for testing. Use `valueFrom` in all other cases.",
+                    "nullable": true,
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "description": "SecretKeySelector selects a key of a Secret.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "logFormat": {
+                    "description": "The log format that all output will follow. Supported: default, json",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "logLevel": {
+                    "description": "The log level to run the service with. Supported: info, debug, trace",
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "nodeSelector": {
                     "additionalProperties": {
                       "type": "string"
@@ -1018,10 +986,25 @@
                   },
                   "nodes": {
                     "default": 1,
-                    "description": "Number of Coyote nodes. Should be odd for quorum (1, 3, 5...).",
+                    "description": "Number of Coyote nodes. Should be an odd number.",
                     "format": "int32",
                     "minimum": 1.0,
                     "type": "integer"
+                  },
+                  "opentelemetryAddress": {
+                    "description": "The OpenTelemetry address to send events to if given.\n\nCurrently only GRPC exports are supported.",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "opentelemetryMetricsAddress": {
+                    "description": "The OpenTelemetry address to send metrics to if given.\n\nIf not specified, the server will attempt to fall back\nto `opentelemetry_address`.",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "opentelemetryMetricsUseHttp": {
+                    "description": "Send OpenTelemetry metrics via HTTP.\n\nBy default, `opentelemetry_address` and `opentelemetry_metrics_address`\nare expected to be a GRPC servers. When this is set to true,\nHTTP is used instead for metrics exports.",
+                    "nullable": true,
+                    "type": "boolean"
                   },
                   "podAnnotations": {
                     "additionalProperties": {
@@ -1121,7 +1104,7 @@
                         "type": "object"
                       },
                       "persistent": {
-                        "description": "Persistent database storage (fjall persistent DB).",
+                        "description": "Persistent database storage",
                         "properties": {
                           "size": {
                             "description": "Storage size, e.g. \"10Gi\".",

--- a/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
+++ b/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
@@ -986,7 +986,7 @@
                   },
                   "nodes": {
                     "default": 1,
-                    "description": "Number of Coyote nodes. Should be an odd number.",
+                    "description": "Number of Coyote nodes.\n\nShould be an odd number. Recommended value is 3, or 1 if you want only a single node.",
                     "format": "int32",
                     "minimum": 1.0,
                     "type": "integer"

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -3,7 +3,7 @@
 
 use k8s_openapi::{
     api::core::v1::{
-        Affinity, EnvVar, ResourceRequirements, SecretKeySelector, Toleration,
+        Affinity, EnvVar, EnvVarSource, ResourceRequirements, SecretKeySelector, Toleration,
         TopologySpreadConstraint,
     },
     apimachinery::pkg::api::resource::Quantity,
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 pub(crate) const DEFAULT_API_PORT: u16 = 8080;
+pub(crate) const INTRACLUSTER_PORT: u16 = 18080;
 
 fn default_api_port() -> u16 {
     DEFAULT_API_PORT
@@ -47,10 +48,9 @@ fn default_topology_spread_constraints() -> Vec<TopologySpreadConstraint> {
     printcolumn = r#"{"name":"Ready","type":"integer","jsonPath":".status.readyReplicas"}"#
 )]
 pub(crate) struct CoyoteClusterSpec {
-    /// Number of Coyote nodes. Should be odd for quorum (1, 3, 5...).
-    #[serde(default = "default_nodes")]
-    #[schemars(schema_with = "nodes_schema")]
-    pub nodes: i32,
+    /// Cluster/replication configuration.
+    #[serde(flatten)]
+    pub coyote: CoyoteSpec,
 
     /// Container image to deploy.
     pub image: String,
@@ -59,26 +59,9 @@ pub(crate) struct CoyoteClusterSpec {
     #[serde(default)]
     pub image_pull_policy: Option<String>,
 
-    /// Storage configuration.
-    pub storage: StorageSpec,
-
-    /// Cluster/replication configuration.
-    #[serde(default)]
-    pub cluster: ClusterSpec,
-
     /// Configuration for the externally-facing Service.
     #[serde(default)]
     pub service: ServiceSpec,
-
-    /// Port for the external API. The inter-node port is this value + 10000.
-    #[serde(default = "default_api_port")]
-    pub api_port: u16,
-
-    /// Additional environment variables to inject into pods.
-    /// Follows the Kubernetes EnvVar API spec (v1.EnvVar): supports plain `value`
-    /// and `valueFrom` (secretKeyRef, configMapKeyRef, fieldRef, resourceFieldRef)
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub env_var: Vec<EnvVar>,
 
     /// CPU and memory resource requests and limits for the coyote container.
     #[serde(default)]
@@ -87,12 +70,6 @@ pub(crate) struct CoyoteClusterSpec {
     /// Additional annotations to add to pods.
     #[serde(default)]
     pub pod_annotations: BTreeMap<String, String>,
-
-    /// Bootstrap script to run on cluster startup.
-    /// Currently a YAML file defining namespaces to pre-create; may become a shell script in future.
-    /// Mounted into pods and passed to the server via COYOTE_BOOTSTRAP_CFG_PATH.
-    #[serde(default)]
-    pub bootstrap: Option<String>,
 
     /// Topology spread constraints for pod scheduling.
     ///
@@ -116,18 +93,12 @@ pub(crate) struct CoyoteClusterSpec {
     /// Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity).
     #[serde(default)]
     pub affinity: Option<Affinity>,
-
-    /// Admin token for privileged API access.
-    /// Set either `value` for a plain string or `valueFrom` to pull from a Kubernetes Secret.
-    /// Using a plain string value is only recommended for testing. Use `valueFrom` in all other cases.
-    #[serde(default)]
-    pub admin_token: Option<AdminTokenSource>,
 }
 
 /// Storage configuration for a Coyote cluster.
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
-pub(crate) struct StorageSpec {
-    /// Persistent database storage (fjall persistent DB).
+pub(crate) struct CoyoteStorageSpec {
+    /// Persistent database storage
     pub persistent: VolumeSpec,
 
     // TODO: ephemeral DB storage — fjall ephemeral DB
@@ -156,43 +127,74 @@ pub(crate) struct VolumeSpec {
     pub storage_class: Option<String>,
 }
 
-/// Cluster/replication configuration.
-#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
+/// Coyote configuration.
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct ClusterSpec {
-    /// Reference to a Secret containing the inter-node authentication token.
-    /// `name` is the name of the Kubernetes Secret.
-    /// `key` is the key within the Secret whose value is the token.
-    #[serde(default)]
-    pub secret_ref: Option<SecretKeySelector>,
+pub(crate) struct CoyoteSpec {
+    /// Number of Coyote nodes. Should be an odd number.
+    #[serde(default = "default_nodes")]
+    #[schemars(schema_with = "nodes_schema")]
+    pub nodes: i32,
 
-    /// Heartbeat interval in milliseconds.
-    #[serde(default)]
-    pub heartbeat_interval_ms: Option<u64>,
+    /// Port for the external API and service.
+    #[serde(default = "default_api_port")]
+    pub api_port: u16,
 
-    /// Minimum election timeout in milliseconds.
+    /// Inter-node authentication token.
+    ///
+    /// Set either `value` for a plain string or `valueFrom` to pull from a Kubernetes Secret.
+    /// Using a plain string value is only recommended for testing. Use `valueFrom` in all other cases.
     #[serde(default)]
-    pub election_timeout_min_ms: Option<u64>,
+    pub internode_secret: Option<ValueOrSecretRef>,
 
-    /// Maximum election timeout in milliseconds.
-    #[serde(default)]
-    pub election_timeout_max_ms: Option<u64>,
-
-    /// Replication request timeout in milliseconds.
-    #[serde(default)]
-    pub replication_request_timeout_ms: Option<u64>,
-
-    /// Trigger a background snapshot after this many writes.
-    #[serde(default)]
-    pub snapshot_after_writes: Option<u32>,
-
-    /// Trigger a background snapshot after this many milliseconds.
-    #[serde(default)]
-    pub snapshot_after_ms: Option<u64>,
-
-    /// Log level (info, debug, trace). Defaults to info.
+    /// The log level to run the service with. Supported: info, debug, trace
     #[serde(default)]
     pub log_level: Option<String>,
+
+    /// The log format that all output will follow. Supported: default, json
+    #[serde(default)]
+    pub log_format: Option<String>,
+
+    /// The OpenTelemetry address to send events to if given.
+    ///
+    /// Currently only GRPC exports are supported.
+    #[serde(default)]
+    pub opentelemetry_address: Option<String>,
+
+    /// The OpenTelemetry address to send metrics to if given.
+    ///
+    /// If not specified, the server will attempt to fall back
+    /// to `opentelemetry_address`.
+    #[serde(default)]
+    pub opentelemetry_metrics_address: Option<String>,
+
+    /// Send OpenTelemetry metrics via HTTP.
+    ///
+    /// By default, `opentelemetry_address` and `opentelemetry_metrics_address`
+    /// are expected to be a GRPC servers. When this is set to true,
+    /// HTTP is used instead for metrics exports.
+    #[serde(default)]
+    pub opentelemetry_metrics_use_http: Option<bool>,
+
+    /// Newline-delimited bootstrap script to run on cluster startup.
+    #[serde(default)]
+    pub bootstrap: Option<String>,
+
+    /// Admin token for privileged API access.
+    ///
+    /// Set either `value` for a plain string or `valueFrom` to pull from a Kubernetes Secret.
+    /// Using a plain string value is only recommended for testing. Use `valueFrom` in all other cases.
+    #[serde(default)]
+    pub admin_token: Option<ValueOrSecretRef>,
+
+    /// Additional environment variables to inject into pods.
+    /// Follows the Kubernetes EnvVar API spec (v1.EnvVar): supports plain `value`
+    /// and `valueFrom` (secretKeyRef, configMapKeyRef, fieldRef, resourceFieldRef)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_var: Vec<EnvVar>,
+
+    /// Storage configuration.
+    pub storage: CoyoteStorageSpec,
 }
 
 /// Configuration for the client-facing Service.
@@ -230,7 +232,7 @@ pub(crate) enum Phase {
 /// Set either `value` for a plain string or `valueFrom` to reference a Kubernetes Secret.
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(untagged)]
-pub(crate) enum AdminTokenSource {
+pub(crate) enum ValueOrSecretRef {
     Value {
         value: String,
     },
@@ -240,9 +242,23 @@ pub(crate) enum AdminTokenSource {
     },
 }
 
-impl CoyoteClusterSpec {
-    pub(crate) fn cluster_port(&self) -> u16 {
-        self.api_port + 10000
+impl ValueOrSecretRef {
+    pub(crate) fn to_env_var(&self, name: &str) -> EnvVar {
+        match self {
+            ValueOrSecretRef::Value { value } => EnvVar {
+                name: name.into(),
+                value: Some(value.clone()),
+                ..Default::default()
+            },
+            ValueOrSecretRef::ValueFrom { value_from } => EnvVar {
+                name: name.into(),
+                value_from: Some(EnvVarSource {
+                    secret_key_ref: Some(value_from.clone()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        }
     }
 }
 

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -131,7 +131,9 @@ pub(crate) struct VolumeSpec {
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CoyoteSpec {
-    /// Number of Coyote nodes. Should be an odd number.
+    /// Number of Coyote nodes.
+    ///
+    /// Should be an odd number. Recommended value is 3, or 1 if you want only a single node.
     #[serde(default = "default_nodes")]
     #[schemars(schema_with = "nodes_schema")]
     pub nodes: i32,

--- a/infra/operator/src/reconciler.rs
+++ b/infra/operator/src/reconciler.rs
@@ -69,7 +69,7 @@ pub(crate) async fn reconcile(cluster: Arc<CoyoteCluster>, ctx: Arc<Context>) ->
         .await?;
 
     // PodDisruptionBudget (only meaningful for nodes > 1)
-    if cluster.spec.nodes > 1 {
+    if cluster.spec.coyote.nodes > 1 {
         let pdb_api: Api<PodDisruptionBudget> = Api::namespaced(client.clone(), &ns);
         let pdb = resources::pdb::build(&cluster, &ns)?;
         pdb_api
@@ -99,7 +99,7 @@ async fn update_status(cluster: &CoyoteCluster, client: &Client, ns: &str) -> Re
                 .as_ref()
                 .and_then(|s| s.ready_replicas)
                 .unwrap_or(0);
-            let desired = cluster.spec.nodes;
+            let desired = cluster.spec.coyote.nodes;
             let phase = if ready == desired {
                 Phase::Running
             } else if ready == 0 {

--- a/infra/operator/src/resources/pdb.rs
+++ b/infra/operator/src/resources/pdb.rs
@@ -8,7 +8,7 @@ use crate::{crd::CoyoteCluster, error::Result, labels};
 
 pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<PodDisruptionBudget> {
     let cluster_name = cluster.name_any();
-    let replicas = cluster.spec.nodes;
+    let replicas = cluster.spec.coyote.nodes;
 
     // Require a strict majority to be available at all times, which maintains quorum.
     let min_available = (replicas / 2) + 1;

--- a/infra/operator/src/resources/services.rs
+++ b/infra/operator/src/resources/services.rs
@@ -21,7 +21,7 @@ pub(crate) fn client_name(cluster_name: &str) -> String {
 pub(crate) fn build_headless(cluster: &CoyoteCluster, ns: &str) -> Result<Service> {
     let cluster_name = cluster.name_any();
     let spec = &cluster.spec;
-    let cluster_port = spec.api_port + 10000;
+    let cluster_port = spec.coyote.api_port + 10000;
 
     Ok(Service {
         metadata: ObjectMeta {
@@ -38,8 +38,8 @@ pub(crate) fn build_headless(cluster: &CoyoteCluster, ns: &str) -> Result<Servic
             ports: Some(vec![
                 ServicePort {
                     name: Some("api".into()),
-                    port: spec.api_port as i32,
-                    target_port: Some(IntOrString::Int(spec.api_port as i32)),
+                    port: spec.coyote.api_port as i32,
+                    target_port: Some(IntOrString::Int(spec.coyote.api_port as i32)),
                     ..Default::default()
                 },
                 ServicePort {
@@ -86,8 +86,8 @@ pub(crate) fn build_client(cluster: &CoyoteCluster, ns: &str) -> Result<Service>
             traffic_distribution: Some("PreferSameZone".into()),
             ports: Some(vec![ServicePort {
                 name: Some("api".into()),
-                port: spec.api_port as i32,
-                target_port: Some(IntOrString::Int(spec.api_port as i32)),
+                port: spec.coyote.api_port as i32,
+                target_port: Some(IntOrString::Int(spec.coyote.api_port as i32)),
                 ..Default::default()
             }]),
             ..Default::default()

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -17,7 +17,7 @@ use k8s_openapi::{
 use kube::{Resource, ResourceExt, core::ObjectMeta};
 
 use crate::{
-    crd::{AdminTokenSource, CoyoteCluster, CoyoteClusterSpec},
+    crd::{CoyoteCluster, CoyoteClusterSpec, INTRACLUSTER_PORT},
     error::Result,
     labels,
     resources::services,
@@ -82,7 +82,7 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<StatefulSet> {
             ..Default::default()
         },
         spec: Some(StatefulSetSpec {
-            replicas: Some(spec.nodes),
+            replicas: Some(spec.coyote.nodes),
             service_name: Some(headless_svc),
             selector: LabelSelector {
                 match_labels: Some(labels::selector(&cluster_name)),
@@ -113,7 +113,7 @@ fn build_env(
     headless_svc: &str,
     ns: &str,
 ) -> Vec<EnvVar> {
-    let cluster_port = spec.cluster_port();
+    let intracluster_port = INTRACLUSTER_PORT;
 
     // These must come before any vars that reference them via $(VAR) substitution.
     let mut env: Vec<EnvVar> = vec![
@@ -124,12 +124,20 @@ fn build_env(
         // Uses k8s env var substitution: $(VAR) references earlier vars in this list.
         env_var(
             "COYOTE_CLUSTER_ADVERTISED_ADDRESS",
-            format!("$(POD_NAME).{headless_svc}.$(POD_NAMESPACE).svc.cluster.local:{cluster_port}"),
+            format!(
+                "$(POD_NAME).{headless_svc}.$(POD_NAMESPACE).svc.cluster.local:{intracluster_port}"
+            ),
         ),
         // Seed nodes: all pods in the StatefulSet by their stable DNS names.
         env_var(
             "COYOTE_CLUSTER_SEED_NODES",
-            seed_nodes_value(cluster_name, headless_svc, ns, spec.nodes, cluster_port),
+            seed_nodes_value(
+                cluster_name,
+                headless_svc,
+                ns,
+                spec.coyote.nodes,
+                intracluster_port,
+            ),
         ),
         // Allow any pod to initialize a new cluster if it can't find peers and has no state.
         // StatefulSets start pods sequentially (pod-0 first), so in practice pod-0 initializes
@@ -137,28 +145,16 @@ fn build_env(
         env_var("COYOTE_CLUSTER_AUTO_INITIALIZE", "true"),
         env_var(
             "COYOTE_LISTEN_ADDRESS",
-            format!("0.0.0.0:{}", spec.api_port),
+            format!("0.0.0.0:{}", spec.coyote.api_port),
         ),
         env_var("COYOTE_PERSISTENT_DB_PATH", PERSISTENT_DATA_PATH),
     ];
-
-    // Inter-node secret, if configured.
-    if let Some(secret_ref) = &spec.cluster.secret_ref {
-        env.push(EnvVar {
-            name: "COYOTE_CLUSTER_SECRET".into(),
-            value_from: Some(EnvVarSource {
-                secret_key_ref: Some(secret_ref.clone()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        });
-    }
 
     // Always set log and snapshot paths explicitly to avoid the Dockerfile defaults, which point
     // to ephemeral storage and cause crashes on pod restart if Raft references a missing snapshot.
     env.push(env_var(
         "COYOTE_CLUSTER_LOG_PATH",
-        if spec.storage.logs.is_some() {
+        if spec.coyote.storage.logs.is_some() {
             LOGS_DATA_PATH.into()
         } else {
             format!("{PERSISTENT_DATA_PATH}/logs")
@@ -166,75 +162,52 @@ fn build_env(
     ));
     env.push(env_var(
         "COYOTE_CLUSTER_SNAPSHOT_PATH",
-        if spec.storage.snapshots.is_some() {
+        if spec.coyote.storage.snapshots.is_some() {
             SNAPSHOTS_DATA_PATH.into()
         } else {
             format!("{PERSISTENT_DATA_PATH}/snapshots")
         },
     ));
 
-    // Optional cluster tuning parameters.
-    push_opt_env(
-        &mut env,
-        "COYOTE_CLUSTER_HEARTBEAT_INTERVAL_MS",
-        spec.cluster.heartbeat_interval_ms,
-    );
-    push_opt_env(
-        &mut env,
-        "COYOTE_CLUSTER_ELECTION_TIMEOUT_MIN_MS",
-        spec.cluster.election_timeout_min_ms,
-    );
-    push_opt_env(
-        &mut env,
-        "COYOTE_CLUSTER_ELECTION_TIMEOUT_MAX_MS",
-        spec.cluster.election_timeout_max_ms,
-    );
-    push_opt_env(
-        &mut env,
-        "COYOTE_CLUSTER_REPLICATION_REQUEST_TIMEOUT_MS",
-        spec.cluster.replication_request_timeout_ms,
-    );
-    push_opt_env(
-        &mut env,
-        "COYOTE_SNAPSHOT_AFTER_WRITES",
-        spec.cluster.snapshot_after_writes,
-    );
-    push_opt_env(
-        &mut env,
-        "COYOTE_CLUSTER_SNAPSHOT_AFTER_MS",
-        spec.cluster.snapshot_after_ms,
-    );
-
-    if let Some(level) = &spec.cluster.log_level {
+    if let Some(level) = &spec.coyote.log_level {
         env.push(env_var("COYOTE_LOG_LEVEL", level));
     }
 
-    if let Some(bootstrap) = &spec.bootstrap {
+    if let Some(format) = &spec.coyote.log_format {
+        env.push(env_var("COYOTE_LOG_FORMAT", format));
+    }
+
+    if let Some(addr) = &spec.coyote.opentelemetry_address {
+        env.push(env_var("COYOTE_OPENTELEMETRY_ADDRESS", addr));
+    }
+
+    if let Some(addr) = &spec.coyote.opentelemetry_metrics_address {
+        env.push(env_var("COYOTE_OPENTELEMETRY_METRICS_ADDRESS", addr));
+    }
+
+    if let Some(use_http) = spec.coyote.opentelemetry_metrics_use_http {
+        env.push(env_var(
+            "COYOTE_OPENTELEMETRY_METRICS_USE_HTTP",
+            use_http.to_string(),
+        ));
+    }
+
+    if let Some(bootstrap) = &spec.coyote.bootstrap {
         env.push(env_var("COYOTE_BOOTSTRAP_CFG", bootstrap));
     }
 
     // Extra user-provided env vars.
-    env.extend(spec.env_var.iter().cloned());
+    env.extend(spec.coyote.env_var.iter().cloned());
 
-    // Admin token is pushed last so spec.admin_token always takes precedence over
-    // any COYOTE_ADMIN_TOKEN set via spec.env_var. If both are set, the spec.env_var
-    // value is silently shadowed.
-    if let Some(admin_token) = &spec.admin_token {
-        match admin_token {
-            AdminTokenSource::Value { value } => env.push(EnvVar {
-                name: "COYOTE_ADMIN_TOKEN".into(),
-                value: Some(value.clone()),
-                ..Default::default()
-            }),
-            AdminTokenSource::ValueFrom { value_from } => env.push(EnvVar {
-                name: "COYOTE_ADMIN_TOKEN".into(),
-                value_from: Some(EnvVarSource {
-                    secret_key_ref: Some(value_from.clone()),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }),
-        }
+    // The rest will shadow any manually applied env vars with
+    // the same name.
+
+    if let Some(admin_token) = &spec.coyote.admin_token {
+        env.push(admin_token.to_env_var("COYOTE_ADMIN_TOKEN"));
+    }
+
+    if let Some(internode_secret) = &spec.coyote.internode_secret {
+        env.push(internode_secret.to_env_var("COYOTE_CLUSTER_SECRET"));
     }
 
     env
@@ -245,7 +218,7 @@ fn build_container(
     env: Vec<EnvVar>,
     volume_mounts: Vec<VolumeMount>,
 ) -> Container {
-    let cluster_port = spec.cluster_port();
+    let intracluster_port = INTRACLUSTER_PORT;
     const API_HEALTH_ENDPOINT: &str = "/api/v1.health.ping";
     const CLUSTER_HEALTH_ENDPOINT: &str = "/repl/health";
 
@@ -258,12 +231,12 @@ fn build_container(
         ports: Some(vec![
             ContainerPort {
                 name: Some("api".into()),
-                container_port: spec.api_port as i32,
+                container_port: spec.coyote.api_port as i32,
                 ..Default::default()
             },
             ContainerPort {
                 name: Some("cluster".into()),
-                container_port: cluster_port as i32,
+                container_port: intracluster_port as i32,
                 ..Default::default()
             },
         ]),
@@ -272,7 +245,7 @@ fn build_container(
         liveness_probe: Some(Probe {
             http_get: Some(HTTPGetAction {
                 path: Some(API_HEALTH_ENDPOINT.into()),
-                port: IntOrString::Int(spec.api_port as _),
+                port: IntOrString::Int(spec.coyote.api_port as _),
                 ..Default::default()
             }),
             initial_delay_seconds: Some(5),
@@ -284,7 +257,7 @@ fn build_container(
         readiness_probe: Some(Probe {
             http_get: Some(HTTPGetAction {
                 path: Some(CLUSTER_HEALTH_ENDPOINT.into()),
-                port: IntOrString::Int(cluster_port as _),
+                port: IntOrString::Int(intracluster_port as _),
                 ..Default::default()
             }),
             initial_delay_seconds: Some(15),
@@ -296,7 +269,7 @@ fn build_container(
         startup_probe: Some(Probe {
             http_get: Some(HTTPGetAction {
                 path: Some(CLUSTER_HEALTH_ENDPOINT.into()),
-                port: IntOrString::Int(cluster_port as _),
+                port: IntOrString::Int(intracluster_port as _),
                 ..Default::default()
             }),
             initial_delay_seconds: Some(15),
@@ -312,11 +285,11 @@ fn build_container(
 fn build_volume_claim_templates(spec: &CoyoteClusterSpec) -> Vec<PersistentVolumeClaim> {
     let mut templates = vec![pvc_template(
         "persistent",
-        &spec.storage.persistent.size,
-        spec.storage.persistent.storage_class.as_deref(),
+        &spec.coyote.storage.persistent.size,
+        spec.coyote.storage.persistent.storage_class.as_deref(),
     )];
 
-    if let Some(logs) = &spec.storage.logs {
+    if let Some(logs) = &spec.coyote.storage.logs {
         templates.push(pvc_template(
             "logs",
             &logs.size,
@@ -324,7 +297,7 @@ fn build_volume_claim_templates(spec: &CoyoteClusterSpec) -> Vec<PersistentVolum
         ));
     }
 
-    if let Some(snapshots) = &spec.storage.snapshots {
+    if let Some(snapshots) = &spec.coyote.storage.snapshots {
         templates.push(pvc_template(
             "snapshots",
             &snapshots.size,
@@ -342,7 +315,7 @@ fn build_volume_mounts(spec: &CoyoteClusterSpec) -> Vec<VolumeMount> {
         ..Default::default()
     }];
 
-    if spec.storage.logs.is_some() {
+    if spec.coyote.storage.logs.is_some() {
         mounts.push(VolumeMount {
             name: "logs".into(),
             mount_path: LOGS_DATA_PATH.into(),
@@ -350,7 +323,7 @@ fn build_volume_mounts(spec: &CoyoteClusterSpec) -> Vec<VolumeMount> {
         });
     }
 
-    if spec.storage.snapshots.is_some() {
+    if spec.coyote.storage.snapshots.is_some() {
         mounts.push(VolumeMount {
             name: "snapshots".into(),
             mount_path: SNAPSHOTS_DATA_PATH.into(),
@@ -382,12 +355,6 @@ fn env_from_field(name: &str, field_path: &str) -> EnvVar {
             ..Default::default()
         }),
         ..Default::default()
-    }
-}
-
-fn push_opt_env(env: &mut Vec<EnvVar>, name: &str, value: Option<impl ToString>) {
-    if let Some(v) = value {
-        env.push(env_var(name, v.to_string()));
     }
 }
 

--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -29,19 +29,14 @@ cluster:
       persistent:
         size: 64Gi
         storageClass: gp3-encrypted
+    logLevel: debug
+    logFormat: json
+    opentelemetryAddress: grpc://datadog-agent.datadog.svc.cluster.local:4317
+    opentelemetryMetricsAddress: "http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090/api/v1/otlp/v1/metrics"
+    opentelemetryMetricsUseHttp: true
     envVar:
-      - name: COYOTE_OPENTELEMETRY_METRICS_ADDRESS
-        value: "http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090/api/v1/otlp/v1/metrics"
-      - name: COYOTE_OPENTELEMETRY_METRICS_USE_HTTP
-        value: "true"
-      - name: COYOTE_LOG_LEVEL
-        value: debug
       - name: RUST_BACKTRACE
         value: "1"
-      - name: COYOTE_LOG_FORMAT
-        value: "json"
-      - name: COYOTE_OPENTELEMETRY_ADDRESS
-        value: grpc://datadog-agent.datadog.svc.cluster.local:4317
     nodeSelector:
       db-name: coyote
     tolerations:

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -468,17 +468,21 @@ pub struct ConfigurationInner {
     pub log_format: LogFormat,
 
     /// The OpenTelemetry address to send events to if given.
+    ///
+    /// Currently only GRPC exports are supported.
     pub opentelemetry_address: Option<String>,
 
     /// The OpenTelemetry address to send metrics to if given.
     ///
     /// If not specified, the server will attempt to fall back
-    /// to `opentelemetry_address`
+    /// to `opentelemetry_address`.
     pub opentelemetry_metrics_address: Option<String>,
 
-    /// By default, `opentelemetry_address` is expected to be a GRPC server.
+    /// Send OpenTelemetry metrics via HTTP.
     ///
-    /// When this is set to true, HTTP is used instead.
+    /// By default, `opentelemetry_address` and `opentelemetry_metrics_address`
+    /// are expected to be a GRPC servers. When this is set to true,
+    /// HTTP is used instead for metrics exports.
     #[serde(default)]
     pub opentelemetry_metrics_use_http: bool,
 


### PR DESCRIPTION
While working on the README, I decided to try and simplify the configurable fields that the CRD exposes. A lot of the cluster-specific config params that were added initially don't need to be first-class items in the CRD for now, so I've removed them entirely. They can still be added as env vars if they need to be overridden.

Otherwise, I've tried to reorganize how the cluster spec is defined in the CRD to better isolate Coyote-specific configurations (currently in the `CoyoteSpec` struct) from more general k8s things like pod affinities and resource requests/limits.

The README has been updated with the relevant fields that the operator and CRD expose directly. I think this is a good start at something that's publicly shareable.