### PR TITLE
infra: keep coyote names

### DIFF
--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -12,6 +12,10 @@ operator:
       operator: Equal
       value: diom
       effect: NoSchedule
+    - key: db-name
+      operator: Equal
+      value: coyote
+      effect: NoSchedule
 
 cluster:
   image:
@@ -24,7 +28,7 @@ cluster:
         service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
         service.beta.kubernetes.io/aws-load-balancer-attributes: dns_record.client_routing_policy=availability_zone_affinity
-        external-dns.alpha.kubernetes.io/hostname: "diom.svix.local"
+        external-dns.alpha.kubernetes.io/hostname: "coyote.svix.local"
     storage:
       persistent:
         size: 64Gi
@@ -38,11 +42,16 @@ cluster:
       - name: RUST_BACKTRACE
         value: "1"
     nodeSelector:
-      db-name: diom
+      db-name: coyote
     tolerations:
       - key: db-name
         operator: Equal
         value: diom
+        effect: NoSchedule
+    tolerations:
+      - key: db-name
+        operator: Equal
+        value: coyote
         effect: NoSchedule
     affinity:
       podAntiAffinity:

--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -48,7 +48,6 @@ cluster:
         operator: Equal
         value: diom
         effect: NoSchedule
-    tolerations:
       - key: db-name
         operator: Equal
         value: coyote


### PR DESCRIPTION
This should allow us to continue to deploy to the same infrastructure in staging until monorepo is changed.