### PR TITLE
Rate-limit: add a fast-path to avoid raft for exhausted limits

### DIFF
--- a/crates/rate-limit/src/controller.rs
+++ b/crates/rate-limit/src/controller.rs
@@ -74,6 +74,33 @@ impl RateLimitController {
         .await?
     }
 
+    /// Checks whether a request will be denied if called by `limit`.
+    pub async fn check_limit<I: AsRef<str> + 'static + Send>(
+        &self,
+        now: Timestamp,
+        namespace_id: NamespaceId,
+        identifier: I,
+        wanted: u64,
+        config: TokenBucket,
+    ) -> Result<(bool, u64, Option<DurationMs>)> {
+        let tables = self.tables.clone();
+        spawn_blocking_in_current_span(move || {
+            let identifier = identifier.as_ref();
+            let (capacity, _) =
+                Self::calculate_capacity(&tables, namespace_id, identifier, &config, now)?;
+            if capacity < wanted {
+                Ok((
+                    false,
+                    capacity,
+                    Some(config.calculate_retry_after(capacity, wanted)),
+                ))
+            } else {
+                Ok((true, capacity, None))
+            }
+        })
+        .await?
+    }
+
     pub async fn get_remaining<I: AsRef<str> + 'static + Send>(
         &self,
         now: Timestamp,

--- a/crates/rate-limit/src/controller.rs
+++ b/crates/rate-limit/src/controller.rs
@@ -74,38 +74,12 @@ impl RateLimitController {
         .await?
     }
 
-    /// Checks whether a request will be denied if called by `limit`.
-    pub async fn check_limit<I: AsRef<str> + 'static + Send>(
-        &self,
-        now: Timestamp,
-        namespace_id: NamespaceId,
-        identifier: I,
-        wanted: u64,
-        config: TokenBucket,
-    ) -> Result<(bool, u64, Option<DurationMs>)> {
-        let tables = self.tables.clone();
-        spawn_blocking_in_current_span(move || {
-            let identifier = identifier.as_ref();
-            let (capacity, _) =
-                Self::calculate_capacity(&tables, namespace_id, identifier, &config, now)?;
-            if capacity < wanted {
-                Ok((
-                    false,
-                    capacity,
-                    Some(config.calculate_retry_after(capacity, wanted)),
-                ))
-            } else {
-                Ok((true, capacity, None))
-            }
-        })
-        .await?
-    }
-
     pub async fn get_remaining<I: AsRef<str> + 'static + Send>(
         &self,
         now: Timestamp,
         namespace_id: NamespaceId,
         identifier: I,
+        wanted: u64,
         config: TokenBucket,
     ) -> Result<(u64, Option<DurationMs>)> {
         let tables = self.tables.clone();
@@ -114,9 +88,9 @@ impl RateLimitController {
             let (capacity, _) =
                 Self::calculate_capacity(&tables, namespace_id, identifier, &config, now)?;
 
-            if capacity == 0 {
-                let retry_after = config.calculate_retry_after(capacity, 1);
-                return Ok((0, Some(retry_after)));
+            if capacity < wanted {
+                let retry_after = config.calculate_retry_after(capacity, wanted);
+                return Ok((capacity, Some(retry_after)));
             }
 
             Ok((capacity, None))
@@ -223,7 +197,7 @@ mod tests {
 
         clock += Duration::from_millis(100);
         let (remaining, retry_after) = limiter
-            .get_remaining(clock, ns(), id, config_refill_2())
+            .get_remaining(clock, ns(), id, 1, config_refill_2())
             .await
             .unwrap();
         assert_eq!(remaining, 2);
@@ -231,7 +205,7 @@ mod tests {
 
         clock += Duration::from_millis(200);
         let (remaining, retry_after) = limiter
-            .get_remaining(clock, ns(), id, config_refill_2())
+            .get_remaining(clock, ns(), id, 1, config_refill_2())
             .await
             .unwrap();
         assert_eq!(remaining, 5);

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -146,11 +146,26 @@ async fn rate_limit_limit(
         .fetch_namespace(data.namespace.as_deref())?
         .ok_or_not_found()?;
 
-    let key = data.key.0.clone();
-    let units = data.tokens;
-    let method = data.config.into();
+    let key = data.key.0;
+    let tokens = data.tokens;
+    let config: TokenBucket = data.config.into();
 
-    let operation = LimitOperation::new(namespace, key, units, method);
+    // Fast path: if local state already shows exhaustion, no need to go to raft.
+    let now = repl.time.now();
+    let rate_limit_state = repl.state_machine.rate_limit_store().await;
+    let (allowed, remaining, retry_after) = rate_limit_state
+        .controller()
+        .check_limit(now, namespace.id, key.clone(), tokens, config.clone())
+        .await?;
+    if !allowed {
+        return Ok(MsgPackOrJson(RateLimitCheckOut {
+            allowed,
+            remaining,
+            retry_after,
+        }));
+    }
+
+    let operation = LimitOperation::new(namespace, key, tokens, config);
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 
     Ok(MsgPackOrJson(RateLimitCheckOut {

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -153,15 +153,15 @@ async fn rate_limit_limit(
     // Fast path: if local state already shows exhaustion, no need to go to raft.
     let now = repl.time.now();
     let rate_limit_state = repl.state_machine.rate_limit_store().await;
-    let (allowed, remaining, retry_after) = rate_limit_state
+    let (remaining, retry_after) = rate_limit_state
         .controller()
-        .check_limit(now, namespace.id, key.clone(), tokens, config.clone())
+        .get_remaining(now, namespace.id, key.clone(), tokens, config.clone())
         .await?;
-    if !allowed {
+    if let Some(retry_after) = retry_after {
         return Ok(MsgPackOrJson(RateLimitCheckOut {
-            allowed,
+            allowed: false,
             remaining,
-            retry_after,
+            retry_after: Some(retry_after),
         }));
     }
 
@@ -193,7 +193,7 @@ async fn rate_limit_get_remaining(
     let rate_limit_state = repl.state_machine.rate_limit_store().await;
     let controller = rate_limit_state.controller();
     let (remaining, retry_after) = controller
-        .get_remaining(now, namespace.id, data.key, data.config.into())
+        .get_remaining(now, namespace.id, data.key, 1, data.config.into())
         .await?;
 
     Ok(MsgPackOrJson(RateLimitGetRemainingOut {


### PR DESCRIPTION
If a rate-limit is already exhausted (no tokens available) there's no need to spam raft with this request. We can just exit quickly locally. For extra efficiency we don't even need to wait for linearized reads, we can just see what our current version says (means extra noise on raft, but faster to respond in non-late-limited case).

We may want to change that to linearized for slight latency impact on the happy path, but less raft load on the bad path. I decided to not do it for now.