### PR TITLE
fjall serialization: serialize postcard directly to byteview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,12 +2049,16 @@ name = "fjall-utils"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "byteview",
+ "criterion",
  "diom-error",
  "fjall",
  "itertools 0.14.0",
  "postcard",
+ "rand 0.9.2",
  "schemars 1.2.1",
  "serde",
+ "serde_bytes",
  "tap",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ axum-extra = { version = "0.12", features = ["typed-header"] }
 base64 = "0.22"
 byteorder = "1.5.0"
 bytes = "1.11.1"
+byteview = "~0.10.1"
 clap = { version = "4.1.8", features = ["derive"] }
 clap_complete = "4.5.38"
 comfy-table = "7"

--- a/crates/fjall-utils/Cargo.toml
+++ b/crates/fjall-utils/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
+byteview.workspace = true
 diom-error.workspace = true
 fjall.workspace = true
 itertools.workspace = true
@@ -17,5 +18,14 @@ serde.workspace = true
 tap.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+rand.workspace = true
+serde_bytes.workspace = true
+
 [lints]
 workspace = true
+
+[[bench]]
+name = "postcard_serialize"
+harness = false

--- a/crates/fjall-utils/benches/postcard_serialize.rs
+++ b/crates/fjall-utils/benches/postcard_serialize.rs
@@ -38,8 +38,7 @@ fn bench_size(c: &mut Criterion, name: &str, row: &KvPairLike) {
             let size =
                 postcard::serialize_with_flavor(&wrapped, ser_flavors::Size::default()).unwrap();
             let mut builder = byteview::ByteView::builder(size);
-            postcard::serialize_with_flavor(&wrapped, ser_flavors::Slice::new(&mut builder))
-                .unwrap();
+            postcard::to_slice(&wrapped, &mut builder).unwrap();
             let _slice: fjall::Slice = builder.freeze().into();
         });
     });

