### PR TITLE
Operator: rename nodes -> replicas

### DIFF
--- a/infra/helm-diom/README.md
+++ b/infra/helm-diom/README.md
@@ -48,7 +48,7 @@ Example configuration for a 3-node cluster:
 ```yaml
 cluster:
   spec:
-    nodes: 3
+    replicas: 3
     storage:
       persistent:
         size: 10Gi
@@ -71,7 +71,7 @@ cluster:
 | `cluster.name` | Name of the `DiomCluster` resource. Defaults to the release name. | `diom` |
 | `cluster.image.repository` | Diom server image repository. | `ghcr.io/svix/diom-server` |
 | `cluster.image.tag` | Diom server image tag. | Chart pre-populates current tag. |
-| `cluster.spec.nodes` | Number of Diom nodes. Should be an odd number. Recommended value is 3 for a cluster, or 1 for a single node. | `1` |
+| `cluster.spec.replicas` | Number of Diom replicas. Should be an odd number. Recommended value is 3 for a cluster, or 1 for a single node. | `1` |
 | `cluster.spec.apiPort` | Port for the external API and service. | `8080` |
 | `cluster.spec.envVar` | Additional environment variables to inject into pods (list of `{name, value}`). | `[]` |
 | `cluster.spec.bootstrap` | Newline-delimited bootstrap script to run on cluster startup. | `""` |

--- a/infra/helm-diom/charts/crds/crds/diomclusters.json
+++ b/infra/helm-diom/charts/crds/crds/diomclusters.json
@@ -20,8 +20,8 @@
       {
         "additionalPrinterColumns": [
           {
-            "jsonPath": ".spec.nodes",
-            "name": "Nodes",
+            "jsonPath": ".spec.replicas",
+            "name": "Replicas",
             "type": "integer"
           },
           {
@@ -984,13 +984,6 @@
                     "nullable": true,
                     "type": "object"
                   },
-                  "nodes": {
-                    "default": 1,
-                    "description": "Number of Diom nodes.\n\nShould be an odd number. Recommended value is 3, or 1 if you want only a single node.",
-                    "format": "int32",
-                    "minimum": 1.0,
-                    "type": "integer"
-                  },
                   "opentelemetryAddress": {
                     "description": "The OpenTelemetry address to send events to if given.\n\nCurrently only GRPC exports are supported.",
                     "nullable": true,
@@ -1013,6 +1006,13 @@
                     "default": {},
                     "description": "Additional annotations to add to pods.",
                     "type": "object"
+                  },
+                  "replicas": {
+                    "default": 1,
+                    "description": "Number of Diom replicas.\n\nShould be an odd number. Recommended value is 3, or 1 if you want only a single node.",
+                    "format": "int32",
+                    "minimum": 1.0,
+                    "type": "integer"
                   },
                   "resources": {
                     "default": {},

--- a/infra/helm-diom/values.yaml
+++ b/infra/helm-diom/values.yaml
@@ -51,7 +51,7 @@ cluster:
     # tag is required when cluster.enabled=true.
     tag: ""
   spec:
-    nodes: 3
+    replicas: 3
     service:
       type: ClusterIP
       # annotations: {}

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -20,7 +20,7 @@ fn default_api_port() -> u16 {
     DEFAULT_API_PORT
 }
 
-fn default_nodes() -> i32 {
+fn default_replicas() -> i32 {
     1
 }
 
@@ -34,7 +34,7 @@ fn default_nodes() -> i32 {
     namespaced,
     status = "DiomClusterStatus",
     shortname = "cc",
-    printcolumn = r#"{"name":"Nodes","type":"integer","jsonPath":".spec.nodes"}"#,
+    printcolumn = r#"{"name":"Replicas","type":"integer","jsonPath":".spec.replicas"}"#,
     printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
     printcolumn = r#"{"name":"Ready","type":"integer","jsonPath":".status.readyReplicas"}"#
 )]
@@ -134,12 +134,12 @@ pub(crate) struct VolumeSpec {
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DiomSpec {
-    /// Number of Diom nodes.
+    /// Number of Diom replicas.
     ///
     /// Should be an odd number. Recommended value is 3, or 1 if you want only a single node.
-    #[serde(default = "default_nodes")]
-    #[schemars(schema_with = "nodes_schema")]
-    pub nodes: i32,
+    #[serde(default = "default_replicas")]
+    #[schemars(schema_with = "replicas_schema")]
+    pub replicas: i32,
 
     /// Port for the external API and service.
     #[serde(default = "default_api_port")]
@@ -267,12 +267,12 @@ impl ValueOrSecretRef {
     }
 }
 
-fn nodes_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+fn replicas_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({
         "type": "integer",
         "format": "int32",
         "default": 1,
         "minimum": 1.0,
-        "description": "Number of Diom nodes. Should be odd for quorum (1, 3, 5...)."
+        "description": "Number of Diom replicas. Should be odd for quorum (1, 3, 5...)."
     })
 }

--- a/infra/operator/src/reconciler.rs
+++ b/infra/operator/src/reconciler.rs
@@ -68,8 +68,8 @@ pub(crate) async fn reconcile(cluster: Arc<DiomCluster>, ctx: Arc<Context>) -> R
         )
         .await?;
 
-    // PodDisruptionBudget (only meaningful for nodes > 1)
-    if cluster.spec.diom.nodes > 1 {
+    // PodDisruptionBudget (only meaningful for replicas > 1)
+    if cluster.spec.diom.replicas > 1 {
         let pdb_api: Api<PodDisruptionBudget> = Api::namespaced(client.clone(), &ns);
         let pdb = resources::pdb::build(&cluster, &ns)?;
         pdb_api
@@ -99,7 +99,7 @@ async fn update_status(cluster: &DiomCluster, client: &Client, ns: &str) -> Resu
                 .as_ref()
                 .and_then(|s| s.ready_replicas)
                 .unwrap_or(0);
-            let desired = cluster.spec.diom.nodes;
+            let desired = cluster.spec.diom.replicas;
             let phase = if ready == desired {
                 Phase::Running
             } else if ready == 0 {

--- a/infra/operator/src/resources/pdb.rs
+++ b/infra/operator/src/resources/pdb.rs
@@ -8,7 +8,7 @@ use crate::{crd::DiomCluster, error::Result, labels};
 
 pub(crate) fn build(cluster: &DiomCluster, ns: &str) -> Result<PodDisruptionBudget> {
     let cluster_name = cluster.name_any();
-    let replicas = cluster.spec.diom.nodes;
+    let replicas = cluster.spec.diom.replicas;
 
     // Require a strict majority to be available at all times, which maintains quorum.
     let min_available = (replicas / 2) + 1;

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -72,7 +72,7 @@ pub(crate) fn build(cluster: &DiomCluster, ns: &str) -> Result<StatefulSet> {
             ..Default::default()
         },
         spec: Some(StatefulSetSpec {
-            replicas: Some(spec.diom.nodes),
+            replicas: Some(spec.diom.replicas),
             service_name: Some(headless_svc),
             selector: LabelSelector {
                 match_labels: Some(labels::selector(&cluster_name)),
@@ -125,7 +125,7 @@ fn build_env(
                 cluster_name,
                 headless_svc,
                 ns,
-                spec.diom.nodes,
+                spec.diom.replicas,
                 intracluster_port,
             ),
         ),

--- a/infra/svix-values.yaml
+++ b/infra/svix-values.yaml
@@ -17,6 +17,7 @@ cluster:
   image:
     tag: ""
   spec:
+    replicas: 3
     service:
       type: LoadBalancer
       annotations:


### PR DESCRIPTION
Small but `nodes` is a bit confusing, and `replicas` is more consistent w/ k8s terminology anyway