### PR TITLE
Fix and clean up benchmarks/

### DIFF
--- a/benchmarks/benches/cache.rs
+++ b/benchmarks/benches/cache.rs
@@ -31,13 +31,11 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             || (test_key.clone(), test_val.clone()),
             |(key, val)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.cache().set(
-                        key,
-                        val,
-                        CacheSetIn::new(Duration::from_secs(60)),
-                    ))
-                    .await
-                    .unwrap();
+                    client
+                        .cache()
+                        .set(key, val, CacheSetIn::new(Duration::from_secs(60)))
+                        .await
+                        .unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -49,13 +47,11 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             || (test_key.clone(), test_val.clone()),
             |(key, val)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.cache().set(
-                        key,
-                        val,
-                        CacheSetIn::new(Duration::from_millis(1)),
-                    ))
-                    .await
-                    .unwrap();
+                    client
+                        .cache()
+                        .set(key, val, CacheSetIn::new(Duration::from_millis(1)))
+                        .await
+                        .unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -72,13 +68,11 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.cache().set(
-                        k,
-                        v,
-                        CacheSetIn::new(Duration::from_secs(60)),
-                    ))
-                    .await
-                    .unwrap();
+                    client
+                        .cache()
+                        .set(k, v, CacheSetIn::new(Duration::from_secs(60)))
+                        .await
+                        .unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -95,13 +89,11 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.cache().set(
-                        k,
-                        v,
-                        CacheSetIn::new(Duration::from_secs(60)),
-                    ))
-                    .await
-                    .unwrap();
+                    client
+                        .cache()
+                        .set(k, v, CacheSetIn::new(Duration::from_secs(60)))
+                        .await
+                        .unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -118,13 +110,11 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.cache().set(
-                        k,
-                        v,
-                        CacheSetIn::new(Duration::from_secs(60)),
-                    ))
-                    .await
-                    .unwrap();
+                    client
+                        .cache()
+                        .set(k, v, CacheSetIn::new(Duration::from_secs(60)))
+                        .await
+                        .unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -133,13 +123,15 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
 
     // Make sure we have a key to test repeated gets
     rt.block_on(async {
-        std::hint::black_box(client.cache().set(
-            test_key.clone(),
-            test_val.clone(),
-            CacheSetIn::new(Duration::from_secs(60)),
-        ))
-        .await
-        .unwrap();
+        client
+            .cache()
+            .set(
+                test_key.clone(),
+                test_val.clone(),
+                CacheSetIn::new(Duration::from_secs(60)),
+            )
+            .await
+            .unwrap();
     });
 
     group.bench_function("cache_get", |b| {
@@ -147,9 +139,7 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             || test_key.clone(),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.cache().get(key, CacheGetIn::new()))
-                        .await
-                        .unwrap();
+                    client.cache().get(key, CacheGetIn::new()).await.unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -161,14 +151,14 @@ fn bench_cache<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             || (test_key.clone(), test_key.clone(), test_val.clone()),
             |(key1, key2, val)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.cache().set(
-                        key1,
-                        val,
-                        CacheSetIn::new(Duration::from_secs(60)),
-                    ))
-                    .await
-                    .unwrap();
-                    std::hint::black_box(client.cache().delete(key2, CacheDeleteIn::new()))
+                    client
+                        .cache()
+                        .set(key1, val, CacheSetIn::new(Duration::from_secs(60)))
+                        .await
+                        .unwrap();
+                    client
+                        .cache()
+                        .delete(key2, CacheDeleteIn::new())
                         .await
                         .unwrap();
                 })

--- a/benchmarks/benches/idempotency.rs
+++ b/benchmarks/benches/idempotency.rs
@@ -29,7 +29,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
                 rt.block_on(async {
                     std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                         "key": &key,
-                        "ttl": 60
+                        "lock_period_ms": 60
                     })))
                     .await
                     .unwrap()
@@ -56,7 +56,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
                 rt.block_on(async {
                     std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                         "key": &key,
-                        "ttl": 60
+                        "lock_period_ms": 60
                     })))
                     .await
                     .unwrap()
@@ -65,7 +65,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
                     std::hint::black_box(client.post("v1.idempotency.complete").json(json!({
                         "key": &key,
                         "response": "ok".as_bytes(),
-                        "ttl": 60
+                        "ttl_ms": 60
                     })))
                     .await
                     .unwrap()
