### PR TITLE
Change timestamp representation to milliseconds since unix epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5317,6 +5317,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body-util",
+ "jiff",
  "reqwest 0.13.2",
  "rmp-serde",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4852,7 +4852,6 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "indexmap 2.14.0",
- "jiff",
  "ref-cast",
  "schemars_derive 1.2.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ reqwest = { version = "0.13.1", default-features = false, features = ["json", "r
 rmp-serde = "1.3.1"
 rmpv = "1.3.1"
 rustls = "0.23.31"
-schemars = { version = "1.2.0", features = ["jiff02", "uuid1"] }
+schemars = { version = "1.2.0", features = ["uuid1"] }
 serde = { version = "1.0.184", features = ["derive", "rc"] }
 serde_bytes = "0.11.19"
 serde_json = "1.0.74"

--- a/codegen/templates/go/types/macros.go.jinja
+++ b/codegen/templates/go/types/macros.go.jinja
@@ -6,13 +6,14 @@
 	{{ f_name }}
 {%- endmacro %}
 {% macro field_type(field) -%}
+	{% if field.type.is_datetime() %}{% do panic("Diom API must not use string timestamps") %}{% endif -%}
 	{% set f_type = field.type.to_go() -%}
 	{% if field.name is endingwith "_ms" -%}
-		{%- if not (field.type.is_u64() or field.type.is_duration_ms() or field.type.is_unix_timestamp_ms()) %}{% do panic("_ms type should be uint64, current type is " ~ field.type) %}{% endif -%}
+		{% if not (field.type.is_u64() or field.type.is_duration_ms() or field.type.is_unix_timestamp_ms()) %}{% do panic("_ms type should be uint64, current type is " ~ field.type) %}{% endif -%}
 		{% set f_type = "diom_types.DurationMs" -%}
 	{% endif -%}
 	{% if (not field.required or field.nullable) -%}
-		{% if field.type.is_datetime() -%}
+		{% if field.type.is_unix_timestamp_ms() -%}
 			{% set f_type = "diom_types.Timestamp" -%}
 		{% endif -%}
 		{% if not field.type.is_set() and not field.type.is_list() -%}

--- a/codegen/templates/javascript/types/macros.ts.jinja
+++ b/codegen/templates/javascript/types/macros.ts.jinja
@@ -27,9 +27,9 @@
         {%- endif -%}
     {%- elif type.is_datetime() or type.is_unix_timestamp_ms() -%}
         {% if not field_required -%}
-            {{ field_expr }} ? new Date({{ field_expr }}) : null
+            {{ field_expr }} ? new Date(Number({{ field_expr }})) : null
         {%- else -%}
-            new Date({{ field_expr }})
+            new Date(Number({{ field_expr }}))
         {%- endif -%}
     {%- elif type.is_duration_ms() -%}
         {% if not field_required -%}

--- a/codegen/templates/python/types/macros.py.jinja
+++ b/codegen/templates/python/types/macros.py.jinja
@@ -11,7 +11,9 @@
 {%- endmacro -%}
 {% macro field_type(field) -%}
     {% set field_ty = field.type.to_python() -%}
-    {% if field.name is endingwith "_ms" -%}
+    {% if field.type.is_unix_timestamp_ms() -%}
+        {% set field_ty = "UnixTimestampMs" -%}
+    {% elif field.name is endingwith "_ms" -%}
         {% set field_ty = "TimeDeltaMs" -%}
     {% endif -%}
     {{ field_ty }}

--- a/codegen/templates/python/types/struct.py.jinja
+++ b/codegen/templates/python/types/struct.py.jinja
@@ -2,11 +2,10 @@
 {% set type_name = type.name | to_upper_camel_case -%}
 {% set positional_fields = type.fields | selectattr("positional") -%}
 import typing as t
-from datetime import datetime
-from pydantic import  Field
+from pydantic import Field
 
 from ..internal.base_model import BaseModel
-from ..internal.types import TimeDeltaMs
+from ..internal.types import TimeDeltaMs, UnixTimestampMs
 
 {% for c in referenced_components -%}
 from . {{ c | to_snake_case }} import {{ c | to_upper_camel_case }}

--- a/codegen/templates/rust/types/macros.rs.jinja
+++ b/codegen/templates/rust/types/macros.rs.jinja
@@ -16,7 +16,9 @@
 {%- endmacro %}
 {% macro field_type(field) -%}
     {% set field_ty = field.type.to_rust() -%}
-    {% if field.name is endingwith "_ms" -%}
+    {% if field.type.is_unix_timestamp_ms() -%}
+        {% set field_ty = "jiff::Timestamp" -%}
+    {% elif field.name is endingwith "_ms" -%}
         {% set field_ty = "std::time::Duration" -%}
     {% endif -%}
     {% if not field.required or field.nullable -%}
@@ -35,6 +37,10 @@
         {% else -%}
             with = "serde_bytes",
         {% endif -%}
+    {% elif field.type.is_unix_timestamp_ms() -%}
+        with = "crate::unix_timestamp_ms_serde
+            {%- if not field.required or field.nullable %}::optional{% endif -%}
+        ",
     {% endif -%}
     {% if not field.required or field.nullable -%}
         skip_serializing_if = "Option::is_none",

--- a/crates/diom-core/src/types/mod.rs
+++ b/crates/diom-core/src/types/mod.rs
@@ -12,8 +12,12 @@ use crate::validation::validation_error;
 mod byte_string;
 mod duration_ms;
 mod metadata;
+mod unix_timestamp_ms;
 
-pub use self::{byte_string::ByteString, duration_ms::DurationMs, metadata::Metadata};
+pub use self::{
+    byte_string::ByteString, duration_ms::DurationMs, metadata::Metadata,
+    unix_timestamp_ms::UnixTimestampMs,
+};
 
 const ALL_ERROR: &str = "__all__";
 

--- a/crates/diom-core/src/types/unix_timestamp_ms.rs
+++ b/crates/diom-core/src/types/unix_timestamp_ms.rs
@@ -1,0 +1,74 @@
+use std::{borrow::Cow, fmt};
+
+use schemars::{JsonSchema, Schema, json_schema};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnixTimestampMs(u64);
+
+impl UnixTimestampMs {
+    fn new(millis: u64) -> Result<Self, &'static str> {
+        if millis > jiff::Timestamp::MAX.as_millisecond() as u64 {
+            return Err("timestamp too large");
+        }
+        Ok(Self(millis))
+    }
+}
+
+impl fmt::Debug for UnixTimestampMs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ts = jiff::Timestamp::from_millisecond(
+            self.0
+                .try_into()
+                .expect("timestamps beyond year 9999 not supported"),
+        );
+        ts.fmt(f)
+    }
+}
+
+impl From<jiff::Timestamp> for UnixTimestampMs {
+    #[track_caller]
+    fn from(value: jiff::Timestamp) -> Self {
+        let value = u64::try_from(value.as_millisecond())
+            .expect("timestamps in diom must never be before the unix epoch");
+        Self(value)
+    }
+}
+
+impl Serialize for UnixTimestampMs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for UnixTimestampMs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let millis = u64::deserialize(deserializer)?;
+        Self::new(millis).map_err(serde::de::Error::custom)
+    }
+}
+
+impl JsonSchema for UnixTimestampMs {
+    fn schema_name() -> Cow<'static, str> {
+        "UnixTimestampMs".into()
+    }
+
+    fn json_schema(_: &mut schemars::SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs",
+        })
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+}

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, fmt, num::NonZeroU64, ops::Deref, str::FromStr};
 
