### PR TITLE
cli: teach the cli to allow strings for values

### DIFF
--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -8,6 +8,9 @@
 use coyote::CoyoteClient;
 use clap::{Args, Subcommand};
 
+#[allow(unused)]
+use crate::prelude::*;
+
 {% for _, sub in resource.subresources | items -%}
 use super::{{ sub.name | to_upper_camel_case }}Args;
 {% endfor %}
@@ -65,7 +68,12 @@ pub enum {{ resource_type_name }}Commands {
                     {% if field.description is defined -%}
                         {{ field.description | to_doc_comment(style="rust") }}
                     {% endif -%}
-                    {{ field.name | to_snake_case }}: {{ field.type.to_rust() }},
+                    {% if field.type.is_bytes() -%}
+                        {% set field_type = "ByteString" -%}
+                    {% else -%}
+                        {% set field_type = field.type.to_rust() -%}
+                    {% endif -%}
+                    {{ field.name | to_snake_case }}: {{ field_type }},
                 {% endfor -%}
 
                 {# body parameter struct -#}
@@ -121,7 +129,11 @@ impl {{ resource_type_name }}Commands {
                                     | selectattr("positional", "false")
                                     | length == 0 %}
                                 {% for field in body_schema.fields | selectattr("positional") -%}
-                                    {{ field.name | to_snake_case }},
+                                    {% if field.type.is_bytes() -%}
+                                        {{ field.name | to_snake_case }}.into(),
+                                    {% else -%}
+                                        {{ field.name | to_snake_case }},
+                                    {% endif -%}
                                 {% endfor -%}
 
                                 {# body parameter struct -#}

--- a/z-clients/cli/src/cmds/api/admin.rs
+++ b/z-clients/cli/src/cmds/api/admin.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 use super::{AdminAuthPolicyArgs, AdminAuthRoleArgs, AdminAuthTokenArgs, AdminClusterArgs};
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]

--- a/z-clients/cli/src/cmds/api/admin_auth_policy.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_policy.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct AdminAuthPolicyArgs {

--- a/z-clients/cli/src/cmds/api/admin_auth_role.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_role.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct AdminAuthRoleArgs {

--- a/z-clients/cli/src/cmds/api/admin_auth_token.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_token.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct AdminAuthTokenArgs {

--- a/z-clients/cli/src/cmds/api/admin_cluster.rs
+++ b/z-clients/cli/src/cmds/api/admin_cluster.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct AdminClusterArgs {

--- a/z-clients/cli/src/cmds/api/cache.rs
+++ b/z-clients/cli/src/cmds/api/cache.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 use super::CacheNamespaceArgs;
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
@@ -23,7 +26,7 @@ pub enum CacheCommands {
 }")]
     Set {
         key: String,
-        value: Vec<u8>,
+        value: ByteString,
         cache_set_in: crate::json::JsonOf<coyote::models::CacheSetIn>,
     },
     /// Cache Get
@@ -67,7 +70,7 @@ impl CacheCommands {
             } => {
                 let resp = client
                     .cache()
-                    .set(key, value, cache_set_in.into_inner())
+                    .set(key, value.into(), cache_set_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp)?;
             }

--- a/z-clients/cli/src/cmds/api/cache_namespace.rs
+++ b/z-clients/cli/src/cmds/api/cache_namespace.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct CacheNamespaceArgs {

--- a/z-clients/cli/src/cmds/api/health.rs
+++ b/z-clients/cli/src/cmds/api/health.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct HealthArgs {

--- a/z-clients/cli/src/cmds/api/idempotency.rs
+++ b/z-clients/cli/src/cmds/api/idempotency.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 use super::IdempotencyNamespaceArgs;
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]

--- a/z-clients/cli/src/cmds/api/idempotency_namespace.rs
+++ b/z-clients/cli/src/cmds/api/idempotency_namespace.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct IdempotencyNamespaceArgs {

--- a/z-clients/cli/src/cmds/api/kv.rs
+++ b/z-clients/cli/src/cmds/api/kv.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 use super::KvNamespaceArgs;
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
@@ -27,7 +30,7 @@ pub enum KvCommands {
 }")]
     Set {
         key: String,
-        value: Vec<u8>,
+        value: ByteString,
         kv_set_in: Option<crate::json::JsonOf<coyote::models::KvSetIn>>,
     },
     /// KV Get
@@ -73,7 +76,11 @@ impl KvCommands {
             } => {
                 let resp = client
                     .kv()
-                    .set(key, value, kv_set_in.unwrap_or_default().into_inner())
+                    .set(
+                        key,
+                        value.into(),
+                        kv_set_in.unwrap_or_default().into_inner(),
+                    )
                     .await?;
                 crate::json::print_json_output(&resp)?;
             }

--- a/z-clients/cli/src/cmds/api/kv_namespace.rs
+++ b/z-clients/cli/src/cmds/api/kv_namespace.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct KvNamespaceArgs {

--- a/z-clients/cli/src/cmds/api/msgs.rs
+++ b/z-clients/cli/src/cmds/api/msgs.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 use super::{MsgsNamespaceArgs, MsgsQueueArgs, MsgsStreamArgs, MsgsTopicArgs};
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]

--- a/z-clients/cli/src/cmds/api/msgs_namespace.rs
+++ b/z-clients/cli/src/cmds/api/msgs_namespace.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct MsgsNamespaceArgs {

--- a/z-clients/cli/src/cmds/api/msgs_queue.rs
+++ b/z-clients/cli/src/cmds/api/msgs_queue.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct MsgsQueueArgs {

--- a/z-clients/cli/src/cmds/api/msgs_stream.rs
+++ b/z-clients/cli/src/cmds/api/msgs_stream.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct MsgsStreamArgs {

--- a/z-clients/cli/src/cmds/api/msgs_topic.rs
+++ b/z-clients/cli/src/cmds/api/msgs_topic.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct MsgsTopicArgs {

--- a/z-clients/cli/src/cmds/api/rate_limit.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 use super::RateLimitNamespaceArgs;
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]

--- a/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
@@ -2,6 +2,9 @@
 use clap::{Args, Subcommand};
 use coyote::CoyoteClient;
 
+#[allow(unused)]
+use crate::prelude::*;
+
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]
 pub struct RateLimitNamespaceArgs {

--- a/z-clients/cli/src/main.rs
+++ b/z-clients/cli/src/main.rs
@@ -22,6 +22,7 @@ use self::{
 mod cmds;
 mod config;
 mod json;
+mod prelude;
 mod utils;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/z-clients/cli/src/prelude.rs
+++ b/z-clients/cli/src/prelude.rs
@@ -1,0 +1,54 @@
+/// A wrapper type that allows passing a string or a byte array as an argument
+///
+/// If the argument starts with `[` and ends with `]`, it will be parsed as a series
+/// of decimal values (e.g., `[1, 2, 3]` will be encoded as 0x010203); otherwise, it will
+/// be treated as a utf-8 string (e.g., `123` will be encoded as 0x495051).
+#[derive(Debug, Clone)]
+pub(crate) enum ByteString {
+    String(String),
+    Bytes(Vec<u8>),
+}
+
+impl std::str::FromStr for ByteString {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("[") && s.ends_with("]") {
+            let bytes = s[1..s.len() - 1]
+                .split(",")
+                .map(|s| s.trim().parse::<u8>())
+                .collect::<Result<Vec<u8>, _>>()?;
+            Ok(Self::Bytes(bytes))
+        } else {
+            Ok(Self::String(s.to_owned()))
+        }
+    }
+}
+
+impl std::fmt::Display for ByteString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::String(s) => s.fmt(f),
+            Self::Bytes(b) => {
+                write!(f, "[")?;
+                for (i, item) in b.iter().enumerate() {
+                    if i == 0 {
+                        write!(f, "{item}")?;
+                    } else {
+                        write!(f, ", {item}")?;
+                    }
+                }
+                write!(f, "]")
+            }
+        }
+    }
+}
+
+impl From<ByteString> for Vec<u8> {
+    fn from(value: ByteString) -> Self {
+        match value {
+            ByteString::String(s) => s.into_bytes(),
+            ByteString::Bytes(v) => v,
+        }
+    }
+}


### PR DESCRIPTION
This is maybe an off-the-wall idea I had, but it would be nice to be able to use the `kv` / `cache` / etc modules without hand-crafting binary strings.

Without this branch (a.k.a. on main):

```
$ coyote kv set foo bar
error: invalid value 'bar' for '[VALUE]...': invalid digit found in string
$ coyote kv set foo 49 50 51
{
    "success": true,
    "version": 19225
}
$ coyote kv get foo
{
    "value": "123",
    "version": 19225
}
```

With this branch:

```
$ coyote kv set foo bar
{
    "success": true,
    "version": 18282
}
$ coyote kv get foo
{
    "value": "bar",
    "version": 18282
}
```