### PR TITLE
build docker in CI if relevant things changed

### DIFF
--- a/.github/workflows/docker-test-build.yml
+++ b/.github/workflows/docker-test-build.yml
@@ -1,0 +1,68 @@
+name: Diom Docker Test Build
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+      context:
+        required: false
+        type: string
+        default: '.'
+      file:
+        required: false
+        type: string
+        default: './Dockerfile'
+
+jobs:
+  build-image:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: '0'
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          target: ${{ inputs.target }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
+
+      - name: Scan image with Grype for only fixable
+        id: scan
+        uses: anchore/scan-action@v6
+        with:
+          image: ${{ steps.build.outputs.imageid }}
+          fail-build: true
+          severity-cutoff: high
+          only-fixed: true
+          output-file: grype.sarif
+
+      - name: Inspect action SARIF report
+        if: ${{ always() && hashFiles('grype.sarif') != '' }}
+        run: cat ${{ steps.scan.outputs.sarif }}
+
+      - name: Scan image with Grype for all
+        id: scan-all
+        uses: anchore/scan-action@v6
+        with:
+          image: ${{ steps.build.outputs.imageid }}
+          fail-build: false
+          severity-cutoff: negligible
+          only-fixed: false
+          output-file: grype-all.sarif
+
+      - name: Inspect action SARIF report for all CVEs
+        if: ${{ !cancelled() && hashFiles('grype-all.sarif') != '' }}
+        run: cat ${{ steps.scan-all.outputs.sarif }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -16,6 +16,8 @@ jobs:
       java: ${{ steps.filter.outputs.java }}
       javascript: ${{ steps.filter.outputs.javascript }}
       python: ${{ steps.filter.outputs.python }}
+      main-docker: ${{ steps.filter.outputs.main-docker }}
+      operator-docker: ${{ steps.filter.outputs.operator-docker }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -37,6 +39,14 @@ jobs:
             python:
               - '.github/workflows/python.yml'
               - 'z-clients/python/**'
+            main-docker:
+              - '.github/workflows/docker-test-build.yml'
+              - 'Dockerfile'
+              - 'Cargo.toml'
+            operator-docker:
+              - '.github/workflows/docker-test-build.yml'
+              - 'infra/operator/Dockerfile'
+              - 'infra/operator/Cargo.toml'
 
   ci:
     permissions:
@@ -74,6 +84,22 @@ jobs:
     if: needs.filter.outputs.python == 'true'
     uses: ./.github/workflows/python.yml
 
+  main-docker-test-build:
+    needs: filter
+    if: needs.filter.outputs.main-docker == 'true'
+    uses: ./.github/workflows/docker-test-build.yml
+    with:
+      target: prod
+      file: ./Dockerfile
+
+  operator-docker-test-build:
+    needs: filter
+    if: needs.filter.outputs.operator-docker == 'true'
+    uses: ./.github/workflows/docker-test-build.yml
+    with:
+      target: prod
+      file: ./infra/operator/Dockerfile
+
   ci-required-checks:
     name: CI Required Checks
     runs-on: ubuntu-24.04
@@ -84,6 +110,7 @@ jobs:
       - java
       - javascript
       - python
+      - main-docker-test-build
     # Always run so that this job is a stable required status check: if an
     # upstream job is skipped (e.g. due to path filters added in the future)
     # that is fine; we only fail if something actually failed or was cancelled.


### PR DESCRIPTION
This way we'll be less likely to have to wait until landing on main to find out we broke builds.

It's kind of a guess what kinds of changes will be likely to break Docker, but I don't want to make every CI build wait for the very slow Docker build so I'm starting off with just changes to the root `Cargo.toml` or to the Dockerfile itself.

Fixes #886