### PR TITLE
API: use the repl stores instead of initing new ones ad-hoc.

### DIFF
--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -903,6 +903,36 @@ impl StoreHandle {
             .clone()
     }
 
+    pub(crate) async fn rate_limit_store(&self) -> diom_rate_limit::State {
+        self.inner
+            .read()
+            .await
+            .stores
+            .read()
+            .rate_limit_state
+            .clone()
+    }
+
+    pub(crate) async fn auth_token_store(&self) -> diom_auth_token::State {
+        self.inner
+            .read()
+            .await
+            .stores
+            .read()
+            .auth_token_state
+            .clone()
+    }
+
+    pub(crate) async fn admin_auth_store(&self) -> diom_admin_auth::State {
+        self.inner
+            .read()
+            .await
+            .stores
+            .read()
+            .admin_auth_state
+            .clone()
+    }
+
     /// Mark this node as removed from a cluster and ineligible to continue
     pub(super) async fn poison(&self, cluster_id: ClusterId) -> anyhow::Result<()> {
         let handle = self.inner.write().await;

--- a/src/v1/endpoints/admin/auth/policy.rs
+++ b/src/v1/endpoints/admin/auth/policy.rs
@@ -1,7 +1,6 @@
 use aide::axum::{ApiRouter, routing::post_with};
-use axum::extract::{Extension, State};
+use axum::extract::Extension;
 use diom_admin_auth::{
-    State as AdminAuthState,
     controller::AccessPolicyModel,
     operations::{DeleteAccessPolicyOperation, UpsertAccessPolicyOperation},
 };
@@ -146,12 +145,11 @@ request_input!(AdminAccessPolicyGetIn, "get");
 /// Get an access policy by ID
 #[aide_annotate(op_id = "v1.admin.auth-policy.get")]
 async fn access_policy_get(
-    State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<AdminAccessPolicyGetIn>,
 ) -> Result<MsgPackOrJson<AdminAccessPolicyOut>> {
     repl.wait_linearizable().await.or_internal_error()?;
-    let admin_auth_state = AdminAuthState::init(state.do_not_use_dbs.clone())?;
+    let admin_auth_state = repl.state_machine.admin_auth_store().await;
     let model = admin_auth_state
         .controller
         .get_policy(&data.id)
@@ -179,12 +177,11 @@ pub type AdminAccessPolicyListOut = ListResponse<AdminAccessPolicyOut>;
 /// List all access policies
 #[aide_annotate(op_id = "v1.admin.auth-policy.list")]
 async fn access_policy_list(
-    State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<AdminAccessPolicyListIn>,
 ) -> Result<MsgPackOrJson<AdminAccessPolicyListOut>> {
     repl.wait_linearizable().await.or_internal_error()?;
-    let admin_auth_state = AdminAuthState::init(state.do_not_use_dbs.clone())?;
+    let admin_auth_state = repl.state_machine.admin_auth_store().await;
     let limit = data.pagination.limit.into();
     let iterator = data.pagination.iterator;
     let models = admin_auth_state

--- a/src/v1/endpoints/admin/auth/role.rs
+++ b/src/v1/endpoints/admin/auth/role.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use aide::axum::{ApiRouter, routing::post_with};
-use axum::extract::{Extension, State};
+use axum::extract::Extension;
 use diom_admin_auth::{
-    State as AdminAuthState,
     controller::RoleModel,
     operations::{DeleteRoleOperation, UpsertRoleOperation},
 };
@@ -162,12 +161,11 @@ request_input!(AdminRoleGetIn, "get");
 /// Get a role by ID
 #[aide_annotate(op_id = "v1.admin.auth-role.get")]
 async fn role_get(
-    State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<AdminRoleGetIn>,
 ) -> Result<MsgPackOrJson<AdminRoleOut>> {
     repl.wait_linearizable().await.or_internal_error()?;
-    let admin_auth_state = AdminAuthState::init(state.do_not_use_dbs.clone())?;
+    let admin_auth_state = repl.state_machine.admin_auth_store().await;
     let model = admin_auth_state
         .controller
         .get_role(&data.id)
@@ -195,12 +193,11 @@ pub type AdminRoleListOut = ListResponse<AdminRoleOut>;
 /// List all roles
 #[aide_annotate(op_id = "v1.admin.auth-role.list")]
 async fn role_list(
-    State(state): State<AppState>,
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<AdminRoleListIn>,
 ) -> Result<MsgPackOrJson<AdminRoleListOut>> {
     repl.wait_linearizable().await.or_internal_error()?;
-    let admin_auth_state = AdminAuthState::init(state.do_not_use_dbs.clone())?;
+    let admin_auth_state = repl.state_machine.admin_auth_store().await;
     let limit = data.pagination.limit.into();
     let iterator = data.pagination.iterator;
     let models = admin_auth_state

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -257,7 +257,7 @@ async fn auth_token_verify(
         .ok_or_not_found()?;
 
     let token_hashed = TokenHashed::from(data.token.as_str());
-    let auth_token_state = diom_auth_token::State::init(state.do_not_use_dbs.clone())?;
+    let auth_token_state = repl.state_machine.auth_token_store().await;
     let token = auth_token_state
         .controller
         .fetch_non_expired(namespace.id, &token_hashed, repl.time.now())
@@ -299,7 +299,7 @@ async fn auth_token_list(
     let limit = data.pagination.limit.0 as usize;
     let iterator = data.pagination.iterator.map(|id| id.into_inner());
 
-    let auth_token_state = diom_auth_token::State::init(state.do_not_use_dbs.clone())?;
+    let auth_token_state = repl.state_machine.auth_token_store().await;
     let models = auth_token_state
         .controller
         .list_by_owner(namespace.id, &data.owner_id, limit + 1, iterator)

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -176,7 +176,7 @@ async fn cache_get(
         repl.wait_linearizable().await.or_internal_error()?;
     }
 
-    let cache_state = diom_cache::State::init(state.do_not_use_dbs.clone())?;
+    let cache_state = repl.state_machine.cache_store().await;
     let controller = cache_state.controller();
 
     let model = controller

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -176,8 +176,7 @@ async fn kv_get(
         repl.wait_linearizable().await.or_internal_error()?;
     }
 
-    // FIXME: this state should be passed, not created every time.
-    let kv_state = diom_kv::State::init(state.do_not_use_dbs.clone())?;
+    let kv_state = repl.state_machine.kv_store().await;
     let controller = kv_state.controller();
 
     let model = controller

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -175,8 +175,7 @@ async fn rate_limit_get_remaining(
     repl.wait_linearizable().await.or_internal_error()?;
 
     let now = repl.time.now();
-    // FIXME: this state should be passed, not created every time.
-    let rate_limit_state = diom_rate_limit::State::init(state.do_not_use_dbs.clone())?;
+    let rate_limit_state = repl.state_machine.rate_limit_store().await;
     let controller = rate_limit_state.controller();
     let (remaining, retry_after) = controller
         .get_remaining(now, namespace.id, data.key, data.config.into())


### PR DESCRIPTION
We already have the stores in repl, so we can just use that from the API. Anyway, we don't want to init the State manually every time in the API as it involves creating a keyspace object and potentially initializing other things, which is just wasteful.