### PR TITLE
cluster: support autoscaling the log fsync interval

### DIFF
--- a/config.bench.toml
+++ b/config.bench.toml
@@ -15,6 +15,7 @@ sync_mode = "buffer"
 [cluster]
 # fsync very infrequently
 log_sync_interval_commits = 0
-log_sync_interval_ms = 10000
+log_sync_interval_ms = 600000
+log_sync_interval_auto = false
 # acknowledge commits before we fsync
 log_ack_immediately = true

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -312,6 +312,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
             snapshot_after_time: None,
             log_sync_interval_commits: 0,
             log_sync_interval_duration: DurationMs::from_secs(30),
+            log_sync_interval_auto: false,
             log_ack_immediately: true,
             shut_down_on_go_away: true,
             replication_lag_threshold: 1_000_000,

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -91,7 +91,7 @@ pub(super) fn cluster_log_sync_interval_commits() -> usize {
 }
 
 pub(super) fn cluster_log_sync_interval_duration() -> DurationMs {
-    DurationMs::from(10)
+    DurationMs::from(2)
 }
 
 pub(super) fn cluster_send_snapshot_timeout() -> DurationMs {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -344,17 +344,16 @@ pub struct ClusterConfiguration {
 
     /// Interval (in transactions) between fsyncing the commit log.
     ///
-    /// This should be set to 1 for full ACID compliance; at any other value,
-    /// data may be lost in the event of catastrophic hardware failure.
-    /// If you are using a multi-node cluster and set this to a value other than
-    /// 1, if a node experiences catastrophic failure and the OS shuts down uncleanly, that node
-    /// should be removed from the cluster and rebuilt. If set to 0, logs will only be fsynced on a
-    /// timer
-    #[validate(range(min = 0, max = 1024))]
+    /// This can be used to force transactions to fsync logs more often than the
+    /// default `log_sync_interval_ms` timer.
+    #[validate(range(min = 0, max = 1024000))]
     #[serde(default = "defaults::cluster_log_sync_interval_commits")]
     pub log_sync_interval_commits: usize,
 
     /// Interval (in milliseconds) between fsyncing the commit log.
+    ///
+    /// If `log_sync_interval_auto` is set to true, this is just the initial estimate
+    /// and will be auto-scaled
     #[validate(custom(function = "validators::validate_log_sync_interval_duration"))]
     #[serde(
         rename = "log_sync_interval_ms",
@@ -362,11 +361,16 @@ pub struct ClusterConfiguration {
     )]
     pub log_sync_interval_duration: DurationMs,
 
+    /// Automatically attempt to determine the log sync interval from observed fsync timings
+    #[serde(default = "defaults::default_true")]
+    pub log_sync_interval_auto: bool,
+
     /// Commit logs to the cluster immediately, before fsyncing them to persistent storage.
     ///
     /// This should be set to `false` for full ACID compliance, but can be set to `true` to enable
     /// higher throughput than your fsync rate. Note that we always flush to the OS buffers before
-    /// acking, so data will only be lost of the OS crashes.
+    /// acking, so data will only be lost if the OS crashes. If that happens, the node should be
+    /// removed from the cluster, erased, and resynced
     #[serde(default = "defaults::default_false")]
     pub log_ack_immediately: bool,
 

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -33,6 +33,7 @@ use coyote_error::Result;
 type LogEntry = <TypeConfig as RaftTypeConfig>::Entry;
 type LogId = LogIdOf<TypeConfig>;
 type Vote = VoteOf<TypeConfig>;
+type IoFlushedCallback = IOFlushed<TypeConfig>;
 
 #[derive(Debug)]
 struct LogCacheInner {
@@ -253,98 +254,134 @@ impl std::error::Error for BackgroundFsyncFailedError {
     }
 }
 
-// Specialization for `flush_worker` when commits_before_fsync is 1 (which implies
-// that ack_immediately is false) which just fsyncs as fast as it can.
-async fn flush_every_worker(
-    db: Database,
-    mut channel: tokio::sync::mpsc::Receiver<IOFlushed<TypeConfig>>,
-) {
-    while let Some(callback) = channel.recv().await {
-        let db = db.clone();
-        // this shouldn't inherit our span
-        #[allow(clippy::disallowed_methods)]
-        let result = tokio::task::spawn_blocking(move || {
-            let _guard = tracing::info_span!("logs:flush_worker:every").entered();
-            tracing::trace!("fsyncing logs to disk");
-            db.persist(PersistMode::SyncAll)
-                // fjall::Error isn't Clone
-                .map_err(|err| {
-                    tracing::error!(?err, "error flushing fjall in background");
-                    BackgroundFsyncFailedError(err.to_string())
-                })
-        })
-        .await
-        .expect("failed joining blocking task");
-        callback.io_completed(result.map_err(std::io::Error::other));
+struct SimpleEstimator<const COUNT: usize> {
+    samples: [Option<Duration>; COUNT],
+    count: usize,
+}
+
+impl<const COUNT: usize> SimpleEstimator<COUNT> {
+    fn new(initial: Duration) -> Self {
+        let mut samples = [None; COUNT];
+        samples[0] = Some(initial);
+        Self { samples, count: 1 }
     }
+
+    fn push(&mut self, sample: Duration) {
+        self.samples[self.count % 5] = Some(sample);
+        self.count += 1;
+    }
+
+    fn estimate(&self) -> Duration {
+        let count = self.samples.iter().filter(|x| x.is_some()).count() as u64;
+        if count == 0 {
+            panic!("this is impossible, there's always at least one count")
+        }
+        let sum: u64 = self
+            .samples
+            .iter()
+            .filter_map(|o| o.map(|d| d.as_micros().try_into().unwrap_or(u64::MAX)))
+            .sum();
+
+        Duration::from_micros(sum / count)
+    }
+}
+
+enum FlushMessage {
+    EnableMetrics(LogMetrics),
+    Callback(IoFlushedCallback),
 }
 
 /// General background worker for flushing the fjall database
 async fn flush_worker(
     db: Database,
-    mut channel: tokio::sync::mpsc::Receiver<IOFlushed<TypeConfig>>,
+    mut channel: tokio::sync::mpsc::Receiver<FlushMessage>,
     commits_before_fsync: usize,
     duration_before_fsync: Duration,
+    autoscale_duration: bool,
     ack_immediately: bool,
     fsync_mode: FsyncMode,
 ) {
     let mut pending = Vec::new();
     let mut done = false;
     let shutting_down = crate::shutting_down_token();
+    let mut duration_estimator = SimpleEstimator::<7>::new(duration_before_fsync);
+    let mut last_estimate = duration_before_fsync;
     let mut ticker = tokio::time::interval(duration_before_fsync);
+
+    let mut metrics = None;
+
     while !done {
+        let mut synced = false;
+
         async {
-            let mut sync_now = false;
+            let mut sync_from_ticker = false;
 
             tokio::select! {
                 message = channel.recv() => {
-                    if let Some(callback) = message {
-                        if ack_immediately {
-                            let db = db.clone();
-                            let result = spawn_blocking_in_current_span(move || {
-                                let _guard = tracing::info_span!("logs:flush_worker:buffer").entered();
-                                db.persist(PersistMode::Buffer)
-                                    // fjall::Error isn't Clone
-                                    .map_err(|err| {
-                                        tracing::error!(?err, "error flushing fjall in background");
-                                        BackgroundFsyncFailedError(err.to_string())
-                                    })
-                            })
-                            .await
-                            .expect("failed joining blocking task");
-                            callback.io_completed(result.map_err(std::io::Error::other));
-                            pending.push(None);
-                        } else {
-                            pending.push(Some(callback))
-                        }
-                    } else {
-                        done = true;
+                    match message {
+                        Some(FlushMessage::EnableMetrics(new_metrics)) => {
+                            tracing::info!("enabling metrics in background flush worker");
+                            metrics = Some(new_metrics)
+                        },
+                        Some(FlushMessage::Callback(callback)) => {
+                            if ack_immediately {
+                                let db = db.clone();
+                                let result = spawn_blocking_in_current_span(move || {
+                                    let _guard = tracing::info_span!("logs:flush_worker:buffer").entered();
+                                    db.persist(PersistMode::Buffer)
+                                        // fjall::Error isn't Clone
+                                        .map_err(|err| {
+                                            tracing::error!(?err, "error flushing fjall in background");
+                                            BackgroundFsyncFailedError(err.to_string())
+                                        })
+                                })
+                                .await
+                                .expect("failed joining blocking task");
+                                callback.io_completed(result.map_err(std::io::Error::other));
+                                pending.push(None);
+                            } else {
+                                pending.push(Some(callback))
+                            }
+                        },
+                        None => { done = true }
                     }
                 },
                 _ = shutting_down.cancelled() => {
                     done = true
                 },
                 _ = ticker.tick() => {
-                    sync_now = !pending.is_empty()
+                    sync_from_ticker = true;
                 }
             }
 
-            if sync_now || (commits_before_fsync > 0 && pending.len() >= commits_before_fsync) {
+            let sync_from_count = commits_before_fsync > 0 && pending.len() >= commits_before_fsync;
+
+            if !pending.is_empty() && (sync_from_ticker || sync_from_count) {
                 let db = db.clone();
                 let num_commits = pending.len();
                 let result = spawn_blocking_in_current_span(
-                    move || -> Result<(), BackgroundFsyncFailedError> {
+                    move || -> Result<Duration, BackgroundFsyncFailedError> {
                         let _guard =
                             tracing::info_span!("logs:flush_worker:flush", num_commits).entered();
                         tracing::trace!("flushing logs to disk");
+                        let start_persist = std::time::Instant::now();
                         db.persist(fsync_mode.into()).map_err(|err| {
                             tracing::error!(?err, "error flushing fjall");
                             BackgroundFsyncFailedError(err.to_string())
-                        })
+                        })?;
+                        let persist_time = start_persist.elapsed();
+                        Ok(persist_time)
                     },
                 )
                 .await
-                .expect("failed joining blocking task");
+                .expect("failed joining blocking task")
+                .map(|persist_time| {
+                    duration_estimator.push(persist_time);
+                    if let Some(metrics) = &metrics {
+                        metrics.record_fsync(persist_time, pending.len());
+                    }
+                    synced = true;
+                });
                 tracing::trace!(num_pending = pending.len(), "committed for some items");
                 tracing::info_span!("logs:flush_worker:drain").in_scope(|| {
                     for callback in pending.drain(..).flatten() {
@@ -354,7 +391,24 @@ async fn flush_worker(
             }
         }
         .instrument(tracing::info_span!("logs:flush_worker"))
-        .await
+        .await;
+
+        if autoscale_duration && synced {
+            let new_estimate = duration_estimator.estimate();
+            if new_estimate < Duration::from_micros(1) {
+                tracing::debug!(?new_estimate, "ignoring obviously bogus fsync time")
+            } else if new_estimate.abs_diff(last_estimate) > Duration::from_micros(100) {
+                // only update when it changed significantly so we're not tearing down and
+                // recreating the tokio timer all the time
+                tracing::trace!(
+                    ?last_estimate,
+                    ?new_estimate,
+                    "updating fsync time estimate"
+                );
+                ticker = tokio::time::interval(new_estimate);
+                last_estimate = new_estimate;
+            }
+        }
     }
     if let Err(err) = db.persist(fsync_mode.into()) {
         tracing::error!(?err, "error flushing fjall at shutdown");
@@ -366,7 +420,7 @@ pub struct CoyoteLogs {
     db: Database,
     meta_keyspace: Keyspace,
     log_keyspace: Keyspace,
-    flush_tx: tokio::sync::mpsc::Sender<IOFlushed<TypeConfig>>,
+    flush_tx: tokio::sync::mpsc::Sender<FlushMessage>,
     log_cache: LogCache,
     metrics: Option<LogMetrics>,
     last_vote: Arc<Mutex<Option<Vote>>>,
@@ -379,6 +433,7 @@ impl CoyoteLogs {
         path: Dir,
         commits_before_fsync: usize,
         duration_before_fsync: Duration,
+        autoscale_duration: bool,
         ack_immediately: bool,
         fsync_mode: FsyncMode,
     ) -> anyhow::Result<Self> {
@@ -391,18 +446,15 @@ impl CoyoteLogs {
         })?;
         let meta_keyspace = db.keyspace("cluster:meta", KeyspaceCreateOptions::default)?;
         let (flush_tx, flush_rx) = tokio::sync::mpsc::channel(65536);
-        if commits_before_fsync == 1 {
-            tokio::spawn(flush_every_worker(db.clone(), flush_rx));
-        } else {
-            tokio::spawn(flush_worker(
-                db.clone(),
-                flush_rx,
-                commits_before_fsync,
-                duration_before_fsync,
-                ack_immediately,
-                fsync_mode,
-            ));
-        }
+        tokio::spawn(flush_worker(
+            db.clone(),
+            flush_rx,
+            commits_before_fsync,
+            duration_before_fsync,
+            autoscale_duration,
+            ack_immediately,
+            fsync_mode,
+        ));
         Ok(Self {
             db,
             log_keyspace,
@@ -414,9 +466,13 @@ impl CoyoteLogs {
         })
     }
 
-    pub(crate) fn enable_metrics(&mut self, metrics: LogMetrics) {
+    pub(crate) async fn enable_metrics(&mut self, metrics: LogMetrics) -> anyhow::Result<()> {
         self.metrics = Some(metrics.clone());
+        self.flush_tx
+            .send(FlushMessage::EnableMetrics(metrics.clone()))
+            .await?;
         self.start_metrics(metrics);
+        Ok(())
     }
 
     fn metric_record<F>(&self, f: F)
@@ -493,7 +549,7 @@ impl CoyoteLogs {
         .await??;
 
         self.flush_tx
-            .send(callback)
+            .send(FlushMessage::Callback(callback))
             .await
             .context("requesting background fsync")?;
 
@@ -795,6 +851,7 @@ mod tests {
                 logdir,
                 0,
                 Duration::from_hours(1),
+                false,
                 true,
                 FsyncMode::default(),
             )

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -76,6 +76,7 @@ pub async fn initialize_raft(
         cfg.cluster.log_path(cfg)?,
         cfg.cluster.log_sync_interval_commits,
         cfg.cluster.log_sync_interval_duration.into(),
+        cfg.cluster.log_sync_interval_auto,
         cfg.cluster.log_ack_immediately,
         cfg.fsync_mode,
     )
@@ -84,7 +85,8 @@ pub async fn initialize_raft(
         .get_node_id()
         .await
         .context("reading node ID from logs")?;
-    logs.enable_metrics(LogMetrics::new(&app_state.meter, id));
+    logs.enable_metrics(LogMetrics::new(&app_state.meter, id))
+        .await?;
     let config = openraft::Config {
         heartbeat_interval: cfg.cluster.heartbeat_interval.as_millis(),
         election_timeout_min: cfg.cluster.election_timeout_min.as_millis(),
@@ -239,6 +241,7 @@ mod tests {
                 log_path,
                 1,
                 Duration::from_secs(10),
+                false,
                 true,
                 FsyncMode::default(),
             )?;

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -161,6 +161,9 @@ pub struct LogMetrics {
     read_operations: Counter<u64>,
     read_batch_size: Histogram<u64>,
 
+    sync_latency: Histogram<u64>,
+    sync_entry_count: Histogram<u64>,
+
     context: Vec<KeyValue>,
 }
 
@@ -190,6 +193,16 @@ impl LogMetrics {
                 .u64_histogram("coyote.raft.log.read_batch_size")
                 .with_description("Raft log read operation batch sizes")
                 .build(),
+            sync_latency: meter
+                .u64_histogram("coyote.raft.log.sync_latency")
+                .with_description("Raft log sync latency")
+                .with_unit("us")
+                .build(),
+            sync_entry_count: meter
+                .u64_histogram("coyote.raft.log.sync_entry_count")
+                .with_description("Number of entries included in a log sync")
+                .with_unit("message")
+                .build(),
             context,
         }
     }
@@ -211,6 +224,12 @@ impl LogMetrics {
 
     pub fn entry_count(&self, count: u64) {
         self.entry_count.record(count, &self.context);
+    }
+
+    pub fn record_fsync(&self, duration: Duration, entries: usize) {
+        self.sync_latency
+            .record(duration.as_micros() as _, &self.context);
+        self.sync_entry_count.record(entries as _, &self.context);
     }
 }
 


### PR DESCRIPTION
I'd worked on this way back around #314; figured I'd finish it out.

This automatically adjusts the log fsync interval based on observed times. It also removes the (imo useless) fsync-per-commit code and updates some comments.