### PR TITLE
rust: fix rust client to properly decode error bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,6 +1221,7 @@ name = "coyote-client"
 version = "0.0.1"
 dependencies = [
  "form_urlencoded",
+ "headers",
  "http",
  "http-body-util",
  "hyper",

--- a/z-clients/rust/Cargo.toml
+++ b/z-clients/rust/Cargo.toml
@@ -18,6 +18,7 @@ rustls-tls = ["dep:hyper-rustls", "dep:rustls", "hyper-rustls?/rustls-native-cer
 
 [dependencies]
 form_urlencoded.workspace = true
+headers.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true

--- a/z-clients/rust/src/error.rs
+++ b/z-clients/rust/src/error.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use headers::ContentType;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use serde::Deserialize;
@@ -17,24 +18,48 @@ pub enum Error {
     Validation(HttpErrorContent<HttpValidationError>),
 }
 
+fn deserialize_body<'b, 'a, T>(mime: &headers::Mime, bytes: &'b [u8]) -> Option<T>
+where
+    T: Deserialize<'a>,
+    'b: 'a,
+{
+    let payload = if mime.subtype() == "json" {
+        serde_json::from_slice(&bytes).ok()
+    } else if mime.essence_str() == "application/msgpack" {
+        rmp_serde::from_slice(&bytes).ok()
+    } else {
+        None
+    };
+    if payload.is_none() {
+        let as_str = String::from_utf8_lossy(&bytes);
+        tracing::warn!(mime_type=?mime, response = %as_str, "unparsable error");
+    }
+    payload
+}
+
 impl Error {
     pub(crate) fn generic(err: impl std::error::Error) -> Self {
         Self::Generic(format!("{err:?}"))
     }
 
-    pub(crate) async fn from_response(status_code: http::StatusCode, body: Incoming) -> Self {
+    pub(crate) async fn from_response(
+        status_code: http::StatusCode,
+        body: Incoming,
+        content_type: ContentType,
+    ) -> Self {
         match body.collect().await {
             Ok(collected) => {
                 let bytes = collected.to_bytes();
+                let mime: headers::Mime = content_type.into();
                 if status_code == http::StatusCode::UNPROCESSABLE_ENTITY {
                     Self::Validation(HttpErrorContent {
                         status: http::StatusCode::UNPROCESSABLE_ENTITY,
-                        payload: serde_json::from_slice(&bytes).ok(),
+                        payload: deserialize_body(&mime, &bytes),
                     })
                 } else {
                     Error::Http(HttpErrorContent {
                         status: status_code,
-                        payload: serde_json::from_slice(&bytes).ok(),
+                        payload: deserialize_body(&mime, &bytes),
                     })
                 }
             }

--- a/z-clients/rust/src/error.rs
+++ b/z-clients/rust/src/error.rs
@@ -24,14 +24,14 @@ where
     'b: 'a,
 {
     let payload = if mime.subtype() == "json" {
-        serde_json::from_slice(&bytes).ok()
+        serde_json::from_slice(bytes).ok()
     } else if mime.essence_str() == "application/msgpack" {
-        rmp_serde::from_slice(&bytes).ok()
+        rmp_serde::from_slice(bytes).ok()
     } else {
         None
     };
     if payload.is_none() {
-        let as_str = String::from_utf8_lossy(&bytes);
+        let as_str = String::from_utf8_lossy(bytes);
         tracing::warn!(mime_type=?mime, response = %as_str, "unparsable error");
     }
     payload

--- a/z-clients/rust/src/request.rs
+++ b/z-clients/rust/src/request.rs
@@ -3,6 +3,7 @@
 
 use std::{collections::HashMap, time::Duration};
 
+use headers::{ContentType, Header as _};
 use http::header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, USER_AGENT};
 use http_body_util::{BodyExt as _, Full};
 use hyper::body::Bytes;
@@ -97,7 +98,10 @@ impl Request {
 
             let status = response.status();
             if !status.is_success() {
-                Err(Error::from_response(status, response.into_body()).await)
+                let mut values = response.headers().get_all(CONTENT_TYPE).iter();
+                let content_type =
+                    ContentType::decode(&mut values).unwrap_or_else(|_| ContentType::json());
+                Err(Error::from_response(status, response.into_body(), content_type).await)
             } else if no_return_type {
                 Ok(None)
             } else {


### PR DESCRIPTION
Before this change:

```
Error: Http error (status=500 Internal Server Error) None
```

After this change:

```
Error: Http error (status=500 Internal Server Error) Some(StandardHttpError { code: "NOT_READY", detail: "this node has not yet finished bootstrapping" })
```