### PR TITLE
Operator: Support increasing storage size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,7 @@ dependencies = [
  "futures-util",
  "k8s-openapi",
  "kube",
+ "kube_quantity",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -2439,7 +2440,7 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -3192,6 +3193,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kube_quantity"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5006102fbd11aa86b196a0c76bda5e2ae0cd71d4c9126c9b8bdfe7c7b7a7158"
+dependencies = [
+ "k8s-openapi",
+ "nom 8.0.0",
+ "rust_decimal",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,6 +3454,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6037,6 +6059,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ jiff = { version = "0.2.18", features = ["serde"] }
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 k8s-openapi = { version = "0.27.1", features = ["v1_31"] }
 kube = { version = "3.0.1", features = ["runtime", "derive", "client"] }
+kube_quantity = "0.9.0"
 maplit = "1"
 mimalloc = { version = "0.1.48", features = ["v3"] }
 mime = "0.3"

--- a/infra/helm-diom/templates/clusterrole.yaml
+++ b/infra/helm-diom/templates/clusterrole.yaml
@@ -6,35 +6,38 @@ metadata:
   labels:
     {{- include "diom-operator.labels" . | nindent 4 }}
 rules:
-  # Manage DiomCluster resources and their status subresource.
   - apiGroups: ["diom.svix.com"]
     resources: ["diomclusters"]
     verbs: ["get", "list", "watch", "patch", "update"]
+
   - apiGroups: ["diom.svix.com"]
     resources: ["diomclusters/status"]
     verbs: ["get", "patch", "update"]
 
-  # Manage owned StatefulSets.
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # Manage owned Services.
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # Manage owned PodDisruptionBudgets.
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # Read pod status (used to determine cluster health).
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
 
-  # Emit Kubernetes events.
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]

--- a/infra/operator/Cargo.toml
+++ b/infra/operator/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 futures-util.workspace = true
 k8s-openapi = { workspace = true, features = ["schemars"] }
 kube.workspace = true
+kube_quantity.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/infra/operator/src/context.rs
+++ b/infra/operator/src/context.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use k8s_openapi::api::{apps::v1::StatefulSet, core::v1::Service, policy::v1::PodDisruptionBudget};
+use kube::{Api, Client, ResourceExt, api::PatchParams};
+
+use crate::{
+    crd::DiomCluster,
+    error::{Error, Result},
+};
+
+pub(crate) const FIELD_MANAGER: &str = "diom-operator";
+
+pub(crate) struct ClusterCtx {
+    pub cluster: Arc<DiomCluster>,
+    pub client: Client,
+    pub ns: String,
+    pub name: String,
+}
+
+impl ClusterCtx {
+    pub(crate) fn new(cluster: Arc<DiomCluster>, client: Client) -> Result<Self> {
+        let ns = cluster
+            .namespace()
+            .ok_or(Error::MissingField("namespace"))?;
+        let name = cluster.name_any();
+        Ok(Self {
+            cluster,
+            client,
+            ns,
+            name,
+        })
+    }
+
+    pub(crate) fn cluster_api(&self) -> Api<DiomCluster> {
+        Api::namespaced(self.client.clone(), &self.ns)
+    }
+
+    pub(crate) fn sts_api(&self) -> Api<StatefulSet> {
+        Api::namespaced(self.client.clone(), &self.ns)
+    }
+
+    pub(crate) fn pdb_api(&self) -> Api<PodDisruptionBudget> {
+        Api::namespaced(self.client.clone(), &self.ns)
+    }
+
+    pub(crate) fn svc_api(&self) -> Api<Service> {
+        Api::namespaced(self.client.clone(), &self.ns)
+    }
+
+    pub(crate) fn pp(&self) -> PatchParams {
+        PatchParams::apply(FIELD_MANAGER).force()
+    }
+
+    pub(crate) fn status_pp(&self) -> PatchParams {
+        PatchParams::apply(FIELD_MANAGER)
+    }
+}

--- a/infra/operator/src/error.rs
+++ b/infra/operator/src/error.rs
@@ -7,6 +7,12 @@ pub(crate) enum Error {
 
     #[error("Missing field: {0}")]
     MissingField(&'static str),
+
+    #[error("Timeout: {0}")]
+    Timeout(String),
+
+    #[error("Storage error: {0}")]
+    Storage(String),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/infra/operator/src/main.rs
+++ b/infra/operator/src/main.rs
@@ -8,6 +8,7 @@ use kube::{
 };
 use tracing::*;
 
+mod context;
 mod crd;
 mod error;
 mod labels;

--- a/infra/operator/src/reconciler.rs
+++ b/infra/operator/src/reconciler.rs
@@ -27,7 +27,7 @@ impl Reconciler {
     async fn run(self) -> Result<Action> {
         services::reconcile(&self.ctx).await?;
         statefulset::reconcile(&self.ctx).await?;
-        pvcs::reconcile_pvcs(&self.ctx).await?;
+        pvcs::reconcile(&self.ctx).await?;
         pdb::reconcile(&self.ctx).await?;
 
         self.update_status().await?;

--- a/infra/operator/src/reconciler.rs
+++ b/infra/operator/src/reconciler.rs
@@ -6,7 +6,7 @@ use crate::{
     context::ClusterCtx,
     crd::{DiomCluster, Phase},
     error::{Error, Result},
-    resources::{pdb, services, statefulset},
+    resources::{pdb, pvcs, services, statefulset},
 };
 
 pub(crate) struct Context {
@@ -26,14 +26,13 @@ impl Reconciler {
 
     async fn run(self) -> Result<Action> {
         services::reconcile(&self.ctx).await?;
-
         statefulset::reconcile(&self.ctx).await?;
-
+        pvcs::reconcile_pvcs(&self.ctx).await?;
         pdb::reconcile(&self.ctx).await?;
 
         self.update_status().await?;
         tracing::info!(name = %self.ctx.name, ns = %self.ctx.ns, "Reconcile complete");
-        Ok(Action::requeue(Duration::from_secs(300)))
+        Ok(Action::requeue(Duration::from_secs(60)))
     }
 
     async fn update_status(&self) -> Result<()> {

--- a/infra/operator/src/reconciler.rs
+++ b/infra/operator/src/reconciler.rs
@@ -1,138 +1,131 @@
 use std::{sync::Arc, time::Duration};
 
-use k8s_openapi::api::{apps::v1::StatefulSet, core::v1::Service, policy::v1::PodDisruptionBudget};
-use kube::{
-    Api, Client, Resource, ResourceExt,
-    api::{Patch, PatchParams},
-    runtime::controller::Action,
-};
-use tracing::*;
+use kube::{Client, Resource, api::Patch, runtime::controller::Action};
 
 use crate::{
+    context::ClusterCtx,
     crd::{DiomCluster, Phase},
     error::{Error, Result},
-    resources,
+    resources::{pdb, services, statefulset},
 };
-
-const FIELD_MANAGER: &str = "diom-operator";
 
 pub(crate) struct Context {
     pub client: Client,
 }
 
-pub(crate) async fn reconcile(cluster: Arc<DiomCluster>, ctx: Arc<Context>) -> Result<Action> {
-    let ns = cluster
-        .namespace()
-        .ok_or(Error::MissingField("namespace"))?;
-    let name = cluster.name_any();
-    let client = &ctx.client;
-    let pp = PatchParams::apply(FIELD_MANAGER).force();
+struct Reconciler {
+    ctx: ClusterCtx,
+}
 
-    // If the cluster is being deleted, nothing to do — owned resources are
-    // garbage collected automatically via owner references.
+impl Reconciler {
+    fn new(cluster: Arc<DiomCluster>, client: Client) -> Result<Self> {
+        Ok(Self {
+            ctx: ClusterCtx::new(cluster, client)?,
+        })
+    }
+
+    async fn run(self) -> Result<Action> {
+        services::reconcile(&self.ctx).await?;
+
+        statefulset::reconcile(&self.ctx).await?;
+
+        pdb::reconcile(&self.ctx).await?;
+
+        self.update_status().await?;
+        tracing::info!(name = %self.ctx.name, ns = %self.ctx.ns, "Reconcile complete");
+        Ok(Action::requeue(Duration::from_secs(300)))
+    }
+
+    async fn update_status(&self) -> Result<()> {
+        let name = &self.ctx.name;
+        let current_status = self.ctx.cluster.status.as_ref();
+        let current_phase = current_status.map(|s| s.phase.clone()).unwrap_or_default();
+        let current_ready = current_status.map(|s| s.ready_replicas).unwrap_or(0);
+
+        let (ready_replicas, phase) = match self.ctx.sts_api().get_opt(name).await? {
+            Some(sts) => {
+                let ready = sts
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.ready_replicas)
+                    .unwrap_or(0);
+                let desired = self.ctx.cluster.spec.diom.replicas;
+                let phase = compute_phase(ready, desired, &current_phase);
+                (ready, phase)
+            }
+            None => (0, Phase::Initializing),
+        };
+
+        if phase == current_phase && ready_replicas == current_ready {
+            return Ok(());
+        }
+
+        let status_patch = serde_json::json!({
+            "apiVersion": "diom.svix.com/v1alpha1",
+            "kind": "DiomCluster",
+            "status": {
+                "readyReplicas": ready_replicas,
+                "phase": phase,
+            }
+        });
+
+        self.ctx
+            .cluster_api()
+            .patch_status(name, &self.ctx.status_pp(), &Patch::Apply(status_patch))
+            .await?;
+
+        Ok(())
+    }
+}
+
+fn compute_phase(ready: i32, desired: i32, current_phase: &Phase) -> Phase {
+    if ready == desired {
+        Phase::Running
+    } else if matches!(current_phase, Phase::Initializing) {
+        Phase::Initializing
+    } else {
+        Phase::Degraded
+    }
+}
+
+pub(crate) async fn reconcile(cluster: Arc<DiomCluster>, ctx: Arc<Context>) -> Result<Action> {
     if cluster.meta().deletion_timestamp.is_some() {
         return Ok(Action::await_change());
     }
 
-    info!(name, ns, "Reconciling DiomCluster");
-
-    // Headless service (inter-node DNS)
-    let svc_api: Api<Service> = Api::namespaced(client.clone(), &ns);
-    let headless = resources::services::build_headless(&cluster, &ns)?;
-    svc_api
-        .patch(
-            headless.metadata.name.as_deref().unwrap(),
-            &pp,
-            &Patch::Apply(&headless),
-        )
-        .await?;
-
-    // Client-facing service
-    let client_svc = resources::services::build_client(&cluster, &ns)?;
-    svc_api
-        .patch(
-            client_svc.metadata.name.as_deref().unwrap(),
-            &pp,
-            &Patch::Apply(&client_svc),
-        )
-        .await?;
-
-    // StatefulSet
-    let sts_api: Api<StatefulSet> = Api::namespaced(client.clone(), &ns);
-    let sts = resources::statefulset::build(&cluster, &ns)?;
-    sts_api
-        .patch(
-            sts.metadata.name.as_deref().unwrap(),
-            &pp,
-            &Patch::Apply(&sts),
-        )
-        .await?;
-
-    // PodDisruptionBudget (only meaningful for replicas > 1)
-    if cluster.spec.diom.replicas > 1 {
-        let pdb_api: Api<PodDisruptionBudget> = Api::namespaced(client.clone(), &ns);
-        let pdb = resources::pdb::build(&cluster, &ns)?;
-        pdb_api
-            .patch(
-                pdb.metadata.name.as_deref().unwrap(),
-                &pp,
-                &Patch::Apply(&pdb),
-            )
-            .await?;
-    }
-
-    update_status(&cluster, client, &ns).await?;
-
-    info!(name, ns, "Reconcile complete");
-    Ok(Action::requeue(Duration::from_secs(300)))
-}
-
-async fn update_status(cluster: &DiomCluster, client: &Client, ns: &str) -> Result<()> {
-    let cluster_api: Api<DiomCluster> = Api::namespaced(client.clone(), ns);
-    let name = cluster.name_any();
-
-    let sts_api: Api<StatefulSet> = Api::namespaced(client.clone(), ns);
-    let (ready_replicas, phase) = match sts_api.get_opt(&name).await? {
-        Some(sts) => {
-            let ready = sts
-                .status
-                .as_ref()
-                .and_then(|s| s.ready_replicas)
-                .unwrap_or(0);
-            let desired = cluster.spec.diom.replicas;
-            let phase = if ready == desired {
-                Phase::Running
-            } else if ready == 0 {
-                Phase::Initializing
-            } else {
-                Phase::Degraded
-            };
-            (ready, phase)
-        }
-        None => (0, Phase::Initializing),
-    };
-
-    let status_patch = serde_json::json!({
-        "apiVersion": "diom.svix.com/v1alpha1",
-        "kind": "DiomCluster",
-        "status": {
-            "readyReplicas": ready_replicas,
-            "phase": phase,
-        }
-    });
-
-    cluster_api
-        .patch_status(
-            &name,
-            &PatchParams::apply(FIELD_MANAGER),
-            &Patch::Apply(status_patch),
-        )
-        .await?;
-
-    Ok(())
+    let r = Reconciler::new(cluster, ctx.client.clone())?;
+    tracing::info!(name = %r.ctx.name, ns = %r.ctx.ns, "Reconciling DiomCluster");
+    r.run().await
 }
 
 pub(crate) fn error_policy(_cluster: Arc<DiomCluster>, err: &Error, _ctx: Arc<Context>) -> Action {
-    warn!("Reconcile error: {err:?}");
+    tracing::warn!("Reconcile error: {err:?}");
     Action::requeue(Duration::from_secs(30))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_phase() {
+        assert_eq!(compute_phase(3, 3, &Phase::Initializing), Phase::Running);
+        assert_eq!(compute_phase(3, 3, &Phase::Degraded), Phase::Running);
+        assert_eq!(compute_phase(3, 3, &Phase::Running), Phase::Running);
+        assert_eq!(
+            compute_phase(0, 3, &Phase::Initializing),
+            Phase::Initializing
+        );
+        assert_eq!(compute_phase(0, 3, &Phase::Running), Phase::Degraded);
+        assert_eq!(compute_phase(0, 3, &Phase::Degraded), Phase::Degraded);
+        assert_eq!(
+            compute_phase(1, 3, &Phase::Initializing),
+            Phase::Initializing
+        );
+        assert_eq!(
+            compute_phase(2, 3, &Phase::Initializing),
+            Phase::Initializing
+        );
+        assert_eq!(compute_phase(1, 3, &Phase::Running), Phase::Degraded);
+    }
 }

--- a/infra/operator/src/resources/mod.rs
+++ b/infra/operator/src/resources/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod pdb;
+pub(crate) mod pvcs;
 pub(crate) mod services;
 pub(crate) mod statefulset;

--- a/infra/operator/src/resources/pdb.rs
+++ b/infra/operator/src/resources/pdb.rs
@@ -2,12 +2,41 @@ use k8s_openapi::{
     api::policy::v1::{PodDisruptionBudget, PodDisruptionBudgetSpec},
     apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString},
 };
-use kube::{Resource, ResourceExt, core::ObjectMeta};
+use kube::{
+    Resource,
+    api::{DeleteParams, Patch},
+    core::ObjectMeta,
+};
 
-use crate::{crd::DiomCluster, error::Result, labels};
+use crate::{context::ClusterCtx, error::Result, labels};
 
-pub(crate) fn build(cluster: &DiomCluster, ns: &str) -> Result<PodDisruptionBudget> {
-    let cluster_name = cluster.name_any();
+pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
+    if ctx.cluster.spec.diom.replicas > 1 {
+        let pdb = build(ctx)?;
+        ctx.pdb_api()
+            .patch(
+                pdb.metadata.name.as_deref().unwrap(),
+                &ctx.pp(),
+                &Patch::Apply(&pdb),
+            )
+            .await?;
+    } else {
+        match ctx
+            .pdb_api()
+            .delete(&ctx.name, &DeleteParams::default())
+            .await
+        {
+            Ok(_) => {}
+            Err(kube::Error::Api(e)) if e.code == 404 => {} // already absent
+            Err(e) => return Err(e.into()),
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn build(ctx: &ClusterCtx) -> Result<PodDisruptionBudget> {
+    let cluster = &ctx.cluster;
+    let cluster_name = &ctx.name;
     let replicas = cluster.spec.diom.replicas;
 
     // Require a strict majority to be available at all times, which maintains quorum.
@@ -16,15 +45,15 @@ pub(crate) fn build(cluster: &DiomCluster, ns: &str) -> Result<PodDisruptionBudg
     Ok(PodDisruptionBudget {
         metadata: ObjectMeta {
             name: Some(cluster_name.clone()),
-            namespace: Some(ns.into()),
-            labels: Some(labels::general_labels(&cluster_name)),
+            namespace: Some(ctx.ns.clone()),
+            labels: Some(labels::general_labels(cluster_name)),
             owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
             ..Default::default()
         },
         spec: Some(PodDisruptionBudgetSpec {
             min_available: Some(IntOrString::Int(min_available)),
             selector: Some(LabelSelector {
-                match_labels: Some(labels::selector(&cluster_name)),
+                match_labels: Some(labels::selector(cluster_name)),
                 ..Default::default()
             }),
             ..Default::default()

--- a/infra/operator/src/resources/pdb.rs
+++ b/infra/operator/src/resources/pdb.rs
@@ -8,17 +8,17 @@ use kube::{
     core::ObjectMeta,
 };
 
-use crate::{context::ClusterCtx, error::Result, labels};
+use crate::{
+    context::ClusterCtx,
+    error::{Error, Result},
+    labels,
+};
 
 pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
     if ctx.cluster.spec.diom.replicas > 1 {
         let pdb = build(ctx)?;
         ctx.pdb_api()
-            .patch(
-                pdb.metadata.name.as_deref().unwrap(),
-                &ctx.pp(),
-                &Patch::Apply(&pdb),
-            )
+            .patch(&ctx.name, &ctx.pp(), &Patch::Apply(&pdb))
             .await?;
     } else {
         match ctx
@@ -47,7 +47,11 @@ pub(crate) fn build(ctx: &ClusterCtx) -> Result<PodDisruptionBudget> {
             name: Some(cluster_name.clone()),
             namespace: Some(ctx.ns.clone()),
             labels: Some(labels::general_labels(cluster_name)),
-            owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
+            owner_references: Some(vec![
+                cluster
+                    .controller_owner_ref(&())
+                    .ok_or(Error::MissingField("owner UID"))?,
+            ]),
             ..Default::default()
         },
         spec: Some(PodDisruptionBudgetSpec {

--- a/infra/operator/src/resources/pvcs.rs
+++ b/infra/operator/src/resources/pvcs.rs
@@ -15,7 +15,8 @@ use crate::{
     error::{Error, Result},
 };
 
-pub(crate) async fn reconcile_pvcs(ctx: &ClusterCtx) -> Result<()> {
+/// Reconcile persistent volume claims.
+pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
     let storage = &ctx.cluster.spec.diom.storage;
     let nodes = ctx.cluster.spec.diom.replicas;
 
@@ -66,7 +67,7 @@ async fn reconcile_volume(
         let name = pvc_name(volume_name, &ctx.name, ordinal);
 
         let Some(pvc) = pvc_api.get_opt(&name).await? else {
-            tracing::debug!(name, "PVC not found; skipping resize.");
+            tracing::warn!(name, "PVC not found; skipping reconcile.");
             continue;
         };
 
@@ -119,7 +120,7 @@ async fn patch_pvc_size(
     });
     tracing::info!(
         name,
-        desired = desired.to_string(),
+        %desired,
         "Patching PVC with new size"
     );
     pvc_api
@@ -158,9 +159,7 @@ async fn storage_class_allows_expansion(
 fn pvc_requested_size(pvc: &PersistentVolumeClaim) -> Result<ParsedQuantity> {
     pvc.spec
         .as_ref()
-        .and_then(|s| s.resources.as_ref())
-        .and_then(|r| r.requests.as_ref())
-        .and_then(|r| r.get("storage"))
+        .and_then(|s| s.resources.as_ref()?.requests.as_ref()?.get("storage"))
         .cloned()
         .ok_or_else(|| Error::Storage("Storage not found".to_owned()))?
         .try_into()

--- a/infra/operator/src/resources/pvcs.rs
+++ b/infra/operator/src/resources/pvcs.rs
@@ -1,0 +1,216 @@
+use std::collections::BTreeMap;
+
+use k8s_openapi::{
+    api::{core::v1::PersistentVolumeClaim, storage::v1::StorageClass},
+    apimachinery::pkg::api::resource::Quantity,
+};
+use kube::{
+    Api,
+    api::{ListParams, Patch, PatchParams},
+};
+use kube_quantity::{ParseQuantityError, ParsedQuantity};
+
+use crate::{
+    context::ClusterCtx,
+    error::{Error, Result},
+};
+
+pub(crate) async fn reconcile_pvcs(ctx: &ClusterCtx) -> Result<()> {
+    let storage = &ctx.cluster.spec.diom.storage;
+    let nodes = ctx.cluster.spec.diom.replicas;
+
+    reconcile_volume(
+        ctx,
+        "persistent",
+        &storage.persistent.size,
+        storage.persistent.storage_class.as_deref(),
+        nodes,
+    )
+    .await?;
+
+    if let Some(logs) = &storage.logs {
+        reconcile_volume(
+            ctx,
+            "logs",
+            &logs.size,
+            logs.storage_class.as_deref(),
+            nodes,
+        )
+        .await?;
+    }
+
+    if let Some(snaps) = &storage.snapshots {
+        reconcile_volume(
+            ctx,
+            "snapshots",
+            &snaps.size,
+            snaps.storage_class.as_deref(),
+            nodes,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn reconcile_volume(
+    ctx: &ClusterCtx,
+    volume_name: &str,
+    desired_size: &Quantity,
+    storage_class: Option<&str>,
+    nodes: i32,
+) -> Result<()> {
+    let pvc_api: Api<PersistentVolumeClaim> = Api::namespaced(ctx.client.clone(), &ctx.ns);
+
+    for ordinal in 0..nodes {
+        let name = pvc_name(volume_name, &ctx.name, ordinal);
+
+        let Some(pvc) = pvc_api.get_opt(&name).await? else {
+            tracing::debug!(name, "PVC not found; skipping resize.");
+            continue;
+        };
+
+        let desired_size: ParsedQuantity = desired_size
+            .try_into()
+            .map_err(|e: ParseQuantityError| Error::Storage(e.to_string()))?;
+        let current_size = pvc_requested_size(&pvc)?;
+
+        if desired_size <= current_size {
+            if desired_size < current_size {
+                tracing::warn!(name, "Desired size smaller than current; skipping resize.");
+            }
+            continue;
+        }
+
+        let sc_name = pvc
+            .spec
+            .as_ref()
+            .and_then(|s| s.storage_class_name.as_deref())
+            .or(storage_class);
+
+        if !storage_class_allows_expansion(&ctx.client, sc_name).await? {
+            tracing::warn!(
+                name,
+                sc_name,
+                "StorageClass does not support resize; skipping."
+            );
+            continue;
+        }
+
+        patch_pvc_size(&pvc_api, &name, &desired_size).await?;
+    }
+
+    Ok(())
+}
+
+async fn patch_pvc_size(
+    pvc_api: &Api<PersistentVolumeClaim>,
+    name: &str,
+    desired: &ParsedQuantity,
+) -> Result<()> {
+    let mut requests: BTreeMap<String, String> = BTreeMap::new();
+    requests.insert("storage".into(), desired.to_string());
+    let patch = serde_json::json!({
+        "spec": {
+            "resources": {
+                "requests": requests
+            }
+        }
+    });
+    tracing::info!(
+        name,
+        desired = desired.to_string(),
+        "Patching PVC with new size"
+    );
+    pvc_api
+        .patch(name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await?;
+    Ok(())
+}
+
+async fn storage_class_allows_expansion(
+    client: &kube::Client,
+    sc_name: Option<&str>,
+) -> Result<bool> {
+    let sc_api: Api<StorageClass> = Api::all(client.clone());
+
+    let sc = match sc_name {
+        Some(name) => sc_api.get_opt(name).await?,
+        None => {
+            let list = sc_api.list(&ListParams::default()).await?;
+            list.items.into_iter().find(|sc| {
+                sc.metadata
+                    .annotations
+                    .as_ref()
+                    .and_then(|a| a.get("storageclass.kubernetes.io/is-default-class"))
+                    .map(|v| v == "true")
+                    .unwrap_or(false)
+            })
+        }
+    };
+
+    Ok(sc
+        .as_ref()
+        .and_then(|sc| sc.allow_volume_expansion)
+        .unwrap_or(false))
+}
+
+fn pvc_requested_size(pvc: &PersistentVolumeClaim) -> Result<ParsedQuantity> {
+    pvc.spec
+        .as_ref()
+        .and_then(|s| s.resources.as_ref())
+        .and_then(|r| r.requests.as_ref())
+        .and_then(|r| r.get("storage"))
+        .cloned()
+        .ok_or_else(|| Error::Storage("Storage not found".to_owned()))?
+        .try_into()
+        .map_err(|e: ParseQuantityError| Error::Storage(e.to_string()))
+}
+
+pub(crate) fn pvc_name(volume_name: &str, cluster_name: &str, ordinal: i32) -> String {
+    format!("{volume_name}-{cluster_name}-{ordinal}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{PersistentVolumeClaimSpec, VolumeResourceRequirements};
+
+    fn pvc_with_storage(size: &str) -> PersistentVolumeClaim {
+        let mut requests = BTreeMap::new();
+        requests.insert("storage".to_string(), Quantity(size.to_string()));
+        PersistentVolumeClaim {
+            spec: Some(PersistentVolumeClaimSpec {
+                resources: Some(VolumeResourceRequirements {
+                    requests: Some(requests),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_pvc_name() {
+        assert_eq!(
+            pvc_name("persistent", "mycluster", 0),
+            "persistent-mycluster-0"
+        );
+        assert_eq!(pvc_name("logs", "mycluster", 2), "logs-mycluster-2");
+    }
+
+    #[test]
+    fn test_pvc_requested_size() {
+        let size = pvc_requested_size(&pvc_with_storage("10Gi")).unwrap();
+        assert_eq!(size, Quantity("10Gi".to_string()).try_into().unwrap());
+
+        assert!(pvc_requested_size(&PersistentVolumeClaim::default()).is_err());
+
+        let pvc = PersistentVolumeClaim {
+            spec: Some(PersistentVolumeClaimSpec::default()),
+            ..Default::default()
+        };
+        assert!(pvc_requested_size(&pvc).is_err());
+    }
+}

--- a/infra/operator/src/resources/services.rs
+++ b/infra/operator/src/resources/services.rs
@@ -4,13 +4,19 @@ use k8s_openapi::{
 };
 use kube::{Resource, api::Patch, core::ObjectMeta};
 
-use crate::{context::ClusterCtx, error::Result, labels};
+use crate::{
+    context::ClusterCtx,
+    error::{Error, Result},
+    labels,
+};
 
-pub(crate) fn headless_name(cluster_name: &str) -> String {
+/// Name of headless service
+pub(crate) fn headless_svc_name(cluster_name: &str) -> String {
     format!("{cluster_name}-headless")
 }
 
-pub(crate) fn client_name(cluster_name: &str) -> String {
+/// Name of load-balancing service
+pub(crate) fn lb_svc_name(cluster_name: &str) -> String {
     cluster_name.to_string()
 }
 
@@ -20,25 +26,18 @@ pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
 
     let headless = build_headless(ctx)?;
     svc_api
-        .patch(
-            headless.metadata.name.as_deref().unwrap(),
-            &pp,
-            &Patch::Apply(&headless),
-        )
+        .patch(&headless_svc_name(&ctx.name), &pp, &Patch::Apply(&headless))
         .await?;
 
-    let client_svc = build_client_facing(ctx)?;
+    let client_svc = build_lb_svc(ctx)?;
     svc_api
-        .patch(
-            client_svc.metadata.name.as_deref().unwrap(),
-            &pp,
-            &Patch::Apply(&client_svc),
-        )
+        .patch(&lb_svc_name(&ctx.name), &pp, &Patch::Apply(&client_svc))
         .await?;
 
     Ok(())
 }
 
+/// Build headless service.
 pub(crate) fn build_headless(ctx: &ClusterCtx) -> Result<Service> {
     let cluster = &ctx.cluster;
     let cluster_name = &ctx.name;
@@ -47,10 +46,14 @@ pub(crate) fn build_headless(ctx: &ClusterCtx) -> Result<Service> {
 
     Ok(Service {
         metadata: ObjectMeta {
-            name: Some(headless_name(cluster_name)),
+            name: Some(headless_svc_name(cluster_name)),
             namespace: Some(ctx.ns.clone()),
             labels: Some(labels::general_labels(cluster_name)),
-            owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
+            owner_references: Some(vec![
+                cluster
+                    .controller_owner_ref(&())
+                    .ok_or(Error::MissingField("owner UID"))?,
+            ]),
             ..Default::default()
         },
         spec: Some(ServiceSpec {
@@ -77,8 +80,8 @@ pub(crate) fn build_headless(ctx: &ClusterCtx) -> Result<Service> {
     })
 }
 
-/// Client-facing service — load-balances across all ready pods.
-pub(crate) fn build_client_facing(ctx: &ClusterCtx) -> Result<Service> {
+/// Build load-balancing service
+pub(crate) fn build_lb_svc(ctx: &ClusterCtx) -> Result<Service> {
     let cluster = &ctx.cluster;
     let cluster_name = &ctx.name;
     let spec = &cluster.spec;
@@ -90,7 +93,7 @@ pub(crate) fn build_client_facing(ctx: &ClusterCtx) -> Result<Service> {
         .unwrap_or_else(|| "ClusterIP".into());
 
     let mut metadata = ObjectMeta {
-        name: Some(client_name(cluster_name)),
+        name: Some(lb_svc_name(cluster_name)),
         namespace: Some(ctx.ns.clone()),
         labels: Some(labels::general_labels(cluster_name)),
         owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),

--- a/infra/operator/src/resources/services.rs
+++ b/infra/operator/src/resources/services.rs
@@ -2,38 +2,60 @@ use k8s_openapi::{
     api::core::v1::{Service, ServicePort, ServiceSpec},
     apimachinery::pkg::util::intstr::IntOrString,
 };
-use kube::{Resource, ResourceExt, core::ObjectMeta};
+use kube::{Resource, api::Patch, core::ObjectMeta};
 
-use crate::{crd::DiomCluster, error::Result, labels};
+use crate::{context::ClusterCtx, error::Result, labels};
 
-/// Name of the headless service used for inter-node DNS.
 pub(crate) fn headless_name(cluster_name: &str) -> String {
     format!("{cluster_name}-headless")
 }
 
-/// Name of the client-facing service.
 pub(crate) fn client_name(cluster_name: &str) -> String {
     cluster_name.to_string()
 }
 
-/// Headless service — gives each pod a stable DNS name for peer discovery.
-/// Pods are reachable as `<pod>.<headless-name>.<ns>.svc.cluster.local`.
-pub(crate) fn build_headless(cluster: &DiomCluster, ns: &str) -> Result<Service> {
-    let cluster_name = cluster.name_any();
+pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
+    let svc_api = ctx.svc_api();
+    let pp = ctx.pp();
+
+    let headless = build_headless(ctx)?;
+    svc_api
+        .patch(
+            headless.metadata.name.as_deref().unwrap(),
+            &pp,
+            &Patch::Apply(&headless),
+        )
+        .await?;
+
+    let client_svc = build_client_facing(ctx)?;
+    svc_api
+        .patch(
+            client_svc.metadata.name.as_deref().unwrap(),
+            &pp,
+            &Patch::Apply(&client_svc),
+        )
+        .await?;
+
+    Ok(())
+}
+
+pub(crate) fn build_headless(ctx: &ClusterCtx) -> Result<Service> {
+    let cluster = &ctx.cluster;
+    let cluster_name = &ctx.name;
     let spec = &cluster.spec;
     let cluster_port = spec.diom.api_port + 10000;
 
     Ok(Service {
         metadata: ObjectMeta {
-            name: Some(headless_name(&cluster_name)),
-            namespace: Some(ns.into()),
-            labels: Some(labels::general_labels(&cluster_name)),
+            name: Some(headless_name(cluster_name)),
+            namespace: Some(ctx.ns.clone()),
+            labels: Some(labels::general_labels(cluster_name)),
             owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
             ..Default::default()
         },
         spec: Some(ServiceSpec {
             cluster_ip: Some("None".into()), // headless
-            selector: Some(labels::selector(&cluster_name)),
+            selector: Some(labels::selector(cluster_name)),
             publish_not_ready_addresses: Some(true), // needed for seed_nodes to work during startup
             ports: Some(vec![
                 ServicePort {
@@ -56,8 +78,9 @@ pub(crate) fn build_headless(cluster: &DiomCluster, ns: &str) -> Result<Service>
 }
 
 /// Client-facing service — load-balances across all ready pods.
-pub(crate) fn build_client(cluster: &DiomCluster, ns: &str) -> Result<Service> {
-    let cluster_name = cluster.name_any();
+pub(crate) fn build_client_facing(ctx: &ClusterCtx) -> Result<Service> {
+    let cluster = &ctx.cluster;
+    let cluster_name = &ctx.name;
     let spec = &cluster.spec;
     let svc_spec = &spec.service;
 
@@ -67,9 +90,9 @@ pub(crate) fn build_client(cluster: &DiomCluster, ns: &str) -> Result<Service> {
         .unwrap_or_else(|| "ClusterIP".into());
 
     let mut metadata = ObjectMeta {
-        name: Some(client_name(&cluster_name)),
-        namespace: Some(ns.into()),
-        labels: Some(labels::general_labels(&cluster_name)),
+        name: Some(client_name(cluster_name)),
+        namespace: Some(ctx.ns.clone()),
+        labels: Some(labels::general_labels(cluster_name)),
         owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
         ..Default::default()
     };
@@ -82,7 +105,7 @@ pub(crate) fn build_client(cluster: &DiomCluster, ns: &str) -> Result<Service> {
         metadata,
         spec: Some(ServiceSpec {
             type_: Some(svc_type),
-            selector: Some(labels::selector(&cluster_name)),
+            selector: Some(labels::selector(cluster_name)),
             traffic_distribution: Some("PreferSameZone".into()),
             ports: Some(vec![ServicePort {
                 name: Some("api".into()),

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -73,7 +73,7 @@ pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
 fn build(ctx: &ClusterCtx) -> Result<StatefulSet> {
     let cluster_name = &ctx.name;
     let spec = &ctx.cluster.spec;
-    let headless_svc = services::headless_name(cluster_name);
+    let headless_svc = services::headless_svc_name(cluster_name);
 
     let env = build_env(spec, cluster_name, &headless_svc, &ctx.ns);
     let volume_claim_templates = build_volume_claim_templates(spec);
@@ -104,7 +104,11 @@ fn build(ctx: &ClusterCtx) -> Result<StatefulSet> {
             name: Some(cluster_name.clone()),
             namespace: Some(ctx.ns.clone()),
             labels: Some(labels::general_labels(cluster_name)),
-            owner_references: Some(vec![ctx.cluster.controller_owner_ref(&()).unwrap()]),
+            owner_references: Some(vec![
+                ctx.cluster
+                    .controller_owner_ref(&())
+                    .ok_or(Error::MissingField("owner UID"))?,
+            ]),
             ..Default::default()
         },
         spec: Some(StatefulSetSpec {

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -1,8 +1,8 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 use k8s_openapi::{
     api::{
-        apps::v1::{StatefulSet, StatefulSetSpec},
+        apps::v1::{StatefulSet, StatefulSetPersistentVolumeClaimRetentionPolicy, StatefulSetSpec},
         core::v1::{
             Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction, ObjectFieldSelector,
             PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSecurityContext, PodSpec,
@@ -13,12 +13,16 @@ use k8s_openapi::{
         api::resource::Quantity, apis::meta::v1::LabelSelector, util::intstr::IntOrString,
     },
 };
-use kube::{Resource, api::Patch, core::ObjectMeta};
+use kube::{
+    Resource,
+    api::{DeleteParams, Patch, PostParams, PropagationPolicy},
+    core::ObjectMeta,
+};
 
 use crate::{
     context::ClusterCtx,
     crd::{DiomClusterSpec, INTRACLUSTER_PORT},
-    error::Result,
+    error::{Error, Result},
     labels,
     resources::services,
 };
@@ -36,10 +40,33 @@ const LOGS_DATA_PATH: &str = "/data/logs";
 const SNAPSHOTS_DATA_PATH: &str = "/data/snapshots";
 
 pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
-    let sts = build(ctx)?;
-    ctx.sts_api()
-        .patch(&ctx.name, &ctx.pp(), &Patch::Apply(&sts))
-        .await?;
+    let new_sts = build(ctx)?;
+    let sts_api = ctx.sts_api();
+
+    if let Some(current) = sts_api.get_opt(&ctx.name).await?
+        && volume_claim_templates_differ(&current, &new_sts)
+    {
+        tracing::info!(
+            name = %ctx.name,
+            "volumeClaimTemplates changed. Orphaning/Deleting the StatefulSet."
+        );
+        sts_api
+            .delete(
+                &ctx.name,
+                &DeleteParams {
+                    propagation_policy: Some(PropagationPolicy::Orphan),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        wait_for_sts_deleted(&sts_api, &ctx.name).await?;
+        sts_api.create(&PostParams::default(), &new_sts).await?;
+    } else {
+        sts_api
+            .patch(&ctx.name, &ctx.pp(), &Patch::Apply(new_sts))
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -100,6 +127,12 @@ fn build(ctx: &ClusterCtx) -> Result<StatefulSet> {
                 spec: Some(pod_spec),
             },
             volume_claim_templates: Some(volume_claim_templates),
+            persistent_volume_claim_retention_policy: Some(
+                StatefulSetPersistentVolumeClaimRetentionPolicy {
+                    when_deleted: Some("Retain".into()),
+                    when_scaled: Some("Retain".into()),
+                },
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -385,4 +418,127 @@ fn seed_nodes_value(
         .map(|i| format!("{cluster_name}-{i}.{headless_svc}.{ns}.svc.cluster.local:{cluster_port}"))
         .collect::<Vec<_>>()
         .join(",")
+}
+
+fn volume_claim_templates_differ(current: &StatefulSet, desired: &StatefulSet) -> bool {
+    let current_templates = current
+        .spec
+        .as_ref()
+        .and_then(|s| s.volume_claim_templates.as_deref())
+        .unwrap_or(&[]);
+    let desired_templates = desired
+        .spec
+        .as_ref()
+        .and_then(|s| s.volume_claim_templates.as_deref())
+        .unwrap_or(&[]);
+
+    for desired_tpl in desired_templates {
+        let desired_name = desired_tpl.metadata.name.as_deref().unwrap_or("");
+        let desired_size = desired_tpl
+            .spec
+            .as_ref()
+            .and_then(|s| s.resources.as_ref())
+            .and_then(|r| r.requests.as_ref())
+            .and_then(|r| r.get("storage"));
+
+        let current_size = current_templates
+            .iter()
+            .find(|t| t.metadata.name.as_deref() == Some(desired_name))
+            .and_then(|t| t.spec.as_ref())
+            .and_then(|s| s.resources.as_ref())
+            .and_then(|r| r.requests.as_ref())
+            .and_then(|r| r.get("storage"));
+
+        if desired_size != current_size {
+            return true;
+        }
+    }
+    false
+}
+
+async fn wait_for_sts_deleted(sts_api: &kube::Api<StatefulSet>, name: &str) -> Result<()> {
+    const TIMEOUT_SECS: u64 = 30;
+    const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(TIMEOUT_SECS);
+
+    loop {
+        if sts_api.get_opt(name).await?.is_none() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(Error::Timeout(format!(
+                "StatefulSet {name} not deleted after {TIMEOUT_SECS}s"
+            )));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::{
+        api::core::v1::{
+            PersistentVolumeClaim, PersistentVolumeClaimSpec, VolumeResourceRequirements,
+        },
+        apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
+    };
+    use std::collections::BTreeMap;
+
+    fn make_pvc(name: &str, storage: &str) -> PersistentVolumeClaim {
+        let mut requests = BTreeMap::new();
+        requests.insert("storage".to_string(), Quantity(storage.to_string()));
+        PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                ..Default::default()
+            },
+            spec: Some(PersistentVolumeClaimSpec {
+                resources: Some(VolumeResourceRequirements {
+                    requests: Some(requests),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn make_sts(pvcs: Vec<PersistentVolumeClaim>) -> StatefulSet {
+        use k8s_openapi::api::apps::v1::StatefulSetSpec;
+        StatefulSet {
+            spec: Some(StatefulSetSpec {
+                volume_claim_templates: Some(pvcs),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_volume_claim_templates_differ() {
+        let a = make_sts(vec![make_pvc("data", "10Gi")]);
+        let b = make_sts(vec![make_pvc("data", "10Gi")]);
+        assert!(!volume_claim_templates_differ(&a, &b));
+
+        let current = make_sts(vec![make_pvc("data", "10Gi")]);
+        let desired = make_sts(vec![make_pvc("data", "20Gi")]);
+        assert!(volume_claim_templates_differ(&current, &desired));
+
+        let current = make_sts(vec![make_pvc("data", "20Gi")]);
+        let desired = make_sts(vec![make_pvc("data", "10Gi")]);
+        assert!(volume_claim_templates_differ(&current, &desired));
+
+        let current = make_sts(vec![make_pvc("data", "10Gi")]);
+        let desired = make_sts(vec![make_pvc("data", "10Gi"), make_pvc("logs", "5Gi")]);
+        assert!(volume_claim_templates_differ(&current, &desired));
+
+        let current = make_sts(vec![make_pvc("data", "10Gi"), make_pvc("logs", "5Gi")]);
+        let desired = make_sts(vec![make_pvc("data", "10Gi")]);
+        assert!(!volume_claim_templates_differ(&current, &desired));
+
+        let empty = make_sts(vec![]);
+        assert!(!volume_claim_templates_differ(&empty, &empty));
+    }
 }

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -13,10 +13,11 @@ use k8s_openapi::{
         api::resource::Quantity, apis::meta::v1::LabelSelector, util::intstr::IntOrString,
     },
 };
-use kube::{Resource, ResourceExt, core::ObjectMeta};
+use kube::{Resource, api::Patch, core::ObjectMeta};
 
 use crate::{
-    crd::{DiomCluster, DiomClusterSpec, INTRACLUSTER_PORT},
+    context::ClusterCtx,
+    crd::{DiomClusterSpec, INTRACLUSTER_PORT},
     error::Result,
     labels,
     resources::services,
@@ -34,17 +35,25 @@ const LOGS_DATA_PATH: &str = "/data/logs";
 /// Path inside the container for Raft snapshots (when a separate volume is configured).
 const SNAPSHOTS_DATA_PATH: &str = "/data/snapshots";
 
-pub(crate) fn build(cluster: &DiomCluster, ns: &str) -> Result<StatefulSet> {
-    let cluster_name = cluster.name_any();
-    let spec = &cluster.spec;
-    let headless_svc = services::headless_name(&cluster_name);
+pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
+    let sts = build(ctx)?;
+    ctx.sts_api()
+        .patch(&ctx.name, &ctx.pp(), &Patch::Apply(&sts))
+        .await?;
+    Ok(())
+}
 
-    let env = build_env(spec, &cluster_name, &headless_svc, ns);
+fn build(ctx: &ClusterCtx) -> Result<StatefulSet> {
+    let cluster_name = &ctx.name;
+    let spec = &ctx.cluster.spec;
+    let headless_svc = services::headless_name(cluster_name);
+
+    let env = build_env(spec, cluster_name, &headless_svc, &ctx.ns);
     let volume_claim_templates = build_volume_claim_templates(spec);
     let volume_mounts = build_volume_mounts(spec);
     let container = build_container(spec, env, volume_mounts);
 
-    let pod_labels = labels::general_labels(&cluster_name);
+    let pod_labels = labels::general_labels(cluster_name);
     let pod_annotations = spec.pod_annotations.clone();
 
     let pod_spec = PodSpec {
@@ -66,16 +75,16 @@ pub(crate) fn build(cluster: &DiomCluster, ns: &str) -> Result<StatefulSet> {
     Ok(StatefulSet {
         metadata: ObjectMeta {
             name: Some(cluster_name.clone()),
-            namespace: Some(ns.into()),
-            labels: Some(labels::general_labels(&cluster_name)),
-            owner_references: Some(vec![cluster.controller_owner_ref(&()).unwrap()]),
+            namespace: Some(ctx.ns.clone()),
+            labels: Some(labels::general_labels(cluster_name)),
+            owner_references: Some(vec![ctx.cluster.controller_owner_ref(&()).unwrap()]),
             ..Default::default()
         },
         spec: Some(StatefulSetSpec {
             replicas: Some(spec.diom.replicas),
             service_name: Some(headless_svc),
             selector: LabelSelector {
-                match_labels: Some(labels::selector(&cluster_name)),
+                match_labels: Some(labels::selector(cluster_name)),
                 ..Default::default()
             },
             template: PodTemplateSpec {
@@ -107,18 +116,14 @@ fn build_env(
 
     // These must come before any vars that reference them via $(VAR) substitution.
     let mut env: Vec<EnvVar> = vec![
-        // Downward API: pod name and namespace, used to construct stable DNS addresses.
         env_from_field("POD_NAME", "metadata.name"),
         env_from_field("POD_NAMESPACE", "metadata.namespace"),
-        // Each pod advertises its stable StatefulSet DNS name so peers can reach it.
-        // Uses k8s env var substitution: $(VAR) references earlier vars in this list.
         env_var(
             "DIOM_CLUSTER_ADVERTISED_ADDRESS",
             format!(
                 "$(POD_NAME).{headless_svc}.$(POD_NAMESPACE).svc.cluster.local:{intracluster_port}"
             ),
         ),
-        // Seed nodes: all pods in the StatefulSet by their stable DNS names.
         env_var(
             "DIOM_CLUSTER_SEED_NODES",
             seed_nodes_value(
@@ -129,16 +134,11 @@ fn build_env(
                 intracluster_port,
             ),
         ),
-        // Allow any pod to initialize a new cluster if it can't find peers and has no state.
-        // StatefulSets start pods sequentially (pod-0 first), so in practice pod-0 initializes
-        // first. Setting this on all pods ensures the cluster can still form if pod-0 restarts.
         env_var("DIOM_CLUSTER_AUTO_INITIALIZE", "true"),
         env_var(
             "DIOM_LISTEN_ADDRESS",
             format!("0.0.0.0:{}", spec.diom.api_port),
         ),
-        // This variable is only used by the CLI, but allows the CLI to talk to the local server
-        // without any special configuration
         env_var(
             "DIOM_SERVER_URL",
             format!("http://localhost:{}", spec.diom.api_port),
@@ -329,8 +329,6 @@ fn build_volume_mounts(spec: &DiomClusterSpec) -> Vec<VolumeMount> {
 
     mounts
 }
-
-// --- Helpers ---
 
 fn env_var(name: &str, value: impl Into<String>) -> EnvVar {
     EnvVar {


### PR DESCRIPTION
The first commit is primarily just re-factoring to try and make 
the code more readable, with some better handling for status
reporting.

The second commit actually adds the resize logic:
* Detect updates to storage size and if applicable / supported by
  the underlying storage, directly resize the PVCs. Afterward,
  orphan/delete/re-create the stateful set so that it reflects the
  updated values.

  This currently does _not_ support restarting pods for those
  file systems that require a pod restart. The vast majority of
  storage classes support online resizing, though, so I think this
  is good enough for now.

