### PR TITLE
Idempotency: add support for request context + update docs

### DIFF
--- a/crates/idempotency/src/lib.rs
+++ b/crates/idempotency/src/lib.rs
@@ -13,7 +13,7 @@ pub mod operations;
 
 use std::time::Duration;
 
-use coyote_core::Monotime;
+use coyote_core::{Monotime, types::Metadata};
 use coyote_error::Result;
 use coyote_kv::kvcontroller::KvController;
 use coyote_namespace::{Namespace, entities::IdempotencyConfig};
@@ -31,7 +31,11 @@ pub(crate) enum IdempotencyState {
     /// Request is in progress (locked)
     InProgress,
     /// Request completed successfully with a response
-    Completed { response: Vec<u8> },
+    Completed {
+        response: Vec<u8>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context: Option<Metadata>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -39,7 +43,11 @@ pub(crate) enum IdempotencyState {
 pub enum IdempotencyStartResult {
     Started,
     Locked,
-    Completed { response: Vec<u8> },
+    Completed {
+        response: Vec<u8>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context: Option<Metadata>,
+    },
 }
 
 impl From<IdempotencyState> for Vec<u8> {

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -1,6 +1,6 @@
 use super::{CompleteResponse, IdempotencyRaftState, IdempotencyRequest};
 use crate::{IdempotencyNamespace, IdempotencyState};
-use coyote_core::types::DurationMs;
+use coyote_core::types::{DurationMs, Metadata};
 use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
@@ -12,6 +12,8 @@ pub struct CompleteOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,
     pub(crate) response: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) context: Option<Metadata>,
     #[serde(rename = "ttl_ms")]
     pub(crate) ttl: DurationMs,
 }
@@ -21,12 +23,14 @@ impl CompleteOperation {
         namespace: IdempotencyNamespace,
         key: String,
         response: Vec<u8>,
+        context: Option<Metadata>,
         ttl: DurationMs,
     ) -> Self {
         Self {
             namespace_id: namespace.id,
             key,
             response,
+            context,
             ttl,
         }
     }
@@ -49,6 +53,7 @@ impl CompleteOperation {
                 KvModelIn {
                     value: IdempotencyState::Completed {
                         response: self.response,
+                        context: self.context,
                     }
                     .into(),
                     expiry: Some(expiry),

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -68,8 +68,8 @@ impl TryStartOperation {
                 let idem_state: IdempotencyState = kv_model.value.into();
                 let result = match idem_state {
                     IdempotencyState::InProgress => IdempotencyStartResult::Locked,
-                    IdempotencyState::Completed { response } => {
-                        IdempotencyStartResult::Completed { response }
+                    IdempotencyState::Completed { response, context } => {
+                        IdempotencyStartResult::Completed { response, context }
                     }
                 };
                 Ok(TryStartResponseData { result })

--- a/docs/content/modules/idempotency.mdx
+++ b/docs/content/modules/idempotency.mdx
@@ -78,7 +78,7 @@ match client.idempotency()
     }
     IdempotencyStartOut::Completed(cached) => {
         // A previous call already finished. Return the cached response.
-        return cached;
+        return cached.response;
     }
 }
 ```
@@ -94,10 +94,14 @@ let success_retention_period = Duration::from_hours(12);
 
 client.idempotency().complete(
     idem_key.clone(),
-    IdempotencyCompleteIn::new(result, success_retention_period),
+    IdempotencyCompleteIn::new(result, success_retention_period)
+        .with_context(Some(extra_data)),
 )
 .await?;
 ```
+
+Context allows you to store additional key-value pairs of information attached to the request. A common pattern is to store the `status_code` and optionally `headers` of a request.
+You can use multiple context keys, or just serialize a full JSON object into one key.
 
 ## Aborting an idempotency request (`idempotency.abort`)
 
@@ -158,6 +162,8 @@ fn middleware() {
 }
 ```
 
+See the [Middleware examples](#middleware-examples) section below for examples for various frameworks.
+
 ### Emulating success vs. returning a 409 conflict
 
 There are two main ways to handle idempotency: emulating a successful request on retries vs. returning a 409 conflict.
@@ -170,3 +176,264 @@ The alternative is to return a `409 (Conflict)` HTTP status code, indicating a c
 ### Storing headers, response status codes, etc.
 
 For simplicity, the examples above only showed how to store the response body for successful idempotency requests. But you can also use the response field in `idempotency.complete` to store the response headers and status code of the original request, making sure you return exactly the same response in case your API utilizes those.
+
+
+## Middleware examples
+
+Below are example middleware implementations for common web frameworks. Each example reads the `Idempotency-Key` header, drives the idempotency state machine, and stores the response body so retries get an identical reply.
+
+### Rust (Axum)
+
+```rust
+use std::time::Duration;
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use coyote_client::{
+    CoyoteClient,
+    models::{IdempotencyAbortIn, IdempotencyCompleteIn, IdempotencyStartIn, IdempotencyStartOut},
+};
+
+pub async fn idempotency_middleware(
+    State(coyote): State<CoyoteClient>,
+    req: Request<Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    // Skip requests without an idempotency key
+    let Some(idem_key) = req
+        .headers()
+        .get("idempotency-key")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+    else {
+        return Ok(next.run(req).await);
+    };
+
+    let lock_period = Duration::from_secs(15);
+
+    match coyote
+        .idempotency()
+        .start(idem_key.clone(), IdempotencyStartIn::new(lock_period))
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    {
+        IdempotencyStartOut::Started => {
+            let response = next.run(req).await;
+
+            if !response.status().is_success() {
+                // Release the lock so the caller can retry
+                let _ = coyote
+                    .idempotency()
+                    .abort(idem_key, IdempotencyAbortIn::new())
+                    .await;
+                return Ok(response);
+            }
+
+            // Buffer the body so we can cache it and still return it
+            let (parts, body) = response.into_parts();
+            let body_bytes = axum::body::to_bytes(body, usize::MAX)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+            let mut context = std::collections::HashMap::new();
+            context.insert("status_code".to_owned(), parts.status.as_u16().to_string());
+            // You can also store response headers here as additional entries, e.g.:
+            // context.insert("x-request-id".to_owned(), header_value);
+
+            let retention = Duration::from_secs(12 * 3600);
+            let _ = coyote
+                .idempotency()
+                .complete(
+                    idem_key,
+                    IdempotencyCompleteIn::new(body_bytes.to_vec(), retention)
+                        .with_context(Some(context)),
+                )
+                .await;
+
+            Ok(Response::from_parts(parts, Body::from(body_bytes)))
+        }
+        IdempotencyStartOut::Locked => {
+            // A concurrent request with the same key is in flight
+            Err(StatusCode::LOCKED)
+        }
+        IdempotencyStartOut::Completed(cached) => {
+            let status = cached.context
+                .as_ref()
+                .and_then(|m| m.get("status_code"))
+                .and_then(|s| s.parse::<u16>().ok())
+                .and_then(|c| StatusCode::from_u16(c).ok())
+                .unwrap_or(StatusCode::OK);
+            Ok(Response::builder()
+                .status(status)
+                .body(Body::from(cached.response))
+                .unwrap())
+        }
+    }
+}
+```
+
+Register the middleware when building your Axum router:
+
+```rust
+use axum::middleware;
+
+let app = Router::new()
+    .route("/charge", post(charge_handler))
+    .layer(middleware::from_fn_with_state(coyote_client, idempotency_middleware));
+```
+
+### Python (FastAPI)
+
+```python
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from coyote import CoyoteAsync
+from coyote.models import IdempotencyAbortIn, IdempotencyCompleteIn, IdempotencyStartIn
+
+
+class IdempotencyMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, coyote: CoyoteAsync) -> None:
+        super().__init__(app)
+        self.coyote = coyote
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        idem_key = request.headers.get("idempotency-key")
+        if idem_key is None:
+            return await call_next(request)
+
+        result = await self.coyote.idempotency.start(
+            idem_key,
+            IdempotencyStartIn(lock_period_ms=15_000),
+        )
+
+        if result.status == "started":
+            response = await call_next(request)
+            # Buffer the body — body_iterator is consumed once
+            body = b"".join([chunk async for chunk in response.body_iterator])
+
+            if response.status_code >= 400:
+                # Release the lock so the caller can retry
+                await self.coyote.idempotency.abort(idem_key, IdempotencyAbortIn())
+                return Response(
+                    content=body,
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                )
+
+            context = {"status_code": str(response.status_code)}
+            # You can also store response headers here as additional entries, e.g.:
+            # context["x-request-id"] = response.headers.get("x-request-id", "")
+
+            retention_ms = 12 * 60 * 60 * 1000  # 12 hours
+            await self.coyote.idempotency.complete(
+                idem_key,
+                IdempotencyCompleteIn(response=body, ttl_ms=retention_ms, context=context),
+            )
+
+            return Response(
+                content=body,
+                status_code=response.status_code,
+                headers=dict(response.headers),
+            )
+
+        elif result.status == "locked":
+            # A concurrent request with the same key is in flight
+            return Response(status_code=423)
+
+        else:  # completed
+            ctx = result.data.context or {}
+            return Response(
+                content=result.data.response,
+                status_code=int(ctx.get("status_code", "200")),
+            )
+```
+
+Register the middleware when creating your FastAPI app:
+
+```python
+from coyote import CoyoteAsync
+from fastapi import FastAPI
+
+coyote = CoyoteAsync(token="...")
+app = FastAPI()
+app.add_middleware(IdempotencyMiddleware, coyote=coyote)
+```
+
+### JavaScript (Next.js)
+
+Next.js does have a `middleware.ts` file, but it runs on the Edge Runtime which doesn't support arbitrary Node.js packages. App Router API routes also don't have a built-in middleware chain, so the idiomatic pattern is a higher-order function that wraps each handler:
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { Coyote } from "coyote";
+
+const coyote = new Coyote(process.env.COYOTE_TOKEN!);
+
+type RouteHandler = (req: NextRequest) => Promise<NextResponse>;
+
+export function withIdempotency(handler: RouteHandler): RouteHandler {
+  return async (req: NextRequest): Promise<NextResponse> => {
+    const idemKey = req.headers.get("idempotency-key");
+    if (!idemKey) {
+      return handler(req);
+    }
+
+    const result = await coyote.idempotency.start(idemKey, { lock_start_ms: 15_000 });
+
+    if (result.status === "started") {
+      const response = await handler(req);
+      const body = await response.arrayBuffer();
+
+      if (!response.ok) {
+        // Release the lock so the caller can retry
+        await coyote.idempotency.abort(idemKey, {});
+        return new NextResponse(body, {
+          status: response.status,
+          headers: response.headers,
+        });
+      }
+
+      const context: Record<string, string> = { status_code: String(response.status) };
+      // You can also store response headers here as additional entries, e.g.:
+      // context["x-request-id"] = response.headers.get("x-request-id") ?? "";
+
+      const retentionMs = 12 * 60 * 60 * 1000; // 12 hours
+      await coyote.idempotency.complete(idemKey, {
+        response: Array.from(new Uint8Array(body)),
+        context,
+        ttlMs: retentionMs,
+      });
+
+      return new NextResponse(body, {
+        status: response.status,
+        headers: response.headers,
+      });
+    } else if (result.status === "locked") {
+      // A concurrent request with the same key is in flight
+      return new NextResponse(null, { status: 423 });
+    } else {
+      // completed — return the cached response
+      const statusCode = parseInt(result.data.context?.status_code ?? "200", 10);
+      return new NextResponse(Buffer.from(result.data.response), {
+        status: statusCode,
+      });
+    }
+  };
+}
+```
+
+Apply the wrapper to any route handler that needs idempotency:
+
+```typescript
+// app/api/charge/route.ts
+import { withIdempotency } from "@/lib/idempotency";
+
+export const POST = withIdempotency(async (req) => {
+  // ... your handler logic
+});

--- a/openapi.json
+++ b/openapi.json
@@ -6152,6 +6152,15 @@
               "maximum": 255
             }
           },
+          "context": {
+            "description": "Optional metadata to store alongside the response",
+            "type": "object",
+            "default": null,
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
           "ttl_ms": {
             "description": "How long to keep the idempotency response for.",
             "type": "integer",
@@ -6182,6 +6191,13 @@
               "minimum": 0,
               "maximum": 255
             }
+          },
+          "context": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
           }
         },
         "required": [

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -4,7 +4,7 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_authorization::RequestedOperation;
-use coyote_core::types::{DurationMs, EntityKey};
+use coyote_core::types::{DurationMs, EntityKey, Metadata};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt as _, ResultExt};
 use coyote_id::Module;
@@ -86,6 +86,8 @@ pub enum IdempotencyStartOut {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct IdempotencyCompleted {
     pub response: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<Metadata>,
 }
 
 impl From<IdempotencyStartResult> for IdempotencyStartOut {
@@ -93,8 +95,8 @@ impl From<IdempotencyStartResult> for IdempotencyStartOut {
         match result {
             IdempotencyStartResult::Started => IdempotencyStartOut::Started,
             IdempotencyStartResult::Locked => IdempotencyStartOut::Locked,
-            IdempotencyStartResult::Completed { response } => {
-                IdempotencyStartOut::Completed(IdempotencyCompleted { response })
+            IdempotencyStartResult::Completed { response, context } => {
+                IdempotencyStartOut::Completed(IdempotencyCompleted { response, context })
             }
         }
     }
@@ -111,6 +113,10 @@ pub struct IdempotencyCompleteIn {
 
     /// The response to cache
     pub response: Vec<u8>,
+
+    /// Optional metadata to store alongside the response
+    #[serde(default)]
+    pub context: Option<Metadata>,
 
     /// How long to keep the idempotency response for.
     #[serde(rename = "ttl_ms")]
@@ -172,8 +178,13 @@ async fn idempotency_complete(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let operation =
-        CompleteOperation::new(namespace, data.key.to_string(), data.response, data.ttl);
+    let operation = CompleteOperation::new(
+        namespace,
+        data.key.to_string(),
+        data.response,
+        data.context,
+        data.ttl,
+    );
     repl.client_write(operation).await.or_internal_error()?.0?;
 
     Ok(MsgPackOrJson(IdempotencyCompleteOut {}))

--- a/z-clients/go/internal/apis/idempotency.go
+++ b/z-clients/go/internal/apis/idempotency.go
@@ -52,6 +52,7 @@ func (idempotency Idempotency) Complete(
 		Namespace: idempotencyCompleteIn.Namespace,
 		Key:       key,
 		Response:  idempotencyCompleteIn.Response,
+		Context:   idempotencyCompleteIn.Context,
 		TtlMs:     idempotencyCompleteIn.TtlMs,
 	}
 

--- a/z-clients/go/internal/models/idempotency_complete_in.go
+++ b/z-clients/go/internal/models/idempotency_complete_in.go
@@ -3,14 +3,16 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type IdempotencyCompleteIn struct {
-	Namespace *string `msgpack:"namespace,omitempty"`
-	Response  []uint8 `msgpack:"response"` // The response to cache
-	TtlMs     uint64  `msgpack:"ttl_ms"`   // How long to keep the idempotency response for.
+	Namespace *string            `msgpack:"namespace,omitempty"`
+	Response  []uint8            `msgpack:"response"`          // The response to cache
+	Context   *map[string]string `msgpack:"context,omitempty"` // Optional metadata to store alongside the response
+	TtlMs     uint64             `msgpack:"ttl_ms"`            // How long to keep the idempotency response for.
 }
 
 type IdempotencyCompleteIn_ struct {
-	Namespace *string `msgpack:"namespace,omitempty"`
-	Key       string  `msgpack:"key"`
-	Response  []uint8 `msgpack:"response"` // The response to cache
-	TtlMs     uint64  `msgpack:"ttl_ms"`   // How long to keep the idempotency response for.
+	Namespace *string            `msgpack:"namespace,omitempty"`
+	Key       string             `msgpack:"key"`
+	Response  []uint8            `msgpack:"response"`          // The response to cache
+	Context   *map[string]string `msgpack:"context,omitempty"` // Optional metadata to store alongside the response
+	TtlMs     uint64             `msgpack:"ttl_ms"`            // How long to keep the idempotency response for.
 }

--- a/z-clients/go/internal/models/idempotency_completed.go
+++ b/z-clients/go/internal/models/idempotency_completed.go
@@ -3,5 +3,6 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type IdempotencyCompleted struct {
-	Response []uint8 `msgpack:"response"`
+	Response []uint8            `msgpack:"response"`
+	Context  *map[string]string `msgpack:"context,omitempty"`
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/Idempotency.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/Idempotency.java
@@ -62,6 +62,7 @@ public class Idempotency {
             idempotencyCompleteIn.getNamespace(),
             key,
             idempotencyCompleteIn.getResponse(),
+            idempotencyCompleteIn.getContext(),
             idempotencyCompleteIn.getTtlMs()
         );
 

--- a/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteIn.java
@@ -30,6 +30,7 @@ import lombok.ToString;
 public class IdempotencyCompleteIn {
     @JsonProperty private String namespace;
     @JsonProperty private List<Byte> response;
+    @JsonProperty private Map<String,String> context;
     @JsonProperty("ttl_ms") private Long ttlMs;
     public IdempotencyCompleteIn() {}
 
@@ -76,6 +77,32 @@ public class IdempotencyCompleteIn {
 
     public void setResponse(List<Byte> response) {
         this.response = response;
+    }
+
+    public IdempotencyCompleteIn context(Map<String,String> context) {
+        this.context = context;
+        return this;
+    }
+
+    public IdempotencyCompleteIn putContextItem(String key, String contextItem) {
+        if (this.context == null) {
+            this.context = new HashMap<>();
+        }
+        this.context.put(key, contextItem);
+        return this;
+    }
+    /**
+    * Optional metadata to store alongside the response
+    *
+     * @return context
+     */
+    @javax.annotation.Nullable
+    public Map<String,String> getContext() {
+        return context;
+    }
+
+    public void setContext(Map<String,String> context) {
+        this.context = context;
     }
 
     public IdempotencyCompleteIn ttlMs(Long ttlMs) {

--- a/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteIn_.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteIn_.java
@@ -26,17 +26,20 @@ public class IdempotencyCompleteIn_ {
     @JsonProperty private String namespace;
     @JsonProperty private String key;
     @JsonProperty private List<Byte> response;
+    @JsonProperty private Map<String,String> context;
     @JsonProperty("ttl_ms") private Long ttlMs;
 
     public IdempotencyCompleteIn_(
         String namespace,
         String key,
         List<Byte> response,
+        Map<String,String> context,
         Long ttlMs
     ) {
         this.namespace = namespace;
         this.key = key;
         this.response = response;
+        this.context = context;
         this.ttlMs = ttlMs;
     }
 

--- a/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleted.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleted.java
@@ -29,6 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class IdempotencyCompleted {
     @JsonProperty private List<Byte> response;
+    @JsonProperty private Map<String,String> context;
     public IdempotencyCompleted() {}
 
     public IdempotencyCompleted response(List<Byte> response) {
@@ -55,6 +56,32 @@ public class IdempotencyCompleted {
 
     public void setResponse(List<Byte> response) {
         this.response = response;
+    }
+
+    public IdempotencyCompleted context(Map<String,String> context) {
+        this.context = context;
+        return this;
+    }
+
+    public IdempotencyCompleted putContextItem(String key, String contextItem) {
+        if (this.context == null) {
+            this.context = new HashMap<>();
+        }
+        this.context.put(key, contextItem);
+        return this;
+    }
+    /**
+    * Get context
+    *
+     * @return context
+     */
+    @javax.annotation.Nullable
+    public Map<String,String> getContext() {
+        return context;
+    }
+
+    public void setContext(Map<String,String> context) {
+        this.context = context;
     }
 
     /**

--- a/z-clients/javascript/src/models/idempotencyCompleteIn.ts
+++ b/z-clients/javascript/src/models/idempotencyCompleteIn.ts
@@ -4,6 +4,8 @@ export interface IdempotencyCompleteIn {
     namespace?: string | null;
     /** The response to cache */
     response: number[];
+    /** Optional metadata to store alongside the response */
+    context?: { [key: string]: string } | null;
     /** How long to keep the idempotency response for. */
     ttlMs: number;
 }
@@ -13,6 +15,8 @@ export interface IdempotencyCompleteIn_ {
     key: string;
     /** The response to cache */
     response: number[];
+    /** Optional metadata to store alongside the response */
+    context?: { [key: string]: string } | null;
     /** How long to keep the idempotency response for. */
     ttlMs: number;
 }
@@ -24,6 +28,7 @@ export const IdempotencyCompleteInSerializer = {
             namespace: object['namespace'],
             key: object['key'],
             response: object['response'],
+            context: object['context'],
             ttlMs: object['ttl_ms'],
         };
     },
@@ -34,6 +39,7 @@ export const IdempotencyCompleteInSerializer = {
             'namespace': self.namespace,
             'key': self.key,
             'response': self.response,
+            'context': self.context,
             'ttl_ms': self.ttlMs,
         };
     }

--- a/z-clients/javascript/src/models/idempotencyCompleted.ts
+++ b/z-clients/javascript/src/models/idempotencyCompleted.ts
@@ -2,6 +2,7 @@
 
 export interface IdempotencyCompleted {
     response: number[];
+    context?: { [key: string]: string } | null;
 }
 
 export const IdempotencyCompletedSerializer = {
@@ -9,6 +10,7 @@ export const IdempotencyCompletedSerializer = {
     _fromJsonObject(object: any): IdempotencyCompleted {
         return {
             response: object['response'],
+            context: object['context'],
         };
     },
 
@@ -16,6 +18,7 @@ export const IdempotencyCompletedSerializer = {
     _toJsonObject(self: IdempotencyCompleted): any {
         return {
             'response': self.response,
+            'context': self.context,
         };
     }
 }

--- a/z-clients/python/coyote/apis/idempotency.py
+++ b/z-clients/python/coyote/apis/idempotency.py
@@ -53,6 +53,7 @@ class IdempotencyAsync(ApiBase):
             namespace=idempotency_complete_in.namespace,
             key=key,
             response=idempotency_complete_in.response,
+            context=idempotency_complete_in.context,
             ttl_ms=idempotency_complete_in.ttl_ms,
         ).model_dump(exclude_none=True)
 
@@ -116,6 +117,7 @@ class Idempotency(ApiBase):
             namespace=idempotency_complete_in.namespace,
             key=key,
             response=idempotency_complete_in.response,
+            context=idempotency_complete_in.context,
             ttl_ms=idempotency_complete_in.ttl_ms,
         ).model_dump(exclude_none=True)
 

--- a/z-clients/python/coyote/models/idempotency_complete_in.py
+++ b/z-clients/python/coyote/models/idempotency_complete_in.py
@@ -1,4 +1,5 @@
 # this file is @generated
+import typing as t
 
 from pydantic import BaseModel
 
@@ -8,6 +9,9 @@ class IdempotencyCompleteIn(BaseModel):
 
     response: bytes
     """The response to cache"""
+
+    context: t.Dict[str, str] | None = None
+    """Optional metadata to store alongside the response"""
 
     ttl_ms: int
     """How long to keep the idempotency response for."""
@@ -20,6 +24,9 @@ class _IdempotencyCompleteIn(BaseModel):
 
     response: bytes
     """The response to cache"""
+
+    context: t.Dict[str, str] | None = None
+    """Optional metadata to store alongside the response"""
 
     ttl_ms: int
     """How long to keep the idempotency response for."""

--- a/z-clients/python/coyote/models/idempotency_completed.py
+++ b/z-clients/python/coyote/models/idempotency_completed.py
@@ -1,7 +1,10 @@
 # this file is @generated
+import typing as t
 
 from pydantic import BaseModel
 
 
 class IdempotencyCompleted(BaseModel):
     response: bytes
+
+    context: t.Dict[str, str] | None = None

--- a/z-clients/rust/src/api/idempotency.rs
+++ b/z-clients/rust/src/api/idempotency.rs
@@ -43,6 +43,7 @@ impl<'a> Idempotency<'a> {
             namespace: idempotency_complete_in.namespace,
             key,
             response: idempotency_complete_in.response,
+            context: idempotency_complete_in.context,
             ttl: idempotency_complete_in.ttl,
         };
 

--- a/z-clients/rust/src/models/idempotency_complete_in.rs
+++ b/z-clients/rust/src/models/idempotency_complete_in.rs
@@ -10,6 +10,10 @@ pub struct IdempotencyCompleteIn {
     #[serde(with = "serde_bytes")]
     pub response: Vec<u8>,
 
+    /// Optional metadata to store alongside the response
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<std::collections::HashMap<String, String>>,
+
     /// How long to keep the idempotency response for.
     #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
@@ -20,12 +24,21 @@ impl IdempotencyCompleteIn {
         Self {
             namespace: None,
             response,
+            context: None,
             ttl,
         }
     }
 
     pub fn with_namespace(mut self, value: impl Into<Option<String>>) -> Self {
         self.namespace = value.into();
+        self
+    }
+
+    pub fn with_context(
+        mut self,
+        value: impl Into<Option<std::collections::HashMap<String, String>>>,
+    ) -> Self {
+        self.context = value.into();
         self
     }
 }
@@ -40,6 +53,10 @@ pub(crate) struct IdempotencyCompleteIn_ {
     /// The response to cache
     #[serde(with = "serde_bytes")]
     pub response: Vec<u8>,
+
+    /// Optional metadata to store alongside the response
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<std::collections::HashMap<String, String>>,
 
     /// How long to keep the idempotency response for.
     #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]

--- a/z-clients/rust/src/models/idempotency_completed.rs
+++ b/z-clients/rust/src/models/idempotency_completed.rs
@@ -5,10 +5,24 @@ use serde::{Deserialize, Serialize};
 pub struct IdempotencyCompleted {
     #[serde(with = "serde_bytes")]
     pub response: Vec<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<std::collections::HashMap<String, String>>,
 }
 
 impl IdempotencyCompleted {
     pub fn new(response: Vec<u8>) -> Self {
-        Self { response }
+        Self {
+            response,
+            context: None,
+        }
+    }
+
+    pub fn with_context(
+        mut self,
+        value: impl Into<Option<std::collections::HashMap<String, String>>>,
+    ) -> Self {
+        self.context = value.into();
+        self
     }
 }


### PR DESCRIPTION
Request context makes it easy to store additional information about the request that can be used by idempotency. For example, you can use it to store response status code and additional headers.

Also update the docs with how to use it and middleware code samples.

Implements one of the ideas in #481