### PR TITLE
improve error handling for edge case errors

### DIFF
--- a/crates/coyote-error/src/lib.rs
+++ b/crates/coyote-error/src/lib.rs
@@ -88,6 +88,12 @@ impl Error {
         })
     }
 
+    pub fn not_ready(s: impl fmt::Display) -> Self {
+        Self::new(ErrorType::NotReady {
+            message: s.to_string(),
+        })
+    }
+
     pub fn shutting_down() -> Self {
         Self::new(ErrorType::ShuttingDown)
     }
@@ -122,7 +128,16 @@ impl Error {
                 detail,
             } => (status, error_code, detail),
             ErrorType::Internal { .. } => (StatusCode::INTERNAL_SERVER_ERROR, None, None),
-            ErrorType::ShuttingDown => (StatusCode::SERVICE_UNAVAILABLE, None, None),
+            ErrorType::NotReady { .. } => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Some("NOT_READY".to_owned()),
+                None,
+            ),
+            ErrorType::ShuttingDown => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Some("SHUTTING_DOWN".to_owned()),
+                None,
+            ),
         }
     }
 
@@ -189,13 +204,18 @@ impl IntoResponse for Error {
                 );
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    MsgPackOrJson(json!({"error": "internal error"})),
+                    MsgPackOrJson(json!({"code": "INTERNAL_ERROR", "detail": ""})),
                 )
                     .into_response()
             }
+            ErrorType::NotReady { message } => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                MsgPackOrJson(json!({"code": "NOT_READY", "detail": message})),
+            )
+                .into_response(),
             ErrorType::ShuttingDown => (
                 StatusCode::SERVICE_UNAVAILABLE,
-                MsgPackOrJson(json!({"error": "server shutting down"})),
+                MsgPackOrJson(json!({"code": "SHUTTING_DOWN", "detail": "server shutting down"})),
             )
                 .into_response(),
         }
@@ -271,6 +291,9 @@ pub enum ErrorType {
         detail: Option<String>,
     },
 
+    /// The operation cannot proceed because the server is not yet ready
+    NotReady { message: String },
+
     /// The operation cannot proceed because the server is shutting down
     ShuttingDown,
 }
@@ -279,6 +302,7 @@ impl fmt::Display for ErrorType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Internal { message, .. } => message.fmt(f),
+            Self::NotReady { message } => write!(f, "not_ready {message}"),
             Self::BadRequest(s) => write!(f, "bad_request {s}"),
             Self::NotFound(s) => write!(f, "not_found {s}"),
             Self::Authentication(s) => write!(f, "authn {s}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ use coyote_error::Error;
 use coyote_msgs::TopicPublishNotifier;
 use coyote_proto::{InternalClient, InternalRequest, InternalRequestError};
 use fjall_utils::{Databases, ReadonlyDatabases};
-use http::StatusCode;
 use opentelemetry::metrics::Meter;
 use tokio::{
     net::TcpListener,
@@ -111,11 +110,6 @@ pub struct AppState {
     pub(crate) topic_publish_notifier: TopicPublishNotifier,
 }
 
-#[derive(Debug, Serialize)]
-struct MinimalError {
-    message: &'static str,
-}
-
 fn handle_panic(err: Box<dyn std::any::Any + Send + 'static>) -> axum::response::Response {
     if let Some(err) = err.downcast_ref::<String>() {
         tracing::error!(?err, "Unhandled panic");
@@ -124,13 +118,7 @@ fn handle_panic(err: Box<dyn std::any::Any + Send + 'static>) -> axum::response:
     } else {
         tracing::error!("Unhandled non-string panic");
     }
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        coyote_proto::MsgPackOrJson(MinimalError {
-            message: "unhandled internal panic",
-        }),
-    )
-        .into_response()
+    Error::internal("unhandled internal panic").into_response()
 }
 
 async fn axum_tcp_listener(
@@ -309,10 +297,7 @@ async fn fail_until_bootstrapped(
         true
     };
     if !(ignore_bootstrap || BOOTSTRAPPED.load(Ordering::Relaxed)) {
-        let response = coyote_proto::MsgPackOrJson(MinimalError {
-            message: "this node has not yet finished bootstarpping",
-        });
-        return (StatusCode::INTERNAL_SERVER_ERROR, response).into_response();
+        return Error::not_ready("this node has not yet finished bootstrapping").into_response();
     }
 
     next.run(request).await


### PR DESCRIPTION
Removes the `MinimalError` type and moves everything that used it to `coyote-error` (specifically, the error from the panic handler, and the error we raise before bootstrap finishes)