### PR TITLE
[draft 2] add idempotency to msgs publish

### DIFF
--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -46,6 +46,13 @@ impl Error {
         )))
     }
 
+    pub fn conflict(detail: impl Into<Option<String>>) -> Self {
+        Self::new(ErrorType::Conflict(StandardErrorBody::new(
+            "conflict",
+            detail.into().unwrap_or_else(|| "Conflict".to_owned()),
+        )))
+    }
+
     pub fn bad_request(code: &'static str, detail: impl fmt::Display) -> Self {
         Self::new(ErrorType::BadRequest(StandardErrorBody::new(code, detail)))
     }
@@ -105,6 +112,11 @@ impl Error {
                 Some(body.code().to_owned()),
                 Some(body.detail().to_owned()),
             ),
+            ErrorType::Conflict(body) => (
+                StatusCode::CONFLICT,
+                Some(body.code().to_owned()),
+                Some(body.detail().to_owned()),
+            ),
             ErrorType::Authentication(body) => (
                 StatusCode::UNAUTHORIZED,
                 Some(body.code().to_owned()),
@@ -157,6 +169,10 @@ impl IntoResponse for Error {
             ErrorType::Validation(body) => {
                 tracing::debug!(error = %body, "validation error");
                 (StatusCode::UNPROCESSABLE_ENTITY, MsgPackOrJson(body)).into_response()
+            }
+            ErrorType::Conflict(body) => {
+                tracing::debug!(error = %body, "conflict");
+                (StatusCode::CONFLICT, MsgPackOrJson(body)).into_response()
             }
             ErrorType::Authentication(body) => {
                 tracing::debug!(error = %body, "authentication");
@@ -255,6 +271,9 @@ pub enum ErrorType {
     /// Entity not found
     NotFound(StandardErrorBody),
 
+    /// Conflict
+    Conflict(StandardErrorBody),
+
     /// Authentication error
     Authentication(StandardErrorBody),
 
@@ -281,6 +300,7 @@ impl fmt::Display for ErrorType {
             Self::Internal { message, .. } => message.fmt(f),
             Self::BadRequest(s) => write!(f, "bad_request {s}"),
             Self::NotFound(s) => write!(f, "not_found {s}"),
+            Self::Conflict(s) => write!(f, "conflict {s}"),
             Self::Authentication(s) => write!(f, "authn {s}"),
             Self::Authorization(s) => write!(f, "authz {s}"),
             Self::Validation(s) => s.fmt(f),

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -192,6 +192,12 @@ fn ensure_defaults(commands: &mut Vec<BootstrapCommand>) {
             name: DEFAULT_NAMESPACE_NAME.to_string(),
         })
     );
+    commands.insert(
+        0,
+        BootstrapCommand::Idempotency(IdempotencyCreateNamespaceIn {
+            name: INTERNAL_NAMESPACE.to_string(),
+        }),
+    );
     ensure_default!(
         Cache,
         BootstrapCommand::Cache(CacheCreateNamespaceIn {

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -1,10 +1,20 @@
 use std::num::NonZeroU16;
 
-use crate::{AppState, core::cluster::RaftState, v1::utils::openapi_tag};
+use crate::{
+    AppState,
+    core::{INTERNAL_NAMESPACE, cluster::RaftState},
+    v1::{
+        endpoints::idempotency::{
+            IdempotencyAbortIn, IdempotencyAbortOut, IdempotencyCompleteIn, IdempotencyCompleteOut,
+            IdempotencyStartIn, IdempotencyStartOut,
+        },
+        utils::openapi_tag,
+    },
+};
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_authorization::RequestedOperation;
-use coyote_core::types::DurationMs;
+use coyote_core::types::{DurationMs, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{Error, OptionExt, Result, ResultExt};
 use coyote_id::Module;
@@ -15,10 +25,10 @@ use coyote_msgs::{
         TopicName, TopicPartition,
     },
     operations::{
-        CreateNamespaceOperation, PublishOperation, QueueAckOperation, QueueConfigureOperation,
-        QueueNackOperation, QueueReceiveOperation, QueueRedriveDlqOperation, SeekTarget,
-        StreamCommitOperation, StreamReceiveOperation, StreamSeekOperation,
-        TopicConfigureOperation,
+        CreateNamespaceOperation, PublishOperation, PublishResponseData, QueueAckOperation,
+        QueueConfigureOperation, QueueNackOperation, QueueReceiveOperation,
+        QueueRedriveDlqOperation, SeekTarget, StreamCommitOperation, StreamReceiveOperation,
+        StreamSeekOperation, TopicConfigureOperation,
     },
 };
 use coyote_namespace::entities::NamespaceName;
@@ -140,6 +150,8 @@ async fn get_namespace(
 struct MsgPublishIn {
     #[serde(default)]
     pub namespace: Option<NamespaceName>,
+    #[serde(default)]
+    pub idempotency_key: Option<EntityKey>,
     pub topic: TopicIn,
     pub msgs: Vec<coyote_msgs::entities::MsgIn>,
 }
@@ -158,6 +170,109 @@ struct MsgPublishOut {
     pub topics: Vec<MsgPublishOutTopic>,
 }
 
+impl TryInto<Vec<u8>> for MsgPublishOut {
+    type Error = Error;
+
+    fn try_into(self) -> Result<Vec<u8>> {
+        rmp_serde::to_vec_named(&self)
+            .or_internal_error()
+            .map_err(|e| Error::internal(e.to_string()))
+    }
+}
+
+impl TryFrom<Vec<u8>> for MsgPublishOut {
+    type Error = Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self> {
+        rmp_serde::from_slice(&value)
+            .or_internal_error()
+            .map_err(|e| Error::internal(e.to_string()))
+    }
+}
+
+fn default_msg_publish_idempotency_ttl() -> DurationMs {
+    DurationMs::from_hours(1)
+}
+
+fn msg_publish_out(response: PublishResponseData) -> MsgPublishOut {
+    MsgPublishOut {
+        topics: response
+            .topics
+            .into_iter()
+            .map(|m| MsgPublishOutTopic {
+                topic: m.topic,
+                start_offset: m.start_offset,
+                offset: m.offset,
+            })
+            .collect(),
+    }
+}
+
+async fn start_msg_publish_idempotency(
+    state: &AppState,
+    key: &EntityKey,
+) -> Result<IdempotencyStartOut> {
+    state
+        .internal_call(
+            "v1.idempotency.start",
+            &IdempotencyStartIn {
+                namespace: Some(INTERNAL_NAMESPACE.to_owned()),
+                key: key.clone(),
+                ttl: default_msg_publish_idempotency_ttl(),
+            },
+        )
+        .await
+        .or_internal_error()
+}
+
+async fn complete_msg_publish_idempotency(
+    state: &AppState,
+    key: &EntityKey,
+    response: &MsgPublishOut,
+) -> Result<()> {
+    let _: IdempotencyCompleteOut = state
+        .internal_call(
+            "v1.idempotency.complete",
+            &IdempotencyCompleteIn {
+                namespace: Some(INTERNAL_NAMESPACE.to_owned()),
+                key: key.clone(),
+                response: response.clone().try_into()?,
+                ttl: default_msg_publish_idempotency_ttl(),
+            },
+        )
+        .await
+        .or_internal_error()?;
+
+    Ok(())
+}
+
+async fn abort_msg_publish_idempotency(state: &AppState, key: &EntityKey) -> Result<()> {
+    let _: IdempotencyAbortOut = state
+        .internal_call(
+            "v1.idempotency.abort",
+            &IdempotencyAbortIn {
+                namespace: Some(INTERNAL_NAMESPACE.to_owned()),
+                key: key.clone(),
+            },
+        )
+        .await
+        .or_internal_error()?;
+
+    Ok(())
+}
+
+async fn do_publish_operation(
+    repl: &RaftState,
+    namespace: &MsgsNamespace,
+    topic: TopicIn,
+    msgs: Vec<coyote_msgs::entities::MsgIn>,
+) -> Result<MsgPublishOut> {
+    let operation = PublishOperation::new(namespace.id, topic, msgs)?;
+    let response = repl.client_write(operation).await.or_internal_error()?.0?;
+
+    Ok(msg_publish_out(response))
+}
+
 /// Publishes messages to a topic within a namespace.
 #[aide_annotate(op_id = "v1.msgs.publish")]
 async fn publish(
@@ -170,20 +285,37 @@ async fn publish(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let operation = PublishOperation::new(namespace.id, data.topic, data.msgs)?;
-    let response = repl.client_write(operation).await.or_internal_error()?.0?;
+    let Some(idempotency_key) = data.idempotency_key else {
+        let response = do_publish_operation(&repl, &namespace, data.topic, data.msgs).await?;
+        return Ok(MsgPackOrJson(response));
+    };
 
-    Ok(MsgPackOrJson(MsgPublishOut {
-        topics: response
-            .topics
-            .into_iter()
-            .map(|m| MsgPublishOutTopic {
-                topic: m.topic,
-                start_offset: m.start_offset,
-                offset: m.offset,
-            })
-            .collect(),
-    }))
+    match start_msg_publish_idempotency(&state, &idempotency_key).await? {
+        IdempotencyStartOut::Started => {}
+        IdempotencyStartOut::Locked => {
+            return Err(Error::conflict(
+                "A publish request with this idempotency key is already in progress.".to_owned(),
+            ));
+        }
+        IdempotencyStartOut::Completed(completed) => {
+            return Ok(MsgPackOrJson(completed.response.try_into()?));
+        }
+    }
+
+    let response = match do_publish_operation(&repl, &namespace, data.topic, data.msgs).await {
+        Ok(response) => response,
+        Err(err) => {
+            abort_msg_publish_idempotency(&state, &idempotency_key)
+                .await
+                .or_internal_error()?;
+
+            return Err(err);
+        }
+    };
+
+    complete_msg_publish_idempotency(&state, &idempotency_key, &response).await?;
+
+    Ok(MsgPackOrJson(response))
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/it/msgs/publish.rs
+++ b/tests/it/msgs/publish.rs
@@ -402,3 +402,136 @@ async fn default_namespace_isolated_from_named() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn publish_returns_cached_response_for_completed_idempotency_key() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.create")
+        .json(json!({ "name": "ns-idem" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-idem",
+            "topic": "my-topic",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let first = client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-idem",
+            "idempotency_key": "publish-once",
+            "topic": "my-topic",
+            "msgs": [{ "value": "hello".as_bytes() }],
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let second = client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-idem",
+            "idempotency_key": "publish-once",
+            "topic": "my-topic",
+            "msgs": [{ "value": "hello".as_bytes() }],
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(second, first);
+
+    let response = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-idem",
+            "topic": "my-topic",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0]["value"], json!("hello".as_bytes()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn publish_fails_when_idempotency_key_is_locked() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.idempotency.start")
+        .json(json!({
+            "namespace": "_internal",
+            "key": "publish-locked",
+            "ttl_ms": 60_000,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "idempotency_key": "publish-locked",
+            "topic": "my-topic",
+            "msgs": [{ "value": "hello".as_bytes() }],
+        }))
+        .await?
+        .expect(StatusCode::CONFLICT)
+        .json();
+
+    assert_eq!(response["code"], "idempotency_locked");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn publish_abandons_idempotency_key_when_publish_fails() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "idempotency_key": "publish-retry",
+            "topic": "my-topic~1",
+            "msgs": [{ "value": "hello".as_bytes() }],
+        }))
+        .await?
+        .expect(StatusCode::BAD_REQUEST);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "idempotency_key": "publish-retry",
+            "topic": "my-topic",
+            "msgs": [{ "value": "hello".as_bytes() }],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    Ok(())
+}


### PR DESCRIPTION
Using internal call to idempotency module (with an extra raft operation)