--- a/crates/fjall-utils/benches/postcard_serialize.rs
+++ b/crates/fjall-utils/benches/postcard_serialize.rs
@@ -1,0 +1,65 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use fjall_utils::V0Wrapper;
+use postcard::ser_flavors;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+/// Mimics KvPairRow: a struct with a large byte payload, an optional timestamp, and a version.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct KvPairLike {
+    #[serde(with = "serde_bytes")]
+    value: Vec<u8>,
+    expiry: Option<i64>,
+    version: u64,
+}
+
+fn make_row(rng: &mut StdRng, value_size: usize) -> KvPairLike {
+    let mut value = vec![0u8; value_size];
+    rng.fill(&mut value[..]);
+    KvPairLike {
+        value,
+        expiry: Some(1_700_000_000_000),
+        version: 42,
+    }
+}
+
+fn bench_size(c: &mut Criterion, name: &str, row: &KvPairLike) {
+    let mut group = c.benchmark_group(name);
+
+    group.bench_function("to_allocvec", |b| {
+        b.iter(|| {
+            let bytes: Vec<u8> = postcard::to_allocvec(&V0Wrapper::V0(row)).unwrap();
+            let _slice: fjall::Slice = bytes.into();
+        });
+    });
+
+    group.bench_function("two_pass_byteview", |b| {
+        b.iter(|| {
+            let wrapped = V0Wrapper::V0(row);
+            let size =
+                postcard::serialize_with_flavor(&wrapped, ser_flavors::Size::default()).unwrap();
+            let mut builder = byteview::ByteView::builder(size);
+            postcard::serialize_with_flavor(&wrapped, ser_flavors::Slice::new(&mut builder))
+                .unwrap();
+            let _slice: fjall::Slice = builder.freeze().into();
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_postcard_serialize(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(0xBEEF);
+
+    let row_20b = make_row(&mut rng, 20);
+    let row_1kb = make_row(&mut rng, 1024);
+    let row_2kb = make_row(&mut rng, 2048);
+    let row_20kb = make_row(&mut rng, 20480);
+
+    bench_size(c, "postcard_serialize_20b", &row_20b);
+    bench_size(c, "postcard_serialize_1kb", &row_1kb);
+    bench_size(c, "postcard_serialize_2kb", &row_2kb);
+    bench_size(c, "postcard_serialize_20kb", &row_20kb);
+}
+
+criterion_group!(benches, bench_postcard_serialize);
+criterion_main!(benches);

--- a/crates/fjall-utils/src/fixed_key.rs
+++ b/crates/fjall-utils/src/fixed_key.rs
@@ -36,7 +36,9 @@ impl<T: Serialize + DeserializeOwned + 'static> FjallFixedKey<T> {
     }
 
     pub fn store(&self, keyspace: &fjall::Keyspace, value: &T) -> Result<()> {
-        let serialized = postcard::to_allocvec(&crate::V0Wrapper::V0(value)).or_internal_error()?;
+        let serialized = crate::postcard_to_byteview(&crate::V0Wrapper::V0(value))
+            .map(fjall::Slice::from)
+            .or_internal_error()?;
         keyspace.insert(self.key, serialized).or_internal_error()
     }
 
@@ -50,7 +52,9 @@ impl<T: Serialize + DeserializeOwned + 'static> FjallFixedKey<T> {
         keyspace: &fjall::Keyspace,
         value: &T,
     ) -> Result<()> {
-        let serialized = postcard::to_allocvec(&crate::V0Wrapper::V0(value)).or_internal_error()?;
+        let serialized = crate::postcard_to_byteview(&crate::V0Wrapper::V0(value))
+            .map(fjall::Slice::from)
+            .or_internal_error()?;
         tx.insert(keyspace, self.key, serialized);
         Ok(())
     }

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -23,6 +23,18 @@ pub enum V0Wrapper<T> {
     V0(T),
 }
 
+/// Serialize `value` directly into a [`byteview::ByteView`],
+/// avoiding an intermediate `Vec<u8>` allocation.
+pub(crate) fn postcard_to_byteview(
+    value: &impl serde::Serialize,
+) -> Result<byteview::ByteView, postcard::Error> {
+    use postcard::ser_flavors;
+    let size = postcard::serialize_with_flavor(value, ser_flavors::Size::default())?;
+    let mut builder = byteview::ByteView::builder(size);
+    postcard::serialize_with_flavor(value, ser_flavors::Slice::new(&mut builder))?;
+    Ok(builder.freeze())
+}
+
 /// Useful for verifying all table prefixes for a given keyspace are unique,
 /// at compile time.
 pub const fn are_all_unique(strings: &[&str]) -> bool {
@@ -95,5 +107,21 @@ mod tests {
         let bare = postcard::to_allocvec(&inner).unwrap();
         assert_eq!(wrapped[0], 0x00);
         assert_eq!(&wrapped[1..], bare.as_slice());
+    }
+
+    #[test]
+    fn postcard_to_byteview_roundtrip() {
+        let original = 0xdeadbeef_u32;
+        let slice = postcard_to_byteview(&V0Wrapper::V0(original)).unwrap();
+        let V0Wrapper::V0(recovered) = postcard::from_bytes::<V0Wrapper<u32>>(&slice).unwrap();
+        assert_eq!(recovered, original);
+    }
+
+    #[test]
+    fn postcard_to_byteview_matches_allocvec() {
+        let original = 42u32;
+        let via_slice = postcard_to_byteview(&V0Wrapper::V0(original)).unwrap();
+        let via_vec = postcard::to_allocvec(&V0Wrapper::V0(original)).unwrap();
+        assert_eq!(&*via_slice, via_vec.as_slice());
     }
 }

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -31,7 +31,7 @@ pub(crate) fn postcard_to_byteview(
     use postcard::ser_flavors;
     let size = postcard::serialize_with_flavor(value, ser_flavors::Size::default())?;
     let mut builder = byteview::ByteView::builder(size);
-    postcard::serialize_with_flavor(value, ser_flavors::Slice::new(&mut builder))?;
+    postcard::to_slice(value, &mut builder)?;
     Ok(builder.freeze())
 }
 

--- a/crates/fjall-utils/src/options.rs
+++ b/crates/fjall-utils/src/options.rs
@@ -149,8 +149,9 @@ impl SerializableKeyspaceCreateOptions {
         keyspace_name: &str,
     ) -> anyhow::Result<fjall::Keyspace> {
         let schema = database.keyspace("_schema", fjall::KeyspaceCreateOptions::default)?;
-        let serialized =
-            postcard::to_allocvec(&crate::V0Wrapper::V0(&self)).context("serializing schema")?;
+        let serialized = crate::postcard_to_byteview(&crate::V0Wrapper::V0(&self))
+            .map(fjall::Slice::from)
+            .context("serializing schema")?;
         schema.insert(keyspace_name, serialized)?;
         database
             .keyspace(keyspace_name, || self.into())

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -16,8 +16,8 @@ pub trait TableRow: Sized + Serialize + DeserializeOwned {
     const ROW_TYPE: u8;
 
     fn to_fjall_value(&self) -> Result<fjall::UserValue> {
-        postcard::to_allocvec(&crate::V0Wrapper::V0(self))
-            .map(|bytes| bytes.into())
+        crate::postcard_to_byteview(&crate::V0Wrapper::V0(self))
+            .map(fjall::Slice::from)
             .or_internal_error()
     }
 


### PR DESCRIPTION
Byteview is used internally by fjall, so this makes it what fjall expects instead of the extra allocations and copies.

Before this change:
1. Alloc a Vec<u8>
2. Serialize it Vec<u8> (increases the size as needed).
3. Alloc a byteview.
4. Copy the Vec to the byteview.

After this change:
1. Measure the size of the object (fast).
2. Alloc a byteview of the right size.
2. Serialize to the byteview.

Benchmarks (in the PR) show ~2.5x improvement across all payload sizes; which adds up to multiple milliseconds of execution per second at thousands of ops per second and also decreases allocator pressure.