### PR TITLE
Enforce NamespaceName restrictions

### DIFF
--- a/crates/diom-core/src/lib.rs
+++ b/crates/diom-core/src/lib.rs
@@ -15,5 +15,8 @@ pub use self::monotime::Monotime;
 
 #[doc(hidden)]
 pub mod __reexport {
+    pub use regex;
+    pub use schemars;
     pub use serde_json;
+    pub use validator;
 }

--- a/crates/diom-core/src/types/mod.rs
+++ b/crates/diom-core/src/types/mod.rs
@@ -81,7 +81,7 @@ pub trait BaseUid: Deref<Target = String> {
 
 #[macro_export]
 macro_rules! string_wrapper {
-    ($name_id:ident) => {
+    ($name_id:ident, $string_schema:expr) => {
         #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
         pub struct $name_id(pub String);
 
@@ -110,10 +110,6 @@ macro_rules! string_wrapper {
                 $name_id(s)
             }
         }
-    };
-
-    ($name_id:ident, $string_schema:expr) => {
-        string_wrapper!($name_id);
 
         impl ::schemars::JsonSchema for $name_id {
             fn schema_name() -> ::std::borrow::Cow<'static, str> {

--- a/crates/diom-core/src/types/mod.rs
+++ b/crates/diom-core/src/types/mod.rs
@@ -127,6 +127,7 @@ macro_rules! string_wrapper {
                 let info = <Self as $crate::types::StringWrapper>::INFO;
                 $crate::__reexport::schemars::json_schema!({
                     "type": "string",
+                    "minLength": info.min_length,
                     "maxLength": info.max_length,
                     "pattern": info.pattern,
                     "example": info.example,
@@ -149,13 +150,10 @@ macro_rules! string_wrapper {
 
                 let info = <Self as $crate::types::StringWrapper>::INFO;
                 let mut errors = $crate::__reexport::validator::ValidationErrors::new();
-                if self.0.is_empty() {
+                if self.0.len() < info.min_length {
                     errors.add(
                         $crate::types::ALL_ERROR,
-                        $crate::validation::validation_error(
-                            Some("length"),
-                            Some("String must be at least one character"),
-                        ),
+                        $crate::validation::validation_error(Some("length"), Some("String too short")),
                     );
                 } else if self.0.len() > info.max_length {
                     errors.add(
@@ -184,6 +182,7 @@ macro_rules! string_wrapper {
 
 #[doc(hidden)]
 pub struct StringSchema {
+    pub min_length: usize,
     pub max_length: usize,
     pub pattern: &'static str,
     pub example: &'static str,
@@ -195,6 +194,7 @@ pub trait StringWrapper {
 }
 
 string_wrapper!(EntityKey {
+    min_length: 1,
     max_length: 256,
     pattern: r"^[a-zA-Z0-9\-/_.=+:]+$",
     example: "some_key"

--- a/crates/diom-core/src/types/mod.rs
+++ b/crates/diom-core/src/types/mod.rs
@@ -3,7 +3,6 @@ use std::{ops::Deref, sync::LazyLock};
 use regex::Regex;
 #[allow(unused_imports)]
 use schemars::JsonSchema;
-use schemars::{Schema, json_schema};
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationErrors};
 
@@ -81,9 +80,15 @@ pub trait BaseUid: Deref<Target = String> {
 
 #[macro_export]
 macro_rules! string_wrapper {
-    ($name_id:ident, $string_schema:expr) => {
+    ($name_id:ident { $($init:tt)* }) => {
         #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
         pub struct $name_id(pub String);
+
+        impl $crate::types::StringWrapper for $name_id {
+            const INFO: $crate::types::StringSchema = $crate::types::StringSchema {
+                $($init)*
+            };
+        }
 
         impl std::ops::Deref for $name_id {
             type Target = String;
@@ -111,31 +116,19 @@ macro_rules! string_wrapper {
             }
         }
 
-        impl ::schemars::JsonSchema for $name_id {
-            fn schema_name() -> ::std::borrow::Cow<'static, str> {
+        impl schemars::JsonSchema for $name_id {
+            fn schema_name() -> std::borrow::Cow<'static, str> {
                 stringify!($name_id).into()
             }
 
-            fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-                let mut schema = String::json_schema(generator);
-
-                if let Some(obj) = schema.as_object_mut() {
-                    // This is just to help with type hints when the macro is expanded.
-                    let options: $crate::types::StringSchema = $string_schema;
-
-                    if let Some(mut v) = options.string_validation {
-                        obj.extend(::std::mem::take(v.ensure_object()));
-                    }
-
-                    if let Some(example) = options.example {
-                        obj.insert(
-                            "example".to_owned(),
-                            $crate::__reexport::serde_json::Value::String(example),
-                        );
-                    }
-                }
-
-                schema
+            fn json_schema(_g: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                let info = <Self as $crate::types::StringWrapper>::INFO;
+                schemars::json_schema!({
+                    "type": "string",
+                    "maxLength": info.max_length,
+                    "pattern": info.pattern,
+                    "example": info.example,
+                })
             }
 
             fn inline_schema() -> bool {
@@ -145,44 +138,23 @@ macro_rules! string_wrapper {
     };
 }
 
-/// A container type for storing schema information commonly used by string
-/// wrapper types.
-#[derive(Default)]
+#[doc(hidden)]
 pub struct StringSchema {
-    pub string_validation: Option<Schema>,
-    pub example: Option<String>,
+    pub max_length: usize,
+    pub pattern: &'static str,
+    pub example: &'static str,
 }
 
-impl StringSchema {
-    pub fn schema_for_ids(prefix: &'static str) -> Self {
-        Self {
-            string_validation: None,
-            example: Some(format!("{prefix}1srOrx2ZWZBpBUvZwXKQmoEYga2")),
-        }
-    }
-
-    pub fn schema_for_uids(prefix: &'static str) -> Self {
-        Self {
-            string_validation: Some(json_schema!({
-                "minLength": 1,
-                "maxLength": 256,
-                "pattern": r"^[a-zA-Z0-9\-_.]+$",
-            })),
-            example: Some(format!("unique-{prefix}identifier").replace('_', "-")),
-        }
-    }
+#[doc(hidden)]
+pub trait StringWrapper {
+    const INFO: StringSchema;
 }
 
-string_wrapper!(
-    EntityKey,
-    StringSchema {
-        string_validation: Some(json_schema!({
-            "maxLength": 256,
-            "pattern": r"^[a-zA-Z0-9\-/_.=+:]+$",
-        })),
-        example: Some("some_key".to_string()),
-    }
-);
+string_wrapper!(EntityKey {
+    max_length: 256,
+    pattern: r"^[a-zA-Z0-9\-/_.=+:]+$",
+    example: "some_key"
+});
 
 impl Validate for EntityKey {
     fn validate(&self) -> Result<(), ValidationErrors> {

--- a/crates/diom-core/src/types/mod.rs
+++ b/crates/diom-core/src/types/mod.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 #[allow(unused_imports)]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use validator::{Validate, ValidationErrors};
+use validator::ValidationErrors;
 
 use crate::validation::validation_error;
 
@@ -18,7 +18,7 @@ pub use self::{
     unix_timestamp_ms::UnixTimestampMs,
 };
 
-const ALL_ERROR: &str = "__all__";
+pub const ALL_ERROR: &str = "__all__";
 
 fn validate_limited_str(s: &str) -> Result<(), ValidationErrors> {
     const MAX_LENGTH: usize = 256;
@@ -116,14 +116,16 @@ macro_rules! string_wrapper {
             }
         }
 
-        impl schemars::JsonSchema for $name_id {
+        impl $crate::__reexport::schemars::JsonSchema for $name_id {
             fn schema_name() -> std::borrow::Cow<'static, str> {
                 stringify!($name_id).into()
             }
 
-            fn json_schema(_g: &mut schemars::SchemaGenerator) -> schemars::Schema {
+            fn json_schema(
+                _g: &mut $crate::__reexport::schemars::SchemaGenerator,
+            ) -> $crate::__reexport::schemars::Schema {
                 let info = <Self as $crate::types::StringWrapper>::INFO;
-                schemars::json_schema!({
+                $crate::__reexport::schemars::json_schema!({
                     "type": "string",
                     "maxLength": info.max_length,
                     "pattern": info.pattern,
@@ -133,6 +135,48 @@ macro_rules! string_wrapper {
 
             fn inline_schema() -> bool {
                 true
+            }
+        }
+
+        impl $crate::__reexport::validator::Validate for $name_id {
+            fn validate(&self) -> Result<(), $crate::__reexport::validator::ValidationErrors> {
+                use std::sync::LazyLock;
+                use $crate::__reexport::regex::Regex;
+
+                static RE: LazyLock<Regex> = LazyLock::new(|| {
+                    Regex::new(<$name_id as $crate::types::StringWrapper>::INFO.pattern).unwrap()
+                });
+
+                let info = <Self as $crate::types::StringWrapper>::INFO;
+                let mut errors = $crate::__reexport::validator::ValidationErrors::new();
+                if self.0.is_empty() {
+                    errors.add(
+                        $crate::types::ALL_ERROR,
+                        $crate::validation::validation_error(
+                            Some("length"),
+                            Some("String must be at least one character"),
+                        ),
+                    );
+                } else if self.0.len() > info.max_length {
+                    errors.add(
+                        $crate::types::ALL_ERROR,
+                        $crate::validation::validation_error(Some("length"), Some("String too long")),
+                    );
+                } else if !RE.is_match(&self.0) {
+                    errors.add(
+                        $crate::types::ALL_ERROR,
+                        $crate::validation::validation_error(
+                            Some("invalid_entity_key"),
+                            Some(r"Entity key must match the following pattern: ^[a-zA-Z0-9\-/_.=+:]+$."),
+                        ),
+                    );
+                }
+
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(errors)
+                }
             }
         }
     };
@@ -155,42 +199,6 @@ string_wrapper!(EntityKey {
     pattern: r"^[a-zA-Z0-9\-/_.=+:]+$",
     example: "some_key"
 });
-
-impl Validate for EntityKey {
-    fn validate(&self) -> Result<(), ValidationErrors> {
-        const MAX_LENGTH: usize = 256;
-        static RE: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9\-/_.=+:]+$").unwrap());
-        let mut errors = ValidationErrors::new();
-        if self.0.is_empty() {
-            errors.add(
-                ALL_ERROR,
-                validation_error(
-                    Some("length"),
-                    Some("String must be at least one character"),
-                ),
-            );
-        } else if self.0.len() > MAX_LENGTH {
-            errors.add(
-                ALL_ERROR,
-                validation_error(Some("length"), Some("String too long")),
-            );
-        } else if !RE.is_match(&self.0) {
-            errors.add(
-                ALL_ERROR,
-                validation_error(
-                    Some("invalid_entity_key"),
-                    Some(r"Entity key must match the following pattern: ^[a-zA-Z0-9\-/_.=+:]+$."),
-                ),
-            );
-        }
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
-    }
-}
 
 /// Consistency level for reads.
 ///

--- a/crates/diom-namespace/src/entities.rs
+++ b/crates/diom-namespace/src/entities.rs
@@ -1,23 +1,15 @@
 use std::{fmt::Debug, num::NonZeroU64};
 
-use diom_core::{
-    string_wrapper,
-    types::{DurationMs, StringSchema},
-};
+use diom_core::{string_wrapper, types::DurationMs};
 use diom_id::Module;
-use schemars::{JsonSchema, json_schema};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-string_wrapper!(
-    NamespaceName,
-    StringSchema {
-        string_validation: Some(json_schema!({
-            "maxLength": 256,
-            "pattern": r"^[a-zA-Z0-9\-/_.=+]+$",
-        })),
-        example: Some("some_namespace".to_string()),
-    }
-);
+string_wrapper!(NamespaceName {
+    max_length: 256,
+    pattern: r"^[a-zA-Z0-9\-/_.=+]+$",
+    example: "some_namespace"
+});
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/diom-namespace/src/entities.rs
+++ b/crates/diom-namespace/src/entities.rs
@@ -6,6 +6,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 string_wrapper!(NamespaceName {
+    min_length: 1,
     max_length: 256,
     pattern: r"^[a-zA-Z0-9\-/_.=+]+$",
     example: "some_namespace"

--- a/openapi.json
+++ b/openapi.json
@@ -5420,6 +5420,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5477,6 +5478,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -5491,6 +5493,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -5548,6 +5551,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5577,6 +5581,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5606,6 +5611,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -5620,6 +5626,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -5648,6 +5655,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5738,6 +5746,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5801,6 +5810,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5851,6 +5861,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5878,6 +5889,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -5896,6 +5908,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -5928,6 +5941,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5936,6 +5950,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -5964,6 +5979,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -5972,6 +5988,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -5993,6 +6010,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6007,6 +6025,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6062,6 +6081,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -6070,6 +6090,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -6237,6 +6258,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -6245,6 +6267,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -6265,6 +6288,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -6273,6 +6297,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -6345,6 +6370,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6359,6 +6385,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6387,6 +6414,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6401,6 +6429,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6429,6 +6458,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -6437,6 +6467,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -6515,6 +6546,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6529,6 +6561,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6557,6 +6590,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -6565,6 +6599,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -6601,6 +6636,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -6609,6 +6645,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -6630,6 +6667,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6644,6 +6682,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6704,6 +6743,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -6712,6 +6752,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -6919,6 +6960,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6943,6 +6985,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6975,6 +7018,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -6992,6 +7036,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -7024,6 +7069,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7095,6 +7141,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7132,6 +7179,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7192,6 +7240,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7236,6 +7285,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7273,6 +7323,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7337,6 +7388,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7367,6 +7419,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7403,6 +7456,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7471,6 +7525,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7511,6 +7566,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7651,6 +7707,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7659,6 +7716,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -7741,6 +7799,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -7755,6 +7814,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -7783,6 +7843,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -7797,6 +7858,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace"
@@ -7825,6 +7887,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7833,6 +7896,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"
@@ -7874,6 +7938,7 @@
         "properties": {
           "namespace": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+]+$",
             "example": "some_namespace",
@@ -7882,6 +7947,7 @@
           },
           "key": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 256,
             "pattern": "^[a-zA-Z0-9\\-/_.=+:]+$",
             "example": "some_key"

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -91,6 +91,7 @@ impl From<AuthTokenModel> for AuthTokenOut {
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenCreateIn {
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub name: String,
     #[serde(default = "default_prefix")]
@@ -163,6 +164,7 @@ async fn auth_token_create(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenExpireIn {
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub id: Public<AuthTokenId>,
     /// Milliseconds from now until the token expires. `None` means expire immediately.
@@ -195,6 +197,7 @@ async fn auth_token_expire(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenDeleteIn {
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub id: Public<AuthTokenId>,
 }
@@ -233,6 +236,7 @@ async fn auth_token_delete(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenVerifyIn {
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub token: String,
 }
@@ -274,6 +278,7 @@ async fn auth_token_verify(
 
 #[derive(Clone, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenListIn {
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub owner_id: String,
     #[serde(flatten)]
@@ -318,6 +323,7 @@ async fn auth_token_list(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenUpdateIn {
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub id: Public<AuthTokenId>,
     pub name: Option<String>,
@@ -360,6 +366,7 @@ async fn auth_token_update(
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate, JsonSchema)]
 pub struct AuthTokenRotateIn {
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub id: Public<AuthTokenId>,
     #[serde(default = "default_prefix")]
@@ -409,6 +416,7 @@ async fn auth_token_rotate(
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct AuthTokenGetNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 
@@ -423,6 +431,7 @@ struct AuthTokenGetNamespaceOut {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub(crate) struct AuthTokenCreateNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -47,6 +47,7 @@ pub type CacheNamespace = Namespace<CacheConfig>;
 #[schemars(extend("x-positional" = ["key", "value"]))]
 pub struct CacheSetIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -68,6 +69,7 @@ pub struct CacheSetOut {}
 #[schemars(extend("x-positional" = ["key"]))]
 pub struct CacheGetIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -99,6 +101,7 @@ impl CacheGetOut {
 #[schemars(extend("x-positional" = ["key"]))]
 pub struct CacheDeleteIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -122,6 +125,7 @@ struct CacheGetNamespaceOut {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub(crate) struct CacheCreateNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
     #[serde(default)]
     pub eviction_policy: EvictionPolicy,
@@ -214,6 +218,7 @@ async fn cache_del(
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct CacheGetNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -49,6 +49,7 @@ pub struct CacheSetIn {
     #[serde(default)]
     pub namespace: Option<NamespaceName>,
 
+    #[validate(nested)]
     pub key: EntityKey,
 
     pub value: ByteString,

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -55,6 +55,7 @@ pub type IdempotencyNamespace = Namespace<IdempotencyConfig>;
 #[schemars(extend("x-positional" = ["key"]))]
 pub struct IdempotencyStartIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -102,6 +103,7 @@ impl From<IdempotencyStartResult> for IdempotencyStartOut {
 #[schemars(extend("x-positional" = ["key"]))]
 pub struct IdempotencyCompleteIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -129,6 +131,7 @@ pub struct IdempotencyCompleteOut {}
 #[schemars(extend("x-positional" = ["key"]))]
 pub struct IdempotencyAbortIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -206,6 +209,7 @@ async fn idempotency_abort(
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct IdempotencyGetNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 
@@ -220,6 +224,7 @@ struct IdempotencyGetNamespaceOut {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub(crate) struct IdempotencyCreateNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -45,6 +45,7 @@ macro_rules! request_input {
 #[schemars(extend("x-positional" = ["key", "value"]))]
 pub struct KvSetIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -78,6 +79,7 @@ pub struct KvSetOut {
 #[schemars(extend("x-positional" = ["key"]))]
 pub struct KvGetIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -114,6 +116,7 @@ impl KvGetOut {
 #[schemars(extend("x-positional" = ["key"]))]
 pub struct KvDeleteIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -217,6 +220,7 @@ async fn kv_del(
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct KvGetNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 
@@ -231,6 +235,7 @@ struct KvGetNamespaceOut {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub(crate) struct KvCreateNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -58,6 +58,7 @@ macro_rules! request_input {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 #[schemars(extend("x-positional" = ["name"]))]
 pub(crate) struct MsgNamespaceCreateIn {
+    #[validate(nested)]
     pub name: NamespaceName,
     #[serde(default)]
     pub retention: Retention,
@@ -99,6 +100,7 @@ async fn create_namespace(
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 #[schemars(extend("x-positional" = ["name"]))]
 struct MsgNamespaceGetIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 
@@ -142,6 +144,7 @@ async fn get_namespace(
 #[schemars(extend("x-positional" = ["topic"]))]
 struct MsgPublishIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicIn,
     pub msgs: Vec<diom_msgs::entities::MsgIn>,
@@ -214,6 +217,7 @@ const fn default_lease_duration_ms() -> DurationMs {
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgStreamReceiveIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicIn,
     pub consumer_group: ConsumerGroup,
@@ -326,6 +330,7 @@ async fn stream_receive(
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgStreamCommitIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicPartition,
     pub consumer_group: ConsumerGroup,
@@ -367,6 +372,7 @@ async fn stream_commit(
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgStreamSeekIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicIn,
     pub consumer_group: ConsumerGroup,
@@ -424,6 +430,7 @@ const fn default_queue_lease_duration() -> DurationMs {
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgQueueReceiveIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicIn,
     pub consumer_group: ConsumerGroup,
@@ -533,6 +540,7 @@ async fn queue_receive(
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgQueueAckIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicName,
     pub consumer_group: ConsumerGroup,
@@ -573,6 +581,7 @@ async fn queue_ack(
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgQueueExtendLeaseIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicName,
     pub consumer_group: ConsumerGroup,
@@ -621,6 +630,7 @@ async fn queue_extend_lease(
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgQueueConfigureIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicName,
     pub consumer_group: ConsumerGroup,
@@ -675,6 +685,7 @@ async fn queue_configure(
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgQueueNackIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicName,
     pub consumer_group: ConsumerGroup,
@@ -716,6 +727,7 @@ async fn queue_nack(
 #[schemars(extend("x-positional" = ["topic", "consumer_group"]))]
 struct MsgQueueRedriveDlqIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicName,
     pub consumer_group: ConsumerGroup,
@@ -752,6 +764,7 @@ async fn queue_redrive_dlq(
 #[schemars(extend("x-positional" = ["topic"]))]
 struct MsgTopicConfigureIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
     pub topic: TopicName,
     pub partitions: u16,

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -75,6 +75,7 @@ fn default_interval_ms() -> DurationMs {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct RateLimitCheckIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -111,6 +112,7 @@ pub struct RateLimitCheckOut {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct RateLimitGetRemainingIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -204,6 +206,7 @@ async fn rate_limit_get_remaining(
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct RateLimitResetIn {
     #[serde(default)]
+    #[validate(nested)]
     pub namespace: Option<NamespaceName>,
 
     #[validate(nested)]
@@ -242,6 +245,7 @@ async fn rate_limit_reset(
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub(crate) struct RateLimitCreateNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 
@@ -262,6 +266,7 @@ struct RateLimitCreateNamespaceOut {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 struct RateLimitGetNamespaceIn {
+    #[validate(nested)]
     pub name: NamespaceName,
 }
 


### PR DESCRIPTION
Closes https://github.com/svix/diom-private/issues/625.

I don't love that this depends on `#[validate(nested)]`, which is easy to forget (as has happened for `EntityKey` in that one place), but this seems like the best short-term solution.