### PR TITLE
Fix how operator handles affinity/topology constraints

### DIFF
--- a/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
+++ b/infra/helm-coyote/charts/crds/crds/coyoteclusters.json
@@ -88,7 +88,7 @@
                     "type": "object"
                   },
                   "affinity": {
-                    "description": "Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity).",
+                    "description": "Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity).\n\nPod affinity/anti-affinity rules that target coyote pods should use the\n`coyote.svix.com/cluster` label (replacing `my-cluster` with the name of your\nCoyoteCluster resource).\n\n```yaml\nlabelSelector:\n  matchLabels:\n    coyote.svix.com/cluster: my-cluster\n```",
                     "nullable": true,
                     "properties": {
                       "nodeAffinity": {
@@ -1179,14 +1179,8 @@
                     "type": "array"
                   },
                   "topologySpreadConstraints": {
-                    "default": [
-                      {
-                        "maxSkew": 1,
-                        "topologyKey": "topology.kubernetes.io/zone",
-                        "whenUnsatisfiable": "ScheduleAnyway"
-                      }
-                    ],
-                    "description": "Topology spread constraints for pod scheduling.\n\nDefaults to (topology.kubernetes.io/zone, ScheduleAnyway, maxSkew=1).\nThe operator automatically injects the cluster's pod labelSelector on any\nconstraint that omits it, so you don't need to specify it yourself.\nSet to `[]` to opt out of all spreading.\n\nSee: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/",
+                    "default": [],
+                    "description": "Topology spread constraints for pod scheduling.\n\nConstraints that target coyote pods should use the `coyote.svix.com/cluster` label\n(replacing `my-cluster` with the name of your CoyoteCluster resource).\n\n```yaml\nlabelSelector:\n  matchLabels:\n    coyote.svix.com/cluster: my-cluster\n```",
                     "items": {
                       "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
                       "properties": {

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -24,15 +24,6 @@ fn default_nodes() -> i32 {
     1
 }
 
-fn default_topology_spread_constraints() -> Vec<TopologySpreadConstraint> {
-    vec![TopologySpreadConstraint {
-        max_skew: 1,
-        topology_key: "topology.kubernetes.io/zone".into(),
-        when_unsatisfiable: "ScheduleAnyway".into(),
-        ..Default::default()
-    }]
-}
-
 /// A Coyote cluster deployment.
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -73,13 +64,15 @@ pub(crate) struct CoyoteClusterSpec {
 
     /// Topology spread constraints for pod scheduling.
     ///
-    /// Defaults to (topology.kubernetes.io/zone, ScheduleAnyway, maxSkew=1).
-    /// The operator automatically injects the cluster's pod labelSelector on any
-    /// constraint that omits it, so you don't need to specify it yourself.
-    /// Set to `[]` to opt out of all spreading.
+    /// Constraints that target coyote pods should use the `coyote.svix.com/cluster` label
+    /// (replacing `my-cluster` with the name of your CoyoteCluster resource).
     ///
-    /// See: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-    #[serde(default = "default_topology_spread_constraints")]
+    /// ```yaml
+    /// labelSelector:
+    ///   matchLabels:
+    ///     coyote.svix.com/cluster: my-cluster
+    /// ```
+    #[serde(default)]
     pub topology_spread_constraints: Vec<TopologySpreadConstraint>,
 
     /// Node selector for scheduling pods onto nodes with matching labels.
@@ -91,6 +84,16 @@ pub(crate) struct CoyoteClusterSpec {
     pub tolerations: Option<Vec<Toleration>>,
 
     /// Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity).
+    ///
+    /// Pod affinity/anti-affinity rules that target coyote pods should use the
+    /// `coyote.svix.com/cluster` label (replacing `my-cluster` with the name of your
+    /// CoyoteCluster resource).
+    ///
+    /// ```yaml
+    /// labelSelector:
+    ///   matchLabels:
+    ///     coyote.svix.com/cluster: my-cluster
+    /// ```
     #[serde(default)]
     pub affinity: Option<Affinity>,
 }

--- a/infra/operator/src/labels.rs
+++ b/infra/operator/src/labels.rs
@@ -6,6 +6,7 @@ pub(crate) fn selector(cluster_name: &str) -> BTreeMap<String, String> {
     BTreeMap::from([
         ("app.kubernetes.io/name".into(), "coyote".into()),
         ("app.kubernetes.io/instance".into(), cluster_name.into()),
+        ("coyote.svix.com/cluster".into(), cluster_name.into()),
     ])
 }
 

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -4,10 +4,9 @@ use k8s_openapi::{
     api::{
         apps::v1::{StatefulSet, StatefulSetSpec},
         core::v1::{
-            Affinity, Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction,
-            ObjectFieldSelector, PersistentVolumeClaim, PersistentVolumeClaimSpec,
-            PodSecurityContext, PodSpec, PodTemplateSpec, Probe, Toleration,
-            TopologySpreadConstraint, VolumeMount, VolumeResourceRequirements,
+            Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction, ObjectFieldSelector,
+            PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSecurityContext, PodSpec,
+            PodTemplateSpec, Probe, VolumeMount, VolumeResourceRequirements,
         },
     },
     apimachinery::pkg::{
@@ -48,15 +47,6 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<StatefulSet> {
     let pod_labels = labels::general_labels(&cluster_name);
     let pod_annotations = spec.pod_annotations.clone();
 
-    let topology_spread_constraints = add_selector_labels(
-        &spec.topology_spread_constraints,
-        &labels::selector(&cluster_name),
-    );
-
-    let node_selector: Option<BTreeMap<String, String>> = spec.node_selector.clone();
-    let tolerations: Option<Vec<Toleration>> = spec.tolerations.clone();
-    let affinity: Option<Affinity> = spec.affinity.clone();
-
     let pod_spec = PodSpec {
         containers: vec![container],
         volumes: None,
@@ -66,10 +56,10 @@ pub(crate) fn build(cluster: &CoyoteCluster, ns: &str) -> Result<StatefulSet> {
             fs_group: Some(1000),
             ..Default::default()
         }),
-        topology_spread_constraints: Some(topology_spread_constraints),
-        node_selector,
-        tolerations,
-        affinity,
+        topology_spread_constraints: Some(spec.topology_spread_constraints.clone()),
+        node_selector: spec.node_selector.clone(),
+        tolerations: spec.tolerations.clone(),
+        affinity: spec.affinity.clone(),
         ..Default::default()
     };
 
@@ -378,28 +368,6 @@ fn pvc_template(name: &str, size: &Quantity, storage_class: Option<&str>) -> Per
         }),
         ..Default::default()
     }
-}
-
-// Add the label selectors to topology constraints,
-// including those supplied by user, which are managed
-// by the operator.
-fn add_selector_labels(
-    constraints: &[TopologySpreadConstraint],
-    pod_selector: &BTreeMap<String, String>,
-) -> Vec<TopologySpreadConstraint> {
-    let selector = LabelSelector {
-        match_labels: Some(pod_selector.clone()),
-        ..Default::default()
-    };
-
-    let mut constraints = constraints.to_vec();
-    for c in &mut constraints {
-        if c.label_selector.is_none() {
-            c.label_selector = Some(selector.clone());
-        }
-    }
-
-    constraints
 }
 
 fn seed_nodes_value(

--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -47,14 +47,13 @@ cluster:
     affinity:
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
               matchLabels:
-                app.kubernetes.io/name: coyote
-            topologyKey: kubernetes.io/hostname
-          - labelSelector:
+                coyote.svix.com/cluster: coyote
+          - topologyKey: topology.kubernetes.io/zone
+            labelSelector:
               matchLabels:
-                app.kubernetes.io/name: coyote
-            topologyKey: topology.kubernetes.io/zone
-    topologySpreadConstraints: []
+                coyote.svix.com/cluster: coyote
     adminToken:
       value: "admin_abcdefghijlmnopqrstuvwxyz012345"


### PR DESCRIPTION
Trying to unbreak staging / fix how the operator handles pod affinity and topology spread constraints. Instead of having the operator try to "inject" the proper match labels for these things, we just document what label the operator applies to cluster pods and let the user specify them as needed to define their own custom rules. This makes the code simpler and seems to match what other operators are doing.

Note that part of this is removing the defaults that were previously added for topology spread constraints. Better to let the user just specify these themselves if they want them.