@@ -82,7 +82,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
                 .post("v1.idempotency.start")
                 .json(json!({
                     "key": key,
-                    "ttl": 60
+                    "lock_period_ms": 60
                 }))
                 .await
                 .unwrap();
@@ -92,9 +92,9 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
             client
                 .post("v1.idempotency.complete")
                 .json(json!({
-                "key": key,
-                "response": payload,
-                "ttl": 60
+                    "key": key,
+                    "response": payload,
+                    "ttk_ms": 60
                 }))
                 .await
                 .unwrap();
@@ -112,7 +112,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
             rt.block_on(async {
                 std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                     "key": &test_key,
-                    "ttl": 60
+                    "lock_period_ms": 60
                 })))
                 .await
                 .unwrap()
@@ -131,7 +131,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
             rt.block_on(async {
                 std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                     "key": &test_key,
-                    "ttl": 60
+                    "lock_period_ms": 60
                 })))
                 .await
                 .unwrap()
@@ -150,7 +150,7 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
             rt.block_on(async {
                 std::hint::black_box(client.post("v1.idempotency.start").json(json!({
                     "key": &test_key,
-                    "ttl": 60
+                    "lock_period_ms": 60
                 })))
                 .await
                 .unwrap()

--- a/benchmarks/benches/idempotency.rs
+++ b/benchmarks/benches/idempotency.rs
@@ -27,22 +27,22 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("v1.idempotency.start").json(json!({
-                        "key": &key,
-                        "lock_period_ms": 60
-                    })))
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
+                    client
+                        .post("v1.idempotency.start")
+                        .json(json!({
+                            "key": &key,
+                            "lock_period_ms": 60
+                        }))
+                        .await
+                        .unwrap()
+                        .expect(StatusCode::OK);
 
-                    std::hint::black_box(
-                        client
-                            .post("v1.idempotency.abort")
-                            .json(json!({ "key": &key })),
-                    )
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
+                    client
+                        .post("v1.idempotency.abort")
+                        .json(json!({ "key": &key }))
+                        .await
+                        .unwrap()
+                        .expect(StatusCode::OK);
                 })
             },
             BatchSize::SmallInput,
@@ -54,22 +54,26 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("v1.idempotency.start").json(json!({
-                        "key": &key,
-                        "lock_period_ms": 60
-                    })))
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
+                    client
+                        .post("v1.idempotency.start")
+                        .json(json!({
+                            "key": &key,
+                            "lock_period_ms": 60
+                        }))
+                        .await
+                        .unwrap()
+                        .expect(StatusCode::OK);
 
-                    std::hint::black_box(client.post("v1.idempotency.complete").json(json!({
-                        "key": &key,
-                        "response": "ok".as_bytes(),
-                        "ttl_ms": 60
-                    })))
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
+                    client
+                        .post("v1.idempotency.complete")
+                        .json(json!({
+                            "key": &key,
+                            "response": "ok".as_bytes(),
+                            "ttl_ms": 60
+                        }))
+                        .await
+                        .unwrap()
+                        .expect(StatusCode::OK);
                 })
             },
             BatchSize::SmallInput,
@@ -110,13 +114,15 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
     group.bench_function("idempotency_small_payload", |b| {
         b.iter(|| {
             rt.block_on(async {
-                std::hint::black_box(client.post("v1.idempotency.start").json(json!({
-                    "key": &test_key,
-                    "lock_period_ms": 60
-                })))
-                .await
-                .unwrap()
-                .expect(StatusCode::OK);
+                client
+                    .post("v1.idempotency.start")
+                    .json(json!({
+                        "key": &test_key,
+                        "lock_period_ms": 60
+                    }))
+                    .await
+                    .unwrap()
+                    .expect(StatusCode::OK);
             })
         })
     });
@@ -129,13 +135,15 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
     group.bench_function("idempotency_medium_payload", |b| {
         b.iter(|| {
             rt.block_on(async {
-                std::hint::black_box(client.post("v1.idempotency.start").json(json!({
-                    "key": &test_key,
-                    "lock_period_ms": 60
-                })))
-                .await
-                .unwrap()
-                .expect(StatusCode::OK);
+                client
+                    .post("v1.idempotency.start")
+                    .json(json!({
+                        "key": &test_key,
+                        "lock_period_ms": 60
+                    }))
+                    .await
+                    .unwrap()
+                    .expect(StatusCode::OK);
             })
         })
     });
