### PR TITLE
Replace Vec<u8> in models and API with custom ByteString type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "regex",
  "schemars 1.2.1",
  "serde",
+ "serde_bytes",
  "serde_json",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,11 +1202,9 @@ dependencies = [
  "coyote-operations",
  "fjall-utils",
  "jiff",
- "schemars 1.2.1",
  "serde",
  "tokio",
  "tracing",
- "validator",
 ]
 
 [[package]]

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -14,11 +14,9 @@ coyote-namespace.workspace = true
 coyote-operations.workspace = true
 fjall-utils.workspace = true
 jiff.workspace = true
-schemars.workspace = true
 serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-validator.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -16,9 +16,6 @@ use coyote_namespace::{Namespace, entities::CacheConfig};
 use coyote_operations::{BackgroundError, BackgroundResult};
 use fjall_utils::Databases;
 use jiff::Timestamp;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use validator::Validate;
 
 pub type CacheNamespace = Namespace<CacheConfig>;
 
@@ -39,13 +36,6 @@ impl State {
     pub fn controller(&self) -> &KvController {
         &self.controller
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
-pub struct CacheModel {
-    pub expiry: Option<Timestamp>,
-
-    pub value: Vec<u8>,
 }
 
 #[derive(Clone)]

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -1,6 +1,6 @@
 use super::{CacheRaftState, CacheRequest, SetResponse};
 use crate::CacheNamespace;
-use coyote_core::types::DurationMs;
+use coyote_core::types::{ByteString, DurationMs};
 use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
@@ -13,7 +13,7 @@ pub struct SetOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,
     ttl: Option<DurationMs>,
-    value: Vec<u8>,
+    value: ByteString,
 }
 
 impl SetOperation {
@@ -21,7 +21,7 @@ impl SetOperation {
         namespace: CacheNamespace,
         key: String,
         ttl: Option<DurationMs>,
-        value: Vec<u8>,
+        value: ByteString,
     ) -> Self {
         Self {
             namespace_id: namespace.id,

--- a/crates/coyote-core/Cargo.toml
+++ b/crates/coyote-core/Cargo.toml
@@ -13,6 +13,7 @@ rand.workspace = true
 regex.workspace = true
 schemars.workspace = true
 serde.workspace = true
+serde_bytes.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/coyote-core/src/types/byte_string.rs
+++ b/crates/coyote-core/src/types/byte_string.rs
@@ -1,0 +1,83 @@
+use std::{fmt, ops::Deref, sync::Arc};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ByteString(Arc<[u8]>);
+
+impl fmt::Debug for ByteString {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Deref for ByteString {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<&[u8]> for ByteString {
+    #[inline]
+    fn from(value: &[u8]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Vec<u8>> for ByteString {
+    #[inline]
+    fn from(value: Vec<u8>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for ByteString {
+    #[inline]
+    fn from(value: &[u8; N]) -> Self {
+        value.as_slice().into()
+    }
+}
+
+impl<const N: usize> PartialEq<&[u8; N]> for ByteString {
+    #[inline]
+    fn eq(&self, other: &&[u8; N]) -> bool {
+        *self.0 == **other
+    }
+}
+
+impl Serialize for ByteString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serde_bytes::Bytes::new(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ByteString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        serde_bytes::deserialize(deserializer).map(|vec: Vec<u8>| Self(vec.into()))
+    }
+}
+
+impl JsonSchema for ByteString {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ByteString".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        <Vec<u8>>::json_schema(generator)
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+}

--- a/crates/coyote-core/src/types/mod.rs
+++ b/crates/coyote-core/src/types/mod.rs
@@ -12,10 +12,11 @@ use validator::{Validate, ValidationErrors};
 
 use crate::validation::validation_error;
 
+mod byte_string;
 mod duration_ms;
 mod metadata;
 
-pub use self::{duration_ms::DurationMs, metadata::Metadata};
+pub use self::{byte_string::ByteString, duration_ms::DurationMs, metadata::Metadata};
 
 const ALL_ERROR: &str = "__all__";
 

--- a/crates/idempotency/src/lib.rs
+++ b/crates/idempotency/src/lib.rs
@@ -13,7 +13,10 @@ pub mod operations;
 
 use std::time::Duration;
 
-use coyote_core::{Monotime, types::Metadata};
+use coyote_core::{
+    Monotime,
+    types::{ByteString, Metadata},
+};
 use coyote_error::Result;
 use coyote_kv::kvcontroller::KvController;
 use coyote_namespace::{Namespace, entities::IdempotencyConfig};
@@ -32,7 +35,7 @@ pub(crate) enum IdempotencyState {
     InProgress,
     /// Request completed successfully with a response
     Completed {
-        response: Vec<u8>,
+        response: ByteString,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         context: Option<Metadata>,
     },
@@ -44,20 +47,23 @@ pub enum IdempotencyStartResult {
     Started,
     Locked,
     Completed {
-        response: Vec<u8>,
+        response: ByteString,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         context: Option<Metadata>,
     },
 }
 
-impl From<IdempotencyState> for Vec<u8> {
+impl From<IdempotencyState> for ByteString {
     fn from(state: IdempotencyState) -> Self {
-        rmp_serde::to_vec_named(&state).expect("Failed to serialize IdempotencyState")
+        // FIXME(jplatte): Could probably serialize in place
+        rmp_serde::to_vec_named(&state)
+            .expect("Failed to serialize IdempotencyState")
+            .into()
     }
 }
 
-impl From<Vec<u8>> for IdempotencyState {
-    fn from(value: Vec<u8>) -> Self {
+impl From<ByteString> for IdempotencyState {
+    fn from(value: ByteString) -> Self {
         rmp_serde::from_slice(&value).expect("Failed to deserialize IdempotencyState")
     }
 }

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -1,6 +1,6 @@
 use super::{CompleteResponse, IdempotencyRaftState, IdempotencyRequest};
 use crate::{IdempotencyNamespace, IdempotencyState};
-use coyote_core::types::{DurationMs, Metadata};
+use coyote_core::types::{ByteString, DurationMs, Metadata};
 use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_kv::kvcontroller::{KvModelIn, OperationBehavior};
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 pub struct CompleteOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,
-    pub(crate) response: Vec<u8>,
+    pub(crate) response: ByteString,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) context: Option<Metadata>,
     #[serde(rename = "ttl_ms")]
@@ -22,7 +22,7 @@ impl CompleteOperation {
     pub fn new(
         namespace: IdempotencyNamespace,
         key: String,
-        response: Vec<u8>,
+        response: ByteString,
         context: Option<Metadata>,
         ttl: DurationMs,
     ) -> Self {

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 use coyote_core::{
     instrumented_mutex::{InstrumentedMutex, InstrumentedMutexGuard},
     task::spawn_blocking_in_current_span,
+    types::ByteString,
 };
 use coyote_error::{Error, Result};
 use coyote_id::NamespaceId;
@@ -30,7 +31,7 @@ pub enum OperationBehavior {
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct KvModel {
     pub expiry: Option<Timestamp>,
-    pub value: Vec<u8>,
+    pub value: ByteString,
     /// Opaque version token for optimistic concurrency control.
     pub version: u64,
 }
@@ -39,7 +40,7 @@ pub struct KvModel {
 /// version for OCC — `None` skips the check.
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct KvModelIn {
-    pub value: Vec<u8>,
+    pub value: ByteString,
     pub expiry: Option<Timestamp>,
     pub version: Option<u64>,
 }
@@ -429,7 +430,7 @@ mod tests {
                 ns(),
                 key,
                 KvModelIn {
-                    value: b"hello world".to_vec(),
+                    value: b"hello world".into(),
                     expiry: None,
                     version: None,
                 },
@@ -464,7 +465,7 @@ mod tests {
                 ns(),
                 "key1",
                 KvModelIn {
-                    value: b"key1 updated".to_vec(),
+                    value: b"key1 updated".into(),
                     expiry: None,
                     version: None,
                 },
@@ -481,7 +482,7 @@ mod tests {
                 ns(),
                 "key1",
                 KvModelIn {
-                    value: b"key1 inserted".to_vec(),
+                    value: b"key1 inserted".into(),
                     expiry: None,
                     version: None,
                 },
@@ -504,7 +505,7 @@ mod tests {
                 ns(),
                 "key1",
                 KvModelIn {
-                    value: b"another value".to_vec(),
+                    value: b"another value".into(),
                     expiry: None,
                     version: None,
                 },
@@ -528,7 +529,7 @@ mod tests {
                 ns(),
                 "key1",
                 KvModelIn {
-                    value: b"key1 upserted".to_vec(),
+                    value: b"key1 upserted".into(),
                     expiry: None,
                     version: None,
                 },
@@ -558,7 +559,7 @@ mod tests {
                 ns(),
                 key,
                 KvModelIn {
-                    value: b"first value".to_vec(),
+                    value: b"first value".into(),
                     expiry: None,
                     version: None,
                 },
@@ -573,7 +574,7 @@ mod tests {
                 ns(),
                 key,
                 KvModelIn {
-                    value: b"second value".to_vec(),
+                    value: b"second value".into(),
                     expiry: None,
                     version: None,
                 },
@@ -605,7 +606,7 @@ mod tests {
                 ns(),
                 "expired:key",
                 KvModelIn {
-                    value: b"expired data".to_vec(),
+                    value: b"expired data".into(),
                     expiry: Some(now.checked_sub(1.hour()).unwrap()),
                     version: None,
                 },
@@ -639,14 +640,14 @@ mod tests {
             ),
         ];
 
-        for (key, expiry, value) in &expired_models {
+        for (key, expiry, value) in expired_models {
             controller
                 .set(
                     ns(),
                     key.to_string(),
                     KvModelIn {
-                        value: value.to_vec(),
-                        expiry: Some(*expiry),
+                        value: value.into(),
+                        expiry: Some(expiry),
                         version: None,
                     },
                     OperationBehavior::Upsert,
@@ -663,7 +664,7 @@ mod tests {
                 ns(),
                 valid_key,
                 KvModelIn {
-                    value: b"valid data".to_vec(),
+                    value: b"valid data".into(),
                     expiry: Some(now.checked_add(1.hour()).unwrap()),
                     version: None,
                 },
@@ -680,7 +681,7 @@ mod tests {
                 ns(),
                 permanent_key,
                 KvModelIn {
-                    value: b"permanent data".to_vec(),
+                    value: b"permanent data".into(),
                     expiry: None,
                     version: None,
                 },
@@ -759,7 +760,7 @@ mod tests {
                 ns,
                 key,
                 KvModelIn {
-                    value: b"first value".to_vec(),
+                    value: b"first value".into(),
                     expiry: Some(expiry),
                     version: None,
                 },
@@ -789,7 +790,7 @@ mod tests {
                 ns,
                 key,
                 KvModelIn {
-                    value: b"first value".to_vec(),
+                    value: b"first value".into(),
                     expiry: Some(later_expiry),
                     version: None,
                 },

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use super::{KvRequest, SetResponse};
-use coyote_core::types::{DurationMs, EntityKey};
+use coyote_core::types::{ByteString, DurationMs, EntityKey};
 use coyote_error::Result;
 use coyote_id::NamespaceId;
 use coyote_operations::OpContext;
@@ -23,7 +23,7 @@ pub struct SetResponseData {
 pub struct SetOperation {
     namespace_id: NamespaceId,
     pub(crate) key: EntityKey,
-    value: Vec<u8>,
+    value: ByteString,
     version: Option<u64>,
     ttl: Option<DurationMs>,
     behavior: OperationBehavior,
@@ -33,7 +33,7 @@ impl SetOperation {
     pub fn new(
         namespace: KvNamespace,
         key: EntityKey,
-        value: Vec<u8>,
+        value: ByteString,
         ttl: Option<DurationMs>,
         behavior: OperationBehavior,
         version: Option<u64>,

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -1,3 +1,4 @@
+use coyote_core::types::ByteString;
 use coyote_error::{Result, ResultExt};
 use coyote_id::NamespaceId;
 use fjall_utils::{TableKey, TableRow};
@@ -13,7 +14,7 @@ enum RowType {
 
 #[derive(Serialize, Deserialize)]
 pub struct KvPairRow {
-    pub value: Vec<u8>,
+    pub value: ByteString,
     pub expiry: Option<Timestamp>,
     #[serde(default)]
     pub version: u64,

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt, num::NonZeroU64, ops::Deref, str::FromStr};
 
-use coyote_core::types::DurationMs;
+use coyote_core::types::{ByteString, DurationMs};
 use coyote_error::Error;
 use jiff::Timestamp;
 use schemars::JsonSchema;
@@ -333,7 +333,7 @@ impl JsonSchema for MsgId {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct MsgIn {
-    pub value: Vec<u8>,
+    pub value: ByteString,
     #[serde(default)]
     pub headers: HashMap<String, String>,
     /// Optional partition key.
@@ -352,7 +352,7 @@ pub struct MsgIn {
 pub struct StreamMsgOut {
     pub offset: Offset,
     pub topic: TopicPartition,
-    pub value: Vec<u8>,
+    pub value: ByteString,
     #[serde(default)]
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,
@@ -363,7 +363,7 @@ pub struct StreamMsgOut {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct QueueMsgOut {
     pub msg_id: MsgId,
-    pub value: Vec<u8>,
+    pub value: ByteString,
     #[serde(default)]
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,

--- a/crates/msgs/src/metrics.rs
+++ b/crates/msgs/src/metrics.rs
@@ -368,7 +368,7 @@ mod tests {
     ) {
         let mut batch = db.batch();
         let row = MsgRow {
-            value: vec![],
+            value: b"".into(),
             headers: HashMap::new(),
             timestamp: Timestamp::UNIX_EPOCH,
             scheduled_at: None,

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, num::NonZeroU16};
 
-use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
+use coyote_core::{
+    task::spawn_blocking_in_current_span,
+    types::{ByteString, DurationMs},
+};
 use coyote_error::{Error, Result};
 use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -279,7 +282,7 @@ pub(crate) fn compact_cursor(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueueReceiveMsg {
     pub msg_id: MsgId,
-    pub value: Vec<u8>,
+    pub value: ByteString,
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,
     pub scheduled_at: Option<Timestamp>,

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -1,6 +1,9 @@
 use std::num::NonZeroU16;
 
-use coyote_core::{task::spawn_blocking_in_current_span, types::DurationMs};
+use coyote_core::{
+    task::spawn_blocking_in_current_span,
+    types::{ByteString, DurationMs},
+};
 use coyote_error::{Error, Result};
 use coyote_id::{NamespaceId, UuidV7RandomBytes};
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -193,7 +196,7 @@ impl StreamReceiveOperation {
 pub struct StreamReceiveMsg {
     pub offset: Offset,
     pub topic: TopicPartition,
-    pub value: Vec<u8>,
+    pub value: ByteString,
     pub headers: std::collections::HashMap<String, String>,
     pub timestamp: Timestamp,
     pub scheduled_at: Option<Timestamp>,

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -1,3 +1,4 @@
+use coyote_core::types::ByteString;
 use coyote_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use std::collections::HashMap;
 
@@ -267,7 +268,7 @@ impl TableRow for QueueConfigRow {
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct MsgRow {
-    pub value: Vec<u8>,
+    pub value: ByteString,
     pub headers: HashMap<String, String>,
     pub timestamp: Timestamp,
     #[serde(default)]

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -5,7 +5,7 @@ use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_authorization::RequestedOperation;
 use coyote_cache::operations::{CreateCacheOperation, DeleteOperation, SetOperation};
-use coyote_core::types::{Consistency, DurationMs, EntityKey};
+use coyote_core::types::{ByteString, Consistency, DurationMs, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt, ResultExt};
 use coyote_id::Module;
@@ -55,7 +55,7 @@ pub struct CacheSetIn {
 
     pub key: EntityKey,
 
-    pub value: Vec<u8>,
+    pub value: ByteString,
 
     /// Time to live in milliseconds
     #[serde(rename = "ttl_ms")]
@@ -86,7 +86,7 @@ pub struct CacheGetOut {
     /// Time of expiry
     pub expiry: Option<Timestamp>,
 
-    pub value: Option<Vec<u8>>,
+    pub value: Option<ByteString>,
 }
 
 impl CacheGetOut {

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -4,7 +4,7 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_authorization::RequestedOperation;
-use coyote_core::types::{DurationMs, EntityKey, Metadata};
+use coyote_core::types::{ByteString, DurationMs, EntityKey, Metadata};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt as _, ResultExt};
 use coyote_id::Module;
@@ -85,7 +85,7 @@ pub enum IdempotencyStartOut {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct IdempotencyCompleted {
-    pub response: Vec<u8>,
+    pub response: ByteString,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<Metadata>,
 }
@@ -112,7 +112,7 @@ pub struct IdempotencyCompleteIn {
     pub key: EntityKey,
 
     /// The response to cache
-    pub response: Vec<u8>,
+    pub response: ByteString,
 
     /// Optional metadata to store alongside the response
     #[serde(default)]

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -4,7 +4,7 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use coyote_authorization::RequestedOperation;
-use coyote_core::types::{Consistency, DurationMs, EntityKey};
+use coyote_core::types::{ByteString, Consistency, DurationMs, EntityKey};
 use coyote_derive::aide_annotate;
 use coyote_error::{OptionExt, ResultExt};
 use coyote_id::Module;
@@ -54,7 +54,7 @@ pub struct KvSetIn {
     #[validate(nested)]
     pub key: EntityKey,
 
-    pub value: Vec<u8>,
+    pub value: ByteString,
 
     /// Time to live in milliseconds
     #[serde(rename = "ttl_ms")]
@@ -97,7 +97,7 @@ pub struct KvGetOut {
     /// Time of expiry
     pub expiry: Option<Timestamp>,
 
-    pub value: Option<Vec<u8>>,
+    pub value: Option<ByteString>,
 
     /// Opaque version token for optimistic concurrency control.
     /// Pass as `version` in a subsequent `set` to perform a conditional write.


### PR DESCRIPTION
… that is cheaper to clone. Also lets us control the JSON Schema for these, though actually doing that is left for another PR.