### PR TITLE
Auth: implement support for JWT tokens.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "jiff",
+ "jsonwebtoken",
  "maplit",
  "openraft",
  "opentelemetry",
@@ -2964,6 +2965,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,10 +3371,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -4993,6 +5028,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ idna_adapter.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 jiff.workspace = true
+jsonwebtoken.workspace = true
 maplit.workspace = true
 openraft.workspace = true
 opentelemetry.workspace = true
@@ -176,6 +177,7 @@ idna_adapter = "=1.1.0"
 indexmap = "2.6.0"
 itertools = "0.14"
 jiff = { version = "0.2.18", features = ["serde"] }
+jsonwebtoken = "9"
 k8s-openapi = { version = "0.27.1", features = ["v1_31"] }
 kube = { version = "3.0.1", features = ["runtime", "derive", "client"] }
 maplit = "1"

--- a/crates/coyote-authorization/src/lib.rs
+++ b/crates/coyote-authorization/src/lib.rs
@@ -176,6 +176,8 @@ pub struct Permissions {
     pub auth_token_id: Option<AuthTokenId>,
     /// The access rules of the requester's role
     pub access_rules: Arc<[AccessRule]>,
+    /// Arbitrary key-value context forwarded from JWT claims (empty for non-JWT auth)
+    pub context: HashMap<String, String>,
 }
 
 impl Permissions {
@@ -188,6 +190,7 @@ impl Permissions {
             role: RoleId::admin(),
             auth_token_id: None,
             access_rules: AccessRule::admin_rules(),
+            context: HashMap::new(),
         }
     }
 
@@ -200,6 +203,7 @@ impl Permissions {
             role: RoleId::operator(),
             auth_token_id: None,
             access_rules: AccessRule::operator_rules(),
+            context: HashMap::new(),
         }
     }
 }

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -320,6 +320,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         bootstrap_cfg: None,
         bootstrap_cfg_path: None,
         admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
+        jwt: None,
     }
 }
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -553,6 +553,7 @@ pub struct ConfigurationInner {
     /// (object with string values) that is forwarded to internal coyote handlers.
     #[serde(default)]
     #[env_overridable(skip)]
+    #[validate(nested)]
     pub jwt: Option<JwtConfig>,
 }
 
