### PR TITLE
Idempotency: rename one of the ttls to lock_period to avoid confusion

### DIFF
--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -11,16 +11,16 @@ use serde::{Deserialize, Serialize};
 pub struct TryStartOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,
-    #[serde(rename = "ttl_ms")]
-    pub(crate) ttl: DurationMs,
+    #[serde(rename = "lock_period_ms")]
+    pub(crate) lock_period: DurationMs,
 }
 
 impl TryStartOperation {
-    pub fn new(namespace: IdempotencyNamespace, key: String, ttl: DurationMs) -> Self {
+    pub fn new(namespace: IdempotencyNamespace, key: String, lock_period: DurationMs) -> Self {
         Self {
             namespace_id: namespace.id,
             key,
-            ttl,
+            lock_period,
         }
     }
 }
@@ -37,7 +37,7 @@ impl TryStartOperation {
         now: Timestamp,
         log_index: u64,
     ) -> Result<TryStartResponseData> {
-        let expiry = now + self.ttl;
+        let expiry = now + self.lock_period;
 
         let controller = state.state.controller();
 

--- a/openapi.json
+++ b/openapi.json
@@ -6076,7 +6076,7 @@
             }
           },
           "ttl_ms": {
-            "description": "TTL in milliseconds for the cached response",
+            "description": "How long to keep the idempotency response for.",
             "type": "integer",
             "format": "uint64",
             "minimum": 1
@@ -6189,8 +6189,8 @@
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
           },
