### PR TITLE
deps: downgrade yanked fastrand dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"


### PR DESCRIPTION
all builds are failing because fastrand 2.4.0 was yanked (for [non-security-sensitive-reasons](https://github.com/smol-rs/fastrand/issues/124)). Let's just go back to 2.3.0.