### PR TITLE
switch interserver protocol to use postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,7 @@ dependencies = [
  "http",
  "http-body-util",
  "mime",
+ "postcard",
  "reqwest 0.13.2",
  "rmp-serde",
  "schemars 1.2.1",

--- a/crates/diom-proto/Cargo.toml
+++ b/crates/diom-proto/Cargo.toml
@@ -18,6 +18,7 @@ diom-core.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 mime.workspace = true
+postcard.workspace = true
 reqwest.workspace = true
 rmp-serde.workspace = true
 schemars.workspace = true

--- a/crates/diom-proto/src/internal_client.rs
+++ b/crates/diom-proto/src/internal_client.rs
@@ -6,7 +6,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use tap::Tap;
 use tokio::sync::{mpsc, oneshot};
 
-const APPLICATION_MSGPACK: HeaderValue = HeaderValue::from_static("application/msgpack");
+use super::msgpack_client::APPLICATION_MSGPACK;
 
 /// API client for interacting with the internal "loopback" API server.
 #[derive(Clone)]

--- a/crates/diom-proto/src/lib.rs
+++ b/crates/diom-proto/src/lib.rs
@@ -3,6 +3,8 @@ mod internal_client;
 mod msgpack;
 mod msgpack_client;
 mod msgpack_or_json;
+mod postcard_;
+mod postcard_client;
 pub mod prelude;
 mod request_input;
 
@@ -11,5 +13,6 @@ pub use self::{
     internal_client::{InternalClient, InternalRequest, InternalRequestError},
     msgpack::MsgPack,
     msgpack_or_json::{MsgPackOrJson, capture_accept_hdr},
+    postcard_::PostCard,
     request_input::{AccessMetadata, RequestInput},
 };

--- a/crates/diom-proto/src/msgpack_client.rs
+++ b/crates/diom-proto/src/msgpack_client.rs
@@ -75,12 +75,12 @@ pub trait MsgpackResponse {
 
 impl MsgpackResponse for reqwest::Response {
     async fn msgpack<T: DeserializeOwned>(self) -> Result<T, MsgpackResponseError> {
-        if let Some(content_type) = self.headers().get(CONTENT_TYPE) {
-            if content_type != APPLICATION_MSGPACK {
-                return Err(MsgpackResponseError::InvalidResponseContentType(
-                    content_type.clone(),
-                ));
-            }
+        if let Some(content_type) = self.headers().get(CONTENT_TYPE)
+            && content_type != APPLICATION_MSGPACK
+        {
+            return Err(MsgpackResponseError::InvalidResponseContentType(
+                content_type.clone(),
+            ));
         }
 
         let full = self.bytes().await?;

--- a/crates/diom-proto/src/msgpack_client.rs
+++ b/crates/diom-proto/src/msgpack_client.rs
@@ -1,8 +1,9 @@
+use http::header::CONTENT_TYPE;
 use serde::{Serialize, de::DeserializeOwned};
 use tap::Pipe;
 
-const CONTENT_TYPE: http::HeaderName = http::HeaderName::from_static("content-type");
-const MSGPACK: http::HeaderValue = http::HeaderValue::from_static("application/msgpack");
+pub(crate) const APPLICATION_MSGPACK: http::HeaderValue =
+    http::HeaderValue::from_static("application/msgpack");
 
 pub trait MsgpackRequestBuilder: Sized {
     fn msgpack<T: Serialize + ?Sized>(self, body: &T) -> Result<Self, rmp_serde::encode::Error>;
@@ -11,7 +12,9 @@ pub trait MsgpackRequestBuilder: Sized {
 impl MsgpackRequestBuilder for reqwest::RequestBuilder {
     fn msgpack<T: Serialize + ?Sized>(self, body: &T) -> Result<Self, rmp_serde::encode::Error> {
         let serialized = rmp_serde::to_vec_named(body)?;
-        self.header(CONTENT_TYPE, MSGPACK).body(serialized).pipe(Ok)
+        self.header(CONTENT_TYPE, APPLICATION_MSGPACK)
+            .body(serialized)
+            .pipe(Ok)
     }
 }
 
@@ -19,6 +22,7 @@ impl MsgpackRequestBuilder for reqwest::RequestBuilder {
 pub enum MsgpackResponseError {
     Network(reqwest::Error),
     Serialization(rmp_serde::decode::Error),
+    InvalidResponseContentType(http::HeaderValue),
 }
 
 impl From<reqwest::Error> for MsgpackResponseError {
@@ -38,6 +42,12 @@ impl std::fmt::Display for MsgpackResponseError {
         match self {
             Self::Network(e) => e.fmt(f),
             Self::Serialization(e) => e.fmt(f),
+            Self::InvalidResponseContentType(ct) => {
+                write!(
+                    f,
+                    "invalid response content-type: got {ct:?}, expected {APPLICATION_MSGPACK:?}"
+                )
+            }
         }
     }
 }
@@ -51,6 +61,7 @@ impl std::error::Error for MsgpackResponseError {
         match self {
             Self::Network(e) => Some(e),
             Self::Serialization(e) => Some(e),
+            Self::InvalidResponseContentType(_) => None,
         }
     }
 }
@@ -64,6 +75,14 @@ pub trait MsgpackResponse {
 
 impl MsgpackResponse for reqwest::Response {
     async fn msgpack<T: DeserializeOwned>(self) -> Result<T, MsgpackResponseError> {
+        if let Some(content_type) = self.headers().get(CONTENT_TYPE) {
+            if content_type != APPLICATION_MSGPACK {
+                return Err(MsgpackResponseError::InvalidResponseContentType(
+                    content_type.clone(),
+                ));
+            }
+        }
+
         let full = self.bytes().await?;
 
         rmp_serde::from_slice(&full).map_err(Into::into)

--- a/crates/diom-proto/src/postcard_.rs
+++ b/crates/diom-proto/src/postcard_.rs
@@ -1,0 +1,201 @@
+use axum::{
+    extract::{FromRequest, OptionalFromRequest, Request, rejection::BytesRejection},
+    response::{IntoResponse, Response},
+};
+use bytes::{Bytes, BytesMut};
+use http::{
+    StatusCode,
+    header::{self, HeaderMap, HeaderValue},
+};
+use serde::{Serialize, de::DeserializeOwned};
+
+const APPLICATION_POSTCARD: HeaderValue = HeaderValue::from_static("application/x-postcard");
+
+#[derive(Debug, Clone)]
+pub struct MissingPostCardContentType;
+
+impl IntoResponse for MissingPostCardContentType {
+    fn into_response(self) -> Response {
+        let status = StatusCode::BAD_REQUEST;
+
+        tracing::warn!(?status, "missing content-type");
+
+        (
+            status,
+            "Expected request with `Content-Type: application/x-postcard`",
+        )
+            .into_response()
+    }
+}
+
+#[derive(Debug)]
+pub struct PostCardParseError(postcard::Error);
+
+impl IntoResponse for PostCardParseError {
+    fn into_response(self) -> Response {
+        let status = StatusCode::BAD_REQUEST;
+
+        tracing::warn!(?status, error = ?self.0, "parse error");
+
+        (status, "Failed to parse the request body as postcard").into_response()
+    }
+}
+
+#[derive(Debug)]
+pub enum PostCardRejection {
+    MissingPostCardContentType(MissingPostCardContentType),
+    PostCardParseError(PostCardParseError),
+    BytesRejection(BytesRejection),
+}
+
+impl IntoResponse for PostCardRejection {
+    fn into_response(self) -> Response {
+        match self {
+            Self::MissingPostCardContentType(r) => r.into_response(),
+            Self::PostCardParseError(r) => r.into_response(),
+            Self::BytesRejection(r) => r.into_response(),
+        }
+    }
+}
+
+impl From<MissingPostCardContentType> for PostCardRejection {
+    fn from(value: MissingPostCardContentType) -> Self {
+        Self::MissingPostCardContentType(value)
+    }
+}
+
+impl From<PostCardParseError> for PostCardRejection {
+    fn from(value: PostCardParseError) -> Self {
+        Self::PostCardParseError(value)
+    }
+}
+
+impl From<BytesRejection> for PostCardRejection {
+    fn from(value: BytesRejection) -> Self {
+        Self::BytesRejection(value)
+    }
+}
+
+/// PostCard Extractor / Response.
+///
+/// When used as an extractor, it can deserialize request bodies into some type that
+/// implements [`serde::de::DeserializeOwned`]. The request will be rejected (and a [`PostCardRejection`] will
+/// be returned) if:
+///
+/// - The request doesn't have a `Content-Type: application/PostCard` (or similar) header.
+/// - The body doesn't contain syntactically valid PostCard.
+/// - The body contains syntactically valid PostCard, but it couldn't be deserialized into the target type.
+/// - Buffering the request body fails.
+///
+/// ⚠️ Since parsing PostCard requires consuming the request body, the `PostCard` extractor must be
+/// *last* if there are multiple extractors in a handler.
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+pub struct PostCard<T>(pub T);
+
+impl<T, S> FromRequest<S> for PostCard<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = PostCardRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        if !postcard_content_type(req.headers()) {
+            return Err(MissingPostCardContentType.into());
+        }
+
+        let bytes = Bytes::from_request(req, state).await?;
+        Self::from_bytes(&bytes)
+    }
+}
+
+impl<T, S> OptionalFromRequest<S> for PostCard<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = PostCardRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Option<Self>, Self::Rejection> {
+        let headers = req.headers();
+        if headers.get(header::CONTENT_TYPE).is_some() {
+            if postcard_content_type(headers) {
+                let bytes = Bytes::from_request(req, state).await?;
+                Ok(Some(Self::from_bytes(&bytes)?))
+            } else {
+                Err(MissingPostCardContentType.into())
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn postcard_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .is_some_and(|c| c == APPLICATION_POSTCARD)
+}
+
+impl<T> std::ops::Deref for PostCard<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for PostCard<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for PostCard<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T> PostCard<T>
+where
+    T: DeserializeOwned,
+{
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, PostCardRejection> {
+        postcard::from_bytes(bytes)
+            .map_err(|e| PostCardRejection::PostCardParseError(PostCardParseError(e)))
+            .map(Self)
+    }
+}
+
+impl<T> IntoResponse for PostCard<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        // Extracted into separate fn so it's only compiled once for all T.
+        fn make_response(ser_result: Result<BytesMut, postcard::Error>) -> Response {
+            match ser_result {
+                Ok(buf) => {
+                    ([(header::CONTENT_TYPE, APPLICATION_POSTCARD)], buf.freeze()).into_response()
+                }
+                Err(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [(
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                    )],
+                    err.to_string(),
+                )
+                    .into_response(),
+            }
+        }
+
+        let buf = BytesMut::with_capacity(128);
+        let res = postcard::to_extend(&self.0, buf);
+        make_response(res)
+    }
+}

--- a/crates/diom-proto/src/postcard_client.rs
+++ b/crates/diom-proto/src/postcard_client.rs
@@ -1,0 +1,90 @@
+use http::header::CONTENT_TYPE;
+use serde::{Serialize, de::DeserializeOwned};
+use tap::Pipe;
+
+pub(crate) const APPLICATION_POSTCARD: http::HeaderValue =
+    http::HeaderValue::from_static("application/x-postcard");
+
+pub trait PostcardRequestBuilder: Sized {
+    fn postcard<T: Serialize + ?Sized>(self, body: &T) -> Result<Self, postcard::Error>;
+}
+
+impl PostcardRequestBuilder for reqwest::RequestBuilder {
+    fn postcard<T: Serialize + ?Sized>(self, body: &T) -> Result<Self, postcard::Error> {
+        let serialized = postcard::to_allocvec(body)?;
+        self.header(CONTENT_TYPE, APPLICATION_POSTCARD)
+            .body(serialized)
+            .pipe(Ok)
+    }
+}
+
+#[derive(Debug)]
+pub enum PostcardResponseError {
+    Network(reqwest::Error),
+    Serialization(postcard::Error),
+    InvalidResponseContentType(http::HeaderValue),
+}
+
+impl From<reqwest::Error> for PostcardResponseError {
+    fn from(value: reqwest::Error) -> Self {
+        Self::Network(value)
+    }
+}
+
+impl From<postcard::Error> for PostcardResponseError {
+    fn from(value: postcard::Error) -> Self {
+        Self::Serialization(value)
+    }
+}
+
+impl std::fmt::Display for PostcardResponseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Network(e) => e.fmt(f),
+            Self::Serialization(e) => e.fmt(f),
+            Self::InvalidResponseContentType(ct) => {
+                write!(
+                    f,
+                    "invalid response content-type: got {ct:?}, expected {APPLICATION_POSTCARD:?}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for PostcardResponseError {
+    fn description(&self) -> &str {
+        "error reading postcard body"
+    }
+
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Network(e) => Some(e),
+            Self::Serialization(e) => Some(e),
+            Self::InvalidResponseContentType(_) => None,
+        }
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait PostcardResponse {
+    // it would be nice if reqwest::Error::new were public so we could return that
+    // instead of wrapping the error...
+    async fn postcard<T: DeserializeOwned>(self) -> Result<T, PostcardResponseError>;
+}
+
+impl PostcardResponse for reqwest::Response {
+    async fn postcard<T: DeserializeOwned>(self) -> Result<T, PostcardResponseError> {
+        if let Some(content_type) = self.headers().get(CONTENT_TYPE) {
+            if content_type != APPLICATION_POSTCARD {
+                return Err(PostcardResponseError::InvalidResponseContentType(
+                    content_type.clone(),
+                ));
+            }
+        }
+
+        let full = self.bytes().await?;
+
+        postcard::from_bytes(&full).map_err(Into::into)
+    }
+}

--- a/crates/diom-proto/src/postcard_client.rs
+++ b/crates/diom-proto/src/postcard_client.rs
@@ -75,12 +75,12 @@ pub trait PostcardResponse {
 
 impl PostcardResponse for reqwest::Response {
     async fn postcard<T: DeserializeOwned>(self) -> Result<T, PostcardResponseError> {
-        if let Some(content_type) = self.headers().get(CONTENT_TYPE) {
-            if content_type != APPLICATION_POSTCARD {
-                return Err(PostcardResponseError::InvalidResponseContentType(
-                    content_type.clone(),
-                ));
-            }
+        if let Some(content_type) = self.headers().get(CONTENT_TYPE)
+            && content_type != APPLICATION_POSTCARD
+        {
+            return Err(PostcardResponseError::InvalidResponseContentType(
+                content_type.clone(),
+            ));
         }
 
         let full = self.bytes().await?;

--- a/crates/diom-proto/src/prelude.rs
+++ b/crates/diom-proto/src/prelude.rs
@@ -1,1 +1,2 @@
 pub use super::msgpack_client::{MsgpackRequestBuilder, MsgpackResponse};
+pub use super::postcard_client::{PostcardRequestBuilder, PostcardResponse};

--- a/crates/diom-proto/src/prelude.rs
+++ b/crates/diom-proto/src/prelude.rs
@@ -1,2 +1,4 @@
-pub use super::msgpack_client::{MsgpackRequestBuilder, MsgpackResponse};
-pub use super::postcard_client::{PostcardRequestBuilder, PostcardResponse};
+pub use super::{
+    msgpack_client::{MsgpackRequestBuilder, MsgpackResponse},
+    postcard_client::{PostcardRequestBuilder, PostcardResponse},
+};

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::disallowed_types)] // we can't use MsgPackOrJson because these endpoints are not OpenAPI-based
-
 use std::sync::Arc;
 
 use axum::{
@@ -10,14 +8,14 @@ use axum::{
     routing::{get, post},
 };
 use axum_extra::TypedHeader;
-use diom_proto::{MsgPack, MsgPackOrJson};
+use diom_proto::{MsgPack, MsgPackOrJson, PostCard};
 use headers::{Authorization, authorization::Bearer};
 use http::StatusCode;
 use openraft::{
     ChangeMembers,
     raft::{AppendEntriesRequest, InstallSnapshotRequest, VoteRequest},
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tap::{Pipe, TapFallible};
 
 use super::{
@@ -116,6 +114,21 @@ where
     }
 }
 
+fn postcard_rpc_response<Ok, Err>(result: Result<Ok, Err>) -> Response
+where
+    Ok: Serialize,
+    Err: Serialize,
+{
+    match result {
+        Ok(ok) => (StatusCode::OK, PostCard(V0Wrapper::V0(ok))).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            PostCard(V0Wrapper::V0(e)),
+        )
+            .into_response(),
+    }
+}
+
 fn admin_response<Ok, Err>(result: Result<Ok, Err>) -> Response
 where
     Ok: Serialize,
@@ -130,18 +143,29 @@ where
     }
 }
 
+/// Version envelope for values used in replication. This allows us to theoretically
+/// change these structures in the future without breaking compatibility
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) enum V0Wrapper<T> {
+    V0(T),
+}
+
 // Standard functions
 
 #[tracing::instrument(skip_all)]
 async fn append_entries(
     Extension(state): Extension<RaftState>,
-    MsgPack(body): MsgPack<AppendEntriesRequest<TypeConfig>>,
+    PostCard(V0Wrapper::V0(body)): PostCard<V0Wrapper<AppendEntriesRequest<TypeConfig>>>,
 ) -> impl IntoResponse {
     tracing::trace!(
         num_entries=body.entries.len(),
         leader_commit=?body.leader_commit,
         "appending some entries to the log");
-    state.raft.append_entries(body).await.pipe(rpc_response)
+    state
+        .raft
+        .append_entries(body)
+        .await
+        .pipe(postcard_rpc_response)
 }
 
 #[tracing::instrument(skip_all)]
@@ -159,7 +183,7 @@ async fn vote(
 #[tracing::instrument(skip_all)]
 async fn stream_snapshot(
     Extension(state): Extension<RaftState>,
-    MsgPack(req): MsgPack<InstallSnapshotRequest<TypeConfig>>,
+    PostCard(V0Wrapper::V0(req)): PostCard<V0Wrapper<InstallSnapshotRequest<TypeConfig>>>,
 ) -> impl IntoResponse {
     tracing::trace!(
         num_bytes = req.data.len(),
@@ -167,14 +191,18 @@ async fn stream_snapshot(
         done = req.done,
         "streaming part of a snapshot"
     );
-    state.raft.install_snapshot(req).await.pipe(rpc_response)
+    state
+        .raft
+        .install_snapshot(req)
+        .await
+        .pipe(postcard_rpc_response)
 }
 
 #[tracing::instrument(skip_all)]
 async fn handle_forwarded_write(
     Extension(state): Extension<RaftState>,
-    MsgPack(mut req): MsgPack<ForwardedWriteRequest>,
-) -> Result<MsgPack<ForwardedWriteResponse>, crate::Error> {
+    PostCard(V0Wrapper::V0(mut req)): PostCard<V0Wrapper<ForwardedWriteRequest>>,
+) -> Result<PostCard<V0Wrapper<ForwardedWriteResponse>>, crate::Error> {
     // reset the timestamp in case the forwarding node was out of sync
     req.request.timestamp = state.state_machine.now();
 
@@ -189,7 +217,7 @@ async fn handle_forwarded_write(
         log_id: response.log_id,
         response: response.data,
     };
-    Ok(MsgPack(response))
+    Ok(PostCard(V0Wrapper::V0(response)))
 }
 
 // Administrative functions

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)] // some things use Json
+
 use std::sync::Arc;
 
 use axum::{

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::cfg::{Configuration, PeerAddr};
 
-use super::{LogId, Node, NodeId, proto, raft::TypeConfig};
+use super::{LogId, Node, NodeId, app::V0Wrapper, proto, raft::TypeConfig};
 use anyhow::Context;
 use diom_proto::prelude::*;
 use http::{HeaderMap, HeaderValue, header};
@@ -76,6 +76,69 @@ pub(super) struct NetworkClient {
     default_timeout: Duration,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Format {
+    Msgpack,
+    Postcard,
+}
+
+fn serialization_error<
+    Err: std::error::Error,
+    E: std::error::Error + std::fmt::Debug + Send + 'static,
+>(
+    err: E,
+) -> RPCError<Err> {
+    tracing::error!(
+        ?err,
+        "serialization error on RPC! this should be impossible!"
+    );
+    RPCError::Network(NetworkError::new(&err))
+}
+
+fn deserialization_error<
+    Err: std::error::Error,
+    E: std::error::Error + std::fmt::Debug + Send + 'static,
+>(
+    err: E,
+) -> RPCError<Err> {
+    tracing::error!(?err, "error deserializing remote RPC; this might be fatal");
+    RPCError::Network(NetworkError::new(&err))
+}
+
+struct RequestBuilder<'a, Req>
+where
+    Req: Serialize + Sized,
+{
+    path: &'a str,
+    req: Req,
+    format: Format,
+    timeout: Duration,
+}
+
+impl<'a, Req> RequestBuilder<'a, Req>
+where
+    Req: Serialize + Sized,
+{
+    fn new(path: &'a str, req: Req, timeout: Duration) -> Self {
+        Self {
+            path,
+            req,
+            format: Format::Msgpack,
+            timeout,
+        }
+    }
+
+    fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    fn with_format(mut self, format: Format) -> Self {
+        self.format = format;
+        self
+    }
+}
+
 impl NetworkClient {
     #[allow(clippy::result_large_err)]
     async fn send_request<Req, Resp, Err>(&self, path: &str, req: Req) -> RPCResult<Resp, Err>
@@ -84,16 +147,21 @@ impl NetworkClient {
         Resp: DeserializeOwned + Sized,
         Err: std::error::Error + DeserializeOwned + Sized,
     {
-        self.send_request_with_timeout(path, req, self.default_timeout)
-            .await
+        let request = self.build_request(path, req).with_format(Format::Msgpack);
+        self.send(request).await
+    }
+
+    fn build_request<'a, Req>(&self, path: &'a str, req: Req) -> RequestBuilder<'a, Req>
+    where
+        Req: Serialize + Sized,
+    {
+        RequestBuilder::new(path, req, self.default_timeout)
     }
 
     #[allow(clippy::result_large_err)]
-    async fn send_request_with_timeout<Req, Resp, Err>(
+    async fn send<'a, Req, Resp, Err>(
         &self,
-        path: &str,
-        req: Req,
-        timeout: Duration,
+        builder: RequestBuilder<'a, Req>,
     ) -> RPCResult<Resp, Err>
     where
         Req: Serialize + Sized,
@@ -102,7 +170,7 @@ impl NetworkClient {
     {
         let start = Instant::now();
         // TODO(jbrown|2026-02-20) handle multiple addresses
-        let Ok(url) = self.node.url_for(path) else {
+        let Ok(url) = self.node.url_for(builder.path) else {
             tracing::warn!(node_id=?self.target, node=?self.node, "node has no valid addresses, cannot send rpc");
             return Err(RPCError::Unreachable(Unreachable::new(
                 &crate::Error::internal("no has no known addresses"),
@@ -110,18 +178,17 @@ impl NetworkClient {
         };
         tracing::trace!(%url, target=?self.target, "sending internal RPC");
 
-        let response = self
-            .client
-            .post(url)
-            .timeout(timeout)
-            .msgpack(&req)
-            .map_err(|err| {
-                tracing::warn!(
-                    ?err,
-                    "serialization error on RPC! this should be impossible!"
-                );
-                RPCError::Network(NetworkError::new(&err))
-            })?
+        let request = self.client.post(url).timeout(builder.timeout);
+        let request = match builder.format {
+            Format::Msgpack => request
+                .msgpack(&builder.req)
+                .map_err(serialization_error::<Err, _>)?,
+            Format::Postcard => request
+                .postcard(&V0Wrapper::V0(builder.req))
+                .map_err(serialization_error::<Err, _>)?,
+        };
+
+        let response = request
             .pipe(|this| -> Result<reqwest::RequestBuilder, RPCError<Err>> {
                 if let Some(secret) = &self.cfg.cluster.secret {
                     let auth = format!("Bearer {secret}");
@@ -155,10 +222,20 @@ impl NetworkClient {
             duration = ?start.elapsed(),
             "response from peer server");
 
-        response
-            .msgpack()
-            .await
-            .map_err(|e| RPCError::Network(NetworkError::new(&e)))
+        match builder.format {
+            Format::Msgpack => response
+                .msgpack()
+                .await
+                .map_err(deserialization_error::<Err, _>),
+            Format::Postcard => {
+                let wrapped = response
+                    .postcard()
+                    .await
+                    .map_err(deserialization_error::<Err, _>)?;
+                let V0Wrapper::V0(resp) = wrapped;
+                Ok(resp)
+            }
+        }
     }
 
     #[tracing::instrument(skip_all)]
@@ -166,8 +243,10 @@ impl NetworkClient {
         &self,
         req: proto::ForwardedWriteRequest,
     ) -> RPCResult<proto::ForwardedWriteResponse> {
-        self.send_request("/repl/raft/handle-forwarded-write", req)
-            .await
+        let req = self
+            .build_request("/repl/raft/handle-forwarded-write", req)
+            .with_format(Format::Postcard);
+        self.send(req).await
     }
 
     pub(super) async fn add_learner(
@@ -202,9 +281,12 @@ impl NetworkClient {
     pub(super) async fn get_last_committed_log_id(&self) -> Result<Option<LogId>, RPCError> {
         let proto::LastIdResponse {
             last_committed_log_id,
-        } = self
-            .send_request("/repl/raft/last-id", proto::LastIdRequest {})
-            .await?;
+        } = {
+            let request = self
+                .build_request("/repl/raft/last-id", proto::LastIdRequest {})
+                .with_format(Format::Postcard);
+            self.send(request).await?
+        };
         Ok(last_committed_log_id)
     }
 
@@ -217,8 +299,11 @@ impl NetworkClient {
         openraft::raft::InstallSnapshotResponse<TypeConfig>,
         RPCError<openraft::errors::RaftError<TypeConfig, openraft::errors::InstallSnapshotError>>,
     > {
-        self.send_request_with_timeout("/repl/raft/stream-snapshot", rpc, option.soft_ttl())
-            .await
+        let req = self
+            .build_request("/repl/raft/stream-snapshot", rpc)
+            .with_timeout(option.soft_ttl())
+            .with_format(Format::Postcard);
+        self.send(req).await
     }
 }
 
@@ -229,8 +314,11 @@ impl RaftNetworkV2<TypeConfig> for NetworkClient {
         rpc: openraft::raft::AppendEntriesRequest<TypeConfig>,
         option: RPCOption,
     ) -> Result<openraft::raft::AppendEntriesResponse<TypeConfig>, RPCError> {
-        self.send_request_with_timeout("/repl/raft/append_entries", rpc, option.soft_ttl())
-            .await
+        let req = self
+            .build_request("/repl/raft/append_entries", rpc)
+            .with_timeout(option.soft_ttl())
+            .with_format(Format::Postcard);
+        self.send(req).await
     }
 
     #[tracing::instrument(skip_all)]
@@ -239,8 +327,11 @@ impl RaftNetworkV2<TypeConfig> for NetworkClient {
         rpc: openraft::raft::VoteRequest<TypeConfig>,
         option: RPCOption,
     ) -> Result<openraft::raft::VoteResponse<TypeConfig>, RPCError> {
-        self.send_request_with_timeout("/repl/raft/vote", rpc, option.soft_ttl())
-            .await
+        let req = self
+            .build_request("/repl/raft/vote", rpc)
+            .with_timeout(option.soft_ttl())
+            .with_format(Format::Msgpack);
+        self.send(req).await
     }
 
     #[tracing::instrument(skip_all, fields(?vote))]


### PR DESCRIPTION
FWIW, I don't think the proposal in svix/rfc#54 will work very well for interserver messages (since they contain the union of all modules' operation messages). Actually doing this correctly will be rather hard (because, e.g., the "version" of an AppendEntries message is going to be the union of all of the versions of the underlying requests). Right now, this will just make the cluster break extremely un-gracefully if we ever change any operation definition. It's also not meaningfully faster, since the actual network time dominates the msgpack time. Anywho, here it is as requested.