@@ -566,17 +567,19 @@ pub struct ConfigurationInner {
 /// The optional `audience` and `issuer` fields enable claim validation.  When
 /// omitted, the respective claims are not checked (and may be absent from the
 /// token).
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Validate)]
 pub struct JwtConfig {
     #[serde(flatten)]
     pub key: JwtKey,
     /// Expected `aud` values. When set, the token must contain one of these
     /// values in its `aud` claim. When absent, `aud` is not validated.
     #[serde(default)]
+    #[validate(length(min = 1, message = "audience must not be empty when set"))]
     pub audience: Option<Vec<String>>,
     /// Expected `iss` values. When set, the token's `iss` claim must match one
     /// of these values. When absent, `iss` is not validated.
     #[serde(default)]
+    #[validate(length(min = 1, message = "issuer must not be empty when set"))]
     pub issuer: Option<Vec<String>>,
 }
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -545,6 +545,67 @@ pub struct ConfigurationInner {
     #[validate(custom(function = "validators::validate_admin_token"))]
     #[serde(default)]
     pub admin_token: Option<String>,
+
+    /// Configuration for verifying JWT bearer tokens.
+    ///
+    /// When set, bearer tokens in JWT format are verified using this configuration.
+    /// The JWT must contain a `role` claim (string) and may contain a `context` claim
+    /// (object with string values) that is forwarded to internal coyote handlers.
+    #[serde(default)]
+    #[env_overridable(skip)]
+    pub jwt: Option<JwtConfig>,
+}
+
+/// JWT configuration for verifying JWT bearer tokens.
+///
+/// The `algorithm` field selects the signature scheme:
+/// - Symmetric (`HS256`, `HS384`, `HS512`) — requires `secret`.
+/// - Asymmetric (`RS256`/`RS384`/`RS512`, `ES256`/`ES384`, `PS256`/`PS384`/`PS512`) —
+///   requires `public_key_pem`.
+///
+/// The optional `audience` and `issuer` fields enable claim validation.  When
+/// omitted, the respective claims are not checked (and may be absent from the
+/// token).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JwtConfig {
+    #[serde(flatten)]
+    pub key: JwtKey,
+    /// Expected `aud` values. When set, the token must contain one of these
+    /// values in its `aud` claim. When absent, `aud` is not validated.
+    #[serde(default)]
+    pub audience: Option<Vec<String>>,
+    /// Expected `iss` values. When set, the token's `iss` claim must match one
+    /// of these values. When absent, `iss` is not validated.
+    #[serde(default)]
+    pub issuer: Option<Vec<String>>,
+}
+
+/// Signature algorithm and corresponding key material.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "algorithm")]
+pub enum JwtKey {
+    #[serde(rename = "HS256")]
+    Hs256 { secret: String },
+    #[serde(rename = "HS384")]
+    Hs384 { secret: String },
+    #[serde(rename = "HS512")]
+    Hs512 { secret: String },
+    #[serde(rename = "RS256")]
+    Rs256 { public_key_pem: String },
+    #[serde(rename = "RS384")]
+    Rs384 { public_key_pem: String },
+    #[serde(rename = "RS512")]
+    Rs512 { public_key_pem: String },
+    #[serde(rename = "ES256")]
+    Es256 { public_key_pem: String },
+    #[serde(rename = "ES384")]
+    Es384 { public_key_pem: String },
+    #[serde(rename = "PS256")]
+    Ps256 { public_key_pem: String },
+    #[serde(rename = "PS384")]
+    Ps384 { public_key_pem: String },
+    #[serde(rename = "PS512")]
+    Ps512 { public_key_pem: String },
 }
 
 impl Default for ConfigurationInner {

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use axum::{
     RequestExt,
@@ -16,16 +16,16 @@ use tracing::Span;
 
 use crate::{
     AppState,
-    core::INTERNAL_NAMESPACE,
+    core::{INTERNAL_NAMESPACE, jwt::JwtVerifier},
     v1::endpoints::auth_token::{AuthTokenVerifyIn, AuthTokenVerifyOut},
 };
 use coyote_admin_auth::State as AdminAuthState;
 use coyote_error::{Error, ResultExt};
 
+pub(crate) use coyote_core::fifo_cache::FifoCache;
+
 const AUTH_TOKEN_CACHE_TTL: Duration = Duration::from_secs(1);
 const RULES_CACHE_TTL: Duration = Duration::from_secs(5);
-
-pub(crate) use coyote_core::fifo_cache::FifoCache;
 
 fn constant_time_eq(a: &str, b: &str) -> bool {
     let a = a.as_bytes();
@@ -102,6 +102,28 @@ async fn authorization_inner(
         return Ok(cached);
     }
 
+    // Attempt JWT verification when a JWT verifier is present and the token looks like a JWT.
+    if let Some(jwt_verifier) = &state.jwt_verifier
+        && JwtVerifier::looks_like_jwt(token)
+    {
+        let claims = jwt_verifier
+            .verify(token)
+            .map_err(axum::response::IntoResponse::into_response)?;
+        let role = RoleId(claims.role);
+        let access_rules = resolve_access_rules(&state, &role).await?;
+        let perms = Permissions {
+            role,
+            auth_token_id: None,
+            access_rules,
+            context: claims.context,
+        };
+        state
+            .auth_token_cache
+            .write()
+            .put(token.to_string(), perms.clone());
+        return Ok(perms);
+    }
+
     let verify_out: AuthTokenVerifyOut = state
         .internal_call(
             "v1.auth-token.verify",
@@ -129,6 +151,7 @@ async fn authorization_inner(
         role,
         auth_token_id: Some(auth_token.id.into_inner()),
         access_rules,
+        context: HashMap::new(),
     };
 
     state

--- a/src/core/jwt.rs
+++ b/src/core/jwt.rs
@@ -1,0 +1,105 @@
+use std::collections::HashMap;
+
+use coyote_error::{Result, ResultExt};
+
+use crate::cfg::{JwtConfig, JwtKey};
+
+#[derive(serde::Deserialize)]
+pub(crate) struct JwtClaims {
+    pub(crate) role: String,
+    #[serde(default)]
+    pub(crate) context: HashMap<String, String>,
+}
+
+/// Pre-parsed JWT key and validation settings, built once at startup from [`JwtConfig`].
+#[derive(Clone)]
+pub(crate) struct JwtVerifier {
+    key: jsonwebtoken::DecodingKey,
+    validation: jsonwebtoken::Validation,
+}
+
+impl JwtVerifier {
+    pub(crate) fn try_new(cfg: &JwtConfig) -> Result<Self> {
+        use jsonwebtoken::{Algorithm, DecodingKey, Validation};
+
+        let (algorithm, key) = match &cfg.key {
+            JwtKey::Hs256 { secret } => (
+                Algorithm::HS256,
+                DecodingKey::from_secret(secret.as_bytes()),
+            ),
+            JwtKey::Hs384 { secret } => (
+                Algorithm::HS384,
+                DecodingKey::from_secret(secret.as_bytes()),
+            ),
+            JwtKey::Hs512 { secret } => (
+                Algorithm::HS512,
+                DecodingKey::from_secret(secret.as_bytes()),
+            ),
+            JwtKey::Rs256 { public_key_pem } => (
+                Algorithm::RS256,
+                DecodingKey::from_rsa_pem(public_key_pem.as_bytes()).or_internal_error()?,
+            ),
+            JwtKey::Rs384 { public_key_pem } => (
+                Algorithm::RS384,
+                DecodingKey::from_rsa_pem(public_key_pem.as_bytes()).or_internal_error()?,
+            ),
+            JwtKey::Rs512 { public_key_pem } => (
+                Algorithm::RS512,
+                DecodingKey::from_rsa_pem(public_key_pem.as_bytes()).or_internal_error()?,
+            ),
+            JwtKey::Es256 { public_key_pem } => (
+                Algorithm::ES256,
+                DecodingKey::from_ec_pem(public_key_pem.as_bytes()).or_internal_error()?,
+            ),
+            JwtKey::Es384 { public_key_pem } => (
+                Algorithm::ES384,
+                DecodingKey::from_ec_pem(public_key_pem.as_bytes()).or_internal_error()?,
+            ),
+            JwtKey::Ps256 { public_key_pem } => (
+                Algorithm::PS256,
+                DecodingKey::from_rsa_pem(public_key_pem.as_bytes()).or_internal_error()?,
+            ),
+            JwtKey::Ps384 { public_key_pem } => (
+                Algorithm::PS384,
+                DecodingKey::from_rsa_pem(public_key_pem.as_bytes()).or_internal_error()?,
+            ),
+            JwtKey::Ps512 { public_key_pem } => (
+                Algorithm::PS512,
+                DecodingKey::from_rsa_pem(public_key_pem.as_bytes()).or_internal_error()?,
+            ),
+        };
+
+        let mut validation = Validation::new(algorithm);
+        // Validate `nbf` (not-before) when present in the token.
+        validation.validate_nbf = true;
+        // Only validate `aud` when expected audiences are configured; otherwise
+        // disable it so tokens with an `aud` claim are still accepted.
+        match &cfg.audience {
+            Some(aud) => {
+                validation.set_audience(aud);
+                // Require the claim to be present, not just valid when present.
+                validation.required_spec_claims.insert("aud".to_string());
+            }
+            None => validation.validate_aud = false,
+        }
+        if let Some(iss) = &cfg.issuer {
+            validation.set_issuer(iss);
+            // Require the claim to be present, not just valid when present.
+            validation.required_spec_claims.insert("iss".to_string());
+        }
+
+        Ok(Self { key, validation })
+    }
+
+    /// Returns `true` if `token` has the three-part `header.payload.signature` structure of a JWT.
+    pub(crate) fn looks_like_jwt(token: &str) -> bool {
+        token.bytes().filter(|&b| b == b'.').count() == 2
+    }
+
+    pub(crate) fn verify(&self, token: &str) -> Result<JwtClaims> {
+        use coyote_error::Error;
+        jsonwebtoken::decode::<JwtClaims>(token, &self.key, &self.validation)
+            .map(|t| t.claims)
+            .map_err(|_| Error::authentication("invalid_token", "Invalid JWT token."))
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod auth;
 pub mod cluster;
+pub mod jwt;
 pub mod metrics;
 pub mod otel_spans;
 pub mod retry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ pub struct AppState {
 
     pub(crate) auth_token_cache: Arc<parking_lot::RwLock<core::auth::FifoCache<Permissions>>>,
     pub(crate) rules_cache: Arc<parking_lot::RwLock<core::auth::FifoCache<Arc<[AccessRule]>>>>,
+    pub(crate) jwt_verifier: Option<core::jwt::JwtVerifier>,
 
     pub(crate) time: Monotime,
 
@@ -259,6 +260,10 @@ impl AppState {
             Arc::new(parking_lot::RwLock::new(core::auth::FifoCache::new(10_000)));
         let rules_cache = Arc::new(parking_lot::RwLock::new(core::auth::FifoCache::new(1_000)));
 
+        let jwt_verifier = cfg.jwt.as_ref().map(|jwt_cfg| {
+            core::jwt::JwtVerifier::try_new(jwt_cfg).expect("invalid JWT configuration")
+        });
+
         AppState {
             cfg,
             namespace_state,
@@ -268,6 +273,7 @@ impl AppState {
             internal_client,
             auth_token_cache,
             rules_cache,
+            jwt_verifier,
             time,
             topic_publish_notifier: TopicPublishNotifier::new(),
         }

--- a/tests/it/jwt_auth.rs
+++ b/tests/it/jwt_auth.rs
@@ -1,0 +1,502 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use jsonwebtoken::{EncodingKey, Header, encode};
+use serde::Serialize;
+use serde_json::json;
+use test_utils::{StatusCode, TestClient, TestResult, server::TestServerBuilder};
+
+use coyote::cfg::{JwtConfig, JwtKey};
+
+const JWT_SECRET: &str = "test-jwt-secret-do-not-use-in-production";
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn hs256_cfg() -> JwtConfig {
+    JwtConfig {
+        key: JwtKey::Hs256 {
+            secret: JWT_SECRET.to_string(),
+        },
+        audience: None,
+        issuer: None,
+    }
+}
+
+fn make_jwt(claims: impl Serialize) -> String {
+    encode(
+        &Header::default(), // HS256
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .unwrap()
+}
+
+/// Start a server with JWT enabled and a role that can read/write the default KV namespace.
+async fn setup() -> (test_utils::server::TestContext, String) {
+    let ctx = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| cfg.jwt = Some(hs256_cfg()))
+        .build()
+        .await;
+
+    ctx.client
+        .post("v1.admin.auth-role.upsert")
+        .json(json!({
+            "id": "jwt-kv-role",
+            "description": "KV read/write role used in JWT tests",
+            "rules": [
+                { "effect": "allow", "resource": "kv:*:*", "actions": ["*"] }
+            ],
+        }))
+        .await
+        .unwrap()
+        .ensure(StatusCode::OK)
+        .unwrap();
+
+    let base_uri = ctx.client.base_uri.clone();
+    (ctx, base_uri)
+}
+
+#[tokio::test]
+async fn test_jwt_valid_token() -> TestResult {
+    let (_ctx, base_uri) = setup().await;
+
+    let token = make_jwt(json!({
+        "role": "jwt-kv-role",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(base_uri, &token);
+
+    jwt_client
+        .post("v1.kv.set")
+        .json(json!({ "key": "jwt-test", "value": "hello".as_bytes(), "behavior": "upsert" }))
+        .await?
+        .ensure(StatusCode::OK)?;
+
+    let resp = jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "jwt-test" }))
+        .await?
+        .ensure(StatusCode::OK)?
+        .json();
+
+    assert!(!resp["value"].is_null());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_context_forwarded() -> TestResult {
+    // Context claims are accepted without error; the role is what gates access.
+    let (_ctx, base_uri) = setup().await;
+
+    let token = make_jwt(json!({
+        "role": "jwt-kv-role",
+        "context": { "team": "platform", "env": "test" },
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(base_uri, &token);
+
+    jwt_client
+        .post("v1.kv.set")
+        .json(json!({ "key": "jwt-ctx-test", "value": "hi".as_bytes(), "behavior": "upsert" }))
+        .await?
+        .ensure(StatusCode::OK)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_expired_token() -> TestResult {
+    let (_ctx, base_uri) = setup().await;
+
+    // exp 100s in the past, well beyond the 60s leeway
+    let token = make_jwt(json!({
+        "role": "jwt-kv-role",
+        "exp": now_secs() - 100,
+    }));
+    let jwt_client = TestClient::new(base_uri, &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_nbf_in_future() -> TestResult {
+    let (_ctx, base_uri) = setup().await;
+
+    // nbf 1 hour in the future, well beyond the 60s leeway
+    let token = make_jwt(json!({
+        "role": "jwt-kv-role",
+        "exp": now_secs() + 7200,
+        "nbf": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(base_uri, &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_missing_exp() -> TestResult {
+    let (_ctx, base_uri) = setup().await;
+
+    // No `exp` claim — must be rejected because exp is required
+    let token = make_jwt(json!({ "role": "jwt-kv-role" }));
+    let jwt_client = TestClient::new(base_uri, &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_invalid_signature() -> TestResult {
+    let (_ctx, base_uri) = setup().await;
+
+    let token = encode(
+        &Header::default(),
+        &json!({
+            "role": "jwt-kv-role",
+            "exp": now_secs() + 3600,
+        }),
+        &EncodingKey::from_secret(b"wrong-secret"),
+    )
+    .unwrap();
+    let jwt_client = TestClient::new(base_uri, &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_not_used_when_unconfigured() -> TestResult {
+    // Without JWT config, a JWT-shaped token should be treated as a regular
+    // auth token and fail with 401 (not a valid auth token).
+    let ctx = TestServerBuilder::with_default_config().build().await;
+
+    let token = make_jwt(json!({
+        "role": "jwt-kv-role",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(ctx.client.base_uri.clone(), &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_audience_valid() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.jwt = Some(JwtConfig {
+                key: JwtKey::Hs256 {
+                    secret: JWT_SECRET.to_string(),
+                },
+                audience: Some(vec!["https://api.example.com".to_string()]),
+                issuer: None,
+            })
+        })
+        .build()
+        .await;
+
+    ctx.client
+        .post("v1.admin.auth-role.upsert")
+        .json(json!({
+            "id": "jwt-aud-role",
+            "description": "Audience test role",
+            "rules": [{ "effect": "allow", "resource": "kv:*:*", "actions": ["*"] }],
+        }))
+        .await?
+        .ensure(StatusCode::OK)?;
+
+    let token = make_jwt(json!({
+        "role": "jwt-aud-role",
+        "aud": "https://api.example.com",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(ctx.client.base_uri.clone(), &token);
+
+    jwt_client
+        .post("v1.kv.set")
+        .json(json!({ "key": "aud-test", "value": "ok".as_bytes(), "behavior": "upsert" }))
+        .await?
+        .ensure(StatusCode::OK)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_audience_mismatch() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.jwt = Some(JwtConfig {
+                key: JwtKey::Hs256 {
+                    secret: JWT_SECRET.to_string(),
+                },
+                audience: Some(vec!["https://api.example.com".to_string()]),
+                issuer: None,
+            })
+        })
+        .build()
+        .await;
+
+    let token = make_jwt(json!({
+        "role": "any-role",
+        "aud": "https://other.example.com",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(ctx.client.base_uri.clone(), &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_audience_not_required_when_unconfigured() -> TestResult {
+    // When no audience is configured, tokens with or without an `aud` claim
+    // should both be accepted (aud validation is disabled).
+    let (_ctx, base_uri) = setup().await;
+
+    // Token with an aud claim — should still work since we don't configure an audience.
+    let token = make_jwt(json!({
+        "role": "jwt-kv-role",
+        "aud": "https://anything.example.com",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(base_uri, &token);
+
+    jwt_client
+        .post("v1.kv.set")
+        .json(json!({ "key": "aud-unconfigured", "value": "ok".as_bytes(), "behavior": "upsert" }))
+        .await?
+        .ensure(StatusCode::OK)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_audience_missing_when_required() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.jwt = Some(JwtConfig {
+                key: JwtKey::Hs256 {
+                    secret: JWT_SECRET.to_string(),
+                },
+                audience: Some(vec!["https://api.example.com".to_string()]),
+                issuer: None,
+            })
+        })
+        .build()
+        .await;
+
+    // Token has no `aud` claim but the config requires one.
+    let token = make_jwt(json!({
+        "role": "any-role",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(ctx.client.base_uri.clone(), &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_multiple_audiences() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.jwt = Some(JwtConfig {
+                key: JwtKey::Hs256 {
+                    secret: JWT_SECRET.to_string(),
+                },
+                audience: Some(vec![
+                    "https://api.example.com".to_string(),
+                    "https://api2.example.com".to_string(),
+                ]),
+                issuer: None,
+            })
+        })
+        .build()
+        .await;
+
+    ctx.client
+        .post("v1.admin.auth-role.upsert")
+        .json(json!({
+            "id": "jwt-multi-aud-role",
+            "description": "Multi-audience test role",
+            "rules": [{ "effect": "allow", "resource": "kv:*:*", "actions": ["*"] }],
+        }))
+        .await?
+        .ensure(StatusCode::OK)?;
+
+    let base_uri = ctx.client.base_uri.clone();
+
+    // Either configured audience value should be accepted.
+    for aud in ["https://api.example.com", "https://api2.example.com"] {
+        let token = make_jwt(json!({
+            "role": "jwt-multi-aud-role",
+            "aud": aud,
+            "exp": now_secs() + 3600,
+        }));
+        TestClient::new(base_uri.clone(), &token)
+            .post("v1.kv.set")
+            .json(
+                json!({ "key": "multi-aud-test", "value": "ok".as_bytes(), "behavior": "upsert" }),
+            )
+            .await?
+            .ensure(StatusCode::OK)?;
+    }
+
+    // An audience not in the configured list must be rejected.
+    let token = make_jwt(json!({
+        "role": "jwt-multi-aud-role",
+        "aud": "https://unlisted.example.com",
+        "exp": now_secs() + 3600,
+    }));
+    TestClient::new(base_uri, &token)
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_issuer_valid() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.jwt = Some(JwtConfig {
+                key: JwtKey::Hs256 {
+                    secret: JWT_SECRET.to_string(),
+                },
+                audience: None,
+                issuer: Some(vec!["https://auth.example.com".to_string()]),
+            })
+        })
+        .build()
+        .await;
+
+    ctx.client
+        .post("v1.admin.auth-role.upsert")
+        .json(json!({
+            "id": "jwt-iss-role",
+            "description": "Issuer test role",
+            "rules": [{ "effect": "allow", "resource": "kv:*:*", "actions": ["*"] }],
+        }))
+        .await?
+        .ensure(StatusCode::OK)?;
+
+    let token = make_jwt(json!({
+        "role": "jwt-iss-role",
+        "iss": "https://auth.example.com",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(ctx.client.base_uri.clone(), &token);
+
+    jwt_client
+        .post("v1.kv.set")
+        .json(json!({ "key": "iss-test", "value": "ok".as_bytes(), "behavior": "upsert" }))
+        .await?
+        .ensure(StatusCode::OK)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_issuer_mismatch() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.jwt = Some(JwtConfig {
+                key: JwtKey::Hs256 {
+                    secret: JWT_SECRET.to_string(),
+                },
+                audience: None,
+                issuer: Some(vec!["https://auth.example.com".to_string()]),
+            })
+        })
+        .build()
+        .await;
+
+    let token = make_jwt(json!({
+        "role": "any-role",
+        "iss": "https://evil.example.com",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(ctx.client.base_uri.clone(), &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jwt_issuer_missing_when_required() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.jwt = Some(JwtConfig {
+                key: JwtKey::Hs256 {
+                    secret: JWT_SECRET.to_string(),
+                },
+                audience: None,
+                issuer: Some(vec!["https://auth.example.com".to_string()]),
+            })
+        })
+        .build()
+        .await;
+
+    // Token has no `iss` claim but the config requires one.
+    let token = make_jwt(json!({
+        "role": "any-role",
+        "exp": now_secs() + 3600,
+    }));
+    let jwt_client = TestClient::new(ctx.client.base_uri.clone(), &token);
+
+    jwt_client
+        .post("v1.kv.get")
+        .json(json!({ "key": "any" }))
+        .await?
+        .ensure(StatusCode::UNAUTHORIZED)?;
+
+    Ok(())
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -3,6 +3,7 @@ mod auth_token;
 mod bootstrap;
 mod cache;
 mod idempotency;
+mod jwt_auth;
 mod kv;
 mod msgpack;
 mod msgs;


### PR DESCRIPTION
We verify exp, nbf (when there), and aud/iss (when configured). We support all common signature schemes.

I can see how it would maybe make sense to only validate aud/iss when set in the JWT but ignore when unset. Though at the moment we require these fields to be set, and set to one of the values we require.

Fixes #133