-          "ttl_ms": {
-            "description": "TTL in milliseconds for the lock/response",
+          "lock_period_ms": {
+            "description": "How long to hold the lock on start before releasing it.",
             "type": "integer",
             "format": "uint64",
             "minimum": 1
@@ -6198,7 +6198,7 @@
         },
         "required": [
           "key",
-          "ttl_ms"
+          "lock_period_ms"
         ],
         "x-positional": [
           "key"

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -64,10 +64,10 @@ pub struct IdempotencyStartIn {
     #[validate(nested)]
     pub key: EntityKey,
 
-    /// TTL in milliseconds for the lock/response
-    #[serde(rename = "ttl_ms")]
+    /// How long to hold the lock on start before releasing it.
+    #[serde(rename = "lock_period_ms")]
     #[validate(range(min = 1))]
-    pub ttl: DurationMs,
+    pub lock_period: DurationMs,
 }
 
 request_input!(IdempotencyStartIn, "start");
@@ -112,7 +112,7 @@ pub struct IdempotencyCompleteIn {
     /// The response to cache
     pub response: Vec<u8>,
 
-    /// TTL in milliseconds for the cached response
+    /// How long to keep the idempotency response for.
     #[serde(rename = "ttl_ms")]
     #[validate(range(min = 1))]
     pub ttl: DurationMs,
@@ -154,7 +154,7 @@ async fn idempotency_start(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let operation = TryStartOperation::new(namespace, data.key.to_string(), data.ttl);
+    let operation = TryStartOperation::new(namespace, data.key.to_string(), data.lock_period);
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 
     Ok(MsgPackOrJson(response.result.into()))

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -12,7 +12,7 @@ async fn start(client: &TestClient, key: &str, ttl_ms: u64) -> TestResult<serde_
         .post("v1.idempotency.start")
         .json(json!({
             "key": key,
-            "ttl_ms": ttl_ms
+            "lock_period_ms": ttl_ms
         }))
         .await?
         .expect(StatusCode::OK)
@@ -62,7 +62,7 @@ async fn test_idempotency_start_and_complete() -> TestResult {
         .post("v1.idempotency.start")
         .json(json!({
             "key": "k2",
-            "ttl_ms": 60_000
+            "lock_period_ms": 60_000
         }))
         .await?
         .expect(StatusCode::OK)
@@ -191,7 +191,7 @@ async fn test_idempotency_validation() -> TestResult {
         .post("v1.idempotency.start")
         .json(json!({
             "key": "k",
-            "ttl_ms": 0
+            "lock_period_ms": 0
         }))
         .await?
         .expect(StatusCode::UNPROCESSABLE_ENTITY);

--- a/z-clients/go/internal/apis/idempotency.go
+++ b/z-clients/go/internal/apis/idempotency.go
@@ -28,9 +28,9 @@ func (idempotency Idempotency) Start(
 	idempotencyStartIn coyote_models.IdempotencyStartIn,
 ) (*coyote_models.IdempotencyStartOut, error) {
 	body := coyote_models.IdempotencyStartIn_{
-		Namespace: idempotencyStartIn.Namespace,
-		Key:       key,
-		TtlMs:     idempotencyStartIn.TtlMs,
+		Namespace:    idempotencyStartIn.Namespace,
+		Key:          key,
+		LockPeriodMs: idempotencyStartIn.LockPeriodMs,
 	}
 
 	return coyote_proto.ExecuteRequest[coyote_models.IdempotencyStartIn_, coyote_models.IdempotencyStartOut](

--- a/z-clients/go/internal/models/idempotency_complete_in.go
+++ b/z-clients/go/internal/models/idempotency_complete_in.go
@@ -5,12 +5,12 @@ package coyote_models
 type IdempotencyCompleteIn struct {
 	Namespace *string `msgpack:"namespace,omitempty"`
 	Response  []uint8 `msgpack:"response"` // The response to cache
-	TtlMs     uint64  `msgpack:"ttl_ms"`   // TTL in milliseconds for the cached response
+	TtlMs     uint64  `msgpack:"ttl_ms"`   // How long to keep the idempotency response for.
 }
 
 type IdempotencyCompleteIn_ struct {
 	Namespace *string `msgpack:"namespace,omitempty"`
 	Key       string  `msgpack:"key"`
 	Response  []uint8 `msgpack:"response"` // The response to cache
-	TtlMs     uint64  `msgpack:"ttl_ms"`   // TTL in milliseconds for the cached response
+	TtlMs     uint64  `msgpack:"ttl_ms"`   // How long to keep the idempotency response for.
 }

--- a/z-clients/go/internal/models/idempotency_start_in.go
+++ b/z-clients/go/internal/models/idempotency_start_in.go
@@ -3,12 +3,12 @@ package coyote_models
 // This file is @generated DO NOT EDIT
 
 type IdempotencyStartIn struct {
-	Namespace *string `msgpack:"namespace,omitempty"`
-	TtlMs     uint64  `msgpack:"ttl_ms"` // TTL in milliseconds for the lock/response
+	Namespace    *string `msgpack:"namespace,omitempty"`
+	LockPeriodMs uint64  `msgpack:"lock_period_ms"` // How long to hold the lock on start before releasing it.
 }
 
 type IdempotencyStartIn_ struct {
-	Namespace *string `msgpack:"namespace,omitempty"`
-	Key       string  `msgpack:"key"`
-	TtlMs     uint64  `msgpack:"ttl_ms"` // TTL in milliseconds for the lock/response
+	Namespace    *string `msgpack:"namespace,omitempty"`
+	Key          string  `msgpack:"key"`
+	LockPeriodMs uint64  `msgpack:"lock_period_ms"` // How long to hold the lock on start before releasing it.
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/apis/Idempotency.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/apis/Idempotency.java
@@ -40,7 +40,7 @@ public class Idempotency {
         IdempotencyStartIn_ body = new IdempotencyStartIn_(
             idempotencyStartIn.getNamespace(),
             key,
-            idempotencyStartIn.getTtlMs()
+            idempotencyStartIn.getLockPeriodMs()
         );
 
         return this.client.executeRequest(

--- a/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyCompleteIn.java
@@ -84,7 +84,7 @@ public class IdempotencyCompleteIn {
     }
 
     /**
-    * TTL in milliseconds for the cached response
+    * How long to keep the idempotency response for.
     *
      * @return ttlMs
      */

--- a/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartIn.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartIn.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class IdempotencyStartIn {
     @JsonProperty private String namespace;
-    @JsonProperty("ttl_ms") private Long ttlMs;
+    @JsonProperty("lock_period_ms") private Long lockPeriodMs;
     public IdempotencyStartIn() {}
 
     public IdempotencyStartIn namespace(String namespace) {
@@ -51,22 +51,22 @@ public class IdempotencyStartIn {
         this.namespace = namespace;
     }
 
-    public IdempotencyStartIn ttlMs(Long ttlMs) {
-        this.ttlMs = ttlMs;
+    public IdempotencyStartIn lockPeriodMs(Long lockPeriodMs) {
+        this.lockPeriodMs = lockPeriodMs;
         return this;
     }
 
     /**
-    * TTL in milliseconds for the lock/response
+    * How long to hold the lock on start before releasing it.
     *
-     * @return ttlMs
+     * @return lockPeriodMs
      */
     @javax.annotation.Nonnull
-    public Long getTtlMs() {
-        return ttlMs;
+    public Long getLockPeriodMs() {
+        return lockPeriodMs;
     }
 
-    public void setTtlMs(Long ttlMs) {
-        this.ttlMs = ttlMs;
+    public void setLockPeriodMs(Long lockPeriodMs) {
+        this.lockPeriodMs = lockPeriodMs;
     }
 }

--- a/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartIn_.java
+++ b/z-clients/java/src/main/java/com/svix/coyote/models/IdempotencyStartIn_.java
@@ -25,16 +25,16 @@ import java.util.Objects;
 public class IdempotencyStartIn_ {
     @JsonProperty private String namespace;
     @JsonProperty private String key;
-    @JsonProperty("ttl_ms") private Long ttlMs;
+    @JsonProperty("lock_period_ms") private Long lockPeriodMs;
 
     public IdempotencyStartIn_(
         String namespace,
         String key,
-        Long ttlMs
+        Long lockPeriodMs
     ) {
         this.namespace = namespace;
         this.key = key;
-        this.ttlMs = ttlMs;
+        this.lockPeriodMs = lockPeriodMs;
     }
 
     /**

--- a/z-clients/javascript/src/models/idempotencyCompleteIn.ts
+++ b/z-clients/javascript/src/models/idempotencyCompleteIn.ts
@@ -4,7 +4,7 @@ export interface IdempotencyCompleteIn {
     namespace?: string | null;
     /** The response to cache */
     response: number[];
-    /** TTL in milliseconds for the cached response */
+    /** How long to keep the idempotency response for. */
     ttlMs: number;
 }
 
@@ -13,7 +13,7 @@ export interface IdempotencyCompleteIn_ {
     key: string;
     /** The response to cache */
     response: number[];
-    /** TTL in milliseconds for the cached response */
+    /** How long to keep the idempotency response for. */
     ttlMs: number;
 }
 

--- a/z-clients/javascript/src/models/idempotencyStartIn.ts
+++ b/z-clients/javascript/src/models/idempotencyStartIn.ts
@@ -2,15 +2,15 @@
 
 export interface IdempotencyStartIn {
     namespace?: string | null;
-    /** TTL in milliseconds for the lock/response */
-    ttlMs: number;
+    /** How long to hold the lock on start before releasing it. */
+    lockPeriodMs: number;
 }
 
 export interface IdempotencyStartIn_ {
     namespace?: string | null;
     key: string;
-    /** TTL in milliseconds for the lock/response */
-    ttlMs: number;
+    /** How long to hold the lock on start before releasing it. */
+    lockPeriodMs: number;
 }
 
 export const IdempotencyStartInSerializer = {
@@ -19,7 +19,7 @@ export const IdempotencyStartInSerializer = {
         return {
             namespace: object['namespace'],
             key: object['key'],
-            ttlMs: object['ttl_ms'],
+            lockPeriodMs: object['lock_period_ms'],
         };
     },
 
@@ -28,7 +28,7 @@ export const IdempotencyStartInSerializer = {
         return {
             'namespace': self.namespace,
             'key': self.key,
-            'ttl_ms': self.ttlMs,
+            'lock_period_ms': self.lockPeriodMs,
         };
     }
 }

--- a/z-clients/python/coyote/apis/idempotency.py
+++ b/z-clients/python/coyote/apis/idempotency.py
@@ -33,7 +33,7 @@ class IdempotencyAsync(ApiBase):
         body = _IdempotencyStartIn(
             namespace=idempotency_start_in.namespace,
             key=key,
-            ttl_ms=idempotency_start_in.ttl_ms,
+            lock_period_ms=idempotency_start_in.lock_period_ms,
         ).model_dump(exclude_none=True)
 
         return await self._request_asyncio(
@@ -96,7 +96,7 @@ class Idempotency(ApiBase):
         body = _IdempotencyStartIn(
             namespace=idempotency_start_in.namespace,
             key=key,
-            ttl_ms=idempotency_start_in.ttl_ms,
+            lock_period_ms=idempotency_start_in.lock_period_ms,
         ).model_dump(exclude_none=True)
 
         return self._request_sync(

--- a/z-clients/python/coyote/models/idempotency_complete_in.py
+++ b/z-clients/python/coyote/models/idempotency_complete_in.py
@@ -10,7 +10,7 @@ class IdempotencyCompleteIn(BaseModel):
     """The response to cache"""
 
     ttl_ms: int
-    """TTL in milliseconds for the cached response"""
+    """How long to keep the idempotency response for."""
 
 
 class _IdempotencyCompleteIn(BaseModel):
@@ -22,4 +22,4 @@ class _IdempotencyCompleteIn(BaseModel):
     """The response to cache"""
 
     ttl_ms: int
-    """TTL in milliseconds for the cached response"""
+    """How long to keep the idempotency response for."""

--- a/z-clients/python/coyote/models/idempotency_start_in.py
+++ b/z-clients/python/coyote/models/idempotency_start_in.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel
 class IdempotencyStartIn(BaseModel):
     namespace: str | None = None
 
-    ttl_ms: int
-    """TTL in milliseconds for the lock/response"""
+    lock_period_ms: int
+    """How long to hold the lock on start before releasing it."""
 
 
 class _IdempotencyStartIn(BaseModel):
@@ -15,5 +15,5 @@ class _IdempotencyStartIn(BaseModel):
 
     key: str
 
-    ttl_ms: int
-    """TTL in milliseconds for the lock/response"""
+    lock_period_ms: int
+    """How long to hold the lock on start before releasing it."""

--- a/z-clients/rust/src/api/idempotency.rs
+++ b/z-clients/rust/src/api/idempotency.rs
@@ -24,7 +24,7 @@ impl<'a> Idempotency<'a> {
         let idempotency_start_in = IdempotencyStartIn_ {
             namespace: idempotency_start_in.namespace,
             key,
-            ttl: idempotency_start_in.ttl,
+            lock_period: idempotency_start_in.lock_period,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1.idempotency.start")

--- a/z-clients/rust/src/models/idempotency_complete_in.rs
+++ b/z-clients/rust/src/models/idempotency_complete_in.rs
@@ -10,7 +10,7 @@ pub struct IdempotencyCompleteIn {
     #[serde(with = "serde_bytes")]
     pub response: Vec<u8>,
 
-    /// TTL in milliseconds for the cached response
+    /// How long to keep the idempotency response for.
     #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
 }
@@ -41,7 +41,7 @@ pub(crate) struct IdempotencyCompleteIn_ {
     #[serde(with = "serde_bytes")]
     pub response: Vec<u8>,
 
-    /// TTL in milliseconds for the cached response
+    /// How long to keep the idempotency response for.
     #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
     pub ttl: std::time::Duration,
 }

--- a/z-clients/rust/src/models/idempotency_start_in.rs
+++ b/z-clients/rust/src/models/idempotency_start_in.rs
@@ -6,16 +6,16 @@ pub struct IdempotencyStartIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 
-    /// TTL in milliseconds for the lock/response
-    #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
-    pub ttl: std::time::Duration,
+    /// How long to hold the lock on start before releasing it.
+    #[serde(rename = "lock_period_ms", with = "crate::duration_ms_serde")]
+    pub lock_period: std::time::Duration,
 }
 
 impl IdempotencyStartIn {
-    pub fn new(ttl: std::time::Duration) -> Self {
+    pub fn new(lock_period: std::time::Duration) -> Self {
         Self {
             namespace: None,
-            ttl,
+            lock_period,
         }
     }
 
@@ -32,7 +32,7 @@ pub(crate) struct IdempotencyStartIn_ {
 
     pub key: String,
 
-    /// TTL in milliseconds for the lock/response
-    #[serde(rename = "ttl_ms", with = "crate::duration_ms_serde")]
-    pub ttl: std::time::Duration,
+    /// How long to hold the lock on start before releasing it.
+    #[serde(rename = "lock_period_ms", with = "crate::duration_ms_serde")]
+    pub lock_period: std::time::Duration,
 }


### PR DESCRIPTION
We had two TTLs which was very confusing. Now we just have one, which is the TTL for the response (which matches how we do it in kv and cache). The original lock period ("ttl for the lock") is now called lock_period.