### PR TITLE
Reserve _-prefixed namespaces and disallow user access

### DIFF
--- a/crates/coyote-authorization/src/lib.rs
+++ b/crates/coyote-authorization/src/lib.rs
@@ -134,6 +134,10 @@ impl AccessRule {
             .clone()
     }
 
+    pub fn uses_reserved_namespace(&self) -> bool {
+        self.resource.namespace.is_reserved()
+    }
+
     pub fn matches(&self, operation: &RequestedOperation<'_>) -> bool {
         self.resource.matches(operation)
             && self

--- a/crates/coyote-authorization/src/pattern.rs
+++ b/crates/coyote-authorization/src/pattern.rs
@@ -148,11 +148,15 @@ impl FromStr for ModulePattern {
 }
 
 impl NamespacePattern {
+    pub(crate) fn is_reserved(&self) -> bool {
+        matches!(self, Self::Named(ns) if ns.starts_with('_'))
+    }
+
     fn matches(&self, namespace: Option<&str>) -> bool {
         match self {
             Self::Default => namespace.is_none(),
             Self::Named(ns) => namespace == Some(ns),
-            Self::Any => true,
+            Self::Any => namespace.is_none_or(|ns| !ns.starts_with("_")),
         }
     }
 }

--- a/docs/content/namespaces.mdx
+++ b/docs/content/namespaces.mdx
@@ -22,6 +22,8 @@ All configuration values are optional and fall back to the `default` namespace's
 
 Namespaces are scoped per module type. A `cache` namespace named `payments` is independent from a `kv` namespace named `payments`. Using a namespace that doesn't exist returns an error.
 
+Namespace identifiers starting with `_` are reserved for internal use.
+
 
 ## Using namespaces
 

--- a/src/v1/endpoints/admin/auth/mod.rs
+++ b/src/v1/endpoints/admin/auth/mod.rs
@@ -3,6 +3,8 @@ pub mod role;
 pub mod token;
 
 use aide::axum::ApiRouter;
+use coyote_authorization::AccessRule;
+use validator::ValidationError;
 
 use crate::AppState;
 
@@ -11,4 +13,14 @@ pub fn router() -> ApiRouter<AppState> {
         .merge(token::router())
         .merge(role::router())
         .merge(policy::router())
+}
+
+fn validate_access_rule_list(list: &[AccessRule]) -> Result<(), ValidationError> {
+    if let Some(pos) = list.iter().position(|rule| rule.uses_reserved_namespace()) {
+        return Err(ValidationError::new("reserved_namespace").with_message(
+            format!("access rule {} refers to a reserved namespace", pos + 1).into(),
+        ));
+    }
+
+    Ok(())
 }

--- a/src/v1/endpoints/admin/auth/policy.rs
+++ b/src/v1/endpoints/admin/auth/policy.rs
@@ -18,6 +18,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
+use super::validate_access_rule_list;
 use crate::{
     AppState,
     core::cluster::RaftState,
@@ -81,6 +82,7 @@ pub struct AdminAccessPolicyUpsertIn {
     pub id: AccessPolicyId,
     pub description: String,
     #[serde(default)]
+    #[validate(custom(function = "validate_access_rule_list"))]
     pub rules: Vec<AccessRule>,
 }
 

--- a/src/v1/endpoints/admin/auth/role.rs
+++ b/src/v1/endpoints/admin/auth/role.rs
@@ -20,6 +20,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
+use super::validate_access_rule_list;
 use crate::{
     AppState,
     core::cluster::RaftState,
@@ -87,6 +88,7 @@ pub struct AdminRoleUpsertIn {
     pub id: RoleId,
     pub description: String,
     #[serde(default)]
+    #[validate(custom(function = "validate_access_rule_list"))]
     pub rules: Vec<AccessRule>,
     #[serde(default)]
     pub policies: Vec<AccessPolicyId>,

--- a/tests/it/admin/policy.rs
+++ b/tests/it/admin/policy.rs
@@ -295,3 +295,42 @@ async fn test_admin_access_policy_get_nonexistent() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_admin_access_policy_upsert_internal_ns() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    let resp = client
+        .post("v1.admin.auth-policy.upsert")
+        .json(json!({
+            "id": "canihazinternal",
+            "description": "Trying to access _internal stuff",
+            "rules": [
+                {
+                    "effect": "allow",
+                    "resource": "kv:_internal:*",
+                    "actions": ["get", "set", "delete"],
+                },
+            ],
+        }))
+        .await?
+        .ensure(StatusCode::UNPROCESSABLE_ENTITY)?
+        .json();
+
+    assert_eq!(
+        resp,
+        json!({
+            "detail": [{
+                "type": "value_error",
+                "loc": ["body", "rules"],
+                "msg": "access rule 1 refers to a reserved namespace",
+            }],
+        })
+    );
+
+    Ok(())
+}

--- a/tests/it/admin/role.rs
+++ b/tests/it/admin/role.rs
@@ -289,3 +289,44 @@ async fn test_admin_role_get_nonexistent() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_admin_role_upsert_internal_ns() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    let resp = client
+        .post("v1.admin.auth-role.upsert")
+        .json(json!({
+            "id": "canihazinternal",
+            "description": "Trying to access _internal stuff",
+            "rules": [
+                {
+                    "effect": "allow",
+                    "resource": "kv:_internal:*",
+                    "actions": ["get", "set", "delete"],
+                },
+            ],
+            "policies": [],
+            "context": {},
+        }))
+        .await?
+        .ensure(StatusCode::UNPROCESSABLE_ENTITY)?
+        .json();
+
+    assert_eq!(
+        resp,
+        json!({
+            "detail": [{
+                "type": "value_error",
+                "loc": ["body", "rules"],
+                "msg": "access rule 1 refers to a reserved namespace",
+            }],
+        })
+    );
+
+    Ok(())
+}

--- a/tests/it/auth_token.rs
+++ b/tests/it/auth_token.rs
@@ -484,3 +484,29 @@ async fn test_auth_token_list_pagination() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_global_admin_token_cannot_access_reserved_ns() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    let resp = client
+        .post("v1.auth-token.list")
+        .json(json!({ "namespace": "_internal", "owner_id": "foo" }))
+        .await?
+        .ensure(StatusCode::FORBIDDEN)?
+        .json();
+
+    assert_eq!(
+        resp,
+        json!({
+            "code": "forbidden",
+            "detail": "You do not have permission to perform `list` on `auth_token:_internal:*`",
+        })
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The builtin operator access role is the only one that should have access to `_internal` or any other reserved namespace.

Closes https://github.com/svix/coyote-private/issues/571.