-use diom_core::types::{ByteString, DurationMs};
+use diom_core::types::{ByteString, DurationMs, UnixTimestampMs};
 use diom_error::Error;
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
@@ -375,8 +374,8 @@ pub struct StreamMsgOut {
     pub topic: TopicPartition,
     pub value: ByteString,
     pub headers: HashMap<String, String>,
-    pub timestamp: Timestamp,
-    pub scheduled_at: Option<Timestamp>,
+    pub timestamp: UnixTimestampMs,
+    pub scheduled_at: Option<UnixTimestampMs>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -384,8 +383,8 @@ pub struct QueueMsgOut {
     pub msg_id: MsgId,
     pub value: ByteString,
     pub headers: HashMap<String, String>,
-    pub timestamp: Timestamp,
-    pub scheduled_at: Option<Timestamp>,
+    pub timestamp: UnixTimestampMs,
+    pub scheduled_at: Option<UnixTimestampMs>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -13,6 +13,7 @@ diom-core.workspace = true
 futures-util.workspace = true
 http.workspace = true
 http-body-util.workspace = true
+jiff.workspace = true
 reqwest.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -5,10 +5,12 @@ pub use reqwest::StatusCode;
 mod json;
 pub mod server;
 mod test_client;
+mod time;
 
 pub use self::{
     json::JsonFastAndLoose,
     test_client::{TestClient, TestRequestBuilder, TestResponse},
+    time::U64Ext,
 };
 
 #[derive(Debug)] // needed to be able to return TestResult from #[test] fns

--- a/crates/test-utils/src/time.rs
+++ b/crates/test-utils/src/time.rs
@@ -3,17 +3,17 @@ use std::time::Duration;
 use jiff::Timestamp;
 
 pub trait U64Ext {
-    fn as_duration_ms(self) -> Duration;
-    fn as_timestamp_ms(self) -> Timestamp;
+    fn as_duration_ms(&self) -> Duration;
+    fn as_timestamp_ms(&self) -> Timestamp;
 }
 
 impl U64Ext for u64 {
-    fn as_duration_ms(self) -> Duration {
-        Duration::from_millis(self)
+    fn as_duration_ms(&self) -> Duration {
+        Duration::from_millis(*self)
     }
 
     #[track_caller]
-    fn as_timestamp_ms(self) -> Timestamp {
-        Timestamp::from_millisecond(self.try_into().unwrap()).unwrap()
+    fn as_timestamp_ms(&self) -> Timestamp {
+        Timestamp::from_millisecond((*self).try_into().unwrap()).unwrap()
     }
 }

--- a/crates/test-utils/src/time.rs
+++ b/crates/test-utils/src/time.rs
@@ -1,0 +1,19 @@
+use std::time::Duration;
+
+use jiff::Timestamp;
+
+pub trait U64Ext {
+    fn as_duration_ms(self) -> Duration;
+    fn as_timestamp_ms(self) -> Timestamp;
+}
+
+impl U64Ext for u64 {
+    fn as_duration_ms(self) -> Duration {
+        Duration::from_millis(self)
+    }
+
+    #[track_caller]
+    fn as_timestamp_ms(self) -> Timestamp {
+        Timestamp::from_millisecond(self.try_into().unwrap()).unwrap()
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -4939,12 +4939,16 @@
             }
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -4984,12 +4988,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5036,12 +5044,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5123,16 +5135,22 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "expiry": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs",
             "nullable": true
           },
           "role": {
@@ -5173,12 +5191,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5310,12 +5332,16 @@
             }
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5371,12 +5397,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5457,12 +5487,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5478,12 +5512,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "token": {
             "type": "string"
@@ -5566,12 +5604,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5618,16 +5660,22 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "expiry": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs",
             "nullable": true
           },
           "metadata": {
@@ -5699,12 +5747,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "token": {
             "type": "string"
@@ -5813,12 +5865,16 @@
             "$ref": "#/components/schemas/EvictionPolicy"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5908,12 +5964,16 @@
             "$ref": "#/components/schemas/EvictionPolicy"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -5928,8 +5988,10 @@
         "properties": {
           "expiry": {
             "description": "Time of expiry",
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs",
             "nullable": true
           },
           "value": {
@@ -5996,8 +6058,10 @@
         "properties": {
           "snapshot_time": {
             "description": "The wall-clock time at which the snapshot was initiated",
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "snapshot_log_index": {
             "description": "The log index at which the snapshot was initiated",
@@ -6075,8 +6139,10 @@
           },
           "this_node_last_committed_timestamp": {
             "description": "The timestamp of the last transaction committed on this node",
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "this_node_last_snapshot_id": {
             "description": "The last snapshot taken on this node",
@@ -6232,12 +6298,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -6264,12 +6334,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -6379,12 +6453,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -6478,12 +6556,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -6497,8 +6579,10 @@
         "properties": {
           "expiry": {
             "description": "Time of expiry",
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs",
             "nullable": true
           },
           "value": {
@@ -6765,12 +6849,16 @@
             "$ref": "#/components/schemas/Retention"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -6804,12 +6892,16 @@
             "$ref": "#/components/schemas/Retention"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -7393,12 +7485,16 @@
             }
           },
           "timestamp": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "scheduled_at": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs",
             "nullable": true
           }
         },
@@ -7514,12 +7610,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -7546,12 +7646,16 @@
             "type": "string"
           },
           "created": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "updated": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           }
         },
         "required": [
@@ -7705,12 +7809,16 @@
             }
           },
           "timestamp": {
-            "type": "string",
-            "format": "date-time"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs"
           },
           "scheduled_at": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs",
             "nullable": true
           }
         },

--- a/src/v1/endpoints/admin/auth/policy.rs
+++ b/src/v1/endpoints/admin/auth/policy.rs
@@ -5,11 +5,11 @@ use diom_admin_auth::{
     operations::{DeleteAccessPolicyOperation, UpsertAccessPolicyOperation},
 };
 use diom_authorization::{AccessPolicyId, AccessRule, RequestedOperation};
+use diom_core::types::UnixTimestampMs;
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt, ResultExt};
 use diom_id::Module;
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -49,8 +49,8 @@ pub struct AdminAccessPolicyOut {
     pub id: AccessPolicyId,
     pub description: String,
     pub rules: Vec<AccessRule>,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 impl ListResponseItem for AdminAccessPolicyOut {
@@ -65,8 +65,8 @@ impl From<AccessPolicyModel> for AdminAccessPolicyOut {
             id: model.id,
             description: model.description,
             rules: model.rules,
-            created: model.created,
-            updated: model.updated,
+            created: model.created.into(),
+            updated: model.updated.into(),
         }
     }
 }
@@ -87,8 +87,8 @@ request_input!(AdminAccessPolicyUpsertIn, "upsert");
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AdminAccessPolicyUpsertOut {
     pub id: AccessPolicyId,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Create or update an access policy
@@ -101,8 +101,8 @@ async fn access_policy_upsert(
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(AdminAccessPolicyUpsertOut {
         id: resp.model.id,
-        created: resp.model.created,
-        updated: resp.model.updated,
+        created: resp.model.created.into(),
+        updated: resp.model.updated.into(),
     }))
 }
 

--- a/src/v1/endpoints/admin/auth/role.rs
+++ b/src/v1/endpoints/admin/auth/role.rs
@@ -7,11 +7,11 @@ use diom_admin_auth::{
     operations::{DeleteRoleOperation, UpsertRoleOperation},
 };
 use diom_authorization::{AccessPolicyId, AccessRule, RequestedOperation, RoleId};
+use diom_core::types::UnixTimestampMs;
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt, ResultExt};
 use diom_id::Module;
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -53,8 +53,8 @@ pub struct AdminRoleOut {
     pub rules: Vec<AccessRule>,
     pub policies: Vec<AccessPolicyId>,
     pub context: HashMap<String, String>,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 impl ListResponseItem for AdminRoleOut {
@@ -71,8 +71,8 @@ impl From<RoleModel> for AdminRoleOut {
             rules: model.rules,
             policies: model.policies,
             context: model.context,
-            created: model.created,
-            updated: model.updated,
+            created: model.created.into(),
+            updated: model.updated.into(),
         }
     }
 }
@@ -97,8 +97,8 @@ request_input!(AdminRoleUpsertIn, "upsert");
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AdminRoleUpsertOut {
     pub id: RoleId,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Create or update a role
@@ -117,8 +117,8 @@ async fn role_upsert(
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(AdminRoleUpsertOut {
         id: resp.model.id,
-        created: resp.model.created,
-        updated: resp.model.updated,
+        created: resp.model.created.into(),
+        updated: resp.model.updated.into(),
     }))
 }
 

--- a/src/v1/endpoints/admin/auth/token.rs
+++ b/src/v1/endpoints/admin/auth/token.rs
@@ -3,12 +3,11 @@ use std::collections::HashMap;
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::extract::{Extension, State};
 use diom_authorization::{Permissions, RequestedOperation, RoleId};
-use diom_core::types::{DurationMs, Metadata};
+use diom_core::types::{DurationMs, Metadata, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{Error, ResultExt};
 use diom_id::{AuthTokenId, Module, Public};
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -52,9 +51,9 @@ macro_rules! request_input {
 pub struct AdminAuthTokenOut {
     pub id: Public<AuthTokenId>,
     pub name: String,
-    pub created: Timestamp,
-    pub updated: Timestamp,
-    pub expiry: Option<Timestamp>,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
+    pub expiry: Option<UnixTimestampMs>,
     pub role: String,
     /// Whether this token is currently enabled.
     pub enabled: bool,
@@ -84,8 +83,8 @@ fn default_true() -> bool {
 pub struct AdminAuthTokenCreateOut {
     pub id: Public<AuthTokenId>,
     pub token: String,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Create an auth token
@@ -172,8 +171,8 @@ request_input!(AdminAuthTokenRotateIn, "rotate");
 pub struct AdminAuthTokenRotateOut {
     pub id: Public<AuthTokenId>,
     pub token: String,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Rotate an auth token, invalidating the old one and issuing a new secret

--- a/src/v1/endpoints/admin/cluster.rs
+++ b/src/v1/endpoints/admin/cluster.rs
@@ -6,6 +6,7 @@ use aide::axum::{
 };
 use axum::{Extension, extract::State};
 use diom_authorization::RequestedOperation;
+use diom_core::types::UnixTimestampMs;
 use diom_derive::aide_annotate;
 use diom_error::{Error, ResultExt};
 use diom_id::Module;
@@ -94,7 +95,7 @@ pub struct ClusterStatusOut {
     /// The cluster state of the node servicing this request
     pub this_node_state: ServerState,
     /// The timestamp of the last transaction committed on this node
-    pub this_node_last_committed_timestamp: jiff::Timestamp,
+    pub this_node_last_committed_timestamp: UnixTimestampMs,
     /// The last snapshot taken on this node
     pub this_node_last_snapshot_id: Option<String>,
     /// A list of all nodes known to be in the cluster
@@ -188,7 +189,7 @@ async fn cluster_status(
         cluster_name,
         this_node_id,
         this_node_state,
-        this_node_last_committed_timestamp,
+        this_node_last_committed_timestamp: this_node_last_committed_timestamp.into(),
         this_node_last_snapshot_id,
         nodes,
     }))
@@ -266,7 +267,7 @@ request_input!(ClusterForceSnapshotIn, "force-snapshot");
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 struct ClusterForceSnapshotOut {
     /// The wall-clock time at which the snapshot was initiated
-    snapshot_time: jiff::Timestamp,
+    snapshot_time: UnixTimestampMs,
     /// The log index at which the snapshot was initiated
     snapshot_log_index: u64,
     /// If this is `null`, the snapshot is still building in the background
@@ -336,7 +337,7 @@ async fn cluster_force_snapshot(
     };
 
     Ok(MsgPackOrJson(ClusterForceSnapshotOut {
-        snapshot_time,
+        snapshot_time: snapshot_time.into(),
         snapshot_log_index: log_id.index,
         snapshot_id,
     }))

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -14,13 +14,12 @@ use diom_auth_token::{
     },
 };
 use diom_authorization::RequestedOperation;
-use diom_core::types::{DurationMs, Metadata};
+use diom_core::types::{DurationMs, Metadata, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt, ResultExt};
 use diom_id::{AuthTokenId, Module, Public};
 use diom_namespace::entities::NamespaceName;
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -55,9 +54,9 @@ macro_rules! request_input {
 pub struct AuthTokenOut {
     pub id: Public<AuthTokenId>,
     pub name: String,
-    pub created: Timestamp,
-    pub updated: Timestamp,
-    pub expiry: Option<Timestamp>,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
+    pub expiry: Option<UnixTimestampMs>,
     pub metadata: Metadata,
     pub owner_id: String,
     pub scopes: Vec<String>,
@@ -76,13 +75,13 @@ impl From<AuthTokenModel> for AuthTokenOut {
         Self {
             id: m.id.public(),
             name: m.name,
-            expiry: m.expiry,
+            expiry: m.expiry.map(Into::into),
             metadata: m.metadata,
             owner_id: m.owner_id,
             scopes: m.scopes,
             enabled: m.enabled,
-            created: m.created,
-            updated: m.updated,
+            created: m.created.into(),
+            updated: m.updated.into(),
         }
     }
 }
@@ -120,8 +119,8 @@ pub fn default_prefix() -> String {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthTokenCreateOut {
     pub id: Public<AuthTokenId>,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
     pub token: String,
 }
 
@@ -153,8 +152,8 @@ async fn auth_token_create(
     let ret = AuthTokenCreateOut {
         id: resp.model.id.public(),
         token: token.expose_plaintext_dangerously(),
-        created: resp.model.created,
-        updated: resp.model.updated,
+        created: resp.model.created.into(),
+        updated: resp.model.updated.into(),
     };
     Ok(MsgPackOrJson(ret))
 }
@@ -373,8 +372,8 @@ request_input!(AuthTokenRotateIn, "rotate");
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthTokenRotateOut {
     pub id: Public<AuthTokenId>,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
     pub token: String,
 }
 
@@ -400,8 +399,8 @@ async fn auth_token_rotate(
     Ok(MsgPackOrJson(AuthTokenRotateOut {
         id: model.id.public(),
         token: token.expose_plaintext_dangerously(),
-        created: model.created,
-        updated: model.updated,
+        created: model.created.into(),
+        updated: model.updated.into(),
     }))
 }
 
@@ -415,8 +414,8 @@ namespace_request_input!(AuthTokenGetNamespaceIn, "get");
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct AuthTokenGetNamespaceOut {
     pub name: NamespaceName,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -435,8 +434,8 @@ impl From<AuthTokenCreateNamespaceIn> for CreateAuthTokenNamespaceOperation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct AuthTokenCreateNamespaceOut {
     pub name: NamespaceName,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Create Auth Token namespace
@@ -449,8 +448,8 @@ async fn auth_token_create_namespace(
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(AuthTokenCreateNamespaceOut {
         name: resp.name,
-        created: resp.created,
-        updated: resp.updated,
+        created: resp.created.into(),
+        updated: resp.updated.into(),
     }))
 }
 
@@ -470,8 +469,8 @@ async fn auth_token_get_namespace(
 
     Ok(MsgPackOrJson(AuthTokenGetNamespaceOut {
         name: namespace.name,
-        created: namespace.created,
-        updated: namespace.updated,
+        created: namespace.created.into(),
+        updated: namespace.updated.into(),
     }))
 }
 

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -2,7 +2,7 @@ use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use diom_authorization::RequestedOperation;
 use diom_cache::operations::{CreateCacheOperation, DeleteOperation, SetOperation};
-use diom_core::types::{ByteString, Consistency, DurationMs, EntityKey};
+use diom_core::types::{ByteString, Consistency, DurationMs, EntityKey, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt, ResultExt};
 use diom_id::Module;
@@ -12,7 +12,6 @@ use diom_namespace::{
     entities::{CacheConfig, EvictionPolicy, NamespaceName},
 };
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -81,7 +80,7 @@ request_input!(CacheGetIn, "get");
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 pub struct CacheGetOut {
     /// Time of expiry
-    pub expiry: Option<Timestamp>,
+    pub expiry: Option<UnixTimestampMs>,
 
     pub value: Option<ByteString>,
 }
@@ -89,7 +88,7 @@ pub struct CacheGetOut {
 impl CacheGetOut {
     fn from_model(model: KvModel) -> Self {
         Self {
-            expiry: model.expiry,
+            expiry: model.expiry.map(Into::into),
             value: Some(model.value),
         }
     }
@@ -116,8 +115,8 @@ pub struct CacheDeleteOut {
 struct CacheGetNamespaceOut {
     pub name: NamespaceName,
     pub eviction_policy: EvictionPolicy,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -139,8 +138,8 @@ impl From<CacheCreateNamespaceIn> for CreateCacheOperation {
 struct CacheCreateNamespaceOut {
     pub name: NamespaceName,
     pub eviction_policy: EvictionPolicy,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Cache Set
@@ -230,8 +229,8 @@ async fn cache_create_namespace(
     Ok(MsgPackOrJson(CacheCreateNamespaceOut {
         name: resp.name,
         eviction_policy: resp.eviction_policy,
-        created: resp.created,
-        updated: resp.updated,
+        created: resp.created.into(),
+        updated: resp.updated.into(),
     }))
 }
 
@@ -253,8 +252,8 @@ async fn cache_get_namespace(
     Ok(MsgPackOrJson(CacheGetNamespaceOut {
         name: namespace.name,
         eviction_policy: namespace.config.eviction_policy,
-        created: namespace.created,
-        updated: namespace.updated,
+        created: namespace.created.into(),
+        updated: namespace.updated.into(),
     }))
 }
 

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -1,7 +1,7 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use diom_authorization::RequestedOperation;
-use diom_core::types::{ByteString, DurationMs, EntityKey, Metadata};
+use diom_core::types::{ByteString, DurationMs, EntityKey, Metadata, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt as _, ResultExt};
 use diom_id::Module;
@@ -16,7 +16,6 @@ use diom_namespace::{
     entities::{IdempotencyConfig, NamespaceName},
 };
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -215,8 +214,8 @@ namespace_request_input!(IdempotencyGetNamespaceIn, "get");
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct IdempotencyGetNamespaceOut {
     pub name: NamespaceName,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -235,8 +234,8 @@ impl From<IdempotencyCreateNamespaceIn> for CreateIdempotencyOperation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct IdempotencyCreateNamespaceOut {
     pub name: NamespaceName,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Create idempotency namespace
@@ -249,8 +248,8 @@ async fn idempotency_create_namespace(
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(IdempotencyCreateNamespaceOut {
         name: resp.name,
-        created: resp.created,
-        updated: resp.updated,
+        created: resp.created.into(),
+        updated: resp.updated.into(),
     }))
 }
 
@@ -271,8 +270,8 @@ async fn idempotency_get_namespace(
 
     Ok(MsgPackOrJson(IdempotencyGetNamespaceOut {
         name: namespace.name,
-        created: namespace.created,
-        updated: namespace.updated,
+        created: namespace.created.into(),
+        updated: namespace.updated.into(),
     }))
 }
 

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -1,7 +1,7 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use diom_authorization::RequestedOperation;
-use diom_core::types::{ByteString, Consistency, DurationMs, EntityKey};
+use diom_core::types::{ByteString, Consistency, DurationMs, EntityKey, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt, ResultExt};
 use diom_id::Module;
@@ -12,7 +12,6 @@ use diom_kv::{
 };
 use diom_namespace::entities::NamespaceName;
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -92,7 +91,7 @@ request_input!(KvGetIn, "get");
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct KvGetOut {
     /// Time of expiry
-    pub expiry: Option<Timestamp>,
+    pub expiry: Option<UnixTimestampMs>,
 
     pub value: Option<ByteString>,
 
@@ -104,7 +103,7 @@ pub struct KvGetOut {
 impl KvGetOut {
     fn from_model(model: KvModel) -> Self {
         Self {
-            expiry: model.expiry,
+            expiry: model.expiry.map(Into::into),
             value: Some(model.value),
             version: model.version,
         }
@@ -226,8 +225,8 @@ namespace_request_input!(KvGetNamespaceIn, "get");
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct KvGetNamespaceOut {
     pub name: NamespaceName,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -246,8 +245,8 @@ impl From<KvCreateNamespaceIn> for CreateKvOperation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct KvCreateNamespaceOut {
     pub name: NamespaceName,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Create KV namespace
@@ -260,8 +259,8 @@ async fn kv_create_namespace(
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(KvCreateNamespaceOut {
         name: resp.name,
-        created: resp.created,
-        updated: resp.updated,
+        created: resp.created.into(),
+        updated: resp.updated.into(),
     }))
 }
 
@@ -282,8 +281,8 @@ async fn kv_get_namespace(
 
     Ok(MsgPackOrJson(KvGetNamespaceOut {
         name: namespace.name,
-        created: namespace.created,
-        updated: namespace.updated,
+        created: namespace.created.into(),
+        updated: namespace.updated.into(),
     }))
 }
 

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -8,7 +8,7 @@ use axum::{
     http::{HeaderMap, header::AUTHORIZATION},
 };
 use diom_authorization::RequestedOperation;
-use diom_core::types::DurationMs;
+use diom_core::types::{DurationMs, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{Error, OptionExt, Result, ResultExt};
 use diom_id::Module;
@@ -28,7 +28,6 @@ use diom_msgs::{
 use diom_namespace::entities::NamespaceName;
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
 use fjall_utils::{ReadableDatabase, ReadonlyConnection, StorageType};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -76,8 +75,8 @@ impl From<MsgNamespaceCreateIn> for CreateNamespaceOperation {
 struct MsgNamespaceCreateOut {
     pub name: NamespaceName,
     pub retention: Retention,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Creates or updates a msgs namespace with the given name.
@@ -92,8 +91,8 @@ async fn create_namespace(
     Ok(MsgPackOrJson(MsgNamespaceCreateOut {
         name: response.name,
         retention: response.retention,
-        created: response.created,
-        updated: response.updated,
+        created: response.created.into(),
+        updated: response.updated.into(),
     }))
 }
 
@@ -109,8 +108,8 @@ namespace_request_input!(MsgNamespaceGetIn, "get");
 struct MsgNamespaceGetOut {
     pub name: NamespaceName,
     pub retention: Retention,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Gets a msgs namespace by name.
@@ -134,8 +133,8 @@ async fn get_namespace(
             period: namespace.config.retention_period,
             size_bytes: namespace.config.retention_bytes,
         },
-        created: namespace.created,
-        updated: namespace.updated,
+        created: namespace.created.into(),
+        updated: namespace.updated.into(),
     }))
 }
 
@@ -312,8 +311,8 @@ async fn stream_receive(
                 topic: m.topic,
                 value: m.value,
                 headers: m.headers,
-                timestamp: m.timestamp,
-                scheduled_at: m.scheduled_at,
+                timestamp: m.timestamp.into(),
+                scheduled_at: m.scheduled_at.map(Into::into),
             })
             .collect(),
     }))
@@ -519,8 +518,8 @@ async fn queue_receive(
                 msg_id: m.msg_id,
                 value: m.value,
                 headers: m.headers,
-                timestamp: m.timestamp,
-                scheduled_at: m.scheduled_at,
+                timestamp: m.timestamp.into(),
+                scheduled_at: m.scheduled_at.map(Into::into),
             })
             .collect(),
     }))

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -1,14 +1,13 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use diom_authorization::RequestedOperation;
-use diom_core::types::{DurationMs, EntityKey};
+use diom_core::types::{DurationMs, EntityKey, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt, ResultExt};
 use diom_id::Module;
 use diom_namespace::entities::NamespaceName;
 use diom_proto::{AccessMetadata, MsgPackOrJson, RequestInput};
 use diom_rate_limit::operations::{CreateRateLimitOperation, LimitOperation, ResetOperation};
-use jiff::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -242,8 +241,8 @@ impl From<RateLimitCreateNamespaceIn> for CreateRateLimitOperation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct RateLimitCreateNamespaceOut {
     pub name: NamespaceName,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
@@ -256,8 +255,8 @@ namespace_request_input!(RateLimitGetNamespaceIn, "get");
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct RateLimitGetNamespaceOut {
     pub name: NamespaceName,
-    pub created: Timestamp,
-    pub updated: Timestamp,
+    pub created: UnixTimestampMs,
+    pub updated: UnixTimestampMs,
 }
 
 /// Create rate limiter namespace
@@ -270,8 +269,8 @@ async fn rate_limit_create_namespace(
     let resp = repl.client_write(operation).await.or_internal_error()?.0?;
     Ok(MsgPackOrJson(RateLimitCreateNamespaceOut {
         name: resp.name,
-        created: resp.created,
-        updated: resp.updated,
+        created: resp.created.into(),
+        updated: resp.updated.into(),
     }))
 }
 
@@ -291,8 +290,8 @@ async fn rate_limit_get_namespace(
 
     Ok(MsgPackOrJson(RateLimitGetNamespaceOut {
         name: namespace.name,
-        created: namespace.created,
-        updated: namespace.updated,
+        created: namespace.created.into(),
+        updated: namespace.updated.into(),
     }))
 }
 

--- a/tests/it/admin/auth_token.rs
+++ b/tests/it/admin/auth_token.rs
@@ -364,8 +364,8 @@ async fn test_admin_auth_token_create_with_expiry() -> TestResult {
 
     let id = resp["id"].assert_str().to_owned();
     assert!(!id.is_empty());
-    assert!(resp["created"].is_string());
-    assert!(resp["updated"].is_string());
+    assert!(resp["created"].is_i64());
+    assert!(resp["updated"].is_i64());
 
     let list_resp = client
         .post("v1.admin.auth-token.list")

--- a/tests/it/admin/cluster.rs
+++ b/tests/it/admin/cluster.rs
@@ -165,7 +165,7 @@ async fn test_cluster_force_snapshot() -> TestResult {
         .expect(StatusCode::OK)
         .json();
     assert!(response["snapshot_log_index"].is_number());
-    assert!(response["snapshot_time"].is_string());
+    assert!(response["snapshot_time"].is_i64());
 
     let later_cluster_status = client
         .get("v1.admin.cluster.status")

--- a/tests/it/admin/policy.rs
+++ b/tests/it/admin/policy.rs
@@ -24,8 +24,8 @@ async fn test_admin_access_policy_upsert_and_get() -> TestResult {
         .json();
 
     assert_eq!(resp["id"], "read-only");
-    assert!(resp["created"].is_string());
-    assert!(resp["updated"].is_string());
+    assert!(resp["created"].is_i64());
+    assert!(resp["updated"].is_i64());
 
     let get_resp = client
         .post("v1.admin.auth-policy.get")
@@ -58,7 +58,7 @@ async fn test_admin_access_policy_upsert_preserves_created() -> TestResult {
         .ensure(StatusCode::OK)?
         .json();
 
-    let created_at = first["created"].assert_str().to_owned();
+    let created_at = first["created"].assert_u64();
 
     let second = client
         .post("v1.admin.auth-policy.upsert")

--- a/tests/it/admin/role.rs
+++ b/tests/it/admin/role.rs
@@ -26,8 +26,8 @@ async fn test_admin_role_upsert_and_get() -> TestResult {
         .json();
 
     assert_eq!(resp["id"], "editor");
-    assert!(resp["created"].is_string());
-    assert!(resp["updated"].is_string());
+    assert!(resp["created"].is_i64());
+    assert!(resp["updated"].is_i64());
 
     let get_resp = client
         .post("v1.admin.auth-role.get")
@@ -60,7 +60,7 @@ async fn test_admin_role_upsert_preserves_created() -> TestResult {
         .ensure(StatusCode::OK)?
         .json();
 
-    let created_at = first["created"].assert_str().to_owned();
+    let created_at = first["created"].assert_u64();
 
     let second = client
         .post("v1.admin.auth-role.upsert")

--- a/tests/it/auth_token.rs
+++ b/tests/it/auth_token.rs
@@ -223,8 +223,8 @@ async fn test_auth_token_namespace_create_and_get() -> TestResult {
         .json();
 
     assert_eq!(resp["name"], "at-ns-1");
-    assert!(resp["created"].is_string());
-    assert!(resp["updated"].is_string());
+    assert!(resp["created"].is_i64());
+    assert!(resp["updated"].is_i64());
 
     let get_resp = client
         .post("v1.auth-token.namespace.get")
@@ -261,7 +261,7 @@ async fn test_auth_token_rotate() -> TestResult {
     let new_token = resp["token"].assert_str();
     assert_ne!(new_id, id);
     assert_ne!(new_token, old_token);
-    assert!(resp["created"].is_string());
+    assert!(resp["created"].is_i64());
 
     // Old token is immediately expired.
     let resp = verify_token(&client, &old_token).await?;

--- a/tests/it/cache.rs
+++ b/tests/it/cache.rs
@@ -43,7 +43,7 @@ async fn test_cache_set_and_get() -> TestResult {
     let response = cache_get(&client, "test-key-1").await?;
 
     assert_eq!(response["value"], json!("test-value-123".as_bytes()));
-    assert!(response["expiry"].is_string());
+    assert!(response["expiry"].is_u64());
 
     // set should fail if namespace doesn't exist:
     client
@@ -128,8 +128,8 @@ async fn create_namespace_with_defaults() -> TestResult {
 
     assert_eq!(response["name"], "my-namespace");
     assert_eq!(response["eviction_policy"], "NoEviction");
-    assert!(response["created"].is_string());
-    assert!(response["updated"].is_string());
+    assert!(response["created"].is_u64());
+    assert!(response["updated"].is_u64());
 
     Ok(())
 }
@@ -151,7 +151,7 @@ async fn create_namespace_upserts() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let created_ts = first["created"].assert_str().to_owned();
+    let created_ts = first["created"].assert_u64();
     assert_eq!(first["name"], "upsert-ns");
 
     // Upsert

--- a/tests/it/idempotency.rs
+++ b/tests/it/idempotency.rs
@@ -247,8 +247,8 @@ async fn create_namespace_with_defaults() -> TestResult {
         .json();
 
     assert_eq!(response["name"], "my-namespace");
-    assert!(response["created"].is_string());
-    assert!(response["updated"].is_string());
+    assert!(response["created"].is_u64());
+    assert!(response["updated"].is_u64());
 
     Ok(())
 }
@@ -301,7 +301,7 @@ async fn create_namespace_upserts() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let created_ts = first["created"].assert_str().to_owned();
+    let created_ts = first["created"].assert_u64();
     assert_eq!(first["name"], "upsert-ns");
 
     // Upsert

--- a/tests/it/kv.rs
+++ b/tests/it/kv.rs
@@ -1,9 +1,8 @@
 use std::time::Duration;
 
-use jiff::Timestamp;
 use serde_json::json;
 use test_utils::{
-    JsonFastAndLoose as _, StatusCode, TestClient, TestResult,
+    JsonFastAndLoose as _, StatusCode, TestClient, TestResult, U64Ext,
     server::{TestContext, start_server},
 };
 
@@ -105,7 +104,7 @@ async fn test_kv_set_and_get() -> TestResult {
     .await?;
     let response = kv_get(&client, "kv-key-1").await?;
 
-    let expires_at: Timestamp = serde_json::from_value(response["expiry"].clone())?;
+    let expires_at = response["expiry"].assert_u64().as_timestamp_ms();
     let expected = now + Duration::from_millis(expires_in);
     assert!(
         expires_at
@@ -196,12 +195,12 @@ async fn test_kv_update_expiration() -> TestResult {
     // Test updating expiration time
     kv_set(&client, "kv4", Some(1500), "v4", "upsert").await?;
     let response = kv_get(&client, "kv4").await?;
-    let initial_expires_at = response["expiry"].assert_str();
+    let initial_expires_at = response["expiry"].assert_u64();
 
     kv_set(&client, "kv4", Some(3000), "v4", "upsert").await?;
 
     let response = kv_get(&client, "kv4").await?;
-    let expires_at = response["expiry"].assert_str();
+    let expires_at = response["expiry"].assert_u64();
     assert_ne!(initial_expires_at, expires_at);
 
     time.fast_forward(Duration::from_millis(1500));
@@ -469,8 +468,8 @@ async fn create_namespace_with_defaults() -> TestResult {
         .json();
 
     assert_eq!(response["name"], "my-namespace");
-    assert!(response["created"].is_string());
-    assert!(response["updated"].is_string());
+    assert!(response["created"].is_u64());
+    assert!(response["updated"].is_u64());
 
     Ok(())
 }
@@ -523,7 +522,7 @@ async fn create_namespace_upserts() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let created_ts = first["created"].assert_str().to_owned();
+    let created_ts = first["created"].assert_u64();
     assert_eq!(first["name"], "upsert-ns");
 
     // Upsert

--- a/tests/it/msgpack.rs
+++ b/tests/it/msgpack.rs
@@ -55,7 +55,7 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
 struct CacheGetOut {
     value: Option<Vec<u8>>,
     #[allow(unused)]
-    expiry: Option<String>,
+    expiry: Option<u64>,
 }
 
 #[tokio::test]

--- a/tests/it/msgpack.rs
+++ b/tests/it/msgpack.rs
@@ -46,7 +46,7 @@ async fn test_cache_set_and_get_msgpack_in() -> TestResult {
         .json();
 
     assert_eq!(response["value"], json!(b"test-value-123"));
-    assert!(response["expiry"].is_string());
+    assert!(response["expiry"].is_u64());
 
     Ok(())
 }

--- a/tests/it/msgs/namespace.rs
+++ b/tests/it/msgs/namespace.rs
@@ -25,8 +25,8 @@ async fn create_namespace_with_defaults() -> TestResult {
     // Retention fields are optional; omitting them means no enforcement
     assert!(response["retention"]["period_ms"].is_null());
     assert!(response["retention"]["size_bytes"].is_null());
-    assert!(response["created"].is_string());
-    assert!(response["updated"].is_string());
+    assert!(response["created"].is_u64());
+    assert!(response["updated"].is_u64());
 
     Ok(())
 }
@@ -85,7 +85,7 @@ async fn create_namespace_upserts() -> TestResult {
         .expect(StatusCode::OK)
         .json();
 
-    let created_ts = first["created"].assert_str().to_owned();
+    let created_ts = first["created"].assert_u64();
     assert_eq!(first["name"], "upsert-ns");
     assert_eq!(first["retention"]["size_bytes"], 1024);
     assert_eq!(first["retention"]["period_ms"], 9999);

--- a/z-clients/go/internal/models/admin_access_policy_out.go
+++ b/z-clients/go/internal/models/admin_access_policy_out.go
@@ -2,14 +2,10 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type AdminAccessPolicyOut struct {
 	Id          string       `msgpack:"id"`
 	Description string       `msgpack:"description"`
 	Rules       []AccessRule `msgpack:"rules"`
-	Created     time.Time    `msgpack:"created"`
-	Updated     time.Time    `msgpack:"updated"`
+	Created     uint64       `msgpack:"created"`
+	Updated     uint64       `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/admin_access_policy_upsert_out.go
+++ b/z-clients/go/internal/models/admin_access_policy_upsert_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type AdminAccessPolicyUpsertOut struct {
-	Id      string    `msgpack:"id"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Id      string `msgpack:"id"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/admin_auth_token_create_out.go
+++ b/z-clients/go/internal/models/admin_auth_token_create_out.go
@@ -2,13 +2,9 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type AdminAuthTokenCreateOut struct {
-	Id      string    `msgpack:"id"`
-	Token   string    `msgpack:"token"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Id      string `msgpack:"id"`
+	Token   string `msgpack:"token"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/admin_auth_token_out.go
+++ b/z-clients/go/internal/models/admin_auth_token_out.go
@@ -2,18 +2,12 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-
-	diom_types "github.com/svix/diom/z-clients/go/internal/types"
-)
-
 type AdminAuthTokenOut struct {
-	Id      string                `msgpack:"id"`
-	Name    string                `msgpack:"name"`
-	Created time.Time             `msgpack:"created"`
-	Updated time.Time             `msgpack:"updated"`
-	Expiry  *diom_types.Timestamp `msgpack:"expiry,omitempty"`
-	Role    string                `msgpack:"role"`
-	Enabled bool                  `msgpack:"enabled"` // Whether this token is currently enabled.
+	Id      string  `msgpack:"id"`
+	Name    string  `msgpack:"name"`
+	Created uint64  `msgpack:"created"`
+	Updated uint64  `msgpack:"updated"`
+	Expiry  *uint64 `msgpack:"expiry,omitempty"`
+	Role    string  `msgpack:"role"`
+	Enabled bool    `msgpack:"enabled"` // Whether this token is currently enabled.
 }

--- a/z-clients/go/internal/models/admin_auth_token_out.go
+++ b/z-clients/go/internal/models/admin_auth_token_out.go
@@ -2,12 +2,16 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
+import (
+	diom_types "github.com/svix/diom/z-clients/go/internal/types"
+)
+
 type AdminAuthTokenOut struct {
-	Id      string  `msgpack:"id"`
-	Name    string  `msgpack:"name"`
-	Created uint64  `msgpack:"created"`
-	Updated uint64  `msgpack:"updated"`
-	Expiry  *uint64 `msgpack:"expiry,omitempty"`
-	Role    string  `msgpack:"role"`
-	Enabled bool    `msgpack:"enabled"` // Whether this token is currently enabled.
+	Id      string                `msgpack:"id"`
+	Name    string                `msgpack:"name"`
+	Created uint64                `msgpack:"created"`
+	Updated uint64                `msgpack:"updated"`
+	Expiry  *diom_types.Timestamp `msgpack:"expiry,omitempty"`
+	Role    string                `msgpack:"role"`
+	Enabled bool                  `msgpack:"enabled"` // Whether this token is currently enabled.
 }

--- a/z-clients/go/internal/models/admin_auth_token_rotate_out.go
+++ b/z-clients/go/internal/models/admin_auth_token_rotate_out.go
@@ -2,13 +2,9 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type AdminAuthTokenRotateOut struct {
-	Id      string    `msgpack:"id"`
-	Token   string    `msgpack:"token"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Id      string `msgpack:"id"`
+	Token   string `msgpack:"token"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/admin_role_out.go
+++ b/z-clients/go/internal/models/admin_role_out.go
@@ -2,16 +2,12 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type AdminRoleOut struct {
 	Id          string            `msgpack:"id"`
 	Description string            `msgpack:"description"`
 	Rules       []AccessRule      `msgpack:"rules"`
 	Policies    []string          `msgpack:"policies"`
 	Context     map[string]string `msgpack:"context"`
-	Created     time.Time         `msgpack:"created"`
-	Updated     time.Time         `msgpack:"updated"`
+	Created     uint64            `msgpack:"created"`
+	Updated     uint64            `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/admin_role_upsert_out.go
+++ b/z-clients/go/internal/models/admin_role_upsert_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type AdminRoleUpsertOut struct {
-	Id      string    `msgpack:"id"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Id      string `msgpack:"id"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/cache_create_namespace_out.go
+++ b/z-clients/go/internal/models/cache_create_namespace_out.go
@@ -2,13 +2,9 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type CacheCreateNamespaceOut struct {
 	Name           string         `msgpack:"name"`
 	EvictionPolicy EvictionPolicy `msgpack:"eviction_policy"`
-	Created        time.Time      `msgpack:"created"`
-	Updated        time.Time      `msgpack:"updated"`
+	Created        uint64         `msgpack:"created"`
+	Updated        uint64         `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/cache_get_namespace_out.go
+++ b/z-clients/go/internal/models/cache_get_namespace_out.go
@@ -2,13 +2,9 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type CacheGetNamespaceOut struct {
 	Name           string         `msgpack:"name"`
 	EvictionPolicy EvictionPolicy `msgpack:"eviction_policy"`
-	Created        time.Time      `msgpack:"created"`
-	Updated        time.Time      `msgpack:"updated"`
+	Created        uint64         `msgpack:"created"`
+	Updated        uint64         `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/cache_get_out.go
+++ b/z-clients/go/internal/models/cache_get_out.go
@@ -2,7 +2,11 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
+import (
+	diom_types "github.com/svix/diom/z-clients/go/internal/types"
+)
+
 type CacheGetOut struct {
-	Expiry *uint64 `msgpack:"expiry,omitempty"` // Time of expiry
-	Value  []uint8 `msgpack:"value,omitempty"`
+	Expiry *diom_types.Timestamp `msgpack:"expiry,omitempty"` // Time of expiry
+	Value  []uint8               `msgpack:"value,omitempty"`
 }

--- a/z-clients/go/internal/models/cache_get_out.go
+++ b/z-clients/go/internal/models/cache_get_out.go
@@ -2,11 +2,7 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	diom_types "github.com/svix/diom/z-clients/go/internal/types"
-)
-
 type CacheGetOut struct {
-	Expiry *diom_types.Timestamp `msgpack:"expiry,omitempty"` // Time of expiry
-	Value  []uint8               `msgpack:"value,omitempty"`
+	Expiry *uint64 `msgpack:"expiry,omitempty"` // Time of expiry
+	Value  []uint8 `msgpack:"value,omitempty"`
 }

--- a/z-clients/go/internal/models/cluster_force_snapshot_out.go
+++ b/z-clients/go/internal/models/cluster_force_snapshot_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type ClusterForceSnapshotOut struct {
-	SnapshotTime     time.Time `msgpack:"snapshot_time"`         // The wall-clock time at which the snapshot was initiated
-	SnapshotLogIndex uint64    `msgpack:"snapshot_log_index"`    // The log index at which the snapshot was initiated
-	SnapshotId       *string   `msgpack:"snapshot_id,omitempty"` // If this is `null`, the snapshot is still building in the background
+	SnapshotTime     uint64  `msgpack:"snapshot_time"`         // The wall-clock time at which the snapshot was initiated
+	SnapshotLogIndex uint64  `msgpack:"snapshot_log_index"`    // The log index at which the snapshot was initiated
+	SnapshotId       *string `msgpack:"snapshot_id,omitempty"` // If this is `null`, the snapshot is still building in the background
 }

--- a/z-clients/go/internal/models/cluster_status_out.go
+++ b/z-clients/go/internal/models/cluster_status_out.go
@@ -2,10 +2,6 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type ClusterStatusOut struct {
 	// The unique ID of this cluster.
 	//
@@ -17,7 +13,7 @@ type ClusterStatusOut struct {
 	ClusterName                    *string         `msgpack:"cluster_name,omitempty"`
 	ThisNodeId                     string          `msgpack:"this_node_id"`                         // The unique ID of the node servicing this request
 	ThisNodeState                  ServerState     `msgpack:"this_node_state"`                      // The cluster state of the node servicing this request
-	ThisNodeLastCommittedTimestamp time.Time       `msgpack:"this_node_last_committed_timestamp"`   // The timestamp of the last transaction committed on this node
+	ThisNodeLastCommittedTimestamp uint64          `msgpack:"this_node_last_committed_timestamp"`   // The timestamp of the last transaction committed on this node
 	ThisNodeLastSnapshotId         *string         `msgpack:"this_node_last_snapshot_id,omitempty"` // The last snapshot taken on this node
 	Nodes                          []NodeStatusOut `msgpack:"nodes"`                                // A list of all nodes known to be in the cluster
 }

--- a/z-clients/go/internal/models/idempotency_create_namespace_out.go
+++ b/z-clients/go/internal/models/idempotency_create_namespace_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type IdempotencyCreateNamespaceOut struct {
-	Name    string    `msgpack:"name"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Name    string `msgpack:"name"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/idempotency_get_namespace_out.go
+++ b/z-clients/go/internal/models/idempotency_get_namespace_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type IdempotencyGetNamespaceOut struct {
-	Name    string    `msgpack:"name"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Name    string `msgpack:"name"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/kv_create_namespace_out.go
+++ b/z-clients/go/internal/models/kv_create_namespace_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type KvCreateNamespaceOut struct {
-	Name    string    `msgpack:"name"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Name    string `msgpack:"name"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/kv_get_namespace_out.go
+++ b/z-clients/go/internal/models/kv_get_namespace_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type KvGetNamespaceOut struct {
-	Name    string    `msgpack:"name"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Name    string `msgpack:"name"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/kv_get_out.go
+++ b/z-clients/go/internal/models/kv_get_out.go
@@ -2,13 +2,9 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	diom_types "github.com/svix/diom/z-clients/go/internal/types"
-)
-
 type KvGetOut struct {
-	Expiry *diom_types.Timestamp `msgpack:"expiry,omitempty"` // Time of expiry
-	Value  []uint8               `msgpack:"value,omitempty"`
+	Expiry *uint64 `msgpack:"expiry,omitempty"` // Time of expiry
+	Value  []uint8 `msgpack:"value,omitempty"`
 	// Opaque version token for optimistic concurrency control.
 	// Pass as `version` in a subsequent `set` to perform a conditional write.
 	Version uint64 `msgpack:"version"`

--- a/z-clients/go/internal/models/kv_get_out.go
+++ b/z-clients/go/internal/models/kv_get_out.go
@@ -2,9 +2,13 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
+import (
+	diom_types "github.com/svix/diom/z-clients/go/internal/types"
+)
+
 type KvGetOut struct {
-	Expiry *uint64 `msgpack:"expiry,omitempty"` // Time of expiry
-	Value  []uint8 `msgpack:"value,omitempty"`
+	Expiry *diom_types.Timestamp `msgpack:"expiry,omitempty"` // Time of expiry
+	Value  []uint8               `msgpack:"value,omitempty"`
 	// Opaque version token for optimistic concurrency control.
 	// Pass as `version` in a subsequent `set` to perform a conditional write.
 	Version uint64 `msgpack:"version"`

--- a/z-clients/go/internal/models/msg_namespace_create_out.go
+++ b/z-clients/go/internal/models/msg_namespace_create_out.go
@@ -2,13 +2,9 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type MsgNamespaceCreateOut struct {
 	Name      string    `msgpack:"name"`
 	Retention Retention `msgpack:"retention"`
-	Created   time.Time `msgpack:"created"`
-	Updated   time.Time `msgpack:"updated"`
+	Created   uint64    `msgpack:"created"`
+	Updated   uint64    `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/msg_namespace_get_out.go
+++ b/z-clients/go/internal/models/msg_namespace_get_out.go
@@ -2,13 +2,9 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type MsgNamespaceGetOut struct {
 	Name      string    `msgpack:"name"`
 	Retention Retention `msgpack:"retention"`
-	Created   time.Time `msgpack:"created"`
-	Updated   time.Time `msgpack:"updated"`
+	Created   uint64    `msgpack:"created"`
+	Updated   uint64    `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/queue_msg_out.go
+++ b/z-clients/go/internal/models/queue_msg_out.go
@@ -2,16 +2,10 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-
-	diom_types "github.com/svix/diom/z-clients/go/internal/types"
-)
-
 type QueueMsgOut struct {
-	MsgId       string                `msgpack:"msg_id"`
-	Value       []uint8               `msgpack:"value"`
-	Headers     map[string]string     `msgpack:"headers"`
-	Timestamp   time.Time             `msgpack:"timestamp"`
-	ScheduledAt *diom_types.Timestamp `msgpack:"scheduled_at,omitempty"`
+	MsgId       string            `msgpack:"msg_id"`
+	Value       []uint8           `msgpack:"value"`
+	Headers     map[string]string `msgpack:"headers"`
+	Timestamp   uint64            `msgpack:"timestamp"`
+	ScheduledAt *uint64           `msgpack:"scheduled_at,omitempty"`
 }

--- a/z-clients/go/internal/models/queue_msg_out.go
+++ b/z-clients/go/internal/models/queue_msg_out.go
@@ -2,10 +2,14 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
+import (
+	diom_types "github.com/svix/diom/z-clients/go/internal/types"
+)
+
 type QueueMsgOut struct {
-	MsgId       string            `msgpack:"msg_id"`
-	Value       []uint8           `msgpack:"value"`
-	Headers     map[string]string `msgpack:"headers"`
-	Timestamp   uint64            `msgpack:"timestamp"`
-	ScheduledAt *uint64           `msgpack:"scheduled_at,omitempty"`
+	MsgId       string                `msgpack:"msg_id"`
+	Value       []uint8               `msgpack:"value"`
+	Headers     map[string]string     `msgpack:"headers"`
+	Timestamp   uint64                `msgpack:"timestamp"`
+	ScheduledAt *diom_types.Timestamp `msgpack:"scheduled_at,omitempty"`
 }

--- a/z-clients/go/internal/models/rate_limit_create_namespace_out.go
+++ b/z-clients/go/internal/models/rate_limit_create_namespace_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type RateLimitCreateNamespaceOut struct {
-	Name    string    `msgpack:"name"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Name    string `msgpack:"name"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/rate_limit_get_namespace_out.go
+++ b/z-clients/go/internal/models/rate_limit_get_namespace_out.go
@@ -2,12 +2,8 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-)
-
 type RateLimitGetNamespaceOut struct {
-	Name    string    `msgpack:"name"`
-	Created time.Time `msgpack:"created"`
-	Updated time.Time `msgpack:"updated"`
+	Name    string `msgpack:"name"`
+	Created uint64 `msgpack:"created"`
+	Updated uint64 `msgpack:"updated"`
 }

--- a/z-clients/go/internal/models/stream_msg_out.go
+++ b/z-clients/go/internal/models/stream_msg_out.go
@@ -2,11 +2,15 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
+import (
+	diom_types "github.com/svix/diom/z-clients/go/internal/types"
+)
+
 type StreamMsgOut struct {
-	Offset      uint64            `msgpack:"offset"`
-	Topic       string            `msgpack:"topic"`
-	Value       []uint8           `msgpack:"value"`
-	Headers     map[string]string `msgpack:"headers"`
-	Timestamp   uint64            `msgpack:"timestamp"`
-	ScheduledAt *uint64           `msgpack:"scheduled_at,omitempty"`
+	Offset      uint64                `msgpack:"offset"`
+	Topic       string                `msgpack:"topic"`
+	Value       []uint8               `msgpack:"value"`
+	Headers     map[string]string     `msgpack:"headers"`
+	Timestamp   uint64                `msgpack:"timestamp"`
+	ScheduledAt *diom_types.Timestamp `msgpack:"scheduled_at,omitempty"`
 }

--- a/z-clients/go/internal/models/stream_msg_out.go
+++ b/z-clients/go/internal/models/stream_msg_out.go
@@ -2,17 +2,11 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
-import (
-	"time"
-
-	diom_types "github.com/svix/diom/z-clients/go/internal/types"
-)
-
 type StreamMsgOut struct {
-	Offset      uint64                `msgpack:"offset"`
-	Topic       string                `msgpack:"topic"`
-	Value       []uint8               `msgpack:"value"`
-	Headers     map[string]string     `msgpack:"headers"`
-	Timestamp   time.Time             `msgpack:"timestamp"`
-	ScheduledAt *diom_types.Timestamp `msgpack:"scheduled_at,omitempty"`
+	Offset      uint64            `msgpack:"offset"`
+	Topic       string            `msgpack:"topic"`
+	Value       []uint8           `msgpack:"value"`
+	Headers     map[string]string `msgpack:"headers"`
+	Timestamp   uint64            `msgpack:"timestamp"`
+	ScheduledAt *uint64           `msgpack:"scheduled_at,omitempty"`
 }

--- a/z-clients/go/internal/types/time.go
+++ b/z-clients/go/internal/types/time.go
@@ -12,22 +12,17 @@ import (
 type Timestamp time.Time
 
 func (t *Timestamp) EncodeMsgpack(enc *msgpack.Encoder) error {
-	s := time.Time(*t).Format(time.RFC3339)
-	return enc.EncodeString(s)
+	i := time.Time(*t).UnixMilli()
+	return enc.EncodeInt64(i)
 }
 
 func (t *Timestamp) DecodeMsgpack(dec *msgpack.Decoder) error {
-	s, err := dec.DecodeString()
+	i, err := dec.DecodeInt64()
 	if err != nil {
 		return err
 	}
 
-	time, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return err
-	}
-
-	timestamp := Timestamp(time)
+	timestamp := Timestamp(time.UnixMilli(i))
 	t = &timestamp
 	return nil
 }

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminAccessPolicyOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminAccessPolicyOut.java
@@ -39,8 +39,8 @@ public class AdminAccessPolicyOut {
     @JsonProperty private String id;
     @JsonProperty private String description;
     @JsonProperty private List<AccessRule> rules;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public AdminAccessPolicyOut() {}
 
     public AdminAccessPolicyOut id(String id) {
@@ -107,7 +107,7 @@ public class AdminAccessPolicyOut {
         this.rules = rules;
     }
 
-    public AdminAccessPolicyOut created(OffsetDateTime created) {
+    public AdminAccessPolicyOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -118,15 +118,15 @@ public class AdminAccessPolicyOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public AdminAccessPolicyOut updated(OffsetDateTime updated) {
+    public AdminAccessPolicyOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -137,11 +137,11 @@ public class AdminAccessPolicyOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminAccessPolicyUpsertOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminAccessPolicyUpsertOut.java
@@ -37,8 +37,8 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class AdminAccessPolicyUpsertOut {
     @JsonProperty private String id;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public AdminAccessPolicyUpsertOut() {}
 
     public AdminAccessPolicyUpsertOut id(String id) {
@@ -60,7 +60,7 @@ public class AdminAccessPolicyUpsertOut {
         this.id = id;
     }
 
-    public AdminAccessPolicyUpsertOut created(OffsetDateTime created) {
+    public AdminAccessPolicyUpsertOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -71,15 +71,15 @@ public class AdminAccessPolicyUpsertOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public AdminAccessPolicyUpsertOut updated(OffsetDateTime updated) {
+    public AdminAccessPolicyUpsertOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -90,11 +90,11 @@ public class AdminAccessPolicyUpsertOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminAuthTokenCreateOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminAuthTokenCreateOut.java
@@ -38,8 +38,8 @@ import lombok.ToString;
 public class AdminAuthTokenCreateOut {
     @JsonProperty private String id;
     @JsonProperty private String token;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public AdminAuthTokenCreateOut() {}
 
     public AdminAuthTokenCreateOut id(String id) {
@@ -80,7 +80,7 @@ public class AdminAuthTokenCreateOut {
         this.token = token;
     }
 
-    public AdminAuthTokenCreateOut created(OffsetDateTime created) {
+    public AdminAuthTokenCreateOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -91,15 +91,15 @@ public class AdminAuthTokenCreateOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public AdminAuthTokenCreateOut updated(OffsetDateTime updated) {
+    public AdminAuthTokenCreateOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -110,11 +110,11 @@ public class AdminAuthTokenCreateOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminAuthTokenOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminAuthTokenOut.java
@@ -38,9 +38,9 @@ import lombok.ToString;
 public class AdminAuthTokenOut {
     @JsonProperty private String id;
     @JsonProperty private String name;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
-    @JsonProperty private OffsetDateTime expiry;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant expiry;
     @JsonProperty private String role;
     @JsonProperty private Boolean enabled;
     public AdminAuthTokenOut() {}
@@ -83,7 +83,7 @@ public class AdminAuthTokenOut {
         this.name = name;
     }
 
-    public AdminAuthTokenOut created(OffsetDateTime created) {
+    public AdminAuthTokenOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -94,15 +94,15 @@ public class AdminAuthTokenOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public AdminAuthTokenOut updated(OffsetDateTime updated) {
+    public AdminAuthTokenOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -113,15 +113,15 @@ public class AdminAuthTokenOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 
-    public AdminAuthTokenOut expiry(OffsetDateTime expiry) {
+    public AdminAuthTokenOut expiry(Instant expiry) {
         this.expiry = expiry;
         return this;
     }
@@ -132,11 +132,11 @@ public class AdminAuthTokenOut {
      * @return expiry
      */
     @javax.annotation.Nullable
-    public OffsetDateTime getExpiry() {
+    public Instant getExpiry() {
         return expiry;
     }
 
-    public void setExpiry(OffsetDateTime expiry) {
+    public void setExpiry(Instant expiry) {
         this.expiry = expiry;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminAuthTokenRotateOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminAuthTokenRotateOut.java
@@ -38,8 +38,8 @@ import lombok.ToString;
 public class AdminAuthTokenRotateOut {
     @JsonProperty private String id;
     @JsonProperty private String token;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public AdminAuthTokenRotateOut() {}
 
     public AdminAuthTokenRotateOut id(String id) {
@@ -80,7 +80,7 @@ public class AdminAuthTokenRotateOut {
         this.token = token;
     }
 
-    public AdminAuthTokenRotateOut created(OffsetDateTime created) {
+    public AdminAuthTokenRotateOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -91,15 +91,15 @@ public class AdminAuthTokenRotateOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public AdminAuthTokenRotateOut updated(OffsetDateTime updated) {
+    public AdminAuthTokenRotateOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -110,11 +110,11 @@ public class AdminAuthTokenRotateOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminRoleOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminRoleOut.java
@@ -41,8 +41,8 @@ public class AdminRoleOut {
     @JsonProperty private List<AccessRule> rules;
     @JsonProperty private List<String> policies;
     @JsonProperty private Map<String,String> context;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public AdminRoleOut() {}
 
     public AdminRoleOut id(String id) {
@@ -161,7 +161,7 @@ public class AdminRoleOut {
         this.context = context;
     }
 
-    public AdminRoleOut created(OffsetDateTime created) {
+    public AdminRoleOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -172,15 +172,15 @@ public class AdminRoleOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public AdminRoleOut updated(OffsetDateTime updated) {
+    public AdminRoleOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -191,11 +191,11 @@ public class AdminRoleOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminRoleUpsertOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminRoleUpsertOut.java
@@ -37,8 +37,8 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class AdminRoleUpsertOut {
     @JsonProperty private String id;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public AdminRoleUpsertOut() {}
 
     public AdminRoleUpsertOut id(String id) {
@@ -60,7 +60,7 @@ public class AdminRoleUpsertOut {
         this.id = id;
     }
 
-    public AdminRoleUpsertOut created(OffsetDateTime created) {
+    public AdminRoleUpsertOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -71,15 +71,15 @@ public class AdminRoleUpsertOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public AdminRoleUpsertOut updated(OffsetDateTime updated) {
+    public AdminRoleUpsertOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -90,11 +90,11 @@ public class AdminRoleUpsertOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/CacheCreateNamespaceOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/CacheCreateNamespaceOut.java
@@ -38,8 +38,8 @@ import lombok.ToString;
 public class CacheCreateNamespaceOut {
     @JsonProperty private String name;
     @JsonProperty("eviction_policy") private EvictionPolicy evictionPolicy;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public CacheCreateNamespaceOut() {}
 
     public CacheCreateNamespaceOut name(String name) {
@@ -80,7 +80,7 @@ public class CacheCreateNamespaceOut {
         this.evictionPolicy = evictionPolicy;
     }
 
-    public CacheCreateNamespaceOut created(OffsetDateTime created) {
+    public CacheCreateNamespaceOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -91,15 +91,15 @@ public class CacheCreateNamespaceOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public CacheCreateNamespaceOut updated(OffsetDateTime updated) {
+    public CacheCreateNamespaceOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -110,11 +110,11 @@ public class CacheCreateNamespaceOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/CacheGetNamespaceOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/CacheGetNamespaceOut.java
@@ -38,8 +38,8 @@ import lombok.ToString;
 public class CacheGetNamespaceOut {
     @JsonProperty private String name;
     @JsonProperty("eviction_policy") private EvictionPolicy evictionPolicy;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public CacheGetNamespaceOut() {}
 
     public CacheGetNamespaceOut name(String name) {
@@ -80,7 +80,7 @@ public class CacheGetNamespaceOut {
         this.evictionPolicy = evictionPolicy;
     }
 
-    public CacheGetNamespaceOut created(OffsetDateTime created) {
+    public CacheGetNamespaceOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -91,15 +91,15 @@ public class CacheGetNamespaceOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public CacheGetNamespaceOut updated(OffsetDateTime updated) {
+    public CacheGetNamespaceOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -110,11 +110,11 @@ public class CacheGetNamespaceOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/CacheGetOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/CacheGetOut.java
@@ -36,11 +36,11 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class CacheGetOut {
-    @JsonProperty private OffsetDateTime expiry;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant expiry;
     @JsonProperty private byte[] value;
     public CacheGetOut() {}
 
-    public CacheGetOut expiry(OffsetDateTime expiry) {
+    public CacheGetOut expiry(Instant expiry) {
         this.expiry = expiry;
         return this;
     }
@@ -51,11 +51,11 @@ public class CacheGetOut {
      * @return expiry
      */
     @javax.annotation.Nullable
-    public OffsetDateTime getExpiry() {
+    public Instant getExpiry() {
         return expiry;
     }
 
-    public void setExpiry(OffsetDateTime expiry) {
+    public void setExpiry(Instant expiry) {
         this.expiry = expiry;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/ClusterForceSnapshotOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/ClusterForceSnapshotOut.java
@@ -36,12 +36,12 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class ClusterForceSnapshotOut {
-    @JsonProperty("snapshot_time") private OffsetDateTime snapshotTime;
+    @JsonProperty("snapshot_time") @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant snapshotTime;
     @JsonProperty("snapshot_log_index") private Long snapshotLogIndex;
     @JsonProperty("snapshot_id") private String snapshotId;
     public ClusterForceSnapshotOut() {}
 
-    public ClusterForceSnapshotOut snapshotTime(OffsetDateTime snapshotTime) {
+    public ClusterForceSnapshotOut snapshotTime(Instant snapshotTime) {
         this.snapshotTime = snapshotTime;
         return this;
     }
@@ -52,11 +52,11 @@ public class ClusterForceSnapshotOut {
      * @return snapshotTime
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getSnapshotTime() {
+    public Instant getSnapshotTime() {
         return snapshotTime;
     }
 
-    public void setSnapshotTime(OffsetDateTime snapshotTime) {
+    public void setSnapshotTime(Instant snapshotTime) {
         this.snapshotTime = snapshotTime;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/ClusterStatusOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/ClusterStatusOut.java
@@ -40,7 +40,7 @@ public class ClusterStatusOut {
     @JsonProperty("cluster_name") private String clusterName;
     @JsonProperty("this_node_id") private String thisNodeId;
     @JsonProperty("this_node_state") private ServerState thisNodeState;
-    @JsonProperty("this_node_last_committed_timestamp") private OffsetDateTime thisNodeLastCommittedTimestamp;
+    @JsonProperty("this_node_last_committed_timestamp") @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant thisNodeLastCommittedTimestamp;
     @JsonProperty("this_node_last_snapshot_id") private String thisNodeLastSnapshotId;
     @JsonProperty private List<NodeStatusOut> nodes;
     public ClusterStatusOut() {}
@@ -125,7 +125,7 @@ This value is not replicated and should only be used for debugging.
         this.thisNodeState = thisNodeState;
     }
 
-    public ClusterStatusOut thisNodeLastCommittedTimestamp(OffsetDateTime thisNodeLastCommittedTimestamp) {
+    public ClusterStatusOut thisNodeLastCommittedTimestamp(Instant thisNodeLastCommittedTimestamp) {
         this.thisNodeLastCommittedTimestamp = thisNodeLastCommittedTimestamp;
         return this;
     }
@@ -136,11 +136,11 @@ This value is not replicated and should only be used for debugging.
      * @return thisNodeLastCommittedTimestamp
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getThisNodeLastCommittedTimestamp() {
+    public Instant getThisNodeLastCommittedTimestamp() {
         return thisNodeLastCommittedTimestamp;
     }
 
-    public void setThisNodeLastCommittedTimestamp(OffsetDateTime thisNodeLastCommittedTimestamp) {
+    public void setThisNodeLastCommittedTimestamp(Instant thisNodeLastCommittedTimestamp) {
         this.thisNodeLastCommittedTimestamp = thisNodeLastCommittedTimestamp;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyCreateNamespaceOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyCreateNamespaceOut.java
@@ -37,8 +37,8 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class IdempotencyCreateNamespaceOut {
     @JsonProperty private String name;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public IdempotencyCreateNamespaceOut() {}
 
     public IdempotencyCreateNamespaceOut name(String name) {
@@ -60,7 +60,7 @@ public class IdempotencyCreateNamespaceOut {
         this.name = name;
     }
 
-    public IdempotencyCreateNamespaceOut created(OffsetDateTime created) {
+    public IdempotencyCreateNamespaceOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -71,15 +71,15 @@ public class IdempotencyCreateNamespaceOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public IdempotencyCreateNamespaceOut updated(OffsetDateTime updated) {
+    public IdempotencyCreateNamespaceOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -90,11 +90,11 @@ public class IdempotencyCreateNamespaceOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyGetNamespaceOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyGetNamespaceOut.java
@@ -37,8 +37,8 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class IdempotencyGetNamespaceOut {
     @JsonProperty private String name;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public IdempotencyGetNamespaceOut() {}
 
     public IdempotencyGetNamespaceOut name(String name) {
@@ -60,7 +60,7 @@ public class IdempotencyGetNamespaceOut {
         this.name = name;
     }
 
-    public IdempotencyGetNamespaceOut created(OffsetDateTime created) {
+    public IdempotencyGetNamespaceOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -71,15 +71,15 @@ public class IdempotencyGetNamespaceOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public IdempotencyGetNamespaceOut updated(OffsetDateTime updated) {
+    public IdempotencyGetNamespaceOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -90,11 +90,11 @@ public class IdempotencyGetNamespaceOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/KvCreateNamespaceOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/KvCreateNamespaceOut.java
@@ -37,8 +37,8 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class KvCreateNamespaceOut {
     @JsonProperty private String name;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public KvCreateNamespaceOut() {}
 
     public KvCreateNamespaceOut name(String name) {
@@ -60,7 +60,7 @@ public class KvCreateNamespaceOut {
         this.name = name;
     }
 
-    public KvCreateNamespaceOut created(OffsetDateTime created) {
+    public KvCreateNamespaceOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -71,15 +71,15 @@ public class KvCreateNamespaceOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public KvCreateNamespaceOut updated(OffsetDateTime updated) {
+    public KvCreateNamespaceOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -90,11 +90,11 @@ public class KvCreateNamespaceOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/KvGetNamespaceOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/KvGetNamespaceOut.java
@@ -37,8 +37,8 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class KvGetNamespaceOut {
     @JsonProperty private String name;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public KvGetNamespaceOut() {}
 
     public KvGetNamespaceOut name(String name) {
@@ -60,7 +60,7 @@ public class KvGetNamespaceOut {
         this.name = name;
     }
 
-    public KvGetNamespaceOut created(OffsetDateTime created) {
+    public KvGetNamespaceOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -71,15 +71,15 @@ public class KvGetNamespaceOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public KvGetNamespaceOut updated(OffsetDateTime updated) {
+    public KvGetNamespaceOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -90,11 +90,11 @@ public class KvGetNamespaceOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/KvGetOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/KvGetOut.java
@@ -36,12 +36,12 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class KvGetOut {
-    @JsonProperty private OffsetDateTime expiry;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant expiry;
     @JsonProperty private byte[] value;
     @JsonProperty private Long version;
     public KvGetOut() {}
 
-    public KvGetOut expiry(OffsetDateTime expiry) {
+    public KvGetOut expiry(Instant expiry) {
         this.expiry = expiry;
         return this;
     }
@@ -52,11 +52,11 @@ public class KvGetOut {
      * @return expiry
      */
     @javax.annotation.Nullable
-    public OffsetDateTime getExpiry() {
+    public Instant getExpiry() {
         return expiry;
     }
 
-    public void setExpiry(OffsetDateTime expiry) {
+    public void setExpiry(Instant expiry) {
         this.expiry = expiry;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/MsgNamespaceCreateOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/MsgNamespaceCreateOut.java
@@ -38,8 +38,8 @@ import lombok.ToString;
 public class MsgNamespaceCreateOut {
     @JsonProperty private String name;
     @JsonProperty private Retention retention;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public MsgNamespaceCreateOut() {}
 
     public MsgNamespaceCreateOut name(String name) {
@@ -80,7 +80,7 @@ public class MsgNamespaceCreateOut {
         this.retention = retention;
     }
 
-    public MsgNamespaceCreateOut created(OffsetDateTime created) {
+    public MsgNamespaceCreateOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -91,15 +91,15 @@ public class MsgNamespaceCreateOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public MsgNamespaceCreateOut updated(OffsetDateTime updated) {
+    public MsgNamespaceCreateOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -110,11 +110,11 @@ public class MsgNamespaceCreateOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/MsgNamespaceGetOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/MsgNamespaceGetOut.java
@@ -38,8 +38,8 @@ import lombok.ToString;
 public class MsgNamespaceGetOut {
     @JsonProperty private String name;
     @JsonProperty private Retention retention;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public MsgNamespaceGetOut() {}
 
     public MsgNamespaceGetOut name(String name) {
@@ -80,7 +80,7 @@ public class MsgNamespaceGetOut {
         this.retention = retention;
     }
 
-    public MsgNamespaceGetOut created(OffsetDateTime created) {
+    public MsgNamespaceGetOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -91,15 +91,15 @@ public class MsgNamespaceGetOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public MsgNamespaceGetOut updated(OffsetDateTime updated) {
+    public MsgNamespaceGetOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -110,11 +110,11 @@ public class MsgNamespaceGetOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/QueueMsgOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/QueueMsgOut.java
@@ -39,8 +39,8 @@ public class QueueMsgOut {
     @JsonProperty("msg_id") private String msgId;
     @JsonProperty private byte[] value;
     @JsonProperty private Map<String,String> headers;
-    @JsonProperty private OffsetDateTime timestamp;
-    @JsonProperty("scheduled_at") private OffsetDateTime scheduledAt;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant timestamp;
+    @JsonProperty("scheduled_at") @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant scheduledAt;
     public QueueMsgOut() {}
 
     public QueueMsgOut msgId(String msgId) {
@@ -107,7 +107,7 @@ public class QueueMsgOut {
         this.headers = headers;
     }
 
-    public QueueMsgOut timestamp(OffsetDateTime timestamp) {
+    public QueueMsgOut timestamp(Instant timestamp) {
         this.timestamp = timestamp;
         return this;
     }
@@ -118,15 +118,15 @@ public class QueueMsgOut {
      * @return timestamp
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 
-    public void setTimestamp(OffsetDateTime timestamp) {
+    public void setTimestamp(Instant timestamp) {
         this.timestamp = timestamp;
     }
 
-    public QueueMsgOut scheduledAt(OffsetDateTime scheduledAt) {
+    public QueueMsgOut scheduledAt(Instant scheduledAt) {
         this.scheduledAt = scheduledAt;
         return this;
     }
@@ -137,11 +137,11 @@ public class QueueMsgOut {
      * @return scheduledAt
      */
     @javax.annotation.Nullable
-    public OffsetDateTime getScheduledAt() {
+    public Instant getScheduledAt() {
         return scheduledAt;
     }
 
-    public void setScheduledAt(OffsetDateTime scheduledAt) {
+    public void setScheduledAt(Instant scheduledAt) {
         this.scheduledAt = scheduledAt;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/RateLimitCreateNamespaceOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/RateLimitCreateNamespaceOut.java
@@ -37,8 +37,8 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class RateLimitCreateNamespaceOut {
     @JsonProperty private String name;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public RateLimitCreateNamespaceOut() {}
 
     public RateLimitCreateNamespaceOut name(String name) {
@@ -60,7 +60,7 @@ public class RateLimitCreateNamespaceOut {
         this.name = name;
     }
 
-    public RateLimitCreateNamespaceOut created(OffsetDateTime created) {
+    public RateLimitCreateNamespaceOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -71,15 +71,15 @@ public class RateLimitCreateNamespaceOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public RateLimitCreateNamespaceOut updated(OffsetDateTime updated) {
+    public RateLimitCreateNamespaceOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -90,11 +90,11 @@ public class RateLimitCreateNamespaceOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/RateLimitGetNamespaceOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/RateLimitGetNamespaceOut.java
@@ -37,8 +37,8 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class RateLimitGetNamespaceOut {
     @JsonProperty private String name;
-    @JsonProperty private OffsetDateTime created;
-    @JsonProperty private OffsetDateTime updated;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public RateLimitGetNamespaceOut() {}
 
     public RateLimitGetNamespaceOut name(String name) {
@@ -60,7 +60,7 @@ public class RateLimitGetNamespaceOut {
         this.name = name;
     }
 
-    public RateLimitGetNamespaceOut created(OffsetDateTime created) {
+    public RateLimitGetNamespaceOut created(Instant created) {
         this.created = created;
         return this;
     }
@@ -71,15 +71,15 @@ public class RateLimitGetNamespaceOut {
      * @return created
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(OffsetDateTime created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public RateLimitGetNamespaceOut updated(OffsetDateTime updated) {
+    public RateLimitGetNamespaceOut updated(Instant updated) {
         this.updated = updated;
         return this;
     }
@@ -90,11 +90,11 @@ public class RateLimitGetNamespaceOut {
      * @return updated
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getUpdated() {
+    public Instant getUpdated() {
         return updated;
     }
 
-    public void setUpdated(OffsetDateTime updated) {
+    public void setUpdated(Instant updated) {
         this.updated = updated;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/StreamMsgOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/StreamMsgOut.java
@@ -40,8 +40,8 @@ public class StreamMsgOut {
     @JsonProperty private String topic;
     @JsonProperty private byte[] value;
     @JsonProperty private Map<String,String> headers;
-    @JsonProperty private OffsetDateTime timestamp;
-    @JsonProperty("scheduled_at") private OffsetDateTime scheduledAt;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant timestamp;
+    @JsonProperty("scheduled_at") @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant scheduledAt;
     public StreamMsgOut() {}
 
     public StreamMsgOut offset(Long offset) {
@@ -127,7 +127,7 @@ public class StreamMsgOut {
         this.headers = headers;
     }
 
-    public StreamMsgOut timestamp(OffsetDateTime timestamp) {
+    public StreamMsgOut timestamp(Instant timestamp) {
         this.timestamp = timestamp;
         return this;
     }
@@ -138,15 +138,15 @@ public class StreamMsgOut {
      * @return timestamp
      */
     @javax.annotation.Nonnull
-    public OffsetDateTime getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 
-    public void setTimestamp(OffsetDateTime timestamp) {
+    public void setTimestamp(Instant timestamp) {
         this.timestamp = timestamp;
     }
 
-    public StreamMsgOut scheduledAt(OffsetDateTime scheduledAt) {
+    public StreamMsgOut scheduledAt(Instant scheduledAt) {
         this.scheduledAt = scheduledAt;
         return this;
     }
@@ -157,11 +157,11 @@ public class StreamMsgOut {
      * @return scheduledAt
      */
     @javax.annotation.Nullable
-    public OffsetDateTime getScheduledAt() {
+    public Instant getScheduledAt() {
         return scheduledAt;
     }
 
-    public void setScheduledAt(OffsetDateTime scheduledAt) {
+    public void setScheduledAt(Instant scheduledAt) {
         this.scheduledAt = scheduledAt;
     }
 

--- a/z-clients/javascript/src/models/adminAccessPolicyOut.ts
+++ b/z-clients/javascript/src/models/adminAccessPolicyOut.ts
@@ -19,8 +19,8 @@ export const AdminAccessPolicyOutSerializer = {
             id: object['id'],
             description: object['description'],
             rules: object['rules'].map((item: AccessRule) => AccessRuleSerializer._fromJsonObject(item)),
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/adminAccessPolicyOut.ts
+++ b/z-clients/javascript/src/models/adminAccessPolicyOut.ts
@@ -30,8 +30,8 @@ export const AdminAccessPolicyOutSerializer = {
             'id': self.id,
             'description': self.description,
             'rules': self.rules.map((item) => AccessRuleSerializer._toJsonObject(item)),
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/adminAccessPolicyUpsertOut.ts
+++ b/z-clients/javascript/src/models/adminAccessPolicyUpsertOut.ts
@@ -20,8 +20,8 @@ export const AdminAccessPolicyUpsertOutSerializer = {
     _toJsonObject(self: AdminAccessPolicyUpsertOut): any {
         return {
             'id': self.id,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/adminAccessPolicyUpsertOut.ts
+++ b/z-clients/javascript/src/models/adminAccessPolicyUpsertOut.ts
@@ -11,8 +11,8 @@ export const AdminAccessPolicyUpsertOutSerializer = {
     _fromJsonObject(object: any): AdminAccessPolicyUpsertOut {
         return {
             id: object['id'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/adminAuthTokenCreateOut.ts
+++ b/z-clients/javascript/src/models/adminAuthTokenCreateOut.ts
@@ -13,8 +13,8 @@ export const AdminAuthTokenCreateOutSerializer = {
         return {
             id: object['id'],
             token: object['token'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/adminAuthTokenCreateOut.ts
+++ b/z-clients/javascript/src/models/adminAuthTokenCreateOut.ts
@@ -23,8 +23,8 @@ export const AdminAuthTokenCreateOutSerializer = {
         return {
             'id': self.id,
             'token': self.token,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/adminAuthTokenOut.ts
+++ b/z-clients/javascript/src/models/adminAuthTokenOut.ts
@@ -30,9 +30,9 @@ export const AdminAuthTokenOutSerializer = {
         return {
             'id': self.id,
             'name': self.name,
-            'created': self.created,
-            'updated': self.updated,
-            'expiry': self.expiry,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
+            'expiry': self.expiry != null ? self.expiry.getTime() : undefined,
             'role': self.role,
             'enabled': self.enabled,
         };

--- a/z-clients/javascript/src/models/adminAuthTokenOut.ts
+++ b/z-clients/javascript/src/models/adminAuthTokenOut.ts
@@ -17,9 +17,9 @@ export const AdminAuthTokenOutSerializer = {
         return {
             id: object['id'],
             name: object['name'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
-            expiry: object['expiry'] ? new Date(object['expiry']) : null,
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
+            expiry: object['expiry'] ? new Date(Number(object['expiry'])) : null,
             role: object['role'],
             enabled: object['enabled'],
         };

--- a/z-clients/javascript/src/models/adminAuthTokenRotateOut.ts
+++ b/z-clients/javascript/src/models/adminAuthTokenRotateOut.ts
@@ -13,8 +13,8 @@ export const AdminAuthTokenRotateOutSerializer = {
         return {
             id: object['id'],
             token: object['token'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/adminAuthTokenRotateOut.ts
+++ b/z-clients/javascript/src/models/adminAuthTokenRotateOut.ts
@@ -23,8 +23,8 @@ export const AdminAuthTokenRotateOutSerializer = {
         return {
             'id': self.id,
             'token': self.token,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/adminRoleOut.ts
+++ b/z-clients/javascript/src/models/adminRoleOut.ts
@@ -36,8 +36,8 @@ export const AdminRoleOutSerializer = {
             'rules': self.rules.map((item) => AccessRuleSerializer._toJsonObject(item)),
             'policies': self.policies,
             'context': self.context,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/adminRoleOut.ts
+++ b/z-clients/javascript/src/models/adminRoleOut.ts
@@ -23,8 +23,8 @@ export const AdminRoleOutSerializer = {
             rules: object['rules'].map((item: AccessRule) => AccessRuleSerializer._fromJsonObject(item)),
             policies: object['policies'],
             context: object['context'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/adminRoleUpsertOut.ts
+++ b/z-clients/javascript/src/models/adminRoleUpsertOut.ts
@@ -11,8 +11,8 @@ export const AdminRoleUpsertOutSerializer = {
     _fromJsonObject(object: any): AdminRoleUpsertOut {
         return {
             id: object['id'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/adminRoleUpsertOut.ts
+++ b/z-clients/javascript/src/models/adminRoleUpsertOut.ts
@@ -20,8 +20,8 @@ export const AdminRoleUpsertOutSerializer = {
     _toJsonObject(self: AdminRoleUpsertOut): any {
         return {
             'id': self.id,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/cacheCreateNamespaceOut.ts
+++ b/z-clients/javascript/src/models/cacheCreateNamespaceOut.ts
@@ -17,8 +17,8 @@ export const CacheCreateNamespaceOutSerializer = {
         return {
             name: object['name'],
             evictionPolicy: EvictionPolicySerializer._fromJsonObject(object['eviction_policy']),
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/cacheCreateNamespaceOut.ts
+++ b/z-clients/javascript/src/models/cacheCreateNamespaceOut.ts
@@ -27,8 +27,8 @@ export const CacheCreateNamespaceOutSerializer = {
         return {
             'name': self.name,
             'eviction_policy': EvictionPolicySerializer._toJsonObject(self.evictionPolicy),
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/cacheGetNamespaceOut.ts
+++ b/z-clients/javascript/src/models/cacheGetNamespaceOut.ts
@@ -27,8 +27,8 @@ export const CacheGetNamespaceOutSerializer = {
         return {
             'name': self.name,
             'eviction_policy': EvictionPolicySerializer._toJsonObject(self.evictionPolicy),
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/cacheGetNamespaceOut.ts
+++ b/z-clients/javascript/src/models/cacheGetNamespaceOut.ts
@@ -17,8 +17,8 @@ export const CacheGetNamespaceOutSerializer = {
         return {
             name: object['name'],
             evictionPolicy: EvictionPolicySerializer._fromJsonObject(object['eviction_policy']),
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/cacheGetOut.ts
+++ b/z-clients/javascript/src/models/cacheGetOut.ts
@@ -18,7 +18,7 @@ export const CacheGetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _toJsonObject(self: CacheGetOut): any {
         return {
-            'expiry': self.expiry,
+            'expiry': self.expiry != null ? self.expiry.getTime() : undefined,
             'value': self.value != null ? Array.from(self.value) : undefined,
         };
     }

--- a/z-clients/javascript/src/models/cacheGetOut.ts
+++ b/z-clients/javascript/src/models/cacheGetOut.ts
@@ -10,7 +10,7 @@ export const CacheGetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject(object: any): CacheGetOut {
         return {
-            expiry: object['expiry'] ? new Date(object['expiry']) : null,
+            expiry: object['expiry'] ? new Date(Number(object['expiry'])) : null,
             value: object['value'] != null ? new Uint8Array(object['value']) : null,
         };
     },

--- a/z-clients/javascript/src/models/clusterForceSnapshotOut.ts
+++ b/z-clients/javascript/src/models/clusterForceSnapshotOut.ts
@@ -22,7 +22,7 @@ export const ClusterForceSnapshotOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _toJsonObject(self: ClusterForceSnapshotOut): any {
         return {
-            'snapshot_time': self.snapshotTime,
+            'snapshot_time': self.snapshotTime.getTime(),
             'snapshot_log_index': self.snapshotLogIndex,
             'snapshot_id': self.snapshotId,
         };

--- a/z-clients/javascript/src/models/clusterForceSnapshotOut.ts
+++ b/z-clients/javascript/src/models/clusterForceSnapshotOut.ts
@@ -13,7 +13,7 @@ export const ClusterForceSnapshotOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject(object: any): ClusterForceSnapshotOut {
         return {
-            snapshotTime: new Date(object['snapshot_time']),
+            snapshotTime: new Date(Number(object['snapshot_time'])),
             snapshotLogIndex: object['snapshot_log_index'],
             snapshotId: object['snapshot_id'],
         };

--- a/z-clients/javascript/src/models/clusterStatusOut.ts
+++ b/z-clients/javascript/src/models/clusterStatusOut.ts
@@ -41,7 +41,7 @@ export const ClusterStatusOutSerializer = {
             clusterName: object['cluster_name'],
             thisNodeId: object['this_node_id'],
             thisNodeState: ServerStateSerializer._fromJsonObject(object['this_node_state']),
-            thisNodeLastCommittedTimestamp: new Date(object['this_node_last_committed_timestamp']),
+            thisNodeLastCommittedTimestamp: new Date(Number(object['this_node_last_committed_timestamp'])),
             thisNodeLastSnapshotId: object['this_node_last_snapshot_id'],
             nodes: object['nodes'].map((item: NodeStatusOut) => NodeStatusOutSerializer._fromJsonObject(item)),
         };

--- a/z-clients/javascript/src/models/clusterStatusOut.ts
+++ b/z-clients/javascript/src/models/clusterStatusOut.ts
@@ -54,7 +54,7 @@ export const ClusterStatusOutSerializer = {
             'cluster_name': self.clusterName,
             'this_node_id': self.thisNodeId,
             'this_node_state': ServerStateSerializer._toJsonObject(self.thisNodeState),
-            'this_node_last_committed_timestamp': self.thisNodeLastCommittedTimestamp,
+            'this_node_last_committed_timestamp': self.thisNodeLastCommittedTimestamp.getTime(),
             'this_node_last_snapshot_id': self.thisNodeLastSnapshotId,
             'nodes': self.nodes.map((item) => NodeStatusOutSerializer._toJsonObject(item)),
         };

--- a/z-clients/javascript/src/models/idempotencyCreateNamespaceOut.ts
+++ b/z-clients/javascript/src/models/idempotencyCreateNamespaceOut.ts
@@ -20,8 +20,8 @@ export const IdempotencyCreateNamespaceOutSerializer = {
     _toJsonObject(self: IdempotencyCreateNamespaceOut): any {
         return {
             'name': self.name,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/idempotencyCreateNamespaceOut.ts
+++ b/z-clients/javascript/src/models/idempotencyCreateNamespaceOut.ts
@@ -11,8 +11,8 @@ export const IdempotencyCreateNamespaceOutSerializer = {
     _fromJsonObject(object: any): IdempotencyCreateNamespaceOut {
         return {
             name: object['name'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/idempotencyGetNamespaceOut.ts
+++ b/z-clients/javascript/src/models/idempotencyGetNamespaceOut.ts
@@ -11,8 +11,8 @@ export const IdempotencyGetNamespaceOutSerializer = {
     _fromJsonObject(object: any): IdempotencyGetNamespaceOut {
         return {
             name: object['name'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/idempotencyGetNamespaceOut.ts
+++ b/z-clients/javascript/src/models/idempotencyGetNamespaceOut.ts
@@ -20,8 +20,8 @@ export const IdempotencyGetNamespaceOutSerializer = {
     _toJsonObject(self: IdempotencyGetNamespaceOut): any {
         return {
             'name': self.name,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/kvCreateNamespaceOut.ts
+++ b/z-clients/javascript/src/models/kvCreateNamespaceOut.ts
@@ -11,8 +11,8 @@ export const KvCreateNamespaceOutSerializer = {
     _fromJsonObject(object: any): KvCreateNamespaceOut {
         return {
             name: object['name'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/kvCreateNamespaceOut.ts
+++ b/z-clients/javascript/src/models/kvCreateNamespaceOut.ts
@@ -20,8 +20,8 @@ export const KvCreateNamespaceOutSerializer = {
     _toJsonObject(self: KvCreateNamespaceOut): any {
         return {
             'name': self.name,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/kvGetNamespaceOut.ts
+++ b/z-clients/javascript/src/models/kvGetNamespaceOut.ts
@@ -20,8 +20,8 @@ export const KvGetNamespaceOutSerializer = {
     _toJsonObject(self: KvGetNamespaceOut): any {
         return {
             'name': self.name,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/kvGetNamespaceOut.ts
+++ b/z-clients/javascript/src/models/kvGetNamespaceOut.ts
@@ -11,8 +11,8 @@ export const KvGetNamespaceOutSerializer = {
     _fromJsonObject(object: any): KvGetNamespaceOut {
         return {
             name: object['name'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/kvGetOut.ts
+++ b/z-clients/javascript/src/models/kvGetOut.ts
@@ -15,7 +15,7 @@ export const KvGetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _fromJsonObject(object: any): KvGetOut {
         return {
-            expiry: object['expiry'] ? new Date(object['expiry']) : null,
+            expiry: object['expiry'] ? new Date(Number(object['expiry'])) : null,
             value: object['value'] != null ? new Uint8Array(object['value']) : null,
             version: object['version'],
         };

--- a/z-clients/javascript/src/models/kvGetOut.ts
+++ b/z-clients/javascript/src/models/kvGetOut.ts
@@ -24,7 +24,7 @@ export const KvGetOutSerializer = {
     // biome-ignore lint/suspicious/noExplicitAny: intentional any
     _toJsonObject(self: KvGetOut): any {
         return {
-            'expiry': self.expiry,
+            'expiry': self.expiry != null ? self.expiry.getTime() : undefined,
             'value': self.value != null ? Array.from(self.value) : undefined,
             'version': self.version,
         };

--- a/z-clients/javascript/src/models/msgNamespaceCreateOut.ts
+++ b/z-clients/javascript/src/models/msgNamespaceCreateOut.ts
@@ -17,8 +17,8 @@ export const MsgNamespaceCreateOutSerializer = {
         return {
             name: object['name'],
             retention: RetentionSerializer._fromJsonObject(object['retention']),
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/msgNamespaceCreateOut.ts
+++ b/z-clients/javascript/src/models/msgNamespaceCreateOut.ts
@@ -27,8 +27,8 @@ export const MsgNamespaceCreateOutSerializer = {
         return {
             'name': self.name,
             'retention': RetentionSerializer._toJsonObject(self.retention),
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/msgNamespaceGetOut.ts
+++ b/z-clients/javascript/src/models/msgNamespaceGetOut.ts
@@ -17,8 +17,8 @@ export const MsgNamespaceGetOutSerializer = {
         return {
             name: object['name'],
             retention: RetentionSerializer._fromJsonObject(object['retention']),
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/msgNamespaceGetOut.ts
+++ b/z-clients/javascript/src/models/msgNamespaceGetOut.ts
@@ -27,8 +27,8 @@ export const MsgNamespaceGetOutSerializer = {
         return {
             'name': self.name,
             'retention': RetentionSerializer._toJsonObject(self.retention),
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/queueMsgOut.ts
+++ b/z-clients/javascript/src/models/queueMsgOut.ts
@@ -26,8 +26,8 @@ export const QueueMsgOutSerializer = {
             'msg_id': self.msgId,
             'value': Array.from(self.value),
             'headers': self.headers,
-            'timestamp': self.timestamp,
-            'scheduled_at': self.scheduledAt,
+            'timestamp': self.timestamp.getTime(),
+            'scheduled_at': self.scheduledAt != null ? self.scheduledAt.getTime() : undefined,
         };
     }
 }

--- a/z-clients/javascript/src/models/queueMsgOut.ts
+++ b/z-clients/javascript/src/models/queueMsgOut.ts
@@ -15,8 +15,8 @@ export const QueueMsgOutSerializer = {
             msgId: object['msg_id'],
             value: new Uint8Array(object['value']),
             headers: object['headers'],
-            timestamp: new Date(object['timestamp']),
-            scheduledAt: object['scheduled_at'] ? new Date(object['scheduled_at']) : null,
+            timestamp: new Date(Number(object['timestamp'])),
+            scheduledAt: object['scheduled_at'] ? new Date(Number(object['scheduled_at'])) : null,
         };
     },
 

--- a/z-clients/javascript/src/models/rateLimitCreateNamespaceOut.ts
+++ b/z-clients/javascript/src/models/rateLimitCreateNamespaceOut.ts
@@ -11,8 +11,8 @@ export const RateLimitCreateNamespaceOutSerializer = {
     _fromJsonObject(object: any): RateLimitCreateNamespaceOut {
         return {
             name: object['name'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/rateLimitCreateNamespaceOut.ts
+++ b/z-clients/javascript/src/models/rateLimitCreateNamespaceOut.ts
@@ -20,8 +20,8 @@ export const RateLimitCreateNamespaceOutSerializer = {
     _toJsonObject(self: RateLimitCreateNamespaceOut): any {
         return {
             'name': self.name,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/rateLimitGetNamespaceOut.ts
+++ b/z-clients/javascript/src/models/rateLimitGetNamespaceOut.ts
@@ -20,8 +20,8 @@ export const RateLimitGetNamespaceOutSerializer = {
     _toJsonObject(self: RateLimitGetNamespaceOut): any {
         return {
             'name': self.name,
-            'created': self.created,
-            'updated': self.updated,
+            'created': self.created.getTime(),
+            'updated': self.updated.getTime(),
         };
     }
 }

--- a/z-clients/javascript/src/models/rateLimitGetNamespaceOut.ts
+++ b/z-clients/javascript/src/models/rateLimitGetNamespaceOut.ts
@@ -11,8 +11,8 @@ export const RateLimitGetNamespaceOutSerializer = {
     _fromJsonObject(object: any): RateLimitGetNamespaceOut {
         return {
             name: object['name'],
-            created: new Date(object['created']),
-            updated: new Date(object['updated']),
+            created: new Date(Number(object['created'])),
+            updated: new Date(Number(object['updated'])),
         };
     },
 

--- a/z-clients/javascript/src/models/streamMsgOut.ts
+++ b/z-clients/javascript/src/models/streamMsgOut.ts
@@ -29,8 +29,8 @@ export const StreamMsgOutSerializer = {
             'topic': self.topic,
             'value': Array.from(self.value),
             'headers': self.headers,
-            'timestamp': self.timestamp,
-            'scheduled_at': self.scheduledAt,
+            'timestamp': self.timestamp.getTime(),
+            'scheduled_at': self.scheduledAt != null ? self.scheduledAt.getTime() : undefined,
         };
     }
 }

--- a/z-clients/javascript/src/models/streamMsgOut.ts
+++ b/z-clients/javascript/src/models/streamMsgOut.ts
@@ -17,8 +17,8 @@ export const StreamMsgOutSerializer = {
             topic: object['topic'],
             value: new Uint8Array(object['value']),
             headers: object['headers'],
-            timestamp: new Date(object['timestamp']),
-            scheduledAt: object['scheduled_at'] ? new Date(object['scheduled_at']) : null,
+            timestamp: new Date(Number(object['timestamp'])),
+            scheduledAt: object['scheduled_at'] ? new Date(Number(object['scheduled_at'])) : null,
         };
     },
 

--- a/z-clients/python/diom/internal/types.py
+++ b/z-clients/python/diom/internal/types.py
@@ -1,9 +1,9 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Annotated
 from pydantic import PlainSerializer, PlainValidator
 
 
-def validate(v: object) -> timedelta:
+def _validate_duration_ms(v: object) -> timedelta:
     if isinstance(v, timedelta):
         # used by constructor calls
         return v
@@ -14,12 +14,34 @@ def validate(v: object) -> timedelta:
         raise ValueError(f"Expected integer or timedelta, got {type(v)}")
 
 
-def serialize(td: timedelta) -> int:
+def _serialize_duration_ms(td: timedelta) -> int:
     return td.seconds * 1000 + int(round(td.microseconds / 1000))
 
 
 TimeDeltaMs = Annotated[
     timedelta,
-    PlainSerializer(serialize, return_type=int),
-    PlainValidator(validate, json_schema_input_type=int),
+    PlainSerializer(_serialize_duration_ms, return_type=int),
+    PlainValidator(_validate_duration_ms, json_schema_input_type=int),
+]
+
+
+def _validate_unix_timestamp_ms(v: object) -> datetime:
+    if isinstance(v, datetime):
+        # used by constructor calls
+        return v
+    if isinstance(v, int):
+        # used by model_validate
+        return datetime.fromtimestamp(v / 1000)
+    else:
+        raise ValueError(f"Expected integer or datetime, got {type(v)}")
+
+
+def _serialize_unix_timestamp_ms(dt: datetime) -> int:
+    return int(round(dt.timestamp() * 1000))
+
+
+UnixTimestampMs = Annotated[
+    datetime,
+    PlainSerializer(_serialize_unix_timestamp_ms, return_type=int),
+    PlainValidator(_validate_unix_timestamp_ms, json_schema_input_type=int),
 ]

--- a/z-clients/python/diom/models/admin_access_policy_out.py
+++ b/z-clients/python/diom/models/admin_access_policy_out.py
@@ -1,6 +1,5 @@
 # this file is @generated
 import typing as t
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -14,6 +13,6 @@ class AdminAccessPolicyOut(BaseModel):
 
     rules: t.List[AccessRule]
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/admin_access_policy_out.py
+++ b/z-clients/python/diom/models/admin_access_policy_out.py
@@ -2,6 +2,7 @@
 import typing as t
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 from .access_rule import AccessRule
 
@@ -13,6 +14,6 @@ class AdminAccessPolicyOut(BaseModel):
 
     rules: t.List[AccessRule]
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/admin_access_policy_upsert_out.py
+++ b/z-clients/python/diom/models/admin_access_policy_upsert_out.py
@@ -1,11 +1,12 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class AdminAccessPolicyUpsertOut(BaseModel):
     id: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/admin_access_policy_upsert_out.py
+++ b/z-clients/python/diom/models/admin_access_policy_upsert_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -7,6 +6,6 @@ from ..internal.base_model import BaseModel
 class AdminAccessPolicyUpsertOut(BaseModel):
     id: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/admin_auth_token_create_out.py
+++ b/z-clients/python/diom/models/admin_auth_token_create_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -9,6 +8,6 @@ class AdminAuthTokenCreateOut(BaseModel):
 
     token: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/admin_auth_token_create_out.py
+++ b/z-clients/python/diom/models/admin_auth_token_create_out.py
@@ -1,6 +1,7 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class AdminAuthTokenCreateOut(BaseModel):
@@ -8,6 +9,6 @@ class AdminAuthTokenCreateOut(BaseModel):
 
     token: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/admin_auth_token_out.py
+++ b/z-clients/python/diom/models/admin_auth_token_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -9,11 +8,11 @@ class AdminAuthTokenOut(BaseModel):
 
     name: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int
 
-    expiry: datetime | None = None
+    expiry: int | None = None
 
     role: str
 

--- a/z-clients/python/diom/models/admin_auth_token_out.py
+++ b/z-clients/python/diom/models/admin_auth_token_out.py
@@ -1,6 +1,7 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class AdminAuthTokenOut(BaseModel):
@@ -8,11 +9,11 @@ class AdminAuthTokenOut(BaseModel):
 
     name: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs
 
-    expiry: int | None = None
+    expiry: UnixTimestampMs | None = None
 
     role: str
 

--- a/z-clients/python/diom/models/admin_auth_token_rotate_out.py
+++ b/z-clients/python/diom/models/admin_auth_token_rotate_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -9,6 +8,6 @@ class AdminAuthTokenRotateOut(BaseModel):
 
     token: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/admin_auth_token_rotate_out.py
+++ b/z-clients/python/diom/models/admin_auth_token_rotate_out.py
@@ -1,6 +1,7 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class AdminAuthTokenRotateOut(BaseModel):
@@ -8,6 +9,6 @@ class AdminAuthTokenRotateOut(BaseModel):
 
     token: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/admin_role_out.py
+++ b/z-clients/python/diom/models/admin_role_out.py
@@ -2,6 +2,7 @@
 import typing as t
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 from .access_rule import AccessRule
 
@@ -17,6 +18,6 @@ class AdminRoleOut(BaseModel):
 
     context: t.Dict[str, str]
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/admin_role_out.py
+++ b/z-clients/python/diom/models/admin_role_out.py
@@ -1,6 +1,5 @@
 # this file is @generated
 import typing as t
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -18,6 +17,6 @@ class AdminRoleOut(BaseModel):
 
     context: t.Dict[str, str]
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/admin_role_upsert_out.py
+++ b/z-clients/python/diom/models/admin_role_upsert_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -7,6 +6,6 @@ from ..internal.base_model import BaseModel
 class AdminRoleUpsertOut(BaseModel):
     id: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/admin_role_upsert_out.py
+++ b/z-clients/python/diom/models/admin_role_upsert_out.py
@@ -1,11 +1,12 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class AdminRoleUpsertOut(BaseModel):
     id: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/cache_create_namespace_out.py
+++ b/z-clients/python/diom/models/cache_create_namespace_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -11,6 +10,6 @@ class CacheCreateNamespaceOut(BaseModel):
 
     eviction_policy: EvictionPolicy
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/cache_create_namespace_out.py
+++ b/z-clients/python/diom/models/cache_create_namespace_out.py
@@ -1,6 +1,7 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 from .eviction_policy import EvictionPolicy
 
@@ -10,6 +11,6 @@ class CacheCreateNamespaceOut(BaseModel):
 
     eviction_policy: EvictionPolicy
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/cache_get_namespace_out.py
+++ b/z-clients/python/diom/models/cache_get_namespace_out.py
@@ -1,6 +1,7 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 from .eviction_policy import EvictionPolicy
 
@@ -10,6 +11,6 @@ class CacheGetNamespaceOut(BaseModel):
 
     eviction_policy: EvictionPolicy
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/cache_get_namespace_out.py
+++ b/z-clients/python/diom/models/cache_get_namespace_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -11,6 +10,6 @@ class CacheGetNamespaceOut(BaseModel):
 
     eviction_policy: EvictionPolicy
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/cache_get_out.py
+++ b/z-clients/python/diom/models/cache_get_out.py
@@ -1,11 +1,10 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
 
 class CacheGetOut(BaseModel):
-    expiry: datetime | None = None
+    expiry: int | None = None
     """Time of expiry"""
 
     value: bytes | None = None

--- a/z-clients/python/diom/models/cache_get_out.py
+++ b/z-clients/python/diom/models/cache_get_out.py
@@ -1,10 +1,11 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class CacheGetOut(BaseModel):
-    expiry: int | None = None
+    expiry: UnixTimestampMs | None = None
     """Time of expiry"""
 
     value: bytes | None = None

--- a/z-clients/python/diom/models/cluster_force_snapshot_out.py
+++ b/z-clients/python/diom/models/cluster_force_snapshot_out.py
@@ -1,10 +1,11 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class ClusterForceSnapshotOut(BaseModel):
-    snapshot_time: int
+    snapshot_time: UnixTimestampMs
     """The wall-clock time at which the snapshot was initiated"""
 
     snapshot_log_index: int

--- a/z-clients/python/diom/models/cluster_force_snapshot_out.py
+++ b/z-clients/python/diom/models/cluster_force_snapshot_out.py
@@ -1,11 +1,10 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
 
 class ClusterForceSnapshotOut(BaseModel):
-    snapshot_time: datetime
+    snapshot_time: int
     """The wall-clock time at which the snapshot was initiated"""
 
     snapshot_log_index: int

--- a/z-clients/python/diom/models/cluster_status_out.py
+++ b/z-clients/python/diom/models/cluster_status_out.py
@@ -2,6 +2,7 @@
 import typing as t
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 from .node_status_out import NodeStatusOut
 from .server_state import ServerState
@@ -24,7 +25,7 @@ class ClusterStatusOut(BaseModel):
     this_node_state: ServerState
     """The cluster state of the node servicing this request"""
 
-    this_node_last_committed_timestamp: int
+    this_node_last_committed_timestamp: UnixTimestampMs
     """The timestamp of the last transaction committed on this node"""
 
     this_node_last_snapshot_id: str | None = None

--- a/z-clients/python/diom/models/cluster_status_out.py
+++ b/z-clients/python/diom/models/cluster_status_out.py
@@ -1,6 +1,5 @@
 # this file is @generated
 import typing as t
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -25,7 +24,7 @@ class ClusterStatusOut(BaseModel):
     this_node_state: ServerState
     """The cluster state of the node servicing this request"""
 
-    this_node_last_committed_timestamp: datetime
+    this_node_last_committed_timestamp: int
     """The timestamp of the last transaction committed on this node"""
 
     this_node_last_snapshot_id: str | None = None

--- a/z-clients/python/diom/models/idempotency_create_namespace_out.py
+++ b/z-clients/python/diom/models/idempotency_create_namespace_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -7,6 +6,6 @@ from ..internal.base_model import BaseModel
 class IdempotencyCreateNamespaceOut(BaseModel):
     name: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/idempotency_create_namespace_out.py
+++ b/z-clients/python/diom/models/idempotency_create_namespace_out.py
@@ -1,11 +1,12 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class IdempotencyCreateNamespaceOut(BaseModel):
     name: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/idempotency_get_namespace_out.py
+++ b/z-clients/python/diom/models/idempotency_get_namespace_out.py
@@ -1,11 +1,12 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class IdempotencyGetNamespaceOut(BaseModel):
     name: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/idempotency_get_namespace_out.py
+++ b/z-clients/python/diom/models/idempotency_get_namespace_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -7,6 +6,6 @@ from ..internal.base_model import BaseModel
 class IdempotencyGetNamespaceOut(BaseModel):
     name: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/kv_create_namespace_out.py
+++ b/z-clients/python/diom/models/kv_create_namespace_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -7,6 +6,6 @@ from ..internal.base_model import BaseModel
 class KvCreateNamespaceOut(BaseModel):
     name: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/kv_create_namespace_out.py
+++ b/z-clients/python/diom/models/kv_create_namespace_out.py
@@ -1,11 +1,12 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class KvCreateNamespaceOut(BaseModel):
     name: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/kv_get_namespace_out.py
+++ b/z-clients/python/diom/models/kv_get_namespace_out.py
@@ -1,11 +1,12 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class KvGetNamespaceOut(BaseModel):
     name: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/kv_get_namespace_out.py
+++ b/z-clients/python/diom/models/kv_get_namespace_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -7,6 +6,6 @@ from ..internal.base_model import BaseModel
 class KvGetNamespaceOut(BaseModel):
     name: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/kv_get_out.py
+++ b/z-clients/python/diom/models/kv_get_out.py
@@ -1,10 +1,11 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class KvGetOut(BaseModel):
-    expiry: int | None = None
+    expiry: UnixTimestampMs | None = None
     """Time of expiry"""
 
     value: bytes | None = None

--- a/z-clients/python/diom/models/kv_get_out.py
+++ b/z-clients/python/diom/models/kv_get_out.py
@@ -1,11 +1,10 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
 
 class KvGetOut(BaseModel):
-    expiry: datetime | None = None
+    expiry: int | None = None
     """Time of expiry"""
 
     value: bytes | None = None

--- a/z-clients/python/diom/models/msg_namespace_create_out.py
+++ b/z-clients/python/diom/models/msg_namespace_create_out.py
@@ -1,6 +1,7 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 from .retention import Retention
 
@@ -10,6 +11,6 @@ class MsgNamespaceCreateOut(BaseModel):
 
     retention: Retention
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/msg_namespace_create_out.py
+++ b/z-clients/python/diom/models/msg_namespace_create_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -11,6 +10,6 @@ class MsgNamespaceCreateOut(BaseModel):
 
     retention: Retention
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/msg_namespace_get_out.py
+++ b/z-clients/python/diom/models/msg_namespace_get_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -11,6 +10,6 @@ class MsgNamespaceGetOut(BaseModel):
 
     retention: Retention
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/msg_namespace_get_out.py
+++ b/z-clients/python/diom/models/msg_namespace_get_out.py
@@ -1,6 +1,7 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 from .retention import Retention
 
@@ -10,6 +11,6 @@ class MsgNamespaceGetOut(BaseModel):
 
     retention: Retention
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/queue_msg_out.py
+++ b/z-clients/python/diom/models/queue_msg_out.py
@@ -1,6 +1,5 @@
 # this file is @generated
 import typing as t
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -12,6 +11,6 @@ class QueueMsgOut(BaseModel):
 
     headers: t.Dict[str, str]
 
-    timestamp: datetime
+    timestamp: int
 
-    scheduled_at: datetime | None = None
+    scheduled_at: int | None = None

--- a/z-clients/python/diom/models/queue_msg_out.py
+++ b/z-clients/python/diom/models/queue_msg_out.py
@@ -2,6 +2,7 @@
 import typing as t
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class QueueMsgOut(BaseModel):
@@ -11,6 +12,6 @@ class QueueMsgOut(BaseModel):
 
     headers: t.Dict[str, str]
 
-    timestamp: int
+    timestamp: UnixTimestampMs
 
-    scheduled_at: int | None = None
+    scheduled_at: UnixTimestampMs | None = None

--- a/z-clients/python/diom/models/rate_limit_create_namespace_out.py
+++ b/z-clients/python/diom/models/rate_limit_create_namespace_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -7,6 +6,6 @@ from ..internal.base_model import BaseModel
 class RateLimitCreateNamespaceOut(BaseModel):
     name: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/rate_limit_create_namespace_out.py
+++ b/z-clients/python/diom/models/rate_limit_create_namespace_out.py
@@ -1,11 +1,12 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class RateLimitCreateNamespaceOut(BaseModel):
     name: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/rate_limit_get_namespace_out.py
+++ b/z-clients/python/diom/models/rate_limit_get_namespace_out.py
@@ -1,11 +1,12 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class RateLimitGetNamespaceOut(BaseModel):
     name: str
 
-    created: int
+    created: UnixTimestampMs
 
-    updated: int
+    updated: UnixTimestampMs

--- a/z-clients/python/diom/models/rate_limit_get_namespace_out.py
+++ b/z-clients/python/diom/models/rate_limit_get_namespace_out.py
@@ -1,5 +1,4 @@
 # this file is @generated
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -7,6 +6,6 @@ from ..internal.base_model import BaseModel
 class RateLimitGetNamespaceOut(BaseModel):
     name: str
 
-    created: datetime
+    created: int
 
-    updated: datetime
+    updated: int

--- a/z-clients/python/diom/models/stream_msg_out.py
+++ b/z-clients/python/diom/models/stream_msg_out.py
@@ -2,6 +2,7 @@
 import typing as t
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 
 class StreamMsgOut(BaseModel):
@@ -13,6 +14,6 @@ class StreamMsgOut(BaseModel):
 
     headers: t.Dict[str, str]
 
-    timestamp: int
+    timestamp: UnixTimestampMs
 
-    scheduled_at: int | None = None
+    scheduled_at: UnixTimestampMs | None = None

--- a/z-clients/python/diom/models/stream_msg_out.py
+++ b/z-clients/python/diom/models/stream_msg_out.py
@@ -1,6 +1,5 @@
 # this file is @generated
 import typing as t
-from datetime import datetime
 
 from ..internal.base_model import BaseModel
 
@@ -14,6 +13,6 @@ class StreamMsgOut(BaseModel):
 
     headers: t.Dict[str, str]
 
-    timestamp: datetime
+    timestamp: int
 
-    scheduled_at: datetime | None = None
+    scheduled_at: int | None = None

--- a/z-clients/rust/src/lib.rs
+++ b/z-clients/rust/src/lib.rs
@@ -6,6 +6,7 @@ mod error;
 pub mod models;
 mod request;
 mod serde_bytes_opt;
+mod unix_timestamp_ms_serde;
 
 pub(crate) use self::client::Configuration;
 pub use self::{

--- a/z-clients/rust/src/models/admin_access_policy_out.rs
+++ b/z-clients/rust/src/models/admin_access_policy_out.rs
@@ -11,9 +11,9 @@ pub struct AdminAccessPolicyOut {
 
     pub rules: Vec<AccessRule>,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl AdminAccessPolicyOut {
@@ -21,8 +21,8 @@ impl AdminAccessPolicyOut {
         id: String,
         description: String,
         rules: Vec<AccessRule>,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
+        created: u64,
+        updated: u64,
     ) -> Self {
         Self {
             id,

--- a/z-clients/rust/src/models/admin_access_policy_out.rs
+++ b/z-clients/rust/src/models/admin_access_policy_out.rs
@@ -11,9 +11,11 @@ pub struct AdminAccessPolicyOut {
 
     pub rules: Vec<AccessRule>,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl AdminAccessPolicyOut {
@@ -21,8 +23,8 @@ impl AdminAccessPolicyOut {
         id: String,
         description: String,
         rules: Vec<AccessRule>,
-        created: u64,
-        updated: u64,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
     ) -> Self {
         Self {
             id,

--- a/z-clients/rust/src/models/admin_access_policy_upsert_out.rs
+++ b/z-clients/rust/src/models/admin_access_policy_upsert_out.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct AdminAccessPolicyUpsertOut {
     pub id: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl AdminAccessPolicyUpsertOut {
-    pub fn new(id: String, created: u64, updated: u64) -> Self {
+    pub fn new(id: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
         Self {
             id,
             created,

--- a/z-clients/rust/src/models/admin_access_policy_upsert_out.rs
+++ b/z-clients/rust/src/models/admin_access_policy_upsert_out.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 pub struct AdminAccessPolicyUpsertOut {
     pub id: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl AdminAccessPolicyUpsertOut {
-    pub fn new(id: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
+    pub fn new(id: String, created: u64, updated: u64) -> Self {
         Self {
             id,
             created,

--- a/z-clients/rust/src/models/admin_auth_token_create_out.rs
+++ b/z-clients/rust/src/models/admin_auth_token_create_out.rs
@@ -7,18 +7,13 @@ pub struct AdminAuthTokenCreateOut {
 
     pub token: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl AdminAuthTokenCreateOut {
-    pub fn new(
-        id: String,
-        token: String,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
-    ) -> Self {
+    pub fn new(id: String, token: String, created: u64, updated: u64) -> Self {
         Self {
             id,
             token,

--- a/z-clients/rust/src/models/admin_auth_token_create_out.rs
+++ b/z-clients/rust/src/models/admin_auth_token_create_out.rs
@@ -7,13 +7,20 @@ pub struct AdminAuthTokenCreateOut {
 
     pub token: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl AdminAuthTokenCreateOut {
-    pub fn new(id: String, token: String, created: u64, updated: u64) -> Self {
+    pub fn new(
+        id: String,
+        token: String,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
+    ) -> Self {
         Self {
             id,
             token,

--- a/z-clients/rust/src/models/admin_auth_token_out.rs
+++ b/z-clients/rust/src/models/admin_auth_token_out.rs
@@ -7,12 +7,17 @@ pub struct AdminAuthTokenOut {
 
     pub name: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry: Option<u64>,
+    #[serde(
+        with = "crate::unix_timestamp_ms_serde::optional",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub expiry: Option<jiff::Timestamp>,
 
     pub role: String,
 
@@ -24,8 +29,8 @@ impl AdminAuthTokenOut {
     pub fn new(
         id: String,
         name: String,
-        created: u64,
-        updated: u64,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
         role: String,
         enabled: bool,
     ) -> Self {
@@ -40,7 +45,7 @@ impl AdminAuthTokenOut {
         }
     }
 
-    pub fn with_expiry(mut self, value: impl Into<Option<u64>>) -> Self {
+    pub fn with_expiry(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
         self.expiry = value.into();
         self
     }

--- a/z-clients/rust/src/models/admin_auth_token_out.rs
+++ b/z-clients/rust/src/models/admin_auth_token_out.rs
@@ -7,12 +7,12 @@ pub struct AdminAuthTokenOut {
 
     pub name: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry: Option<jiff::Timestamp>,
+    pub expiry: Option<u64>,
 
     pub role: String,
 
@@ -24,8 +24,8 @@ impl AdminAuthTokenOut {
     pub fn new(
         id: String,
         name: String,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
+        created: u64,
+        updated: u64,
         role: String,
         enabled: bool,
     ) -> Self {
@@ -40,7 +40,7 @@ impl AdminAuthTokenOut {
         }
     }
 
-    pub fn with_expiry(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
+    pub fn with_expiry(mut self, value: impl Into<Option<u64>>) -> Self {
         self.expiry = value.into();
         self
     }

--- a/z-clients/rust/src/models/admin_auth_token_rotate_out.rs
+++ b/z-clients/rust/src/models/admin_auth_token_rotate_out.rs
@@ -7,18 +7,13 @@ pub struct AdminAuthTokenRotateOut {
 
     pub token: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl AdminAuthTokenRotateOut {
-    pub fn new(
-        id: String,
-        token: String,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
-    ) -> Self {
+    pub fn new(id: String, token: String, created: u64, updated: u64) -> Self {
         Self {
             id,
             token,

--- a/z-clients/rust/src/models/admin_auth_token_rotate_out.rs
+++ b/z-clients/rust/src/models/admin_auth_token_rotate_out.rs
@@ -7,13 +7,20 @@ pub struct AdminAuthTokenRotateOut {
 
     pub token: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl AdminAuthTokenRotateOut {
-    pub fn new(id: String, token: String, created: u64, updated: u64) -> Self {
+    pub fn new(
+        id: String,
+        token: String,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
+    ) -> Self {
         Self {
             id,
             token,

--- a/z-clients/rust/src/models/admin_role_out.rs
+++ b/z-clients/rust/src/models/admin_role_out.rs
@@ -15,9 +15,9 @@ pub struct AdminRoleOut {
 
     pub context: std::collections::HashMap<String, String>,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl AdminRoleOut {
@@ -27,8 +27,8 @@ impl AdminRoleOut {
         rules: Vec<AccessRule>,
         policies: Vec<String>,
         context: std::collections::HashMap<String, String>,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
+        created: u64,
+        updated: u64,
     ) -> Self {
         Self {
             id,

--- a/z-clients/rust/src/models/admin_role_out.rs
+++ b/z-clients/rust/src/models/admin_role_out.rs
@@ -15,9 +15,11 @@ pub struct AdminRoleOut {
 
     pub context: std::collections::HashMap<String, String>,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl AdminRoleOut {
@@ -27,8 +29,8 @@ impl AdminRoleOut {
         rules: Vec<AccessRule>,
         policies: Vec<String>,
         context: std::collections::HashMap<String, String>,
-        created: u64,
-        updated: u64,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
     ) -> Self {
         Self {
             id,

--- a/z-clients/rust/src/models/admin_role_upsert_out.rs
+++ b/z-clients/rust/src/models/admin_role_upsert_out.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 pub struct AdminRoleUpsertOut {
     pub id: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl AdminRoleUpsertOut {
-    pub fn new(id: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
+    pub fn new(id: String, created: u64, updated: u64) -> Self {
         Self {
             id,
             created,

--- a/z-clients/rust/src/models/admin_role_upsert_out.rs
+++ b/z-clients/rust/src/models/admin_role_upsert_out.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct AdminRoleUpsertOut {
     pub id: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl AdminRoleUpsertOut {
-    pub fn new(id: String, created: u64, updated: u64) -> Self {
+    pub fn new(id: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
         Self {
             id,
             created,

--- a/z-clients/rust/src/models/cache_create_namespace_out.rs
+++ b/z-clients/rust/src/models/cache_create_namespace_out.rs
@@ -9,13 +9,20 @@ pub struct CacheCreateNamespaceOut {
 
     pub eviction_policy: EvictionPolicy,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl CacheCreateNamespaceOut {
-    pub fn new(name: String, eviction_policy: EvictionPolicy, created: u64, updated: u64) -> Self {
+    pub fn new(
+        name: String,
+        eviction_policy: EvictionPolicy,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
+    ) -> Self {
         Self {
             name,
             eviction_policy,

--- a/z-clients/rust/src/models/cache_create_namespace_out.rs
+++ b/z-clients/rust/src/models/cache_create_namespace_out.rs
@@ -9,18 +9,13 @@ pub struct CacheCreateNamespaceOut {
 
     pub eviction_policy: EvictionPolicy,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl CacheCreateNamespaceOut {
-    pub fn new(
-        name: String,
-        eviction_policy: EvictionPolicy,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
-    ) -> Self {
+    pub fn new(name: String, eviction_policy: EvictionPolicy, created: u64, updated: u64) -> Self {
         Self {
             name,
             eviction_policy,

--- a/z-clients/rust/src/models/cache_get_namespace_out.rs
+++ b/z-clients/rust/src/models/cache_get_namespace_out.rs
@@ -9,13 +9,20 @@ pub struct CacheGetNamespaceOut {
 
     pub eviction_policy: EvictionPolicy,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl CacheGetNamespaceOut {
-    pub fn new(name: String, eviction_policy: EvictionPolicy, created: u64, updated: u64) -> Self {
+    pub fn new(
+        name: String,
+        eviction_policy: EvictionPolicy,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
+    ) -> Self {
         Self {
             name,
             eviction_policy,

--- a/z-clients/rust/src/models/cache_get_namespace_out.rs
+++ b/z-clients/rust/src/models/cache_get_namespace_out.rs
@@ -9,18 +9,13 @@ pub struct CacheGetNamespaceOut {
 
     pub eviction_policy: EvictionPolicy,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl CacheGetNamespaceOut {
-    pub fn new(
-        name: String,
-        eviction_policy: EvictionPolicy,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
-    ) -> Self {
+    pub fn new(name: String, eviction_policy: EvictionPolicy, created: u64, updated: u64) -> Self {
         Self {
             name,
             eviction_policy,

--- a/z-clients/rust/src/models/cache_get_out.rs
+++ b/z-clients/rust/src/models/cache_get_out.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct CacheGetOut {
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry: Option<jiff::Timestamp>,
+    pub expiry: Option<u64>,
 
     #[serde(
         with = "crate::serde_bytes_opt",
@@ -22,7 +22,7 @@ impl CacheGetOut {
         }
     }
 
-    pub fn with_expiry(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
+    pub fn with_expiry(mut self, value: impl Into<Option<u64>>) -> Self {
         self.expiry = value.into();
         self
     }

--- a/z-clients/rust/src/models/cache_get_out.rs
+++ b/z-clients/rust/src/models/cache_get_out.rs
@@ -4,8 +4,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CacheGetOut {
     /// Time of expiry
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry: Option<u64>,
+    #[serde(
+        with = "crate::unix_timestamp_ms_serde::optional",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub expiry: Option<jiff::Timestamp>,
 
     #[serde(
         with = "crate::serde_bytes_opt",
@@ -22,7 +25,7 @@ impl CacheGetOut {
         }
     }
 
-    pub fn with_expiry(mut self, value: impl Into<Option<u64>>) -> Self {
+    pub fn with_expiry(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
         self.expiry = value.into();
         self
     }

--- a/z-clients/rust/src/models/cluster_force_snapshot_out.rs
+++ b/z-clients/rust/src/models/cluster_force_snapshot_out.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ClusterForceSnapshotOut {
     /// The wall-clock time at which the snapshot was initiated
-    pub snapshot_time: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub snapshot_time: jiff::Timestamp,
 
     /// The log index at which the snapshot was initiated
     pub snapshot_log_index: u64,
@@ -15,7 +16,7 @@ pub struct ClusterForceSnapshotOut {
 }
 
 impl ClusterForceSnapshotOut {
-    pub fn new(snapshot_time: u64, snapshot_log_index: u64) -> Self {
+    pub fn new(snapshot_time: jiff::Timestamp, snapshot_log_index: u64) -> Self {
         Self {
             snapshot_time,
             snapshot_log_index,

--- a/z-clients/rust/src/models/cluster_force_snapshot_out.rs
+++ b/z-clients/rust/src/models/cluster_force_snapshot_out.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ClusterForceSnapshotOut {
     /// The wall-clock time at which the snapshot was initiated
-    pub snapshot_time: jiff::Timestamp,
+    pub snapshot_time: u64,
 
     /// The log index at which the snapshot was initiated
     pub snapshot_log_index: u64,
@@ -15,7 +15,7 @@ pub struct ClusterForceSnapshotOut {
 }
 
 impl ClusterForceSnapshotOut {
-    pub fn new(snapshot_time: jiff::Timestamp, snapshot_log_index: u64) -> Self {
+    pub fn new(snapshot_time: u64, snapshot_log_index: u64) -> Self {
         Self {
             snapshot_time,
             snapshot_log_index,

--- a/z-clients/rust/src/models/cluster_status_out.rs
+++ b/z-clients/rust/src/models/cluster_status_out.rs
@@ -24,7 +24,7 @@ pub struct ClusterStatusOut {
     pub this_node_state: ServerState,
 
     /// The timestamp of the last transaction committed on this node
-    pub this_node_last_committed_timestamp: jiff::Timestamp,
+    pub this_node_last_committed_timestamp: u64,
 
     /// The last snapshot taken on this node
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,7 +38,7 @@ impl ClusterStatusOut {
     pub fn new(
         this_node_id: String,
         this_node_state: ServerState,
-        this_node_last_committed_timestamp: jiff::Timestamp,
+        this_node_last_committed_timestamp: u64,
         nodes: Vec<NodeStatusOut>,
     ) -> Self {
         Self {

--- a/z-clients/rust/src/models/cluster_status_out.rs
+++ b/z-clients/rust/src/models/cluster_status_out.rs
@@ -24,7 +24,8 @@ pub struct ClusterStatusOut {
     pub this_node_state: ServerState,
 
     /// The timestamp of the last transaction committed on this node
-    pub this_node_last_committed_timestamp: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub this_node_last_committed_timestamp: jiff::Timestamp,
 
     /// The last snapshot taken on this node
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,7 +39,7 @@ impl ClusterStatusOut {
     pub fn new(
         this_node_id: String,
         this_node_state: ServerState,
-        this_node_last_committed_timestamp: u64,
+        this_node_last_committed_timestamp: jiff::Timestamp,
         nodes: Vec<NodeStatusOut>,
     ) -> Self {
         Self {

--- a/z-clients/rust/src/models/idempotency_create_namespace_out.rs
+++ b/z-clients/rust/src/models/idempotency_create_namespace_out.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct IdempotencyCreateNamespaceOut {
     pub name: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl IdempotencyCreateNamespaceOut {
-    pub fn new(name: String, created: u64, updated: u64) -> Self {
+    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/idempotency_create_namespace_out.rs
+++ b/z-clients/rust/src/models/idempotency_create_namespace_out.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 pub struct IdempotencyCreateNamespaceOut {
     pub name: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl IdempotencyCreateNamespaceOut {
-    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
+    pub fn new(name: String, created: u64, updated: u64) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/idempotency_get_namespace_out.rs
+++ b/z-clients/rust/src/models/idempotency_get_namespace_out.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 pub struct IdempotencyGetNamespaceOut {
     pub name: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl IdempotencyGetNamespaceOut {
-    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
+    pub fn new(name: String, created: u64, updated: u64) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/idempotency_get_namespace_out.rs
+++ b/z-clients/rust/src/models/idempotency_get_namespace_out.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct IdempotencyGetNamespaceOut {
     pub name: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl IdempotencyGetNamespaceOut {
-    pub fn new(name: String, created: u64, updated: u64) -> Self {
+    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/kv_create_namespace_out.rs
+++ b/z-clients/rust/src/models/kv_create_namespace_out.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 pub struct KvCreateNamespaceOut {
     pub name: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl KvCreateNamespaceOut {
-    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
+    pub fn new(name: String, created: u64, updated: u64) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/kv_create_namespace_out.rs
+++ b/z-clients/rust/src/models/kv_create_namespace_out.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct KvCreateNamespaceOut {
     pub name: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl KvCreateNamespaceOut {
-    pub fn new(name: String, created: u64, updated: u64) -> Self {
+    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/kv_get_namespace_out.rs
+++ b/z-clients/rust/src/models/kv_get_namespace_out.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct KvGetNamespaceOut {
     pub name: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl KvGetNamespaceOut {
-    pub fn new(name: String, created: u64, updated: u64) -> Self {
+    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/kv_get_namespace_out.rs
+++ b/z-clients/rust/src/models/kv_get_namespace_out.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 pub struct KvGetNamespaceOut {
     pub name: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl KvGetNamespaceOut {
-    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
+    pub fn new(name: String, created: u64, updated: u64) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/kv_get_out.rs
+++ b/z-clients/rust/src/models/kv_get_out.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct KvGetOut {
     /// Time of expiry
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry: Option<jiff::Timestamp>,
+    pub expiry: Option<u64>,
 
     #[serde(
         with = "crate::serde_bytes_opt",
@@ -27,7 +27,7 @@ impl KvGetOut {
         }
     }
 
-    pub fn with_expiry(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
+    pub fn with_expiry(mut self, value: impl Into<Option<u64>>) -> Self {
         self.expiry = value.into();
         self
     }

--- a/z-clients/rust/src/models/kv_get_out.rs
+++ b/z-clients/rust/src/models/kv_get_out.rs
@@ -4,8 +4,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KvGetOut {
     /// Time of expiry
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry: Option<u64>,
+    #[serde(
+        with = "crate::unix_timestamp_ms_serde::optional",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub expiry: Option<jiff::Timestamp>,
 
     #[serde(
         with = "crate::serde_bytes_opt",
@@ -27,7 +30,7 @@ impl KvGetOut {
         }
     }
 
-    pub fn with_expiry(mut self, value: impl Into<Option<u64>>) -> Self {
+    pub fn with_expiry(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
         self.expiry = value.into();
         self
     }

--- a/z-clients/rust/src/models/msg_namespace_create_out.rs
+++ b/z-clients/rust/src/models/msg_namespace_create_out.rs
@@ -9,13 +9,20 @@ pub struct MsgNamespaceCreateOut {
 
     pub retention: Retention,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl MsgNamespaceCreateOut {
-    pub fn new(name: String, retention: Retention, created: u64, updated: u64) -> Self {
+    pub fn new(
+        name: String,
+        retention: Retention,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
+    ) -> Self {
         Self {
             name,
             retention,

--- a/z-clients/rust/src/models/msg_namespace_create_out.rs
+++ b/z-clients/rust/src/models/msg_namespace_create_out.rs
@@ -9,18 +9,13 @@ pub struct MsgNamespaceCreateOut {
 
     pub retention: Retention,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl MsgNamespaceCreateOut {
-    pub fn new(
-        name: String,
-        retention: Retention,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
-    ) -> Self {
+    pub fn new(name: String, retention: Retention, created: u64, updated: u64) -> Self {
         Self {
             name,
             retention,

--- a/z-clients/rust/src/models/msg_namespace_get_out.rs
+++ b/z-clients/rust/src/models/msg_namespace_get_out.rs
@@ -9,18 +9,13 @@ pub struct MsgNamespaceGetOut {
 
     pub retention: Retention,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl MsgNamespaceGetOut {
-    pub fn new(
-        name: String,
-        retention: Retention,
-        created: jiff::Timestamp,
-        updated: jiff::Timestamp,
-    ) -> Self {
+    pub fn new(name: String, retention: Retention, created: u64, updated: u64) -> Self {
         Self {
             name,
             retention,

--- a/z-clients/rust/src/models/msg_namespace_get_out.rs
+++ b/z-clients/rust/src/models/msg_namespace_get_out.rs
@@ -9,13 +9,20 @@ pub struct MsgNamespaceGetOut {
 
     pub retention: Retention,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl MsgNamespaceGetOut {
-    pub fn new(name: String, retention: Retention, created: u64, updated: u64) -> Self {
+    pub fn new(
+        name: String,
+        retention: Retention,
+        created: jiff::Timestamp,
+        updated: jiff::Timestamp,
+    ) -> Self {
         Self {
             name,
             retention,

--- a/z-clients/rust/src/models/queue_msg_out.rs
+++ b/z-clients/rust/src/models/queue_msg_out.rs
@@ -10,10 +10,10 @@ pub struct QueueMsgOut {
 
     pub headers: std::collections::HashMap<String, String>,
 
-    pub timestamp: jiff::Timestamp,
+    pub timestamp: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheduled_at: Option<jiff::Timestamp>,
+    pub scheduled_at: Option<u64>,
 }
 
 impl QueueMsgOut {
@@ -21,7 +21,7 @@ impl QueueMsgOut {
         msg_id: String,
         value: Vec<u8>,
         headers: std::collections::HashMap<String, String>,
-        timestamp: jiff::Timestamp,
+        timestamp: u64,
     ) -> Self {
         Self {
             msg_id,
@@ -32,7 +32,7 @@ impl QueueMsgOut {
         }
     }
 
-    pub fn with_scheduled_at(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
+    pub fn with_scheduled_at(mut self, value: impl Into<Option<u64>>) -> Self {
         self.scheduled_at = value.into();
         self
     }

--- a/z-clients/rust/src/models/queue_msg_out.rs
+++ b/z-clients/rust/src/models/queue_msg_out.rs
@@ -10,10 +10,14 @@ pub struct QueueMsgOut {
 
     pub headers: std::collections::HashMap<String, String>,
 
-    pub timestamp: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub timestamp: jiff::Timestamp,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheduled_at: Option<u64>,
+    #[serde(
+        with = "crate::unix_timestamp_ms_serde::optional",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub scheduled_at: Option<jiff::Timestamp>,
 }
 
 impl QueueMsgOut {
@@ -21,7 +25,7 @@ impl QueueMsgOut {
         msg_id: String,
         value: Vec<u8>,
         headers: std::collections::HashMap<String, String>,
-        timestamp: u64,
+        timestamp: jiff::Timestamp,
     ) -> Self {
         Self {
             msg_id,
@@ -32,7 +36,7 @@ impl QueueMsgOut {
         }
     }
 
-    pub fn with_scheduled_at(mut self, value: impl Into<Option<u64>>) -> Self {
+    pub fn with_scheduled_at(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
         self.scheduled_at = value.into();
         self
     }

--- a/z-clients/rust/src/models/rate_limit_create_namespace_out.rs
+++ b/z-clients/rust/src/models/rate_limit_create_namespace_out.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 pub struct RateLimitCreateNamespaceOut {
     pub name: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl RateLimitCreateNamespaceOut {
-    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
+    pub fn new(name: String, created: u64, updated: u64) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/rate_limit_create_namespace_out.rs
+++ b/z-clients/rust/src/models/rate_limit_create_namespace_out.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct RateLimitCreateNamespaceOut {
     pub name: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl RateLimitCreateNamespaceOut {
-    pub fn new(name: String, created: u64, updated: u64) -> Self {
+    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/rate_limit_get_namespace_out.rs
+++ b/z-clients/rust/src/models/rate_limit_get_namespace_out.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 pub struct RateLimitGetNamespaceOut {
     pub name: String,
 
-    pub created: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub created: jiff::Timestamp,
 
-    pub updated: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub updated: jiff::Timestamp,
 }
 
 impl RateLimitGetNamespaceOut {
-    pub fn new(name: String, created: u64, updated: u64) -> Self {
+    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/rate_limit_get_namespace_out.rs
+++ b/z-clients/rust/src/models/rate_limit_get_namespace_out.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 pub struct RateLimitGetNamespaceOut {
     pub name: String,
 
-    pub created: jiff::Timestamp,
+    pub created: u64,
 
-    pub updated: jiff::Timestamp,
+    pub updated: u64,
 }
 
 impl RateLimitGetNamespaceOut {
-    pub fn new(name: String, created: jiff::Timestamp, updated: jiff::Timestamp) -> Self {
+    pub fn new(name: String, created: u64, updated: u64) -> Self {
         Self {
             name,
             created,

--- a/z-clients/rust/src/models/stream_msg_out.rs
+++ b/z-clients/rust/src/models/stream_msg_out.rs
@@ -12,10 +12,10 @@ pub struct StreamMsgOut {
 
     pub headers: std::collections::HashMap<String, String>,
 
-    pub timestamp: jiff::Timestamp,
+    pub timestamp: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheduled_at: Option<jiff::Timestamp>,
+    pub scheduled_at: Option<u64>,
 }
 
 impl StreamMsgOut {
@@ -24,7 +24,7 @@ impl StreamMsgOut {
         topic: String,
         value: Vec<u8>,
         headers: std::collections::HashMap<String, String>,
-        timestamp: jiff::Timestamp,
+        timestamp: u64,
     ) -> Self {
         Self {
             offset,
@@ -36,7 +36,7 @@ impl StreamMsgOut {
         }
     }
 
-    pub fn with_scheduled_at(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
+    pub fn with_scheduled_at(mut self, value: impl Into<Option<u64>>) -> Self {
         self.scheduled_at = value.into();
         self
     }

--- a/z-clients/rust/src/models/stream_msg_out.rs
+++ b/z-clients/rust/src/models/stream_msg_out.rs
@@ -12,10 +12,14 @@ pub struct StreamMsgOut {
 
     pub headers: std::collections::HashMap<String, String>,
 
-    pub timestamp: u64,
+    #[serde(with = "crate::unix_timestamp_ms_serde")]
+    pub timestamp: jiff::Timestamp,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheduled_at: Option<u64>,
+    #[serde(
+        with = "crate::unix_timestamp_ms_serde::optional",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub scheduled_at: Option<jiff::Timestamp>,
 }
 
 impl StreamMsgOut {
@@ -24,7 +28,7 @@ impl StreamMsgOut {
         topic: String,
         value: Vec<u8>,
         headers: std::collections::HashMap<String, String>,
-        timestamp: u64,
+        timestamp: jiff::Timestamp,
     ) -> Self {
         Self {
             offset,
@@ -36,7 +40,7 @@ impl StreamMsgOut {
         }
     }
 
-    pub fn with_scheduled_at(mut self, value: impl Into<Option<u64>>) -> Self {
+    pub fn with_scheduled_at(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
         self.scheduled_at = value.into();
         self
     }

--- a/z-clients/rust/src/unix_timestamp_ms_serde.rs
+++ b/z-clients/rust/src/unix_timestamp_ms_serde.rs
@@ -1,0 +1,40 @@
+use jiff::Timestamp;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+pub(crate) fn serialize<S: Serializer>(
+    duration: &Timestamp,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    duration.as_millisecond().serialize(serializer)
+}
+
+pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Timestamp, D::Error> {
+    let millis = i64::deserialize(deserializer)?;
+    Timestamp::from_millisecond(millis).map_err(serde::de::Error::custom)
+}
+
+pub(crate) mod optional {
+    use jiff::Timestamp;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(crate) fn serialize<S: Serializer>(
+        duration: &Option<Timestamp>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        duration.map(|d| d.as_millisecond()).serialize(serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Timestamp>, D::Error> {
+        let millis = Option::<i64>::deserialize(deserializer)?;
+        millis
+            .map(Timestamp::from_millisecond)
+            .transpose()
+            .map_err(serde::de::Error::custom)
+    }
+}


### PR DESCRIPTION
... from RFC3339 strings. SDKs are updated to work with this, but continue to expose the same language-specific types as before. 

Closes https://github.com/svix/diom-private/issues/809.