### PR TITLE
create a new trait for things that get serialized with postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,8 +1611,10 @@ dependencies = [
 name = "diom-core"
 version = "0.1.0"
 dependencies = [
+ "diom-derive",
  "jiff",
  "parking_lot",
+ "pastey",
  "rand 0.10.1",
  "regex",
  "schemars 1.2.1",
@@ -2073,6 +2075,7 @@ dependencies = [
  "anyhow",
  "byteview",
  "criterion",
+ "diom-core",
  "diom-derive",
  "diom-error",
  "diom-id",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
 name = "diom-authorization"
 version = "0.1.0"
 dependencies = [
+ "diom-core",
  "diom-id",
  "itertools 0.14.0",
  "schemars 1.2.1",
@@ -1659,6 +1660,7 @@ version = "0.1.0"
 dependencies = [
  "data-encoding",
  "data-encoding-macro",
+ "diom-core",
  "itertools 0.14.0",
  "jiff",
  "rand 0.10.1",

--- a/crates/auth-token/src/entities.rs
+++ b/crates/auth-token/src/entities.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use diom_core::PersistableValue;
 use diom_error::Result;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -37,7 +38,7 @@ impl TokenPlaintext {
 }
 
 /// A hashed auth token. The inner bytes are never printed to prevent accidental exposure.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PersistableValue)]
 pub struct TokenHashed([u8; 32]);
 
 impl TokenHashed {

--- a/crates/auth-token/src/operations/create.rs
+++ b/crates/auth-token/src/operations/create.rs
@@ -7,7 +7,7 @@ use crate::{
     entities::TokenHashed,
     operations::{AuthTokenRaftState, AuthTokenRequest, CreateResponse},
 };
-use diom_core::types::Metadata;
+use diom_core::{PersistableValue, types::Metadata};
 use diom_error::Result;
 use diom_id::{AuthTokenId, NamespaceId, UuidV7RandomBytes};
 use diom_operations::OpContext;
@@ -16,7 +16,7 @@ pub struct CreateResponseData {
     pub model: AuthTokenModel,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct CreateAuthTokenOperation {
     namespace_id: NamespaceId,
     id_random_bytes: UuidV7RandomBytes,

--- a/crates/auth-token/src/operations/create_namespace.rs
+++ b/crates/auth-token/src/operations/create_namespace.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::operations::{AuthTokenRaftState, AuthTokenRequest, CreateNamespaceResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct CreateAuthTokenNamespaceOperation {
     pub(crate) name: NamespaceName,
     id_random_bytes: UuidV7RandomBytes,

--- a/crates/auth-token/src/operations/delete.rs
+++ b/crates/auth-token/src/operations/delete.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -12,7 +13,7 @@ pub struct DeleteResponseData {
     pub success: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct DeleteAuthTokenOperation {
     namespace_id: NamespaceId,
     pub id: AuthTokenId,

--- a/crates/auth-token/src/operations/expire.rs
+++ b/crates/auth-token/src/operations/expire.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +16,7 @@ pub struct ExpireResponseData {
     pub model: Option<AuthTokenModel>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct ExpireAuthTokenOperation {
     namespace_id: NamespaceId,
     pub id: AuthTokenId,

--- a/crates/auth-token/src/operations/rotate.rs
+++ b/crates/auth-token/src/operations/rotate.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -16,7 +17,7 @@ pub struct RotateResponseData {
     pub model: Option<AuthTokenModel>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct RotateAuthTokenOperation {
     namespace_id: NamespaceId,
     old_id: AuthTokenId,

--- a/crates/auth-token/src/operations/update.rs
+++ b/crates/auth-token/src/operations/update.rs
@@ -6,7 +6,7 @@ use crate::{
     controller::{AuthTokenModel, PartialUpdateInput},
     operations::{AuthTokenRaftState, AuthTokenRequest, UpdateResponse},
 };
-use diom_core::types::Metadata;
+use diom_core::{PersistableValue, types::Metadata};
 use diom_error::Result;
 use diom_id::{AuthTokenId, NamespaceId};
 use diom_operations::OpContext;
@@ -16,7 +16,7 @@ pub struct UpdateResponseData {
     pub model: Option<AuthTokenModel>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct UpdateAuthTokenOperation {
     namespace_id: NamespaceId,
     pub id: AuthTokenId,

--- a/crates/auth-token/src/tables.rs
+++ b/crates/auth-token/src/tables.rs
@@ -1,5 +1,5 @@
 use crate::entities::TokenHashed;
-use diom_core::types::Metadata;
+use diom_core::{PersistableValue, types::Metadata};
 use diom_error::Result;
 use diom_id::{AuthTokenId, NamespaceId};
 use fjall_utils::{TableKey, TableRow, WriteBatchExt};
@@ -15,7 +15,7 @@ enum RowType {
 }
 
 /// Primary row. Keyed by (namespace_id, token_hashed) — the hot verify path.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct AuthTokenRow {
     pub id: AuthTokenId,
     pub name: String,
@@ -44,7 +44,7 @@ impl AuthTokenRow {
 }
 
 /// Secondary index: maps (namespace_id, id) → token_hashed for ID-based lookups.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PersistableValue)]
 pub struct IdIndexRow {
     pub token_hashed: TokenHashed,
 }
@@ -70,7 +70,7 @@ impl IdIndexRow {
 
 /// Secondary index: keyed by (namespace_id, owner_id, token_hashed) for owner listing.
 /// Prefix-scan on (namespace_id, owner_id) to list all tokens for an owner.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct OwnerIndexRow {}
 
 impl TableRow for OwnerIndexRow {

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::operations::{CacheRaftState, CacheRequest, CreateCacheResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct CreateCacheOperation {
     pub(crate) name: NamespaceName,
     eviction_policy: EvictionPolicy,

--- a/crates/cache/src/operations/delete.rs
+++ b/crates/cache/src/operations/delete.rs
@@ -1,5 +1,6 @@
 use super::{CacheRaftState, CacheRequest, DeleteResponse};
 use crate::CacheNamespace;
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::NamespaceId;
 use diom_operations::OpContext;
@@ -10,7 +11,7 @@ pub struct DeleteResponseData {
     pub success: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct DeleteOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -1,6 +1,9 @@
 use super::{CacheRaftState, CacheRequest, SetResponse};
 use crate::CacheNamespace;
-use diom_core::types::{ByteString, DurationMs};
+use diom_core::{
+    PersistableValue,
+    types::{ByteString, DurationMs},
+};
 use diom_error::Result;
 use diom_id::NamespaceId;
 use diom_kv::kvcontroller::{KvModelIn, OperationBehavior};
@@ -8,7 +11,7 @@ use diom_operations::OpContext;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct SetOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,

--- a/crates/diom-admin-auth/src/operations/delete_policy.rs
+++ b/crates/diom-admin-auth/src/operations/delete_policy.rs
@@ -1,4 +1,5 @@
 use diom_authorization::AccessPolicyId;
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_operations::OpContext;
 use serde::{Deserialize, Serialize};
@@ -13,7 +14,7 @@ pub struct DeleteAccessPolicyResponseData {
     pub success: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct DeleteAccessPolicyOperation {
     pub id: AccessPolicyId,
 }

--- a/crates/diom-admin-auth/src/operations/delete_role.rs
+++ b/crates/diom-admin-auth/src/operations/delete_role.rs
@@ -1,4 +1,5 @@
 use diom_authorization::RoleId;
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_operations::OpContext;
 use serde::{Deserialize, Serialize};
@@ -13,7 +14,7 @@ pub struct DeleteRoleResponseData {
     pub success: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct DeleteRoleOperation {
     pub id: RoleId,
 }

--- a/crates/diom-admin-auth/src/operations/upsert_policy.rs
+++ b/crates/diom-admin-auth/src/operations/upsert_policy.rs
@@ -1,4 +1,5 @@
 use diom_authorization::{AccessPolicyId, AccessRule};
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_operations::OpContext;
 use jiff::Timestamp;
@@ -15,7 +16,7 @@ pub struct UpsertAccessPolicyResponseData {
     pub model: AccessPolicyModel,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct UpsertAccessPolicyOperation {
     pub id: AccessPolicyId,
     pub description: String,

--- a/crates/diom-admin-auth/src/operations/upsert_role.rs
+++ b/crates/diom-admin-auth/src/operations/upsert_role.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use diom_authorization::{AccessPolicyId, AccessRule, RoleId};
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_operations::OpContext;
 use jiff::Timestamp;
@@ -17,7 +18,7 @@ pub struct UpsertRoleResponseData {
     pub model: RoleModel,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct UpsertRoleOperation {
     pub id: RoleId,
     pub description: String,

--- a/crates/diom-admin-auth/src/tables.rs
+++ b/crates/diom-admin-auth/src/tables.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use diom_authorization::{AccessPolicyId, AccessRule, RoleId};
+use diom_core::PersistableValue;
 use diom_error::{Result, ResultExt as _};
 use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
@@ -14,7 +15,7 @@ enum RowType {
 }
 
 /// Primary row for a Role, keyed by `[ROW_TYPE][role_id_bytes]`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct RoleRow {
     // FIXME: remove the id from this, we don't want it serialized.
     pub id: RoleId,
@@ -37,7 +38,7 @@ impl RoleRow {
 }
 
 /// Primary row for an AccessPolicy, keyed by `[ROW_TYPE][policy_id_bytes]`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct AccessPolicyRow {
     pub description: String,
     pub rules: Vec<AccessRule>,

--- a/crates/diom-authorization/Cargo.toml
+++ b/crates/diom-authorization/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+diom-core.workspace = true
 diom-id.workspace = true
 itertools.workspace = true
 schemars.workspace = true

--- a/crates/diom-authorization/src/lib.rs
+++ b/crates/diom-authorization/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
+use diom_core::PersistableValue;
 use diom_id::{AuthTokenId, Module};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -16,7 +17,7 @@ pub use self::{
     verification::{Forbidden, verify_operation},
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 #[serde(transparent)]
 pub struct RoleId(pub String);
 
@@ -47,7 +48,7 @@ impl fmt::Display for RoleId {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 #[serde(transparent)]
 pub struct AccessPolicyId(pub String);
 
@@ -82,7 +83,7 @@ pub struct AccessPolicy {
     pub rules: Vec<AccessRule>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 pub struct AccessRule {
     pub effect: AccessRuleEffect,
     pub resource: ResourcePattern,
@@ -147,7 +148,7 @@ impl AccessRule {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 #[serde(rename_all = "snake_case")]
 pub enum AccessRuleEffect {
     Allow,

--- a/crates/diom-authorization/src/pattern.rs
+++ b/crates/diom-authorization/src/pattern.rs
@@ -4,6 +4,7 @@ use std::{
     str::FromStr,
 };
 
+use diom_core::PersistableValue;
 use diom_id::Module;
 use itertools::Itertools;
 use schemars::JsonSchema;
@@ -11,7 +12,7 @@ use serde::{Deserialize, Serialize, de};
 
 use crate::RequestedOperation;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PersistableValue)]
 pub struct ResourcePattern {
     pub module: ModulePattern,
     pub namespace: NamespacePattern,
@@ -32,7 +33,7 @@ impl JsonSchema for ResourcePattern {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PersistableValue)]
 pub enum ModulePattern {
     /// Wildcard (`*`).
     ///
@@ -41,7 +42,7 @@ pub enum ModulePattern {
     Exactly(Module),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PersistableValue)]
 pub enum NamespacePattern {
     Default,
     Named(String),
@@ -49,7 +50,7 @@ pub enum NamespacePattern {
     // FIXME: Do namespaces have any sort of hierarchy?
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PersistableValue)]
 pub struct KeyPattern {
     pub segments: Vec<KeyPatternSegment>,
     /// Whether the pattern has a trailing `*` segment.
@@ -58,7 +59,7 @@ pub struct KeyPattern {
     pub trailing_any: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PersistableValue)]
 pub enum KeyPatternSegment {
     Fixed(String),
     Placeholder(String),

--- a/crates/diom-core/Cargo.toml
+++ b/crates/diom-core/Cargo.toml
@@ -7,8 +7,10 @@ rust-version.workspace = true
 edition = "2024"
 
 [dependencies]
+diom-derive.workspace = true
 jiff.workspace = true
 parking_lot.workspace = true
+pastey.workspace = true
 rand.workspace = true
 regex.workspace = true
 schemars.workspace = true

--- a/crates/diom-core/src/lib.rs
+++ b/crates/diom-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod backoff;
 pub mod fifo_cache;
 pub mod instrumented_mutex;
 mod monotime;
+pub mod persistable_value;
 pub mod shutdown;
 pub mod task;
 pub mod types;
@@ -20,3 +21,6 @@ pub mod __reexport {
     pub use serde_json;
     pub use validator;
 }
+
+pub use diom_derive::PersistableValue;
+pub use persistable_value::PersistableValue;

--- a/crates/diom-core/src/persistable_value.rs
+++ b/crates/diom-core/src/persistable_value.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    num::NonZeroU64,
+    num::{NonZeroU16, NonZeroU32, NonZeroU64},
 };
 
 /// Marker trait for whether something can be
@@ -28,6 +28,8 @@ impl PersistableValue for i32 {}
 impl PersistableValue for i64 {}
 impl PersistableValue for i128 {}
 // TODO: use std::num::NonZero<T> when stabilized
+impl PersistableValue for NonZeroU16 {}
+impl PersistableValue for NonZeroU32 {}
 impl PersistableValue for NonZeroU64 {}
 impl PersistableValue for String {}
 impl PersistableValue for &str {}

--- a/crates/diom-core/src/persistable_value.rs
+++ b/crates/diom-core/src/persistable_value.rs
@@ -1,0 +1,86 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    num::NonZeroU64,
+};
+
+/// Marker trait for whether something can be
+/// safely represented in fjall.
+///
+/// # Safety
+///
+/// Implementers must guarantee the following:
+///
+/// 1. The serde implementation for this object doesn't do #[serde(skip_serializing_if)] or #[serde(flatten)]
+///  2. The serialization of this object is stable across version
+///
+/// Generally, you should prefer to use the `PersistableValue` derive to implement this safely.
+pub trait PersistableValue {}
+
+impl PersistableValue for bool {}
+impl PersistableValue for u8 {}
+impl PersistableValue for u16 {}
+impl PersistableValue for u32 {}
+impl PersistableValue for u64 {}
+impl PersistableValue for u128 {}
+impl PersistableValue for i8 {}
+impl PersistableValue for i16 {}
+impl PersistableValue for i32 {}
+impl PersistableValue for i64 {}
+impl PersistableValue for i128 {}
+// TODO: use std::num::NonZero<T> when stabilized
+impl PersistableValue for NonZeroU64 {}
+impl PersistableValue for String {}
+impl PersistableValue for &str {}
+impl PersistableValue for &[u8] {}
+impl PersistableValue for uuid::Uuid {}
+// TODO: do we want to serialize jiff timestamps raw?
+impl PersistableValue for jiff::Timestamp {}
+impl PersistableValue for crate::types::ByteString {}
+impl PersistableValue for crate::types::DurationMs {}
+impl PersistableValue for crate::types::UnixTimestampMs {}
+impl PersistableValue for crate::types::Metadata {}
+
+impl<T: PersistableValue> PersistableValue for Option<T> {}
+impl<T: PersistableValue> PersistableValue for Vec<T> {}
+impl<T: PersistableValue> PersistableValue for HashSet<T> {}
+impl<T: PersistableValue> PersistableValue for BTreeSet<T> {}
+impl<K: PersistableValue, T: PersistableValue> PersistableValue for HashMap<K, T> {}
+impl<K: PersistableValue, T: PersistableValue> PersistableValue for BTreeMap<K, T> {}
+
+impl<const N: usize, T: PersistableValue> PersistableValue for [T; N] {}
+
+impl PersistableValue for () {}
+
+macro_rules! impl_persistable_value_for_tuple {
+    ( $( $N:literal )+ ) => {
+        pastey::paste! {
+            impl<$([< T $N >],)+> PersistableValue for ($([< T $N >],)+)
+                where $([< T $N >]: PersistableValue,)+ {}
+        }
+    };
+}
+
+impl_persistable_value_for_tuple! { 0 }
+impl_persistable_value_for_tuple! { 0 1 }
+impl_persistable_value_for_tuple! { 0 1 2 }
+impl_persistable_value_for_tuple! { 0 1 2 3 }
+impl_persistable_value_for_tuple! { 0 1 2 3 4 }
+impl_persistable_value_for_tuple! { 0 1 2 3 4 5 }
+impl_persistable_value_for_tuple! { 0 1 2 3 4 5 6 }
+impl_persistable_value_for_tuple! { 0 1 2 3 4 5 6 7 }
+impl_persistable_value_for_tuple! { 0 1 2 3 4 5 6 7 8 }
+impl_persistable_value_for_tuple! { 0 1 2 3 4 5 6 7 8 9 }
+impl_persistable_value_for_tuple! { 0 1 2 3 4 5 6 7 8 9 10 }
+impl_persistable_value_for_tuple! { 0 1 2 3 4 5 6 7 8 9 10 11 }
+
+/// Helper trait for making sure that composite structures (structs and enums) implement
+/// PersistableValue for all of their fields.
+///
+/// # Safety
+///
+/// This should only be implemented via the PersistableValue derive
+pub trait PersistableStruct {
+    type INNER: PersistableValue;
+}
+
+impl<F: PersistableStruct> PersistableValue for F {}

--- a/crates/diom-core/src/types/mod.rs
+++ b/crates/diom-core/src/types/mod.rs
@@ -84,6 +84,8 @@ macro_rules! string_wrapper {
         #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
         pub struct $name_id(pub String);
 
+        impl $crate::PersistableValue for $name_id {}
+
         impl $crate::types::StringWrapper for $name_id {
             const INFO: $crate::types::StringSchema = $crate::types::StringSchema {
                 $($init)*

--- a/crates/diom-derive/src/lib.rs
+++ b/crates/diom-derive/src/lib.rs
@@ -4,9 +4,13 @@ use syn::{DeriveInput, ItemFn, parse_macro_input};
 mod aide;
 mod dumpable_config;
 mod env_overridable;
+mod persistable_value;
 mod utils;
 
-use crate::{dumpable_config::derive_dumpable_config, env_overridable::derive_env_overridable};
+use crate::{
+    dumpable_config::derive_dumpable_config, env_overridable::derive_env_overridable,
+    persistable_value::derive_persistable_value,
+};
 use utils::add_trait_bounds;
 mod fjall_key;
 mod key_component;
@@ -99,4 +103,10 @@ pub fn macro_derive_env_overridable(input: proc_macro::TokenStream) -> proc_macr
 pub fn macro_derive_dumpable_config(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     derive_dumpable_config(input).into()
+}
+
+#[proc_macro_derive(PersistableValue)]
+pub fn macro_derive_persistable_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    derive_persistable_value(input).into()
 }

--- a/crates/diom-derive/src/persistable_value.rs
+++ b/crates/diom-derive/src/persistable_value.rs
@@ -1,0 +1,120 @@
+use quote::quote;
+use syn::{Attribute, DataEnum, DataStruct, DeriveInput, Field, LitStr, Token};
+
+fn check_serde_container_attrs(attrs: &[Attribute]) -> Result<(), syn::Error> {
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            for ident in ["untagged", "tag", "default"] {
+                if meta.path.is_ident(ident) {
+                    return Err(
+                        meta.error(format!("{ident} is unsafe on persistable value containers"))
+                    );
+                }
+            }
+            // chomp any argument
+            if meta.input.peek(Token![=]) {
+                meta.value()?;
+                let _: LitStr = meta.input.parse()?;
+            }
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+fn check_serde_field_attrs(field: &Field) -> Result<(), syn::Error> {
+    for attr in &field.attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            for ident in ["skip_serializing_if", "alias", "flatten"] {
+                if meta.path.is_ident(ident) {
+                    return Err(
+                        meta.error(format!("{ident} is unsafe on persistable value fields"))
+                    );
+                }
+            }
+            // chomp any argument
+            if meta.input.peek(Token![=]) {
+                meta.value()?;
+                let _: LitStr = meta.input.parse()?;
+            }
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+fn parse_struct(
+    obj: &DataStruct,
+    input: &DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut inner = Vec::with_capacity(obj.fields.len());
+
+    check_serde_container_attrs(&input.attrs)?;
+
+    for field in &obj.fields {
+        check_serde_field_attrs(field)?;
+
+        let ty = &field.ty;
+        inner.push(quote! { #ty });
+    }
+
+    let ident = &input.ident;
+
+    Ok(quote! {
+        #[allow(unsafe_code)]
+        impl #impl_generics diom_core::persistable_value::PersistableStruct for #ident #ty_generics #where_clause {
+            type INNER = ( #(#inner,)* );
+        }
+    })
+}
+
+fn parse_enum(obj: &DataEnum, input: &DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut inner = Vec::with_capacity(obj.variants.len());
+
+    check_serde_container_attrs(&input.attrs)?;
+
+    for variant in obj.variants.iter() {
+        for field in &variant.fields {
+            let ty = &field.ty;
+
+            check_serde_field_attrs(field)?;
+
+            inner.push(quote! { #ty });
+        }
+    }
+
+    let ident = &input.ident;
+
+    Ok(quote! {
+        #[allow(unsafe_code)]
+        impl #impl_generics diom_core::persistable_value::PersistableStruct for #ident #ty_generics #where_clause {
+            type INNER = ( #(#inner,)* );
+        }
+    })
+}
+
+pub(crate) fn derive_persistable_value(input: DeriveInput) -> proc_macro2::TokenStream {
+    let expanded = match &input.data {
+        syn::Data::Enum(obj) => parse_enum(obj, &input),
+        syn::Data::Struct(obj) => parse_struct(obj, &input),
+        _ => {
+            return quote! { compile_error!("This macro may only be applied to structs and enums") };
+        }
+    };
+
+    // Hand the output tokens back to the compiler.
+    match expanded {
+        Ok(expanded) => expanded,
+        Err(e) => e.to_compile_error(),
+    }
+}

--- a/crates/diom-id/Cargo.toml
+++ b/crates/diom-id/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [dependencies]
 data-encoding = "2.10.0"
 data-encoding-macro = "0.1.19"
+diom-core.workspace = true
 jiff.workspace = true
 rand.workspace = true
 schemars.workspace = true

--- a/crates/diom-id/src/lib.rs
+++ b/crates/diom-id/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{fmt, marker::PhantomData};
 
+use diom_core::PersistableValue;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use uuid::{Builder, Uuid};
@@ -17,7 +18,7 @@ pub use self::{
 
 const V7_RANDOM_BYTES_LEN: usize = 10;
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PersistableValue)]
 #[serde(transparent)]
 pub struct UuidV7RandomBytes([u8; V7_RANDOM_BYTES_LEN]);
 
@@ -120,7 +121,7 @@ impl<'de, M: IdMarker> Deserialize<'de> for Id<M> {
 }
 
 // we promise to keep the serialization of Id stable
-impl<M: IdMarker> diom_core::persistable_value::PersistableValue for Id<M> {}
+impl<M: IdMarker> PersistableValue for Id<M> {}
 
 // DO NOT implement JsonSchema for Id<M> (Public<Id<M>> should be used)
 

--- a/crates/diom-id/src/lib.rs
+++ b/crates/diom-id/src/lib.rs
@@ -119,6 +119,9 @@ impl<'de, M: IdMarker> Deserialize<'de> for Id<M> {
     }
 }
 
+// we promise to keep the serialization of Id stable
+impl<M: IdMarker> diom_core::persistable_value::PersistableValue for Id<M> {}
+
 // DO NOT implement JsonSchema for Id<M> (Public<Id<M>> should be used)
 
 #[cfg(test)]

--- a/crates/diom-id/src/module.rs
+++ b/crates/diom-id/src/module.rs
@@ -1,6 +1,7 @@
+use diom_core::PersistableValue;
 use std::{fmt, str::FromStr};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PersistableValue)]
 pub enum Module {
     Cache = 1,
     Idempotency = 2,

--- a/crates/diom-id/src/public.rs
+++ b/crates/diom-id/src/public.rs
@@ -48,6 +48,9 @@ impl<'de, M: PublicIdMarker> Deserialize<'de> for Public<Id<M>> {
     }
 }
 
+// we promise to keep the serialization of Public stable
+impl<M: PublicIdMarker> diom_core::persistable_value::PersistableValue for Public<M> {}
+
 impl<M: PublicIdMarker> JsonSchema for Public<Id<M>> {
     fn schema_name() -> std::borrow::Cow<'static, str> {
         format!("Id<{}>", std::any::type_name::<M>()).into()

--- a/crates/diom-namespace/src/entities.rs
+++ b/crates/diom-namespace/src/entities.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, num::NonZeroU64};
 
-use diom_core::{string_wrapper, types::DurationMs};
+use diom_core::{PersistableValue, string_wrapper, types::DurationMs};
 use diom_id::Module;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -12,7 +12,9 @@ string_wrapper!(NamespaceName {
     example: "some_namespace"
 });
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema, PersistableValue,
+)]
 #[serde(rename_all = "kebab-case")]
 pub enum EvictionPolicy {
     #[default]
@@ -20,12 +22,12 @@ pub enum EvictionPolicy {
 }
 
 pub trait ModuleConfig:
-    Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync
+    Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync + PersistableValue
 {
     fn module() -> Module;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 pub struct KeyValueConfig {}
 
 impl KeyValueConfig {
@@ -38,7 +40,7 @@ impl ModuleConfig for KeyValueConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 pub struct CacheConfig {
     pub eviction_policy: EvictionPolicy,
 }
@@ -53,7 +55,7 @@ impl ModuleConfig for CacheConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, PersistableValue)]
 pub struct MsgsConfig {
     pub retention_period: Option<DurationMs>,
     pub retention_bytes: Option<NonZeroU64>,
@@ -65,7 +67,7 @@ impl ModuleConfig for MsgsConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 pub struct RateLimitConfig {}
 
 impl ModuleConfig for RateLimitConfig {
@@ -74,7 +76,7 @@ impl ModuleConfig for RateLimitConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 pub struct IdempotencyConfig {}
 
 impl ModuleConfig for IdempotencyConfig {
@@ -87,7 +89,7 @@ impl IdempotencyConfig {
     pub const NAMESPACE: &'static str = "idempotency_store";
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
 pub struct AuthTokenConfig {}
 
 impl AuthTokenConfig {

--- a/crates/diom-namespace/src/tables.rs
+++ b/crates/diom-namespace/src/tables.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::NamespaceId;
 use fjall::Keyspace;
@@ -13,7 +14,7 @@ enum RowType {
     Namespace = 0,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PersistableValue)]
 #[serde(bound = "C: ModuleConfig")]
 pub struct Namespace<C: ModuleConfig> {
     pub id: NamespaceId,

--- a/crates/diom-operations/src/lib.rs
+++ b/crates/diom-operations/src/lib.rs
@@ -93,6 +93,7 @@ impl<T, M: ModuleRequest> OperationWriter<M> for T where
 /// Macro support module
 #[doc(hidden)]
 pub mod __reexports {
+    pub use diom_core;
     pub use diom_error;
     pub use pastey;
     pub use serde;

--- a/crates/diom-operations/src/macros.rs
+++ b/crates/diom-operations/src/macros.rs
@@ -59,6 +59,7 @@ macro_rules! raft_module_operations {
                 Clone,
                 $crate::__reexports::serde::Serialize,
                 $crate::__reexports::serde::Deserialize,
+                $crate::__reexports::diom_core::PersistableValue
             )]
             #[serde(crate = "diom_operations::__reexports::serde")]
             pub enum $module_op_name {

--- a/crates/fjall-utils/Cargo.toml
+++ b/crates/fjall-utils/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 [dependencies]
 anyhow.workspace = true
 byteview.workspace = true
+diom-core.workspace = true
 diom-derive.workspace = true
 diom-error.workspace = true
 diom-id.workspace = true

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -11,7 +11,9 @@ use tap::Pipe;
 /// A trait for types that can be stored as rows in a fjall keyspace.
 ///
 /// This is useful for having logical "tables" within the same keyspace.
-pub trait TableRow: Sized + Serialize + DeserializeOwned {
+pub trait TableRow:
+    Sized + Serialize + DeserializeOwned + diom_core::persistable_value::PersistableValue
+{
     // FIXME: can probably get rid of this, and encode it in the type system.
     const ROW_TYPE: u8;
 

--- a/crates/idempotency/src/operations/abort.rs
+++ b/crates/idempotency/src/operations/abort.rs
@@ -1,10 +1,11 @@
 use super::{AbortResponse, IdempotencyRaftState, IdempotencyRequest};
 use crate::IdempotencyNamespace;
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::NamespaceId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct AbortOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -1,13 +1,16 @@
 use super::{CompleteResponse, IdempotencyRaftState, IdempotencyRequest};
 use crate::{IdempotencyNamespace, storage::IdempotencyState};
-use diom_core::types::{ByteString, DurationMs, Metadata};
+use diom_core::{
+    PersistableValue,
+    types::{ByteString, DurationMs, Metadata},
+};
 use diom_error::Result;
 use diom_id::NamespaceId;
 use diom_kv::kvcontroller::{KvModelIn, OperationBehavior};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct CompleteOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::operations::{CreateIdempotencyResponse, IdempotencyRaftState, IdempotencyRequest};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct CreateIdempotencyOperation {
     pub(crate) name: NamespaceName,
     id_random_bytes: UuidV7RandomBytes,

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -1,13 +1,13 @@
 use super::{IdempotencyRaftState, IdempotencyRequest, TryStartResponse};
 use crate::{IdempotencyNamespace, IdempotencyStartResult, storage::IdempotencyState};
-use diom_core::types::DurationMs;
+use diom_core::{PersistableValue, types::DurationMs};
 use diom_error::Result;
 use diom_id::NamespaceId;
 use diom_kv::kvcontroller::{KvModelIn, OperationBehavior};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct TryStartOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,

--- a/crates/idempotency/src/storage.rs
+++ b/crates/idempotency/src/storage.rs
@@ -1,7 +1,10 @@
-use diom_core::types::{ByteString, Metadata};
+use diom_core::{
+    PersistableValue,
+    types::{ByteString, Metadata},
+};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, PersistableValue)]
 pub(crate) enum IdempotencyState {
     /// Request is in progress (locked)
     InProgress,

--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use diom_core::{
+    PersistableValue,
     instrumented_mutex::{InstrumentedMutex, InstrumentedMutexGuard},
     task::spawn_blocking_in_current_span,
     types::ByteString,
@@ -18,7 +19,7 @@ use crate::tables::{ExpirationRow, KvPairRow};
 const EXPIRATION_BATCH_SIZE: usize = 1_000;
 const WARN_LONG_LOCK_DURATION: Duration = Duration::from_millis(100);
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema, PersistableValue)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
 pub enum OperationBehavior {

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::operations::{CreateKvResponse, KvRaftState, KvRequest};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct CreateKvOperation {
     pub(crate) name: NamespaceName,
     id_random_bytes: UuidV7RandomBytes,

--- a/crates/kv/src/operations/delete.rs
+++ b/crates/kv/src/operations/delete.rs
@@ -1,6 +1,6 @@
 use super::{DeleteResponse, KvRequest};
 use crate::{KvNamespace, State, operations::KvRaftState};
-use diom_core::types::EntityKey;
+use diom_core::{PersistableValue, types::EntityKey};
 use diom_error::Result;
 use diom_id::NamespaceId;
 use diom_operations::OpContext;
@@ -11,7 +11,7 @@ pub struct DeleteResponseData {
     pub success: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct DeleteOperation {
     namespace_id: NamespaceId,
     pub(crate) key: EntityKey,

--- a/crates/kv/src/operations/set.rs
+++ b/crates/kv/src/operations/set.rs
@@ -5,7 +5,10 @@ use crate::{
 };
 
 use super::{KvRequest, SetResponse};
-use diom_core::types::{ByteString, DurationMs, EntityKey};
+use diom_core::{
+    PersistableValue,
+    types::{ByteString, DurationMs, EntityKey},
+};
 use diom_error::Result;
 use diom_id::NamespaceId;
 use diom_operations::OpContext;
@@ -19,7 +22,7 @@ pub struct SetResponseData {
     pub version: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct SetOperation {
     namespace_id: NamespaceId,
     pub(crate) key: EntityKey,

--- a/crates/kv/src/tables.rs
+++ b/crates/kv/src/tables.rs
@@ -1,4 +1,4 @@
-use diom_core::types::ByteString;
+use diom_core::{PersistableValue, types::ByteString};
 use diom_error::{Result, ResultExt};
 use diom_id::NamespaceId;
 use fjall_utils::{TableKey, TableRow};
@@ -12,7 +12,7 @@ enum RowType {
     Expiration = 1,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PersistableValue)]
 pub struct KvPairRow {
     pub value: ByteString,
     pub expiry: Option<Timestamp>,
@@ -29,7 +29,7 @@ impl KvPairRow {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PersistableValue)]
 pub(crate) struct ExpirationRow {}
 
 impl ExpirationRow {

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, fmt, num::NonZeroU64, ops::Deref, str::FromStr};
 
-use diom_core::types::{ByteString, DurationMs, UnixTimestampMs};
+use diom_core::{
+    PersistableValue,
+    types::{ByteString, DurationMs, UnixTimestampMs},
+};
 use diom_error::Error;
 use fjall_utils::KeyComponent;
 use schemars::JsonSchema;
@@ -57,7 +60,7 @@ impl FromStr for Partition {
 ///
 /// Carries the `namespace` that owns this topic. Serializes as `"namespace:topic"`, or just
 /// `"topic"` when the namespace is the default.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, KeyComponent)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, KeyComponent, PersistableValue)]
 pub struct TopicName(String);
 
 impl TopicName {

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -24,7 +24,18 @@ pub const MAX_PARTITION_COUNT: u16 = 64;
 pub const TOPIC_PARTITION_DELIMITER: &str = "~";
 
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, KeyComponent,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    fjall_utils::KeyComponent,
+    PersistableValue,
 )]
 #[serde(transparent)]
 pub struct Partition(u16);
@@ -129,7 +140,7 @@ impl JsonSchema for TopicName {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PersistableValue)]
 pub struct TopicPartition {
     pub topic: TopicName,
     pub partition: Partition,
@@ -254,7 +265,9 @@ impl JsonSchema for TopicIn {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, KeyComponent)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, KeyComponent, PersistableValue,
+)]
 #[serde(transparent)]
 pub struct MsgsIdempotencyKey([u8; 32]);
 
@@ -300,7 +313,7 @@ fn djb2_hash(data: &[u8]) -> u32 {
 }
 
 /// An opaque message ID that internally encodes `(partition, offset)`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PersistableValue)]
 pub struct MsgId {
     pub partition: Partition,
     pub offset: Offset,
@@ -357,7 +370,9 @@ impl JsonSchema for MsgId {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema, PersistableValue,
+)]
 pub struct MsgIn {
     pub value: ByteString,
     #[serde(default)]
@@ -393,7 +408,9 @@ pub struct QueueMsgOut {
     pub scheduled_at: Option<UnixTimestampMs>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, PersistableValue,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum SeekPosition {
     Earliest,
@@ -404,7 +421,9 @@ pub enum SeekPosition {
 /// A validated consumer group identifier.
 ///
 /// Must be at most 64 bytes and only contain ASCII alphanumeric characters, `_`, `-`, or `.`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, KeyComponent)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, KeyComponent, PersistableValue,
+)]
 #[serde(transparent)]
 pub struct ConsumerGroup(pub(crate) String);
 
@@ -484,7 +503,9 @@ impl JsonSchema for ConsumerGroup {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize, JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize, JsonSchema, PersistableValue,
+)]
 pub struct Retention {
     #[serde(rename = "period_ms")]
     pub period: Option<DurationMs>,

--- a/crates/msgs/src/operations/create_namespace.rs
+++ b/crates/msgs/src/operations/create_namespace.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -10,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::{CreateNamespaceResponse, MsgsRaftState, MsgsRequest};
 use crate::entities::Retention;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct CreateNamespaceOperation {
     pub name: NamespaceName,
     pub retention: Retention,

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use diom_core::{task::spawn_blocking_in_current_span, types::DurationMs};
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span, types::DurationMs};
 use diom_error::{Error, Result};
 use diom_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use fjall::OwnedWriteBatch;
@@ -19,7 +19,7 @@ use crate::{
     tables::{IdempotencyKey, IdempotencyRow, MsgKey, MsgRow, TopicKey, TopicRow},
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct PublishOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/queue/ack.rs
+++ b/crates/msgs/src/operations/queue/ack.rs
@@ -1,4 +1,4 @@
-use diom_core::task::spawn_blocking_in_current_span;
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span};
 use diom_error::{Error, Result};
 use diom_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -15,7 +15,7 @@ use super::{
     receive::compact_cursor,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct QueueAckOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/queue/configure.rs
+++ b/crates/msgs/src/operations/queue/configure.rs
@@ -1,4 +1,4 @@
-use diom_core::task::spawn_blocking_in_current_span;
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span};
 use diom_error::{Error, Result};
 use diom_id::{NamespaceId, UuidV7RandomBytes};
 use fjall_utils::WriteBatchExt;
@@ -13,7 +13,7 @@ use crate::{
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueConfigureResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct QueueConfigureOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/queue/extend_lease.rs
+++ b/crates/msgs/src/operations/queue/extend_lease.rs
@@ -1,4 +1,4 @@
-use diom_core::{task::spawn_blocking_in_current_span, types::DurationMs};
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span, types::DurationMs};
 use diom_error::{Error, Result};
 use diom_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -13,7 +13,7 @@ use crate::{
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueExtendLeaseResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct QueueExtendLeaseOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use diom_core::task::spawn_blocking_in_current_span;
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span};
 use diom_error::{Error, Result};
 use diom_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -18,7 +18,7 @@ use crate::{
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueNackResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct QueueNackOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, num::NonZeroU16};
 
 use diom_core::{
+    PersistableValue,
     task::spawn_blocking_in_current_span,
     types::{ByteString, DurationMs},
 };
@@ -19,7 +20,7 @@ use crate::{
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueReceiveResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct QueueReceiveOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/queue/redrive_dlq.rs
+++ b/crates/msgs/src/operations/queue/redrive_dlq.rs
@@ -1,4 +1,4 @@
-use diom_core::task::spawn_blocking_in_current_span;
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span};
 use diom_error::{Error, Result};
 use diom_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -12,7 +12,7 @@ use crate::{
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueRedriveDlqResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct QueueRedriveDlqOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -1,4 +1,4 @@
-use diom_core::task::spawn_blocking_in_current_span;
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span};
 use diom_error::{Error, Result};
 use diom_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -12,7 +12,7 @@ use crate::{
 
 use super::super::{MsgsRaftState, MsgsRequest, StreamCommitResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct StreamCommitOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicPartition,

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU16;
 
 use diom_core::{
+    PersistableValue,
     task::spawn_blocking_in_current_span,
     types::{ByteString, DurationMs},
 };
@@ -21,7 +22,7 @@ use crate::{
 
 use super::super::{MsgsRaftState, MsgsRequest, StreamReceiveResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct StreamReceiveOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -1,4 +1,4 @@
-use diom_core::task::spawn_blocking_in_current_span;
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span};
 use diom_error::{Error, Result};
 use diom_id::NamespaceId;
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -13,13 +13,13 @@ use crate::{
 
 use super::super::{MsgsRaftState, MsgsRequest, StreamSeekResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub enum SeekTarget {
     Offset(Offset),
     Position(SeekPosition),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct StreamSeekOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -1,4 +1,4 @@
-use diom_core::task::spawn_blocking_in_current_span;
+use diom_core::{PersistableValue, task::spawn_blocking_in_current_span};
 use diom_error::{Error, Result};
 use diom_id::{NamespaceId, UuidV7RandomBytes};
 use fjall_utils::{TableRow, WriteBatchExt};
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{MsgsRaftState, MsgsRequest, TopicConfigureResponse};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct TopicConfigureOperation {
     namespace_id: NamespaceId,
     pub(crate) topic: TopicName,

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -1,4 +1,4 @@
-use diom_core::types::ByteString;
+use diom_core::{PersistableValue, types::ByteString};
 use diom_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use std::collections::HashMap;
 
@@ -19,7 +19,7 @@ enum RowType {
     Idempotency = 5,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PersistableValue)]
 pub(crate) struct TopicRow {
     pub id: TopicId,
     pub name: TopicName,
@@ -74,7 +74,7 @@ impl TopicRow {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PersistableValue)]
 pub(crate) struct StreamLeaseRow {
     pub offset: u64,
     pub expiry: Timestamp,
@@ -116,7 +116,7 @@ pub(crate) struct StreamLeaseKey {
 /// - No row → message was never leased, available
 ///
 /// Rows below the queue cursor are deleted during cursor compaction to prevent unbounded growth.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PersistableValue)]
 pub(crate) struct QueueLeaseRow {
     pub expiry: Timestamp,
     pub dlq: bool,
@@ -216,7 +216,7 @@ pub(crate) struct QueueLeaseKey {
 }
 
 /// Per-consumer-group queue configuration
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PersistableValue)]
 pub(crate) struct QueueConfigRow {
     pub retry_schedule: Vec<u64>,
     pub dlq_topic: Option<TopicName>,

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -246,7 +246,7 @@ pub(crate) struct MsgKey {
     pub(crate) offset: Offset,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PersistableValue)]
 pub(crate) struct MsgRow {
     pub value: ByteString,
     pub headers: HashMap<String, String>,
@@ -309,7 +309,7 @@ impl TableRow for MsgRow {
     const ROW_TYPE: u8 = RowType::Msg as u8;
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PersistableValue)]
 pub(crate) struct IdempotencyRow {
     pub expiry: Timestamp,
 }

--- a/crates/rate-limit/src/algorithms.rs
+++ b/crates/rate-limit/src/algorithms.rs
@@ -1,8 +1,8 @@
-use diom_core::types::DurationMs;
+use diom_core::{PersistableValue, types::DurationMs};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PersistableValue)]
 pub struct TokenBucket {
     /// Token refill rate in tokens per refill interval
     pub refill_rate: u64,

--- a/crates/rate-limit/src/operations/create_namespace.rs
+++ b/crates/rate-limit/src/operations/create_namespace.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{CreateRateLimitResponse, RateLimitRaftState, RateLimitRequest};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct CreateRateLimitOperation {
     pub(crate) name: NamespaceName,
     id_random_bytes: UuidV7RandomBytes,

--- a/crates/rate-limit/src/operations/limit.rs
+++ b/crates/rate-limit/src/operations/limit.rs
@@ -1,13 +1,13 @@
 use super::{LimitResponse, RateLimitRaftState, RateLimitRequest};
 use crate::{RateLimitNamespace, TokenBucket};
-use diom_core::types::DurationMs;
+use diom_core::{PersistableValue, types::DurationMs};
 use diom_error::Result;
 use diom_id::NamespaceId;
 use diom_operations::OpContext;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct LimitOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,

--- a/crates/rate-limit/src/operations/reset.rs
+++ b/crates/rate-limit/src/operations/reset.rs
@@ -1,10 +1,11 @@
 use super::{RateLimitRaftState, RateLimitRequest, ResetResponse};
 use crate::{RateLimitNamespace, TokenBucket};
+use diom_core::PersistableValue;
 use diom_error::Result;
 use diom_id::NamespaceId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct ResetOperation {
     namespace_id: NamespaceId,
     pub(crate) key: String,

--- a/crates/rate-limit/src/tables.rs
+++ b/crates/rate-limit/src/tables.rs
@@ -1,3 +1,4 @@
+use diom_core::PersistableValue;
 use diom_id::NamespaceId;
 use fjall_utils::{TableKey, TableRow};
 use jiff::Timestamp;
@@ -9,7 +10,7 @@ enum RowType {
     TokenBucket = 0,
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, PersistableValue)]
 pub struct TokenBucketRow {
     pub tokens: u64,
     pub last_refill: Timestamp,

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use anyhow::Context;
-use diom_core::Monotime;
+use diom_core::{Monotime, PersistableValue};
 use diom_error::ResultExt;
 use diom_operations::{OperationRequest, OperationRequestMetadata, OperationResponse};
 use fjall_utils::StorageType;
@@ -46,7 +46,7 @@ impl std::error::Error for ResponseParseError {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PersistableValue)]
 pub enum Request {
     ClusterInternal(InternalOperation),
     Kv(diom_kv::operations::KvOperation),

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::Context;
+use diom_derive::PersistableValue;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
 use fjall_utils::{FjallFixedKey, KeyspaceExt, MonotonicTableRow, TableRow, WriteBatchExt};
 use jiff::Timestamp;
@@ -129,6 +130,9 @@ enum RowType {
 #[serde(transparent)]
 struct Log(LogEntry);
 
+// this one right here officer, this is the bad one
+impl diom_core::persistable_value::PersistableValue for Log {}
+
 impl TableRow for Log {
     const ROW_TYPE: u8 = RowType::Log as u8;
 }
@@ -141,7 +145,7 @@ impl MonotonicTableRow for Log {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PersistableValue)]
 struct LogIndex {
     unix_timestamp_ms: u64,
     log_id: u64,

--- a/src/core/cluster/operations/record_log_timestamp.rs
+++ b/src/core/cluster/operations/record_log_timestamp.rs
@@ -1,10 +1,11 @@
 use super::{InternalRequest, RecordLogTimestampResponse as Response};
 use crate::core::cluster::state_machine::Store;
+use diom_core::PersistableValue;
 use diom_error::Error;
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct RecordLogTimestampOperation {}
 
 impl InternalRequest for RecordLogTimestampOperation {

--- a/src/core/cluster/operations/set_cluster_uuid.rs
+++ b/src/core/cluster/operations/set_cluster_uuid.rs
@@ -1,10 +1,11 @@
 use super::{InternalRequest, SetClusterUuidResponse as Response};
 use crate::core::cluster::state_machine::{ClusterId, Store};
+use diom_core::PersistableValue;
 use diom_error::Error;
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct SetClusterUuidOperation(pub ClusterId);
 
 impl InternalRequest for SetClusterUuidOperation {

--- a/src/core/cluster/operations/tick.rs
+++ b/src/core/cluster/operations/tick.rs
@@ -1,8 +1,9 @@
 use super::{InternalRequest, TickResponse as Response};
 use crate::core::cluster::state_machine::Store;
+use diom_core::PersistableValue;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
 pub struct TickOperation {}
 
 impl InternalRequest for TickOperation {

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -12,7 +12,7 @@ use crate::{
     core::metrics::{DbMetrics, DbType},
 };
 use anyhow::Context;
-use diom_core::{Monotime, task::spawn_blocking_in_current_span};
+use diom_core::{Monotime, PersistableValue, task::spawn_blocking_in_current_span};
 use diom_error::CanFailExt;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
 use fjall_utils::{Databases, FjallFixedKey, ReadonlyKeyspace, StorageType};
@@ -47,7 +47,19 @@ fn io_err(e: anyhow::Error) -> std::io::Error {
     std::io::Error::other(e)
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+    PersistableValue,
+)]
 #[serde(transparent)]
 pub struct ClusterId(#[serde(with = "uuid::serde::simple")] Uuid);
 


### PR DESCRIPTION
This turned out to be a lot more work than I thought.

Fixes #926.

## Basic implementation

We create a new trait (`PersistableValue`) representing any primitive that can be safely serialized to the database. We then provide a derive macro for deriving that on a struct which checks that all of the fields are persistable and that the struct doesn't have any unsafe serde attributes (skip_serializing_if, alias, flatten).

We then implement that on every type that (transitively) gets written to fjall, and make the high-level interfaces (TableRow, handle::Request) require it.

## Pending Questions

 - Do we want to ban `serde::with`? There's no real way to figure out the type that it returns from a proc-macro and someone could probably do something untoward in there; imagine something like

```rust
#[derive(Serialize, Deserialize, PersistableValue)]
struct Safe {
  #[serde(with = "make_me_unsafe")]
  innocuous_value: u32
}

#[derive(Serialize, Deserialize)]
struct Unsafe {
  #[serde(skip_serializing_if = "u32::zero")]
  inner
}

mod make_me_unsafe {
  pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Safe, D::Error>
  where
    D: Deserializer<'de>,
  {
    let buf = Unsafe::deserialize(deserializer)?;
    Safe { innocuous_value: buf.inner }
  } 

  pub(crate) fn serialize<S>(safe: Safe, serializer: S) -> Result<S::Ok, S::Error>
where
    S: Serializer,
  {
    Unsafe { inner: safe.innocuous_value }.serialize(serializer)
  }
```

 - Is any of this actually worth the complexity? Would it be easier to just switch from serde to something else like rkyv since we need to annotate every struct anyway?