@@ -148,13 +156,15 @@ fn bench_idempotency<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benc
     group.bench_function("idempotency_large_payload", |b| {
         b.iter(|| {
             rt.block_on(async {
-                std::hint::black_box(client.post("v1.idempotency.start").json(json!({
-                    "key": &test_key,
-                    "lock_period_ms": 60
-                })))
-                .await
-                .unwrap()
-                .expect(StatusCode::OK);
+                client
+                    .post("v1.idempotency.start")
+                    .json(json!({
+                        "key": &test_key,
+                        "lock_period_ms": 60
+                    }))
+                    .await
+                    .unwrap()
+                    .expect(StatusCode::OK);
             })
         })
     });

--- a/benchmarks/benches/kv.rs
+++ b/benchmarks/benches/kv.rs
@@ -29,9 +29,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             || (test_key.clone(), test_val.clone()),
             |(key, val)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(key, val, KvSetIn::new()))
-                        .await
-                        .unwrap();
+                    client.kv().set(key, val, KvSetIn::new()).await.unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -48,9 +46,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(k, v, KvSetIn::new()))
-                        .await
-                        .unwrap();
+                    client.kv().set(k, v, KvSetIn::new()).await.unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -67,9 +63,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(k, v, KvSetIn::new()))
-                        .await
-                        .unwrap();
+                    client.kv().set(k, v, KvSetIn::new()).await.unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -86,9 +80,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             },
             |(k, v)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(k, v, KvSetIn::new()))
-                        .await
-                        .unwrap();
+                    client.kv().set(k, v, KvSetIn::new()).await.unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -97,13 +89,11 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
 
     // Make sure we have a key to test repeated gets
     rt.block_on(async {
-        std::hint::black_box(
-            client
-                .kv()
-                .set(test_key.clone(), test_val.clone(), KvSetIn::new()),
-        )
-        .await
-        .unwrap();
+        client
+            .kv()
+            .set(test_key.clone(), test_val.clone(), KvSetIn::new())
+            .await
+            .unwrap();
     });
 
     group.bench_function("kv_get", |b| {
@@ -111,9 +101,7 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             || test_key.clone(),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().get(key, KvGetIn::new()))
-                        .await
-                        .unwrap();
+                    client.kv().get(key, KvGetIn::new()).await.unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -125,12 +113,12 @@ fn bench_kv<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkGrou
             || (test_key.clone(), test_key.clone(), test_val.clone()),
             |(key1, key2, test_val)| {
                 rt.block_on(async {
-                    std::hint::black_box(client.kv().set(key1, test_val, KvSetIn::new()))
+                    client
+                        .kv()
+                        .set(key1, test_val, KvSetIn::new())
                         .await
                         .unwrap();
-                    std::hint::black_box(client.kv().delete(key2, KvDeleteIn::new()))
-                        .await
-                        .unwrap();
+                    client.kv().delete(key2, KvDeleteIn::new()).await.unwrap();
                 })
             },
             BatchSize::SmallInput,

--- a/benchmarks/benches/queue.rs
+++ b/benchmarks/benches/queue.rs
@@ -53,34 +53,31 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
         group.bench_function("receive_ack_batch_100", |b| {
             b.iter(|| {
                 rt.block_on(async {
-                    let out = std::hint::black_box(
-                        client
-                            .msgs()
-                            .queue()
-                            .receive(
-                                topic.clone(),
-                                "bench-cg".to_owned(),
-                                MsgQueueReceiveIn::new().with_batch_size(100u16),
-                            )
-                            .await
-                            .unwrap(),
-                    );
+                    let out = client
+                        .msgs()
+                        .queue()
+                        .receive(
+                            topic.clone(),
+                            "bench-cg".to_owned(),
+                            MsgQueueReceiveIn::new().with_batch_size(100u16),
+                        )
+                        .await
+                        .unwrap();
                     if out.msgs.is_empty() {
                         return;
                     }
                     let msg_ids: Vec<String> = out.msgs.into_iter().map(|m| m.msg_id).collect();
-                    std::hint::black_box(
-                        client
-                            .msgs()
-                            .queue()
-                            .ack(
-                                topic.clone(),
-                                "bench-cg".to_owned(),
-                                MsgQueueAckIn::new(msg_ids),
-                            )
-                            .await
-                            .unwrap(),
-                    );
+
+                    client
+                        .msgs()
+                        .queue()
+                        .ack(
+                            topic.clone(),
+                            "bench-cg".to_owned(),
+                            MsgQueueAckIn::new(msg_ids),
+                        )
+                        .await
+                        .unwrap();
                 })
             })
         });
@@ -111,20 +108,18 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
         group.bench_function("receive_only_batch_100", |b| {
             b.iter(|| {
                 rt.block_on(async {
-                    std::hint::black_box(
-                        client
-                            .msgs()
-                            .queue()
-                            .receive(
-                                topic.clone(),
-                                "bench-cg".to_owned(),
-                                MsgQueueReceiveIn::new()
-                                    .with_batch_size(100u16)
-                                    .with_lease_duration(Duration::from_millis(100)),
-                            )
-                            .await
-                            .unwrap(),
-                    );
+                    client
+                        .msgs()
+                        .queue()
+                        .receive(
+                            topic.clone(),
+                            "bench-cg".to_owned(),
+                            MsgQueueReceiveIn::new()
+                                .with_batch_size(100u16)
+                                .with_lease_duration(Duration::from_millis(100)),
+                        )
+                        .await
+                        .unwrap();
                 })
             })
         });

--- a/benchmarks/benches/rate_limit.rs
+++ b/benchmarks/benches/rate_limit.rs
@@ -29,18 +29,20 @@ fn bench_rate_limiter<'a, M: Measurement>(
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
-                        "key": key,
-                        "units": 1,
-                        "config": {
-                            "capacity": 1_000_000,
-                            "refill_amount": 50_000,
-                            "refill_interval_seconds": 1
-                        }
-                    })))
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
+                    client
+                        .post("v1.rate-limit.limit")
+                        .json(json!({
+                            "key": key,
+                            "units": 1,
+                            "config": {
+                                "capacity": 1_000_000,
+                                "refill_amount": 50_000,
+                                "refill_interval_seconds": 1
+                            }
+                        }))
+                        .await
+                        .unwrap()
+                        .expect(StatusCode::OK);
                 })
             },
             BatchSize::SmallInput,
