### PR TITLE
Turn NamespaceName into its own type

### DIFF
--- a/crates/auth-token/src/operations/create_namespace.rs
+++ b/crates/auth-token/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
-    entities::AuthTokenConfig,
+    entities::{AuthTokenConfig, NamespaceName},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 use jiff::Timestamp;
@@ -11,7 +11,7 @@ use crate::operations::{AuthTokenRaftState, AuthTokenRequest, CreateNamespaceRes
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateAuthTokenNamespaceOperation {
-    pub(crate) name: String,
+    pub(crate) name: NamespaceName,
     id_random_bytes: UuidV7RandomBytes,
 }
 
@@ -22,7 +22,7 @@ impl From<CreateAuthTokenNamespaceOperation> for CreateNamespace<AuthTokenConfig
 }
 
 impl CreateAuthTokenNamespaceOperation {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: NamespaceName) -> Self {
         Self {
             name,
             id_random_bytes: UuidV7RandomBytes::new_random(),
@@ -42,7 +42,7 @@ impl CreateAuthTokenNamespaceOperation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateAuthTokenNamespaceResponseData {
-    pub name: String,
+    pub name: NamespaceName,
     pub created: Timestamp,
     pub updated: Timestamp,
 }

--- a/crates/cache/src/operations/create_namespace.rs
+++ b/crates/cache/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
-    entities::{CacheConfig, EvictionPolicy},
+    entities::{CacheConfig, EvictionPolicy, NamespaceName},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 use jiff::Timestamp;
@@ -11,7 +11,7 @@ use crate::operations::{CacheRaftState, CacheRequest, CreateCacheResponse};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateCacheOperation {
-    pub(crate) name: String,
+    pub(crate) name: NamespaceName,
     eviction_policy: EvictionPolicy,
     id_random_bytes: UuidV7RandomBytes,
 }
@@ -29,7 +29,7 @@ impl From<CreateCacheOperation> for CreateNamespace<CacheConfig> {
 }
 
 impl CreateCacheOperation {
-    pub fn new(name: String, eviction_policy: EvictionPolicy) -> Self {
+    pub fn new(name: NamespaceName, eviction_policy: EvictionPolicy) -> Self {
         Self {
             name,
             eviction_policy,
@@ -50,7 +50,7 @@ impl CreateCacheOperation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateCacheResponseData {
-    pub name: String,
+    pub name: NamespaceName,
     pub eviction_policy: EvictionPolicy,
     pub created: Timestamp,
     pub updated: Timestamp,

--- a/crates/diom-core/src/lib.rs
+++ b/crates/diom-core/src/lib.rs
@@ -12,3 +12,8 @@ pub mod validation;
 pub static INSTANCE_ID: LazyLock<String> = LazyLock::new(|| uuid::Uuid::new_v4().to_string());
 
 pub use self::monotime::Monotime;
+
+#[doc(hidden)]
+pub mod __reexport {
+    pub use serde_json;
+}

--- a/crates/diom-core/src/types/mod.rs
+++ b/crates/diom-core/src/types/mod.rs
@@ -79,23 +79,13 @@ pub trait BaseUid: Deref<Target = String> {
     }
 }
 
+#[macro_export]
 macro_rules! string_wrapper {
     ($name_id:ident) => {
         #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
         pub struct $name_id(pub String);
 
-        string_wrapper_impl!($name_id);
-    };
-    ($name_id:ident, $string_schema:expr) => {
-        string_wrapper!($name_id);
-
-        common_jsonschema_impl!($name_id, $string_schema);
-    };
-}
-
-macro_rules! string_wrapper_impl {
-    ($name_id:ident) => {
-        impl Deref for $name_id {
+        impl std::ops::Deref for $name_id {
             type Target = String;
 
             fn deref(&self) -> &Self::Target {
@@ -111,13 +101,49 @@ macro_rules! string_wrapper_impl {
 
         impl std::fmt::Display for $name_id {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                self.0.fmt(f)
+                std::fmt::Display::fmt(&self.0, f)
             }
         }
 
         impl From<String> for $name_id {
             fn from(s: String) -> Self {
                 $name_id(s)
+            }
+        }
+    };
+
+    ($name_id:ident, $string_schema:expr) => {
+        string_wrapper!($name_id);
+
+        impl ::schemars::JsonSchema for $name_id {
+            fn schema_name() -> ::std::borrow::Cow<'static, str> {
+                stringify!($name_id).into()
+            }
+
+            fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                let mut schema = String::json_schema(generator);
+
+                if let Some(obj) = schema.as_object_mut() {
+                    // This is just to help with type hints when the macro is expanded.
+                    let options: $crate::types::StringSchema = $string_schema;
+
+                    if let Some(mut v) = options.string_validation {
+                        obj.extend(::std::mem::take(v.ensure_object()));
+                    }
+
+                    if let Some(example) = options.example {
+                        obj.insert(
+                            "example".to_owned(),
+                            $crate::__reexport::serde_json::Value::String(example),
+                        );
+                    }
+                }
+
+                schema
+            }
+
+            fn inline_schema() -> bool {
+                true
             }
         }
     };
@@ -149,43 +175,6 @@ impl StringSchema {
             example: Some(format!("unique-{prefix}identifier").replace('_', "-")),
         }
     }
-}
-
-/// Macro to generate a [`JsonSchema`] impl for string wrapper types.
-/// * `name_id` is the name of the identifier for which the impl is generated.
-/// * `string_schema` is a [`StringSchema`] to enrich the generated schema with
-///   more information.
-macro_rules! common_jsonschema_impl {
-    ($name_id:ident, $string_schema:expr) => {
-        impl ::schemars::JsonSchema for $name_id {
-            fn schema_name() -> ::std::borrow::Cow<'static, str> {
-                stringify!($name_id).into()
-            }
-
-            fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-                let mut schema = String::json_schema(generator);
-
-                if let Some(obj) = schema.as_object_mut() {
-                    // This is just to help with type hints when the macro is expanded.
-                    let options: $crate::types::StringSchema = $string_schema;
-
-                    if let Some(mut v) = options.string_validation {
-                        obj.extend(::std::mem::take(v.ensure_object()));
-                    }
-
-                    if let Some(example) = options.example {
-                        obj.insert("example".to_owned(), serde_json::Value::String(example));
-                    }
-                }
-
-                schema
-            }
-
-            fn inline_schema() -> bool {
-                true
-            }
-        }
-    };
 }
 
 string_wrapper!(

--- a/crates/diom-namespace/src/entities.rs
+++ b/crates/diom-namespace/src/entities.rs
@@ -1,11 +1,23 @@
 use std::{fmt::Debug, num::NonZeroU64};
 
-use diom_core::types::DurationMs;
+use diom_core::{
+    string_wrapper,
+    types::{DurationMs, StringSchema},
+};
 use diom_id::Module;
-use schemars::JsonSchema;
+use schemars::{JsonSchema, json_schema};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-pub type NamespaceName = String;
+string_wrapper!(
+    NamespaceName,
+    StringSchema {
+        string_validation: Some(json_schema!({
+            "maxLength": 256,
+            "pattern": r"^[a-zA-Z0-9\-/_.=+]+$",
+        })),
+        example: Some("some_namespace".to_string()),
+    }
+);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 pub enum EvictionPolicy {

--- a/crates/diom-namespace/src/lib.rs
+++ b/crates/diom-namespace/src/lib.rs
@@ -1,8 +1,10 @@
+use std::sync::LazyLock;
+
 use diom_error::Result;
 use fjall::{Error, KeyspaceCreateOptions};
 use fjall_utils::Databases;
 
-use crate::entities::ModuleConfig;
+use crate::entities::{ModuleConfig, NamespaceName};
 
 pub mod entities;
 pub mod operations;
@@ -10,12 +12,13 @@ mod tables;
 
 pub use self::tables::Namespace;
 
-pub const DEFAULT_NAMESPACE_NAME: &str = "default";
+pub static DEFAULT_NAMESPACE_NAME: LazyLock<NamespaceName> =
+    LazyLock::new(|| NamespaceName("default".to_owned()));
 
 pub fn parse_namespace(key: &str) -> (Option<&str>, &str) {
     match key.split_once(":") {
         Some((ns, key)) => (
-            if !ns.is_empty() && ns != DEFAULT_NAMESPACE_NAME {
+            if !ns.is_empty() && ns != DEFAULT_NAMESPACE_NAME.as_str() {
                 Some(ns)
             } else {
                 None
@@ -62,10 +65,10 @@ impl State {
     #[tracing::instrument(skip_all, fields(?namespace_name))]
     pub fn fetch_namespace<C: ModuleConfig>(
         &self,
-        namespace_name: Option<&str>,
+        namespace_name: Option<&NamespaceName>,
     ) -> Result<Option<Namespace<C>>> {
         if let Some(ns) = namespace_name
-            && ns == DEFAULT_NAMESPACE_NAME
+            && *ns == *DEFAULT_NAMESPACE_NAME
         {
             return Err(diom_error::Error::bad_request(
                 "no_explicit_default_namespace",
@@ -75,7 +78,7 @@ impl State {
 
         Namespace::fetch(
             &self.keyspace,
-            namespace_name.unwrap_or(DEFAULT_NAMESPACE_NAME),
+            namespace_name.unwrap_or(&DEFAULT_NAMESPACE_NAME),
         )
     }
 
@@ -107,7 +110,7 @@ mod tests {
         assert_eq!(parse_namespace("bill"), (None, "bill"));
         assert_eq!(parse_namespace(":bar"), (None, "bar"));
         assert_eq!(
-            parse_namespace(&format!("{DEFAULT_NAMESPACE_NAME}:bar")),
+            parse_namespace(&format!("{}:bar", DEFAULT_NAMESPACE_NAME.as_str())),
             (None, "bar")
         );
     }

--- a/crates/diom-namespace/src/operations/create_namespace.rs
+++ b/crates/diom-namespace/src/operations/create_namespace.rs
@@ -6,12 +6,16 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use tracing::Span;
 
-use crate::{State, entities::ModuleConfig, tables::Namespace};
+use crate::{
+    State,
+    entities::{ModuleConfig, NamespaceName},
+    tables::Namespace,
+};
 
 #[derive(Deserialize, Serialize)]
 #[serde(bound = "C: ModuleConfig")]
 pub struct CreateNamespace<C: ModuleConfig> {
-    name: String,
+    name: NamespaceName,
     config: C,
     id_random_bytes: UuidV7RandomBytes,
 }
@@ -19,14 +23,14 @@ pub struct CreateNamespace<C: ModuleConfig> {
 #[derive(Deserialize, Serialize)]
 #[serde(bound = "C: ModuleConfig")]
 pub struct CreateNamespaceOutput<C: ModuleConfig> {
-    pub name: String,
+    pub name: NamespaceName,
     pub config: C,
     pub created: Timestamp,
     pub updated: Timestamp,
 }
 
 impl<C: ModuleConfig + 'static> CreateNamespace<C> {
-    pub fn new(name: String, config: C, id_random_bytes: UuidV7RandomBytes) -> Self {
+    pub fn new(name: NamespaceName, config: C, id_random_bytes: UuidV7RandomBytes) -> Self {
         Self {
             name,
             config,

--- a/crates/idempotency/src/operations/create_namespace.rs
+++ b/crates/idempotency/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
-    entities::IdempotencyConfig,
+    entities::{IdempotencyConfig, NamespaceName},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 use jiff::Timestamp;
@@ -11,7 +11,7 @@ use crate::operations::{CreateIdempotencyResponse, IdempotencyRaftState, Idempot
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateIdempotencyOperation {
-    pub(crate) name: String,
+    pub(crate) name: NamespaceName,
     id_random_bytes: UuidV7RandomBytes,
 }
 
@@ -22,7 +22,7 @@ impl From<CreateIdempotencyOperation> for CreateNamespace<IdempotencyConfig> {
 }
 
 impl CreateIdempotencyOperation {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: NamespaceName) -> Self {
         Self {
             name,
             id_random_bytes: UuidV7RandomBytes::new_random(),
@@ -42,7 +42,7 @@ impl CreateIdempotencyOperation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateIdempotencyResponseData {
-    pub name: String,
+    pub name: NamespaceName,
     pub created: Timestamp,
     pub updated: Timestamp,
 }

--- a/crates/kv/src/operations/create_namespace.rs
+++ b/crates/kv/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
-    entities::KeyValueConfig,
+    entities::{KeyValueConfig, NamespaceName},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 use jiff::Timestamp;
@@ -11,7 +11,7 @@ use crate::operations::{CreateKvResponse, KvRaftState, KvRequest};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateKvOperation {
-    pub(crate) name: String,
+    pub(crate) name: NamespaceName,
     id_random_bytes: UuidV7RandomBytes,
 }
 
@@ -22,7 +22,7 @@ impl From<CreateKvOperation> for CreateNamespace<KeyValueConfig> {
 }
 
 impl CreateKvOperation {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: NamespaceName) -> Self {
         Self {
             name,
             id_random_bytes: UuidV7RandomBytes::new_random(),
@@ -42,7 +42,7 @@ impl CreateKvOperation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateKvResponseData {
-    pub name: String,
+    pub name: NamespaceName,
     pub created: Timestamp,
     pub updated: Timestamp,
 }

--- a/crates/msgs/src/operations/mod.rs
+++ b/crates/msgs/src/operations/mod.rs
@@ -56,13 +56,17 @@ impl MsgsOperation {
 #[cfg(test)]
 mod tests {
     use diom_id::NamespaceId;
+    use diom_namespace::entities::NamespaceName;
 
     use super::*;
     use crate::entities::{Retention, TopicIn, TopicName};
 
     #[test]
     fn test_msgs_operation_key_name() {
-        let op = CreateNamespaceOperation::new("my-namespace".to_string(), Retention::default());
+        let op = CreateNamespaceOperation::new(
+            NamespaceName("my-namespace".to_owned()),
+            Retention::default(),
+        );
         assert_eq!(
             MsgsOperation::CreateNamespace(op).key_name(),
             "my-namespace"

--- a/crates/rate-limit/src/operations/create_namespace.rs
+++ b/crates/rate-limit/src/operations/create_namespace.rs
@@ -1,7 +1,7 @@
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
-    entities::RateLimitConfig,
+    entities::{NamespaceName, RateLimitConfig},
     operations::create_namespace::{CreateNamespace, CreateNamespaceOutput},
 };
 use jiff::Timestamp;
@@ -11,7 +11,7 @@ use super::{CreateRateLimitResponse, RateLimitRaftState, RateLimitRequest};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateRateLimitOperation {
-    pub(crate) name: String,
+    pub(crate) name: NamespaceName,
     id_random_bytes: UuidV7RandomBytes,
 }
 
@@ -22,7 +22,7 @@ impl From<CreateRateLimitOperation> for CreateNamespace<RateLimitConfig> {
 }
 
 impl CreateRateLimitOperation {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: NamespaceName) -> Self {
         Self {
             name,
             id_random_bytes: UuidV7RandomBytes::new_random(),
@@ -42,7 +42,7 @@ impl CreateRateLimitOperation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateRateLimitResponseData {
-    pub name: String,
+    pub name: NamespaceName,
     pub created: Timestamp,
     pub updated: Timestamp,
 }

--- a/openapi.json
+++ b/openapi.json
@@ -5420,6 +5420,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "nullable": true
           },
           "name": {
@@ -5473,7 +5476,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -5484,7 +5490,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "created": {
             "type": "integer",
@@ -5539,6 +5548,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "nullable": true
           },
           "id": {
@@ -5565,6 +5577,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "nullable": true
           },
           "id": {
@@ -5590,7 +5605,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -5601,7 +5619,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "created": {
             "type": "integer",
@@ -5627,6 +5648,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "nullable": true
           },
           "owner_id": {
@@ -5714,6 +5738,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "nullable": true
           },
           "id": {
@@ -5774,6 +5801,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "nullable": true
           },
           "id": {
@@ -5821,6 +5851,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "nullable": true
           },
           "token": {
@@ -5844,7 +5877,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "eviction_policy": {
             "default": "NoEviction",
@@ -5859,7 +5895,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "eviction_policy": {
             "$ref": "#/components/schemas/EvictionPolicy"
@@ -5889,6 +5928,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -5922,6 +5964,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -5947,7 +5992,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -5958,7 +6006,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "eviction_policy": {
             "$ref": "#/components/schemas/EvictionPolicy"
@@ -6011,6 +6062,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -6183,6 +6237,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -6208,6 +6265,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -6284,7 +6344,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -6295,7 +6358,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "created": {
             "type": "integer",
@@ -6320,7 +6386,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -6331,7 +6400,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "created": {
             "type": "integer",
@@ -6357,6 +6429,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -6439,7 +6514,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -6450,7 +6528,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "created": {
             "type": "integer",
@@ -6476,6 +6557,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -6517,6 +6601,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -6542,7 +6629,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -6553,7 +6643,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "created": {
             "type": "integer",
@@ -6611,6 +6704,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -6822,7 +6918,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "retention": {
             "default": {
@@ -6843,7 +6942,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "retention": {
             "$ref": "#/components/schemas/Retention"
@@ -6872,7 +6974,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -6886,7 +6991,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "retention": {
             "$ref": "#/components/schemas/Retention"
@@ -6916,6 +7024,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -6984,6 +7095,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7018,6 +7132,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7075,6 +7192,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7116,6 +7236,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7150,6 +7273,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7211,6 +7337,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7238,6 +7367,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7271,6 +7403,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7336,6 +7471,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7373,6 +7511,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7510,6 +7651,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7596,7 +7740,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -7607,7 +7754,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "created": {
             "type": "integer",
@@ -7632,7 +7782,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           }
         },
         "required": [
@@ -7643,7 +7796,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace"
           },
           "created": {
             "type": "integer",
@@ -7669,6 +7825,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },
@@ -7715,6 +7874,9 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
+            "example": "some_namespace",
             "default": null,
             "nullable": true
           },

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -11,7 +11,10 @@ use crate::{
 };
 use anyhow::{Context, bail};
 use diom_msgs::entities::Retention;
-use diom_namespace::{DEFAULT_NAMESPACE_NAME, entities::EvictionPolicy};
+use diom_namespace::{
+    DEFAULT_NAMESPACE_NAME,
+    entities::{EvictionPolicy, NamespaceName},
+};
 
 #[derive(Debug)]
 enum BootstrapCommand {
@@ -27,25 +30,25 @@ impl BootstrapCommand {
     async fn apply(self, raft_state: &RaftState) -> anyhow::Result<()> {
         match self {
             BootstrapCommand::Kv(v) => {
-                tracing::debug!(name = v.name, "bootstrapping kv");
+                tracing::debug!(name = v.name.as_str(), "bootstrapping kv");
                 raft_state
                     .client_write(diom_kv::operations::CreateKvOperation::from(v))
                     .await?;
             }
             BootstrapCommand::Cache(v) => {
-                tracing::debug!(name = v.name, "bootstrapping cache");
+                tracing::debug!(name = v.name.as_str(), "bootstrapping cache");
                 raft_state
                     .client_write(diom_cache::operations::CreateCacheOperation::from(v))
                     .await?;
             }
             BootstrapCommand::Idempotency(v) => {
-                tracing::debug!(name = v.name, "bootstrapping idempotency");
+                tracing::debug!(name = v.name.as_str(), "bootstrapping idempotency");
                 raft_state
                     .client_write(diom_idempotency::operations::CreateIdempotencyOperation::from(v))
                     .await?;
             }
             BootstrapCommand::RateLimit(v) => {
-                tracing::debug!(name = v.name, "bootstrapping rate-limit");
+                tracing::debug!(name = v.name.as_str(), "bootstrapping rate-limit");
                 raft_state
                     .client_write(diom_rate_limit::operations::CreateRateLimitOperation::from(
                         v,
@@ -53,13 +56,13 @@ impl BootstrapCommand {
                     .await?;
             }
             BootstrapCommand::Msgs(v) => {
-                tracing::debug!(name = v.name, "bootstrapping msgs");
+                tracing::debug!(name = v.name.as_str(), "bootstrapping msgs");
                 raft_state
                     .client_write(diom_msgs::operations::CreateNamespaceOperation::from(v))
                     .await?;
             }
             BootstrapCommand::AuthToken(v) => {
-                tracing::debug!(name = v.name, "bootstrapping auth_token");
+                tracing::debug!(name = v.name.as_str(), "bootstrapping auth_token");
                 raft_state
                     .client_write(
                         diom_auth_token::operations::CreateAuthTokenNamespaceOperation::from(v),
@@ -70,7 +73,7 @@ impl BootstrapCommand {
         Ok(())
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> &NamespaceName {
         match self {
             BootstrapCommand::Kv(v) => &v.name,
             BootstrapCommand::Cache(v) => &v.name,
@@ -154,7 +157,7 @@ fn ensure_defaults(commands: &mut Vec<BootstrapCommand>) {
     macro_rules! ensure_default {
         ($variant:ident, $constructor:expr) => {
             if !commands.iter().any(|c| {
-                matches!(c, BootstrapCommand::$variant(_)) && c.name() == DEFAULT_NAMESPACE_NAME
+                matches!(c, BootstrapCommand::$variant(_)) && *c.name() == *DEFAULT_NAMESPACE_NAME
             }) {
                 commands.insert(0, $constructor);
             }
@@ -164,45 +167,45 @@ fn ensure_defaults(commands: &mut Vec<BootstrapCommand>) {
     ensure_default!(
         AuthToken,
         BootstrapCommand::AuthToken(AuthTokenCreateNamespaceIn {
-            name: DEFAULT_NAMESPACE_NAME.to_string(),
+            name: (*DEFAULT_NAMESPACE_NAME).clone(),
         })
     );
     commands.insert(
         0,
         BootstrapCommand::AuthToken(AuthTokenCreateNamespaceIn {
-            name: INTERNAL_NAMESPACE.to_string(),
+            name: (*INTERNAL_NAMESPACE).clone(),
         }),
     );
     ensure_default!(
         Msgs,
         BootstrapCommand::Msgs(MsgNamespaceCreateIn {
-            name: DEFAULT_NAMESPACE_NAME.to_string(),
+            name: (*DEFAULT_NAMESPACE_NAME).clone(),
             retention: Retention::default(),
         })
     );
     ensure_default!(
         RateLimit,
         BootstrapCommand::RateLimit(RateLimitCreateNamespaceIn {
-            name: DEFAULT_NAMESPACE_NAME.to_string(),
+            name: (*DEFAULT_NAMESPACE_NAME).clone(),
         })
     );
     ensure_default!(
         Idempotency,
         BootstrapCommand::Idempotency(IdempotencyCreateNamespaceIn {
-            name: DEFAULT_NAMESPACE_NAME.to_string(),
+            name: (*DEFAULT_NAMESPACE_NAME).clone(),
         })
     );
     ensure_default!(
         Cache,
         BootstrapCommand::Cache(CacheCreateNamespaceIn {
-            name: DEFAULT_NAMESPACE_NAME.to_string(),
+            name: (*DEFAULT_NAMESPACE_NAME).clone(),
             eviction_policy: EvictionPolicy::NoEviction,
         })
     );
     ensure_default!(
         Kv,
         BootstrapCommand::Kv(KvCreateNamespaceIn {
-            name: DEFAULT_NAMESPACE_NAME.to_string(),
+            name: (*DEFAULT_NAMESPACE_NAME).clone(),
         })
     );
 }
@@ -289,7 +292,7 @@ mod tests {
         let BootstrapCommand::Kv(v) = cmd else {
             panic!()
         };
-        assert_eq!(v.name, "myns");
+        assert_eq!(v.name.as_str(), "myns");
     }
 
     #[test]
@@ -308,14 +311,14 @@ mod tests {
         let BootstrapCommand::Idempotency(v) = cmd else {
             panic!()
         };
-        assert_eq!(v.name, "myns");
+        assert_eq!(v.name.as_str(), "myns");
     }
 
     #[test]
     fn rate_limit() {
         let cmd: BootstrapCommand =
             r#"rate-limit namespace create {"name":"myns"}"#.parse().unwrap();
-        assert!(matches!(cmd, BootstrapCommand::RateLimit(v) if &v.name == "myns"));
+        assert!(matches!(cmd, BootstrapCommand::RateLimit(v) if v.name.as_str() == "myns"));
     }
 
     #[test]
@@ -324,7 +327,7 @@ mod tests {
         let BootstrapCommand::Msgs(v) = cmd else {
             panic!()
         };
-        assert_eq!(v.name, "myns");
+        assert_eq!(v.name.as_str(), "myns");
         assert_eq!(v.retention, Retention::default());
     }
 
@@ -395,8 +398,8 @@ mod tests {
         "#;
         let cmds = parse_bootstrap(input).unwrap();
         assert_eq!(cmds.len(), 2);
-        assert!(matches!(&cmds[0], BootstrapCommand::Kv(v) if v.name == "foo"));
-        assert!(matches!(&cmds[1], BootstrapCommand::Cache(v) if v.name == "bar"));
+        assert!(matches!(&cmds[0], BootstrapCommand::Kv(v) if v.name.as_str() == "foo"));
+        assert!(matches!(&cmds[1], BootstrapCommand::Cache(v) if v.name.as_str() == "bar"));
     }
 
     #[test]
@@ -419,22 +422,22 @@ mod tests {
         assert!(cmds.len() >= 5);
         assert!(
             cmds.iter()
-                .any(|c| matches!(c, BootstrapCommand::Kv(v) if v.name == DEFAULT_NAMESPACE_NAME))
+                .any(|c| matches!(c, BootstrapCommand::Kv(v) if v.name == *DEFAULT_NAMESPACE_NAME))
         );
         assert!(
             cmds.iter().any(
-                |c| matches!(c, BootstrapCommand::Cache(v) if v.name == DEFAULT_NAMESPACE_NAME)
+                |c| matches!(c, BootstrapCommand::Cache(v) if v.name == *DEFAULT_NAMESPACE_NAME)
             )
         );
         assert!(cmds.iter().any(
-            |c| matches!(c, BootstrapCommand::Idempotency(v) if v.name == DEFAULT_NAMESPACE_NAME)
+            |c| matches!(c, BootstrapCommand::Idempotency(v) if v.name == *DEFAULT_NAMESPACE_NAME)
         ));
         assert!(cmds.iter().any(
-            |c| matches!(c, BootstrapCommand::RateLimit(v) if v.name == DEFAULT_NAMESPACE_NAME)
+            |c| matches!(c, BootstrapCommand::RateLimit(v) if v.name == *DEFAULT_NAMESPACE_NAME)
         ));
         assert!(
             cmds.iter().any(
-                |c| matches!(c, BootstrapCommand::Msgs(v) if v.name == DEFAULT_NAMESPACE_NAME)
+                |c| matches!(c, BootstrapCommand::Msgs(v) if v.name == *DEFAULT_NAMESPACE_NAME)
             )
         );
     }
@@ -442,12 +445,12 @@ mod tests {
     #[test]
     fn ensure_defaults_does_not_duplicate_existing_default() {
         let mut cmds = vec![BootstrapCommand::Kv(KvCreateNamespaceIn {
-            name: DEFAULT_NAMESPACE_NAME.to_string(),
+            name: DEFAULT_NAMESPACE_NAME.clone(),
         })];
         ensure_defaults(&mut cmds);
         let kv_defaults: Vec<_> = cmds
             .iter()
-            .filter(|c| matches!(c, BootstrapCommand::Kv(v) if v.name == DEFAULT_NAMESPACE_NAME))
+            .filter(|c| matches!(c, BootstrapCommand::Kv(v) if v.name == *DEFAULT_NAMESPACE_NAME))
             .collect();
         assert_eq!(kv_defaults.len(), 1);
     }
@@ -455,7 +458,7 @@ mod tests {
     #[test]
     fn ensure_defaults_does_not_suppress_non_default_namespaces() {
         let mut cmds = vec![BootstrapCommand::Kv(KvCreateNamespaceIn {
-            name: "other".to_string(),
+            name: NamespaceName("other".to_owned()),
         })];
         ensure_defaults(&mut cmds);
         let kv_count = cmds

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -129,7 +129,7 @@ async fn authorization_inner(
             "v1.auth-token.verify",
             &AuthTokenVerifyIn {
                 token: token.to_owned(),
-                namespace: Some(INTERNAL_NAMESPACE.to_owned()),
+                namespace: Some(INTERNAL_NAMESPACE.clone()),
             },
         )
         .await

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,7 @@
+use std::sync::LazyLock;
+
+use diom_namespace::entities::NamespaceName;
+
 pub mod auth;
 pub mod cluster;
 pub mod jwt;
@@ -5,7 +9,8 @@ pub mod metrics;
 pub mod otel_spans;
 pub mod retry;
 
-pub const INTERNAL_NAMESPACE: &str = "_internal";
+pub static INTERNAL_NAMESPACE: LazyLock<NamespaceName> =
+    LazyLock::new(|| NamespaceName("_internal".to_owned()));
 
 #[cfg(test)]
 mod tests {

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -31,10 +31,13 @@ use crate::{
     v1::utils::{ListResponse, ListResponseItem, Pagination, openapi_tag},
 };
 
-fn auth_token_access_metadata<'a>(ns: Option<&'a str>, action: &'static str) -> AccessMetadata<'a> {
+fn auth_token_access_metadata<'a>(
+    ns: Option<&'a NamespaceName>,
+    action: &'static str,
+) -> AccessMetadata<'a> {
     AccessMetadata::RuleProtected(RequestedOperation {
         module: Module::AuthToken,
-        namespace: ns,
+        namespace: ns.map(|n| n.as_str()),
         key: None,
         action,
     })
@@ -44,7 +47,7 @@ macro_rules! request_input {
     ($ty:ty, $action:literal) => {
         impl RequestInput for $ty {
             fn access_metadata(&self) -> AccessMetadata<'_> {
-                auth_token_access_metadata(self.namespace.as_deref(), $action)
+                auth_token_access_metadata(self.namespace.as_ref(), $action)
             }
         }
     };
@@ -88,7 +91,7 @@ impl From<AuthTokenModel> for AuthTokenOut {
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenCreateIn {
-    pub namespace: Option<String>,
+    pub namespace: Option<NamespaceName>,
     pub name: String,
     #[serde(default = "default_prefix")]
     pub prefix: String,
@@ -133,7 +136,7 @@ async fn auth_token_create(
 ) -> Result<MsgPackOrJson<AuthTokenCreateOut>> {
     let namespace: AuthTokenNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let token = TokenPlaintext::generate(&data.prefix, data.suffix.as_deref())?;
@@ -160,7 +163,7 @@ async fn auth_token_create(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenExpireIn {
-    pub namespace: Option<String>,
+    pub namespace: Option<NamespaceName>,
     pub id: Public<AuthTokenId>,
     /// Milliseconds from now until the token expires. `None` means expire immediately.
     #[serde(rename = "expiry_ms")]
@@ -181,7 +184,7 @@ async fn auth_token_expire(
 ) -> Result<MsgPackOrJson<AuthTokenExpireOut>> {
     let namespace: AuthTokenNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let expiry = data.expiry.map(|ms| repl.time.now() + ms);
@@ -192,7 +195,7 @@ async fn auth_token_expire(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenDeleteIn {
-    pub namespace: Option<String>,
+    pub namespace: Option<NamespaceName>,
     pub id: Public<AuthTokenId>,
 }
 
@@ -220,7 +223,7 @@ async fn auth_token_delete(
 ) -> Result<MsgPackOrJson<AuthTokenDeleteOut>> {
     let namespace: AuthTokenNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = DeleteAuthTokenOperation::new(namespace, data.id.into_inner());
@@ -230,7 +233,7 @@ async fn auth_token_delete(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenVerifyIn {
-    pub namespace: Option<String>,
+    pub namespace: Option<NamespaceName>,
     pub token: String,
 }
 
@@ -252,7 +255,7 @@ async fn auth_token_verify(
 
     let namespace: AuthTokenNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let token_hashed = TokenHashed::from(data.token.as_str());
@@ -271,7 +274,7 @@ async fn auth_token_verify(
 
 #[derive(Clone, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenListIn {
-    pub namespace: Option<String>,
+    pub namespace: Option<NamespaceName>,
     pub owner_id: String,
     #[serde(flatten)]
     pub pagination: Pagination<Public<AuthTokenId>>,
@@ -292,7 +295,7 @@ async fn auth_token_list(
 
     let namespace: AuthTokenNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let limit = data.pagination.limit.0 as usize;
@@ -315,7 +318,7 @@ async fn auth_token_list(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenUpdateIn {
-    pub namespace: Option<String>,
+    pub namespace: Option<NamespaceName>,
     pub id: Public<AuthTokenId>,
     pub name: Option<String>,
     #[serde(rename = "expiry_ms")]
@@ -339,7 +342,7 @@ async fn auth_token_update(
 ) -> Result<MsgPackOrJson<AuthTokenUpdateOut>> {
     let namespace: AuthTokenNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = UpdateAuthTokenOperation::new(
@@ -357,7 +360,7 @@ async fn auth_token_update(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenRotateIn {
-    pub namespace: Option<String>,
+    pub namespace: Option<NamespaceName>,
     pub id: Public<AuthTokenId>,
     #[serde(default = "default_prefix")]
     pub prefix: String,
@@ -386,7 +389,7 @@ async fn auth_token_rotate(
 ) -> Result<MsgPackOrJson<AuthTokenRotateOut>> {
     let namespace: AuthTokenNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let token = TokenPlaintext::generate(&data.prefix, data.suffix.as_deref())?;

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -19,13 +19,13 @@ use validator::Validate;
 use crate::{AppState, core::cluster::RaftState, error::Result, v1::utils::openapi_tag};
 
 fn cache_access_metadata<'a>(
-    ns: Option<&'a str>,
+    ns: Option<&'a NamespaceName>,
     key: &'a EntityKey,
     action: &'static str,
 ) -> AccessMetadata<'a> {
     AccessMetadata::RuleProtected(RequestedOperation {
         module: Module::Cache,
-        namespace: ns,
+        namespace: ns.map(|n| n.as_str()),
         key: Some(key.as_str()),
         action,
     })
@@ -35,7 +35,7 @@ macro_rules! request_input {
     ($ty:ty, $action:literal) => {
         impl RequestInput for $ty {
             fn access_metadata(&self) -> AccessMetadata<'_> {
-                cache_access_metadata(self.namespace.as_deref(), &self.key, $action)
+                cache_access_metadata(self.namespace.as_ref(), &self.key, $action)
             }
         }
     };
@@ -151,7 +151,7 @@ async fn cache_set(
 ) -> Result<MsgPackOrJson<CacheSetOut>> {
     let namespace: CacheNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = SetOperation::new(namespace, data.key.to_string(), Some(data.ttl), data.value);
@@ -168,7 +168,7 @@ async fn cache_get(
 ) -> Result<MsgPackOrJson<CacheGetOut>> {
     let namespace: CacheNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     if data.consistency.linearizable() {
@@ -201,7 +201,7 @@ async fn cache_del(
 ) -> Result<MsgPackOrJson<CacheDeleteOut>> {
     let namespace: CacheNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = DeleteOperation::new(namespace, data.key.to_string());

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -23,13 +23,13 @@ use validator::Validate;
 use crate::{AppState, core::cluster::RaftState, error::Result, v1::utils::openapi_tag};
 
 fn idempotency_metadata<'a>(
-    ns: Option<&'a str>,
+    ns: Option<&'a NamespaceName>,
     key: &'a EntityKey,
     action: &'static str,
 ) -> AccessMetadata<'a> {
     AccessMetadata::RuleProtected(RequestedOperation {
         module: Module::Idempotency,
-        namespace: ns,
+        namespace: ns.map(|n| n.as_str()),
         key: Some(key.as_str()),
         action,
     })
@@ -39,7 +39,7 @@ macro_rules! request_input {
     ($ty:ty, $action:literal) => {
         impl RequestInput for $ty {
             fn access_metadata(&self) -> AccessMetadata<'_> {
-                idempotency_metadata(self.namespace.as_deref(), &self.key, $action)
+                idempotency_metadata(self.namespace.as_ref(), &self.key, $action)
             }
         }
     };
@@ -153,7 +153,7 @@ async fn idempotency_start(
 ) -> Result<MsgPackOrJson<IdempotencyStartOut>> {
     let namespace: IdempotencyNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = TryStartOperation::new(namespace, data.key.to_string(), data.lock_period);
@@ -171,7 +171,7 @@ async fn idempotency_complete(
 ) -> Result<MsgPackOrJson<IdempotencyCompleteOut>> {
     let namespace: IdempotencyNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = CompleteOperation::new(
@@ -195,7 +195,7 @@ async fn idempotency_abort(
 ) -> Result<MsgPackOrJson<IdempotencyAbortOut>> {
     let namespace: IdempotencyNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = AbortOperation::new(namespace, data.key.to_string());

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -19,13 +19,13 @@ use validator::Validate;
 use crate::{AppState, core::cluster::RaftState, error::Result, v1::utils::openapi_tag};
 
 fn kv_metadata<'a>(
-    ns: Option<&'a str>,
+    ns: Option<&'a NamespaceName>,
     key: &'a EntityKey,
     action: &'static str,
 ) -> AccessMetadata<'a> {
     AccessMetadata::RuleProtected(RequestedOperation {
         module: Module::Kv,
-        namespace: ns,
+        namespace: ns.map(|n| n.as_str()),
         key: Some(key.as_str()),
         action,
     })
@@ -35,7 +35,7 @@ macro_rules! request_input {
     ($ty:ty, $action:literal) => {
         impl RequestInput for $ty {
             fn access_metadata(&self) -> AccessMetadata<'_> {
-                kv_metadata(self.namespace.as_deref(), &self.key, $action)
+                kv_metadata(self.namespace.as_ref(), &self.key, $action)
             }
         }
     };
@@ -141,7 +141,7 @@ async fn kv_set(
 ) -> Result<MsgPackOrJson<KvSetOut>> {
     let namespace: KvNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = SetOperation::new(
@@ -168,7 +168,7 @@ async fn kv_get(
 ) -> Result<MsgPackOrJson<KvGetOut>> {
     let namespace: KvNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     if data.consistency.linearizable() {
@@ -202,7 +202,7 @@ async fn kv_del(
 ) -> Result<MsgPackOrJson<KvDeleteOut>> {
     let namespace: KvNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let key = data.key;

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -33,13 +33,13 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 fn msgs_metadata<'a>(
-    ns: Option<&'a str>,
+    ns: Option<&'a NamespaceName>,
     tp: &'a TopicName,
     action: &'static str,
 ) -> AccessMetadata<'a> {
     AccessMetadata::RuleProtected(RequestedOperation {
         module: Module::Msgs,
-        namespace: ns,
+        namespace: ns.map(|n| n.as_str()),
         key: Some(tp),
         action,
     })
@@ -49,7 +49,7 @@ macro_rules! request_input {
     ($ty:ty, $action:literal) => {
         impl RequestInput for $ty {
             fn access_metadata(&self) -> AccessMetadata<'_> {
-                msgs_metadata(self.namespace.as_deref(), self.topic.name(), $action)
+                msgs_metadata(self.namespace.as_ref(), self.topic.name(), $action)
             }
         }
     };
@@ -173,7 +173,7 @@ async fn publish(
 ) -> Result<MsgPackOrJson<MsgPublishOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let topic_name = data.topic.name();
@@ -247,7 +247,7 @@ async fn stream_receive(
 ) -> Result<MsgPackOrJson<MsgStreamReceiveOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     if let Some(max_wait) = data.batch_wait {
@@ -349,7 +349,7 @@ async fn stream_commit(
 ) -> Result<MsgPackOrJson<MsgStreamCommitOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation =
@@ -392,7 +392,7 @@ async fn stream_seek(
 ) -> Result<MsgPackOrJson<MsgStreamSeekOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let target = match (data.offset, data.position) {
@@ -456,7 +456,7 @@ async fn queue_receive(
 ) -> Result<MsgPackOrJson<MsgQueueReceiveOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     if let Some(max_wait) = data.batch_wait {
@@ -555,7 +555,7 @@ async fn queue_ack(
 ) -> Result<MsgPackOrJson<MsgQueueAckOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation =
@@ -598,7 +598,7 @@ async fn queue_extend_lease(
 ) -> Result<MsgPackOrJson<MsgQueueExtendLeaseOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = QueueExtendLeaseOperation::new(
@@ -649,7 +649,7 @@ async fn queue_configure(
 ) -> Result<MsgPackOrJson<MsgQueueConfigureOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = QueueConfigureOperation::new(
@@ -698,7 +698,7 @@ async fn queue_nack(
 ) -> Result<MsgPackOrJson<MsgQueueNackOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation =
@@ -735,7 +735,7 @@ async fn queue_redrive_dlq(
 ) -> Result<MsgPackOrJson<MsgQueueRedriveDlqOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = QueueRedriveDlqOperation::new(namespace.id, data.topic, data.consumer_group);
@@ -775,7 +775,7 @@ async fn topic_configure(
 ) -> Result<MsgPackOrJson<MsgTopicConfigureOut>> {
     let namespace: MsgsNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let operation = TopicConfigureOperation::new(namespace.id, data.topic, data.partitions)?;

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -20,13 +20,13 @@ pub use diom_rate_limit::TokenBucket;
 pub use diom_rate_limit::RateLimitNamespace;
 
 fn rate_limit_metadata<'a>(
-    ns: Option<&'a str>,
+    ns: Option<&'a NamespaceName>,
     key: &'a EntityKey,
     action: &'static str,
 ) -> AccessMetadata<'a> {
     AccessMetadata::RuleProtected(RequestedOperation {
         module: Module::RateLimit,
-        namespace: ns,
+        namespace: ns.map(|n| n.as_str()),
         key: Some(key.as_str()),
         action,
     })
@@ -36,7 +36,7 @@ macro_rules! request_input {
     ($ty:ty, $action:literal) => {
         impl RequestInput for $ty {
             fn access_metadata(&self) -> AccessMetadata<'_> {
-                rate_limit_metadata(self.namespace.as_deref(), &self.key, $action)
+                rate_limit_metadata(self.namespace.as_ref(), &self.key, $action)
             }
         }
     };
@@ -142,7 +142,7 @@ async fn rate_limit_limit(
 ) -> Result<MsgPackOrJson<RateLimitCheckOut>> {
     let namespace: RateLimitNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let key = data.key.0.clone();
@@ -168,7 +168,7 @@ async fn rate_limit_get_remaining(
 ) -> Result<MsgPackOrJson<RateLimitGetRemainingOut>> {
     let namespace: RateLimitNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     repl.wait_linearizable().await.or_internal_error()?;
@@ -213,7 +213,7 @@ async fn rate_limit_reset(
 ) -> Result<MsgPackOrJson<RateLimitResetOut>> {
     let namespace: RateLimitNamespace = state
         .namespace_state
-        .fetch_namespace(data.namespace.as_deref())?
+        .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
     let key = data.key.0.clone();

--- a/z-clients/cli/src/cmds/api/cache.rs
+++ b/z-clients/cli/src/cmds/api/cache.rs
@@ -19,7 +19,7 @@ pub enum CacheCommands {
     /// Cache Set
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"ttl_ms\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
@@ -32,7 +32,7 @@ pub enum CacheCommands {
     /// Cache Get
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"consistency\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
@@ -46,7 +46,7 @@ pub enum CacheCommands {
     /// Cache Delete
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\"
+  \"namespace\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"success\": \"...\"

--- a/z-clients/cli/src/cmds/api/cache_namespace.rs
+++ b/z-clients/cli/src/cmds/api/cache_namespace.rs
@@ -17,11 +17,11 @@ pub enum CacheNamespaceCommands {
     /// Create cache namespace
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"eviction_policy\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"eviction_policy\": \"...\",
   \"created\": \"...\",
   \"updated\": \"...\"
@@ -32,10 +32,10 @@ pub enum CacheNamespaceCommands {
     /// Get cache namespace
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"name\": \"...\"
+  \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"eviction_policy\": \"...\",
   \"created\": \"...\",
   \"updated\": \"...\"

--- a/z-clients/cli/src/cmds/api/idempotency.rs
+++ b/z-clients/cli/src/cmds/api/idempotency.rs
@@ -19,7 +19,7 @@ pub enum IdempotencyCommands {
     /// Start an idempotent request
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"lock_period_ms\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
@@ -31,7 +31,7 @@ pub enum IdempotencyCommands {
     /// Complete an idempotent request with a response
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"response\": \"...\",
   \"context\": \"...\",
   \"ttl_ms\": \"...\"
@@ -45,7 +45,7 @@ pub enum IdempotencyCommands {
     /// Abandon an idempotent request (remove lock without saving response)
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\"
+  \"namespace\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
 }")]

--- a/z-clients/cli/src/cmds/api/idempotency_namespace.rs
+++ b/z-clients/cli/src/cmds/api/idempotency_namespace.rs
@@ -17,10 +17,10 @@ pub enum IdempotencyNamespaceCommands {
     /// Create idempotency namespace
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"name\": \"...\"
+  \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"created\": \"...\",
   \"updated\": \"...\"
 }")]
@@ -31,10 +31,10 @@ pub enum IdempotencyNamespaceCommands {
     /// Get idempotency namespace
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"name\": \"...\"
+  \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"created\": \"...\",
   \"updated\": \"...\"
 }")]

--- a/z-clients/cli/src/cmds/api/kv.rs
+++ b/z-clients/cli/src/cmds/api/kv.rs
@@ -19,7 +19,7 @@ pub enum KvCommands {
     /// KV Set
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"ttl_ms\": \"...\",
   \"behavior\": \"...\",
   \"version\": \"...\"
@@ -36,7 +36,7 @@ pub enum KvCommands {
     /// KV Get
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"consistency\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
@@ -51,7 +51,7 @@ pub enum KvCommands {
     /// KV Delete
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"version\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {

--- a/z-clients/cli/src/cmds/api/kv_namespace.rs
+++ b/z-clients/cli/src/cmds/api/kv_namespace.rs
@@ -17,10 +17,10 @@ pub enum KvNamespaceCommands {
     /// Create KV namespace
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"name\": \"...\"
+  \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"created\": \"...\",
   \"updated\": \"...\"
 }")]
@@ -30,10 +30,10 @@ pub enum KvNamespaceCommands {
     /// Get KV namespace
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"name\": \"...\"
+  \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"created\": \"...\",
   \"updated\": \"...\"
 }")]

--- a/z-clients/cli/src/cmds/api/msgs.rs
+++ b/z-clients/cli/src/cmds/api/msgs.rs
@@ -22,7 +22,7 @@ pub enum MsgsCommands {
     /// Publishes messages to a topic within a namespace.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"msgs\": \"...\",
   \"idempotency_key\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m

--- a/z-clients/cli/src/cmds/api/msgs_namespace.rs
+++ b/z-clients/cli/src/cmds/api/msgs_namespace.rs
@@ -20,7 +20,7 @@ pub enum MsgsNamespaceCommands {
   \"retention\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"retention\": \"...\",
   \"created\": \"...\",
   \"updated\": \"...\"
@@ -34,7 +34,7 @@ pub enum MsgsNamespaceCommands {
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"retention\": \"...\",
   \"created\": \"...\",
   \"updated\": \"...\"

--- a/z-clients/cli/src/cmds/api/msgs_queue.rs
+++ b/z-clients/cli/src/cmds/api/msgs_queue.rs
@@ -21,7 +21,7 @@ pub enum MsgsQueueCommands {
     /// are acked or their lease expires.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"batch_size\": \"...\",
   \"lease_duration_ms\": \"...\",
   \"batch_wait_ms\": \"...\"
@@ -39,7 +39,7 @@ pub enum MsgsQueueCommands {
     /// Acked messages are permanently removed from the queue and will never be re-delivered.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"msg_ids\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
@@ -55,7 +55,7 @@ pub enum MsgsQueueCommands {
     /// message from being re-delivered to another consumer.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"msg_ids\": \"...\",
   \"lease_duration_ms\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -72,7 +72,7 @@ pub enum MsgsQueueCommands {
     /// the message is moved to the DLQ (or forwarded to `dlq_topic` if set).
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"retry_schedule\": \"...\",
   \"dlq_topic\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -91,7 +91,7 @@ pub enum MsgsQueueCommands {
     /// move them back to the queue for reprocessing.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"msg_ids\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
@@ -104,7 +104,7 @@ pub enum MsgsQueueCommands {
     /// Moves all dead-letter queue messages back to the main queue for reprocessing.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\"
+  \"namespace\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
 }")]

--- a/z-clients/cli/src/cmds/api/msgs_stream.rs
+++ b/z-clients/cli/src/cmds/api/msgs_stream.rs
@@ -20,7 +20,7 @@ pub enum MsgsStreamCommands {
     /// specified duration to prevent duplicate delivery within the same consumer group.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"batch_size\": \"...\",
   \"lease_duration_ms\": \"...\",
   \"default_starting_position\": \"...\",
@@ -40,7 +40,7 @@ pub enum MsgsStreamCommands {
     /// successfully processed offset; future receives will start after it.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"offset\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
@@ -57,7 +57,7 @@ pub enum MsgsStreamCommands {
     /// `"latest"` and may be used with or without a partition suffix.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"offset\": \"...\",
   \"position\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m

--- a/z-clients/cli/src/cmds/api/msgs_topic.rs
+++ b/z-clients/cli/src/cmds/api/msgs_topic.rs
@@ -19,7 +19,7 @@ pub enum MsgsTopicCommands {
     /// Partition count can only be increased, never decreased. The default for a new topic is 1.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"partitions\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {

--- a/z-clients/cli/src/cmds/api/rate_limit.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit.rs
@@ -19,7 +19,7 @@ pub enum RateLimitCommands {
     /// Rate Limiter Check and Consume
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
   \"tokens\": \"...\",
   \"config\": \"...\"
@@ -35,7 +35,7 @@ pub enum RateLimitCommands {
     /// Rate Limiter Get Remaining
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
   \"config\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -49,7 +49,7 @@ pub enum RateLimitCommands {
     /// Rate Limiter Reset
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"namespace\": \"...\",
+  \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
   \"config\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m

--- a/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
@@ -17,10 +17,10 @@ pub enum RateLimitNamespaceCommands {
     /// Create rate limiter namespace
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"name\": \"...\"
+  \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"created\": \"...\",
   \"updated\": \"...\"
 }")]
@@ -31,10 +31,10 @@ pub enum RateLimitNamespaceCommands {
     /// Get rate limiter namespace
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
-  \"name\": \"...\"
+  \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-  \"name\": \"...\",
+  \"name\": \"some_namespace\",
   \"created\": \"...\",
   \"updated\": \"...\"
 }")]


### PR DESCRIPTION
… instead of an alias.

Doesn't actually enforce the pattern that is added to the OpenAPI spec. The same goes for `EntityKey`. I'll post a follow-up PR for that.

Part of https://github.com/svix/diom-private/issues/625.