### PR TITLE
Remove nonsensical Validate impls (on *Out types)

### DIFF
--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -414,7 +414,7 @@ struct AuthTokenGetNamespaceIn {
 
 namespace_request_input!(AuthTokenGetNamespaceIn, "get");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct AuthTokenGetNamespaceOut {
     pub name: NamespaceName,
     pub created: UnixTimestampMs,
@@ -434,7 +434,7 @@ impl From<AuthTokenCreateNamespaceIn> for CreateAuthTokenNamespaceOperation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct AuthTokenCreateNamespaceOut {
     pub name: NamespaceName,
     pub created: UnixTimestampMs,

--- a/src/v1/endpoints/cache.rs
+++ b/src/v1/endpoints/cache.rs
@@ -106,12 +106,12 @@ pub struct CacheDeleteIn {
 
 request_input!(CacheDeleteIn, "delete");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct CacheDeleteOut {
     pub success: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct CacheGetNamespaceOut {
     pub name: NamespaceName,
     pub eviction_policy: EvictionPolicy,
@@ -134,7 +134,7 @@ impl From<CacheCreateNamespaceIn> for CreateCacheOperation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct CacheCreateNamespaceOut {
     pub name: NamespaceName,
     pub eviction_policy: EvictionPolicy,

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -211,7 +211,7 @@ struct IdempotencyGetNamespaceIn {
 
 namespace_request_input!(IdempotencyGetNamespaceIn, "get");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct IdempotencyGetNamespaceOut {
     pub name: NamespaceName,
     pub created: UnixTimestampMs,
@@ -231,7 +231,7 @@ impl From<IdempotencyCreateNamespaceIn> for CreateIdempotencyOperation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct IdempotencyCreateNamespaceOut {
     pub name: NamespaceName,
     pub created: UnixTimestampMs,

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -67,7 +67,7 @@ pub struct KvSetIn {
 
 request_input!(KvSetIn, "set");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct KvSetOut {
     /// Whether the operation succeeded or was a noop due to pre-conditions.
     pub success: bool,
@@ -88,7 +88,7 @@ pub struct KvGetIn {
 
 request_input!(KvGetIn, "get");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct KvGetOut {
     /// Time of expiry
     pub expiry: Option<UnixTimestampMs>,
@@ -126,7 +126,7 @@ pub struct KvDeleteIn {
 
 request_input!(KvDeleteIn, "delete");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct KvDeleteOut {
     /// Whether the operation succeeded or was a noop due to pre-conditions.
     pub success: bool,
@@ -222,7 +222,7 @@ struct KvGetNamespaceIn {
 
 namespace_request_input!(KvGetNamespaceIn, "get");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct KvGetNamespaceOut {
     pub name: NamespaceName,
     pub created: UnixTimestampMs,
@@ -242,7 +242,7 @@ impl From<KvCreateNamespaceIn> for CreateKvOperation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct KvCreateNamespaceOut {
     pub name: NamespaceName,
     pub created: UnixTimestampMs,

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -71,7 +71,7 @@ impl From<MsgNamespaceCreateIn> for CreateNamespaceOperation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgNamespaceCreateOut {
     pub name: NamespaceName,
     pub retention: Retention,
@@ -104,7 +104,7 @@ struct MsgNamespaceGetIn {
 
 namespace_request_input!(MsgNamespaceGetIn, "get");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgNamespaceGetOut {
     pub name: NamespaceName,
     pub retention: Retention,
@@ -151,14 +151,14 @@ struct MsgPublishIn {
 
 request_input!(MsgPublishIn, "publish");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgPublishOutTopic {
     pub topic: TopicPartition,
     pub start_offset: Offset,
     pub offset: Offset,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgPublishOut {
     pub topics: Vec<MsgPublishOutTopic>,
 }
@@ -230,7 +230,7 @@ struct MsgStreamReceiveIn {
 
 request_input!(MsgStreamReceiveIn, "stream.receive");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgStreamReceiveOut {
     pub msgs: Vec<StreamMsgOut>,
 }
@@ -334,7 +334,7 @@ struct MsgStreamCommitIn {
 
 request_input!(MsgStreamCommitIn, "stream.commit");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgStreamCommitOut {}
 
 /// Commits an offset for a consumer group on a specific partition.
@@ -376,7 +376,7 @@ struct MsgStreamSeekIn {
 
 request_input!(MsgStreamSeekIn, "stream.seek");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgStreamSeekOut {}
 
 /// Repositions a consumer group's read cursor on a topic.
@@ -438,7 +438,7 @@ struct MsgQueueReceiveIn {
 
 request_input!(MsgQueueReceiveIn, "queue.receive");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgQueueReceiveOut {
     pub msgs: Vec<QueueMsgOut>,
 }
@@ -541,7 +541,7 @@ struct MsgQueueAckIn {
 
 request_input!(MsgQueueAckIn, "queue.ack");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgQueueAckOut {}
 
 /// Acknowledges messages by their opaque msg_ids.
@@ -583,7 +583,7 @@ struct MsgQueueExtendLeaseIn {
 
 request_input!(MsgQueueExtendLeaseIn, "extend-lease");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgQueueExtendLeaseOut {}
 
 /// Extends the lease on in-flight messages.
@@ -631,7 +631,7 @@ struct MsgQueueConfigureIn {
 
 request_input!(MsgQueueConfigureIn, "queue.configure");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgQueueConfigureOut {
     pub retry_schedule: Vec<u64>,
     pub dlq_topic: Option<TopicName>,
@@ -683,7 +683,7 @@ struct MsgQueueNackIn {
 
 request_input!(MsgQueueNackIn, "queue.nack");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgQueueNackOut {}
 
 /// Rejects messages, sending them to the dead-letter queue.
@@ -723,7 +723,7 @@ struct MsgQueueRedriveDlqIn {
 
 request_input!(MsgQueueRedriveDlqIn, "queue.redrive-dlq");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgQueueRedriveDlqOut {}
 
 /// Moves all dead-letter queue messages back to the main queue for reprocessing.
@@ -759,7 +759,7 @@ struct MsgTopicConfigureIn {
 
 request_input!(MsgTopicConfigureIn, "topic.configure");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct MsgTopicConfigureOut {
     pub partitions: u16,
 }

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -253,7 +253,7 @@ impl From<RateLimitCreateNamespaceIn> for CreateRateLimitOperation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct RateLimitCreateNamespaceOut {
     pub name: NamespaceName,
     pub created: UnixTimestampMs,
@@ -267,7 +267,7 @@ struct RateLimitGetNamespaceIn {
 
 namespace_request_input!(RateLimitGetNamespaceIn, "get");
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 struct RateLimitGetNamespaceOut {
     pub name: NamespaceName,
     pub created: UnixTimestampMs,


### PR DESCRIPTION
We probably also shouldn't derive `Deserialize` for most of these, but for inter-server requests we actually use it in a place or two IIRC, so leaving that alone for now.

Noticed while working on https://github.com/svix/diom-private/issues/625.