@@ -52,18 +54,20 @@ fn bench_rate_limiter<'a, M: Measurement>(
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
-                        "key": key,
-                        "units": 1,
-                        "config": {
-                            "capacity": 1_000_000,
-                            "refill_amount": 1,
-                            "refill_interval_seconds": 1
-                        }
-                    })))
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
+                    client
+                        .post("v1.rate-limit.limit")
+                        .json(json!({
+                            "key": key,
+                            "units": 1,
+                            "config": {
+                                "capacity": 1_000_000,
+                                "refill_amount": 1,
+                                "refill_interval_seconds": 1
+                            }
+                        }))
+                        .await
+                        .unwrap()
+                        .expect(StatusCode::OK);
                 })
             },
             BatchSize::SmallInput,
@@ -75,18 +79,20 @@ fn bench_rate_limiter<'a, M: Measurement>(
             || Alphanumeric.sample_string(&mut rng, 16),
             |key| {
                 rt.block_on(async {
-                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
-                        "key": key,
-                        "units": 1,
-                        "config": {
-                            "capacity": 5,
-                            "refill_amount": 1,
-                            "refill_interval_seconds": 1
-                        }
-                    })))
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
+                    client
+                        .post("v1.rate-limit.limit")
+                        .json(json!({
+                            "key": key,
+                            "units": 1,
+                            "config": {
+                                "capacity": 5,
+                                "refill_amount": 1,
+                                "refill_interval_seconds": 1
+                            }
+                        }))
+                        .await
+                        .unwrap()
+                        .expect(StatusCode::OK);
                 })
             },
             BatchSize::SmallInput,

--- a/benchmarks/benches/rate_limit.rs
+++ b/benchmarks/benches/rate_limit.rs
@@ -32,7 +32,6 @@ fn bench_rate_limiter<'a, M: Measurement>(
                     std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
                         "key": key,
                         "units": 1,
