### PR TITLE
improve "finished processing request" log line

### DIFF
--- a/src/core/otel_spans.rs
+++ b/src/core/otel_spans.rs
@@ -158,9 +158,9 @@ impl<B> OnResponse<B> for AxumOtelOnResponse {
         span.record("otel.status_code", "OK");
 
         tracing::debug!(
-            "finished processing request latency={} ms status={}",
-            latency.as_millis(),
-            response.status().as_u16(),
+            latency_micros = latency.as_micros(),
+            status = response.status().as_u16(),
+            "finished processing request"
         );
     }
 }


### PR DESCRIPTION
having the message not be constant makes it harder to search in, e.g., cloudwatch, and millis aren't really that useful