### PR TITLE
remove trace logging of request payloads

### DIFF
--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -94,16 +94,12 @@ pub struct RequestWithContext {
 
 impl fmt::Display for RequestWithContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.inner {
-            Request::ClusterInternal(_) => write!(f, "cluster_internal"),
-            Request::Kv(_) => write!(f, "kv"),
-            Request::RateLimit(_) => write!(f, "ratelimiter"),
-            Request::Idempotency(_) => write!(f, "idempotency"),
-            Request::Cache(_) => write!(f, "cache"),
-            Request::Msgs(_) => write!(f, "msgs"),
-            Request::AuthToken(_) => write!(f, "auth_token"),
-            Request::AdminAuth(_) => write!(f, "admin_auth"),
-        }
+        write!(
+            f,
+            "Request(module={}, hashed_key={})",
+            self.module(),
+            self.hashed_key().as_deref().unwrap_or("")
+        )
     }
 }
 

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -473,7 +473,7 @@ impl Store {
                     Response::Blank
                 }
                 EntryPayload::Normal(req) => {
-                    tracing::trace!(log_id=?item.log_id, request=?req, "applying user request");
+                    tracing::trace!(log_id=?item.log_id, request=%req, "applying user request");
 
                     if req.inner.affects_persistent() {
                         touched_persistent = true;


### PR DESCRIPTION
we statically disable `tracing::trace!` in release builds, but this will make debug builds do less work