-                        "method": "token_bucket",
                         "config": {
                             "capacity": 1_000_000,
                             "refill_amount": 50_000,
@@ -56,7 +55,6 @@ fn bench_rate_limiter<'a, M: Measurement>(
                     std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
                         "key": key,
                         "units": 1,
-                        "method": "token_bucket",
                         "config": {
                             "capacity": 1_000_000,
                             "refill_amount": 1,
@@ -80,57 +78,10 @@ fn bench_rate_limiter<'a, M: Measurement>(
                     std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
                         "key": key,
                         "units": 1,
-                        "method": "token_bucket",
                         "config": {
                             "capacity": 5,
                             "refill_amount": 1,
                             "refill_interval_seconds": 1
-                        }
-                    })))
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
-                })
-            },
-            BatchSize::SmallInput,
-        )
-    });
-
-    group.bench_function("fixed_window_large_capacity", |b| {
-        b.iter_batched(
-            || Alphanumeric.sample_string(&mut rng, 16),
-            |key| {
-                rt.block_on(async {
-                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
-                        "key": key,
-                        "units": 1,
-                        "method": "fixed_window",
-                        "config": {
-                            "max_requests": 1_000_000,
-                            "window_size": 1
-                        }
-                    })))
-                    .await
-                    .unwrap()
-                    .expect(StatusCode::OK);
-                })
-            },
-            BatchSize::SmallInput,
-        )
-    });
-
-    group.bench_function("fixed_window_small_capacity", |b| {
-        b.iter_batched(
-            || Alphanumeric.sample_string(&mut rng, 16),
-            |key| {
-                rt.block_on(async {
-                    std::hint::black_box(client.post("v1.rate-limit.limit").json(json!({
-                        "key": key,
-                        "units": 1,
-                        "method": "fixed_window",
-                        "config": {
-                            "max_requests": 10,
-                            "window_size": 1
                         }
                     })))
                     .await

--- a/benchmarks/benches/stream.rs
+++ b/benchmarks/benches/stream.rs
@@ -46,13 +46,11 @@ fn bench_stream<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benchmark
             || make_msg_batch(100),
             |msgs| {
                 rt.block_on(async {
-                    std::hint::black_box(
-                        client
-                            .msgs()
-                            .publish(topic.clone(), MsgPublishIn::new(msgs)),
-                    )
-                    .await
-                    .unwrap();
+                    client
+                        .msgs()
+                        .publish(topic.clone(), MsgPublishIn::new(msgs))
+                        .await
+                        .unwrap();
                 })
             },
             BatchSize::SmallInput,
@@ -76,33 +74,29 @@ fn bench_stream<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut Benchmark
     group.bench_function("receive_commit_batch_100", |b| {
         b.iter(|| {
             rt.block_on(async {
-                let out = std::hint::black_box(
-                    client
-                        .msgs()
-                        .stream()
-                        .receive(
-                            topic.clone(),
-                            consumer_group.clone(),
-                            MsgStreamReceiveIn::new().with_batch_size(100),
-                        )
-                        .await
-                        .unwrap(),
-                );
+                let out = client
+                    .msgs()
+                    .stream()
+                    .receive(
+                        topic.clone(),
+                        consumer_group.clone(),
+                        MsgStreamReceiveIn::new().with_batch_size(100),
+                    )
+                    .await
+                    .unwrap();
                 let Some(last) = out.msgs.last() else {
                     return;
                 };
-                std::hint::black_box(
-                    client
-                        .msgs()
-                        .stream()
-                        .commit(
-                            last.topic.clone(),
-                            consumer_group.clone(),
-                            MsgStreamCommitIn::new(last.offset),
-                        )
-                        .await
-                        .unwrap(),
-                );
+                client
+                    .msgs()
+                    .stream()
+                    .commit(
+                        last.topic.clone(),
+                        consumer_group.clone(),
+                        MsgStreamCommitIn::new(last.offset),
+                    )
+                    .await
+                    .unwrap();
             })
         })
     });


### PR DESCRIPTION
Just getting started on profiling and noticed our `benchmarks/` were out of date. I guess people are using the CLI benchmarks exclusively at the moment.