### PR TITLE
Migrate remaining keys used in msgs module to use FjallKeyAble

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -8,6 +8,7 @@
   ```bash
   code --enable-extension rust-lang.rust-analyzer
   ```
+* Do not bother checking for unused imports. Automatic linting tools will handle that.
 
 # Code Style
 * NEVER make changes to `/clients` or `openapi.json` unless specifically directed to. Code generation tools will handle this for us.

--- a/crates/diom-derive/src/fjall_key.rs
+++ b/crates/diom-derive/src/fjall_key.rs
@@ -176,6 +176,84 @@ fn gen_key_parse(struct_name: &Ident, prefix: &Expr, fields: &[KeyField]) -> Tok
     }
 }
 
+/// Generates `build_key()`: takes all fields by reference, returns `UserKey`.
+fn gen_build_key_method(prefix: &Expr, fields: &[KeyField]) -> TokenStream {
+    let params: Vec<TokenStream> = fields
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            let ty = &f.ty;
+            quote! { #ident: &#ty }
+        })
+        .collect();
+
+    let body = gen_key_build(prefix, fields, |f| {
+        let ident = &f.ident;
+        quote! { *#ident }
+    });
+
+    quote! {
+        /// Serialize a key from borrowed fields without constructing the struct.
+        pub fn build_key(#(#params),*) -> ::fjall_utils::UserKey {
+            #body
+        }
+    }
+}
+
+/// Generates a `prefix_<last_field>()` static method that builds a key prefix
+/// from the first N fields.
+fn gen_prefix_method(_prefix: &Expr, fields: &[KeyField]) -> TokenStream {
+    let last_field = &fields[fields.len() - 1];
+    let method_name = quote::format_ident!("prefix_{}", last_field.ident);
+
+    let params: Vec<TokenStream> = fields
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            let ty = &f.ty;
+            quote! { #ident: &#ty }
+        })
+        .collect();
+
+    let types: Vec<&syn::Type> = fields.iter().map(|f| &f.ty).collect();
+    let len_expr = quote! {
+        1usize #(+ <#types as ::fjall_utils::KeyComponent>::BYTE_SIZE)*
+    };
+
+    let writes: Vec<TokenStream> = fields
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            quote! {
+                pos += ::fjall_utils::KeyComponent::write_to_key(#ident, &mut buf[pos..]);
+            }
+        })
+        .collect();
+
+    let field_names: Vec<String> = fields.iter().map(|f| f.ident.to_string()).collect();
+    let doc = format!(
+        "Returns the key prefix: [PREFIX][{}].",
+        field_names.join("][")
+    );
+
+    quote! {
+        #[doc = #doc]
+        pub fn #method_name(#(#params),*) -> ::std::vec::Vec<u8> {
+            let total_len = #len_expr;
+            let mut buf = ::std::vec![0u8; total_len];
+            let mut pos = 0;
+
+            buf[pos] = <Self as ::fjall_utils::FjallKeyAble>::PREFIX;
+            pos += 1;
+
+            #(#writes)*
+
+            ::std::debug_assert_eq!(pos, total_len);
+            buf
+        }
+    }
+}
+
 pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
     let input: DeriveInput = syn::parse2(input)?;
     let prefix = parse_prefix(&input)?;
@@ -234,7 +312,7 @@ pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
 
             quote! {
                 #[doc = #doc]
-                fn #method_name(key: &::fjall_utils::UserKey) -> ::std::result::Result<
+                pub fn #method_name(key: &::fjall_utils::UserKey) -> ::std::result::Result<
                     <#ty as ::fjall_utils::KeyComponent>::Ref<'_>,
                     ::std::borrow::Cow<'static, str>,
                 > {
@@ -257,6 +335,19 @@ pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
         })
         .collect();
 
+    // Generate prefix_<field> methods for each leading subsequence of fixed-size fields.
+    // For position i in 0..fields.len()-1, generate a method that builds
+    // [PREFIX][field_0]...[field_i]. Skip structs with only 1 field.
+    let prefix_methods: Vec<TokenStream> = if fields.len() >= 2 {
+        (0..fields.len() - 1)
+            .map(|i| gen_prefix_method(&prefix, &fields[..=i]))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let build_key_method = gen_build_key_method(&prefix, &fields);
+
     Ok(quote! {
         #(#fixed_size_assertions)*
 
@@ -277,6 +368,8 @@ pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
         #[allow(dead_code)]
         impl #impl_generics #name #ty_generics #where_clause {
             #(#extract_methods)*
+            #(#prefix_methods)*
+            #build_key_method
         }
     })
 }

--- a/crates/fjall-utils/src/fjall_key_able.rs
+++ b/crates/fjall-utils/src/fjall_key_able.rs
@@ -44,6 +44,10 @@ use crate::{TableKey, TableRow};
 ///   from a raw `fjall::UserKey` without constructing the full struct.
 ///   Returns the borrowed form where possible (`&str` for `String`,
 ///   `&[u8]` for `Vec<u8>`, the value directly for fixed-size types).
+/// - **`prefix_<field>()` methods** on the struct — build a key prefix
+///   from the leading fields up to and including the named field.
+///   Generated for each field except the last (use `fjall_key()` for
+///   full keys). Only generated when the struct has 2+ fields.
 ///
 /// ## Binary layout
 ///
@@ -90,6 +94,12 @@ where
 {
     fn from(value: K) -> Self {
         TableKey::init_from_bytes(&value.fjall_key())
+    }
+}
+
+impl<T: TableRow> From<crate::UserKey> for TableKey<T> {
+    fn from(key: crate::UserKey) -> Self {
+        TableKey::init_from_bytes(&key)
     }
 }
 
@@ -232,6 +242,37 @@ impl KeyComponent for String {
         let s = std::str::from_utf8(buf)
             .map_err(|e| Cow::Owned(format!("invalid utf8 in String key component: {e}")))?;
         Ok((s, buf.len()))
+    }
+}
+
+impl<const N: usize> KeyComponent for [u8; N] {
+    const FIXED_SIZE: bool = true;
+    const BYTE_SIZE: usize = N;
+    type Ref<'a> = [u8; N];
+
+    fn key_len(&self) -> usize {
+        N
+    }
+
+    fn write_to_key(&self, buf: &mut [u8]) -> usize {
+        buf[..N].copy_from_slice(self);
+        N
+    }
+
+    fn read_from_key(buf: &[u8]) -> Result<(Self, usize), Cow<'static, str>> {
+        if buf.len() < N {
+            return Err(Cow::Owned(format!(
+                "key buffer too short for [u8; {N}]: expected {N} bytes, got {}",
+                buf.len()
+            )));
+        }
+        let mut arr = [0u8; N];
+        arr.copy_from_slice(&buf[..N]);
+        Ok((arr, N))
+    }
+
+    fn read_ref_from_key(buf: &[u8]) -> Result<(Self::Ref<'_>, usize), Cow<'static, str>> {
+        Self::read_from_key(buf)
     }
 }
 
@@ -398,5 +439,89 @@ mod tests {
         let bytes = key.fjall_key();
         assert_eq!(ExampleCompositeKey::extract_id(&bytes).unwrap(), 7);
         assert_eq!(ExampleCompositeKey::extract_group(&bytes).unwrap(), "hello");
+    }
+
+    #[derive(FjallKeyAble)]
+    #[table_key(prefix = 3)]
+    struct ExampleTripleKey {
+        #[key(0)]
+        a: u32,
+        #[key(1)]
+        b: u16,
+        #[key(2)]
+        tag: String,
+    }
+
+    #[test]
+    fn test_prefix_composite_key() {
+        let prefix = ExampleCompositeKey::prefix_id(&7u32);
+        let mut expected = Vec::new();
+        expected.push(2u8);
+        expected.extend_from_slice(&7u32.to_be_bytes());
+        assert_eq!(prefix, expected);
+    }
+
+    #[test]
+    fn test_prefix_is_prefix_of_full_key() {
+        let key = ExampleCompositeKey {
+            id: 7,
+            group: "hello".to_string(),
+        };
+        let full = key.fjall_key();
+        let prefix = ExampleCompositeKey::prefix_id(&7u32);
+        assert!(full.starts_with(&prefix));
+    }
+
+    #[test]
+    fn test_prefix_triple_key() {
+        let prefix_a = ExampleTripleKey::prefix_a(&10u32);
+        let mut expected = Vec::new();
+        expected.push(3u8);
+        expected.extend_from_slice(&10u32.to_be_bytes());
+        assert_eq!(prefix_a, expected);
+
+        let prefix_b = ExampleTripleKey::prefix_b(&10u32, &5u16);
+        let mut expected = Vec::new();
+        expected.push(3u8);
+        expected.extend_from_slice(&10u32.to_be_bytes());
+        expected.extend_from_slice(&5u16.to_be_bytes());
+        assert_eq!(prefix_b, expected);
+    }
+
+    #[test]
+    fn test_prefix_nesting() {
+        let prefix_a = ExampleTripleKey::prefix_a(&10u32);
+        let prefix_b = ExampleTripleKey::prefix_b(&10u32, &5u16);
+        let key = ExampleTripleKey {
+            a: 10,
+            b: 5,
+            tag: "x".to_string(),
+        };
+        let full = key.fjall_key();
+        assert!(prefix_b.starts_with(&prefix_a));
+        assert!(full.starts_with(&prefix_b));
+    }
+
+    #[test]
+    fn test_build_key_matches_fjall_key() {
+        let key = ExampleCompositeKey {
+            id: 42,
+            group: "test".to_string(),
+        };
+        let from_struct = key.fjall_key();
+        let from_build = ExampleCompositeKey::build_key(&42u32, &"test".to_string());
+        assert_eq!(&*from_struct, &*from_build);
+    }
+
+    #[test]
+    fn test_build_key_triple() {
+        let key = ExampleTripleKey {
+            a: 1,
+            b: 2,
+            tag: "abc".to_string(),
+        };
+        let from_struct = key.fjall_key();
+        let from_build = ExampleTripleKey::build_key(&1u32, &2u16, &"abc".to_string());
+        assert_eq!(&*from_struct, &*from_build);
     }
 }

--- a/crates/msgs/src/compaction.rs
+++ b/crates/msgs/src/compaction.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::{
         METADATA_KEYSPACE,
         entities::{MsgsIdempotencyKey, TopicName},
-        tables::{IdempotencyRow, TopicRow},
+        tables::{IdempotencyKey, IdempotencyRow, TopicKey, TopicRow},
     };
     use diom_core::Monotime;
     use diom_id::{NamespaceId, UuidV7RandomBytes};
@@ -97,7 +97,7 @@ mod tests {
 
         TopicRow::insert(
             &ks,
-            TopicRow::key_for(ns, &topic),
+            TopicKey::build_key(&ns, &topic),
             &TopicRow::new(
                 topic.clone(),
                 Timestamp::UNIX_EPOCH,
@@ -108,7 +108,7 @@ mod tests {
         let expired_key = MsgsIdempotencyKey::new(None, &topic, "old");
         IdempotencyRow::insert(
             &ks,
-            IdempotencyRow::key_for(ns, &expired_key),
+            IdempotencyKey::build_key(&ns, &expired_key),
             &IdempotencyRow {
                 expiry: Timestamp::from_second(1)?,
             },
@@ -117,7 +117,7 @@ mod tests {
         let fresh_key = MsgsIdempotencyKey::new(None, &topic, "new");
         IdempotencyRow::insert(
             &ks,
-            IdempotencyRow::key_for(ns, &fresh_key),
+            IdempotencyKey::build_key(&ns, &fresh_key),
             &IdempotencyRow {
                 expiry: Timestamp::from_second(20)?,
             },
@@ -127,9 +127,11 @@ mod tests {
         ks.rotate_memtable_and_wait()?;
         ks.major_compact()?;
 
-        assert!(TopicRow::fetch(&ks, TopicRow::key_for(ns, &topic))?.is_some());
-        assert!(IdempotencyRow::fetch(&ks, IdempotencyRow::key_for(ns, &expired_key))?.is_none());
-        assert!(IdempotencyRow::fetch(&ks, IdempotencyRow::key_for(ns, &fresh_key))?.is_some());
+        assert!(TopicRow::fetch(&ks, TopicKey::build_key(&ns, &topic))?.is_some());
+        assert!(
+            IdempotencyRow::fetch(&ks, IdempotencyKey::build_key(&ns, &expired_key))?.is_none()
+        );
+        assert!(IdempotencyRow::fetch(&ks, IdempotencyKey::build_key(&ns, &fresh_key))?.is_some());
 
         Ok(())
     }

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fmt, num::NonZeroU64, ops::Deref, str::FromStr};
 
 use diom_core::types::{ByteString, DurationMs, UnixTimestampMs};
 use diom_error::Error;
+use fjall_utils::KeyComponent;
 use schemars::JsonSchema;
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
@@ -20,17 +21,7 @@ pub const MAX_PARTITION_COUNT: u16 = 64;
 pub const TOPIC_PARTITION_DELIMITER: &str = "~";
 
 #[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    fjall_utils::KeyComponent,
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, KeyComponent,
 )]
 #[serde(transparent)]
 pub struct Partition(u16);
@@ -66,7 +57,7 @@ impl FromStr for Partition {
 ///
 /// Carries the `namespace` that owns this topic. Serializes as `"namespace:topic"`, or just
 /// `"topic"` when the namespace is the default.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, KeyComponent)]
 pub struct TopicName(String);
 
 impl TopicName {
@@ -260,7 +251,7 @@ impl JsonSchema for TopicIn {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, KeyComponent)]
 #[serde(transparent)]
 pub struct MsgsIdempotencyKey([u8; 32]);
 
@@ -410,7 +401,7 @@ pub enum SeekPosition {
 /// A validated consumer group identifier.
 ///
 /// Must be at most 64 bytes and only contain ASCII alphanumeric characters, `_`, `-`, or `.`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, KeyComponent)]
 #[serde(transparent)]
 pub struct ConsumerGroup(pub(crate) String);
 

--- a/crates/msgs/src/lib.rs
+++ b/crates/msgs/src/lib.rs
@@ -7,7 +7,7 @@ use jiff::Timestamp;
 
 use entities::{ConsumerGroup, Partition, TopicName};
 use fjall_utils::{ReadableKeyspace, SerializableKeyspaceCreateOptions, TableRow};
-use tables::{MsgRow, QueueLeaseRow, StreamLeaseRow, TopicRow};
+use tables::{MsgRow, QueueLeaseRow, StreamLeaseKey, StreamLeaseRow, TopicKey, TopicRow};
 
 use crate::metrics::{record_end_offsets, record_topic_lag_metrics};
 
@@ -71,7 +71,8 @@ pub fn estimate_available_queue_messages(
     consumer_group: &ConsumerGroup,
     now: Timestamp,
 ) -> Result<u64> {
-    let Some(topic_row) = TopicRow::fetch(metadata_tables, TopicRow::key_for(namespace_id, topic))?
+    let Some(topic_row) =
+        TopicRow::fetch(metadata_tables, TopicKey::build_key(&namespace_id, topic))?
     else {
         return Ok(0);
     };
@@ -84,7 +85,7 @@ pub fn estimate_available_queue_messages(
         // the name is misleading here.
         let cursor_offset = StreamLeaseRow::fetch(
             metadata_tables,
-            StreamLeaseRow::key_for(topic_row.id, partition, consumer_group),
+            StreamLeaseKey::build_key(&topic_row.id, &partition, consumer_group),
         )?
         .map(|c| c.offset)
         .unwrap_or(0);
@@ -128,7 +129,8 @@ pub fn estimate_available_stream_messages(
     consumer_group: &ConsumerGroup,
     now: Timestamp,
 ) -> Result<StreamEstimate> {
-    let Some(topic_row) = TopicRow::fetch(metadata_tables, TopicRow::key_for(namespace_id, topic))?
+    let Some(topic_row) =
+        TopicRow::fetch(metadata_tables, TopicKey::build_key(&namespace_id, topic))?
     else {
         return Ok(StreamEstimate::default());
     };
@@ -140,7 +142,7 @@ pub fn estimate_available_stream_messages(
 
         let cursor = StreamLeaseRow::fetch(
             metadata_tables,
-            StreamLeaseRow::key_for(topic_row.id, partition, consumer_group),
+            StreamLeaseKey::build_key(&topic_row.id, &partition, consumer_group),
         )?;
 
         // Skip partitions with active leases

--- a/crates/msgs/src/metrics.rs
+++ b/crates/msgs/src/metrics.rs
@@ -3,7 +3,7 @@ use opentelemetry::metrics::{Counter, Gauge, Meter};
 use crate::{
     State,
     entities::{ConsumerGroup, Partition, TopicName},
-    tables::{MsgRow, StreamLeaseRow, TopicRow},
+    tables::{MsgRow, StreamLeaseKey, StreamLeaseRow, TopicRow},
 };
 use diom_error::Result;
 
@@ -259,14 +259,12 @@ fn compute_topic_lag(
         let (_, val) = guard.into_inner()?;
         let topic_row: TopicRow = TopicRow::from_fjall_value(val)?;
 
-        let prefix = StreamLeaseRow::topic_scan_prefix(topic_row.id);
+        let prefix = StreamLeaseKey::prefix_topic_id(&topic_row.id);
 
         let mut consumer_groups = HashSet::new();
         for guard in metadata_tables.prefix(&prefix) {
             let (key, _) = guard.into_inner()?;
-            if let Some(cg_str) = StreamLeaseRow::consumer_group_from_key(&key)
-                && let Ok(consumer_group) = ConsumerGroup::try_from(cg_str)
-            {
+            if let Ok(consumer_group) = StreamLeaseKey::extract_consumer_group(&key) {
                 consumer_groups.insert(consumer_group);
             }
         }
@@ -278,7 +276,7 @@ fn compute_topic_lag(
                 };
                 let cursor_offset = StreamLeaseRow::fetch(
                     metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, partition, &cg),
+                    StreamLeaseKey::build_key(&topic_row.id, &partition, &cg),
                 )?
                 .map(|c| c.offset)
                 .unwrap_or(0);
@@ -335,7 +333,7 @@ mod tests {
     use jiff::Timestamp;
 
     use super::*;
-    use crate::tables::{MsgKey, MsgRow, StreamLeaseRow, TopicRow};
+    use crate::tables::{MsgKey, MsgRow, StreamLeaseKey, StreamLeaseRow, TopicKey, TopicRow};
 
     fn make_db() -> (fjall::Database, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
@@ -352,7 +350,7 @@ mod tests {
         batch
             .insert_row(
                 meta,
-                TopicRow::key_for(NamespaceId::nil(), &topic_row.name),
+                TopicKey::build_key(&NamespaceId::nil(), &topic_row.name),
                 topic_row,
             )
             .unwrap();
@@ -404,7 +402,7 @@ mod tests {
         batch
             .insert_row(
                 meta,
-                StreamLeaseRow::key_for(topic_row.id, partition, cg),
+                StreamLeaseKey::build_key(&topic_row.id, &partition, cg),
                 &row,
             )
             .unwrap();

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -16,7 +16,7 @@ use crate::{
         MsgIn, MsgsIdempotencyKey, Offset, Partition, TopicIn, TopicName, TopicPartition,
         partition_for_key,
     },
-    tables::{IdempotencyRow, MsgKey, MsgRow, TopicRow},
+    tables::{IdempotencyKey, IdempotencyRow, MsgKey, MsgRow, TopicKey, TopicRow},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -71,7 +71,7 @@ impl PublishOperation {
             if let Some(idempotency_key) = self.idempotency_key {
                 let existing = IdempotencyRow::fetch(
                     &state.metadata_tables,
-                    IdempotencyRow::key_for(self.namespace_id, &idempotency_key),
+                    IdempotencyKey::build_key(&self.namespace_id, &idempotency_key),
                 )?;
 
                 if let Some(existing) = existing
@@ -86,7 +86,7 @@ impl PublishOperation {
 
                 batch.insert_row(
                     &state.metadata_tables,
-                    IdempotencyRow::key_for(self.namespace_id, &idempotency_key),
+                    IdempotencyKey::build_key(&self.namespace_id, &idempotency_key),
                     &IdempotencyRow {
                         expiry: now + IDEMPOTENCY_TTL,
                     },
@@ -95,7 +95,7 @@ impl PublishOperation {
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &self.topic),
+                TopicKey::build_key(&self.namespace_id, &self.topic),
             )?;
             let topic_row = match (topic_row, self.partition) {
                 (Some(row), Some(partition)) if (0..row.partitions).contains(&partition.get()) => {
@@ -112,7 +112,7 @@ impl PublishOperation {
                     let row = TopicRow::new(self.topic.clone(), now, self.topic_id_random_bytes);
                     batch.insert_row(
                         &state.metadata_tables,
-                        TopicRow::key_for(self.namespace_id, &self.topic),
+                        TopicKey::build_key(&self.namespace_id, &self.topic),
                         &row,
                     )?;
                     row

--- a/crates/msgs/src/operations/queue/ack.rs
+++ b/crates/msgs/src/operations/queue/ack.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     State,
     entities::{ConsumerGroup, MsgId, TopicName},
-    tables::{QueueLeaseRow, StreamLeaseRow, TopicRow},
+    tables::{QueueLeaseRow, StreamLeaseKey, StreamLeaseRow, TopicKey, TopicRow},
 };
 
 use super::{
@@ -47,7 +47,7 @@ impl QueueAckOperation {
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &self.topic),
+                TopicKey::build_key(&self.namespace_id, &self.topic),
             )?
             .ok_or_else(|| Error::invalid_user_input("topic must exist"))?;
 
@@ -71,7 +71,7 @@ impl QueueAckOperation {
             for partition in affected_partitions {
                 let Some(mut cursor) = StreamLeaseRow::fetch(
                     &state.metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
+                    StreamLeaseKey::build_key(&topic_row.id, &partition, &self.consumer_group),
                 )?
                 else {
                     continue;
@@ -88,7 +88,7 @@ impl QueueAckOperation {
 
                 batch.insert_row(
                     &state.metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
+                    StreamLeaseKey::build_key(&topic_row.id, &partition, &self.consumer_group),
                     &cursor,
                 )?;
             }

--- a/crates/msgs/src/operations/queue/configure.rs
+++ b/crates/msgs/src/operations/queue/configure.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     State,
     entities::{ConsumerGroup, TopicName},
-    tables::{QueueConfigRow, TopicRow},
+    tables::{QueueConfigKey, QueueConfigRow, TopicRow},
 };
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueConfigureResponse};
@@ -63,7 +63,7 @@ impl QueueConfigureOperation {
 
             batch.insert_row(
                 &state.metadata_tables,
-                QueueConfigRow::key_for(topic_row.id, &self.consumer_group),
+                QueueConfigKey::build_key(&topic_row.id, &self.consumer_group),
                 &config,
             )?;
             batch.commit().map_err(Error::from)?;

--- a/crates/msgs/src/operations/queue/extend_lease.rs
+++ b/crates/msgs/src/operations/queue/extend_lease.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     State,
     entities::{ConsumerGroup, MsgId, TopicName},
-    tables::{QueueLeaseRow, TopicRow},
+    tables::{QueueLeaseKey, QueueLeaseRow, TopicKey, TopicRow},
 };
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueExtendLeaseResponse};
@@ -52,7 +52,7 @@ impl QueueExtendLeaseOperation {
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &self.topic),
+                TopicKey::build_key(&self.namespace_id, &self.topic),
             )?
             .ok_or_else(|| Error::invalid_user_input("topic must exist"))?;
 
@@ -65,7 +65,12 @@ impl QueueExtendLeaseOperation {
             for msg_id in &self.msg_ids {
                 let lease = QueueLeaseRow::fetch(
                     &state.metadata_tables,
-                    QueueLeaseRow::key_for(topic_row.id, msg_id, &self.consumer_group),
+                    QueueLeaseKey::build_key(
+                        &topic_row.id,
+                        &msg_id.partition,
+                        &msg_id.offset,
+                        &self.consumer_group,
+                    ),
                 )?;
 
                 let lease = match lease {
@@ -88,7 +93,12 @@ impl QueueExtendLeaseOperation {
 
                 batch.insert_row(
                     &state.metadata_tables,
-                    QueueLeaseRow::key_for(topic_row.id, msg_id, &self.consumer_group),
+                    QueueLeaseKey::build_key(
+                        &topic_row.id,
+                        &msg_id.partition,
+                        &msg_id.offset,
+                        &self.consumer_group,
+                    ),
                     &QueueLeaseRow {
                         expiry: new_expiry,
                         dlq: false,

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     State,
     entities::{ConsumerGroup, MsgId, Partition, TopicName},
-    tables::{MsgKey, MsgRow, QueueConfigRow, QueueLeaseRow, TopicRow},
+    tables::{
+        MsgKey, MsgRow, QueueConfigKey, QueueConfigRow, QueueLeaseKey, QueueLeaseRow, TopicKey,
+        TopicRow,
+    },
 };
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueNackResponse};
@@ -48,13 +51,13 @@ impl QueueNackOperation {
             let nack_count = self.msg_ids.len() as u64;
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &self.topic),
+                TopicKey::build_key(&self.namespace_id, &self.topic),
             )?
             .ok_or_else(|| Error::invalid_user_input("topic must exist"))?;
 
             let config = QueueConfigRow::fetch(
                 &state.metadata_tables,
-                QueueConfigRow::key_for(topic_row.id, &self.consumer_group),
+                QueueConfigKey::build_key(&topic_row.id, &self.consumer_group),
             )?;
 
             let retry_schedule = config
@@ -69,7 +72,12 @@ impl QueueNackOperation {
             for msg_id in &self.msg_ids {
                 let existing = QueueLeaseRow::fetch(
                     &state.metadata_tables,
-                    QueueLeaseRow::key_for(topic_row.id, msg_id, &self.consumer_group),
+                    QueueLeaseKey::build_key(
+                        &topic_row.id,
+                        &msg_id.partition,
+                        &msg_id.offset,
+                        &self.consumer_group,
+                    ),
                 )?;
                 let attempt_count = existing.map(|r| r.attempt_count).unwrap_or(0);
 
@@ -78,7 +86,12 @@ impl QueueNackOperation {
                     let expiry = now + Duration::from_millis(delay_ms);
                     batch.insert_row(
                         &state.metadata_tables,
-                        QueueLeaseRow::key_for(topic_row.id, msg_id, &self.consumer_group),
+                        QueueLeaseKey::build_key(
+                            &topic_row.id,
+                            &msg_id.partition,
+                            &msg_id.offset,
+                            &self.consumer_group,
+                        ),
                         &QueueLeaseRow {
                             expiry,
                             dlq: false,
@@ -104,7 +117,12 @@ impl QueueNackOperation {
                     // No config or no DLQ topic — immediate DLQ
                     batch.insert_row(
                         &state.metadata_tables,
-                        QueueLeaseRow::key_for(topic_row.id, msg_id, &self.consumer_group),
+                        QueueLeaseKey::build_key(
+                            &topic_row.id,
+                            &msg_id.partition,
+                            &msg_id.offset,
+                            &self.consumer_group,
+                        ),
                         &QueueLeaseRow::dlq_marker(attempt_count),
                     )?;
                     dlq_count += 1;

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -14,7 +14,7 @@ use tracing::Span;
 use crate::{
     State,
     entities::{ConsumerGroup, MsgId, Partition, TopicIn, TopicName},
-    tables::{MsgRow, QueueLeaseRow, StreamLeaseRow, TopicRow},
+    tables::{MsgRow, QueueLeaseKey, QueueLeaseRow, StreamLeaseKey, StreamLeaseRow, TopicRow},
 };
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueReceiveResponse};
@@ -89,7 +89,7 @@ impl QueueReceiveOperation {
                 // Queue starts from offset 0 (earliest), unlike stream which starts from latest.
                 let mut cursor = match StreamLeaseRow::fetch(
                     &state.metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
+                    StreamLeaseKey::build_key(&topic_row.id, &partition, &self.consumer_group),
                 )? {
                     Some(cursor) => cursor,
                     None => StreamLeaseRow::new()?,
@@ -146,7 +146,7 @@ impl QueueReceiveOperation {
 
                 batch.insert_row(
                     &state.metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
+                    StreamLeaseKey::build_key(&topic_row.id, &partition, &self.consumer_group),
                     &cursor,
                 )?;
 
@@ -191,7 +191,7 @@ fn lease_available_msgs(
 
         let existing_lease = QueueLeaseRow::fetch(
             &state.metadata_tables,
-            QueueLeaseRow::key_for(topic_id, &msg_id, consumer_group),
+            QueueLeaseKey::build_key(&topic_id, &msg_id.partition, &msg_id.offset, consumer_group),
         )?;
 
         if existing_lease
@@ -209,7 +209,12 @@ fn lease_available_msgs(
         {
             batch.insert_row(
                 &state.metadata_tables,
-                QueueLeaseRow::key_for(topic_id, &msg_id, consumer_group),
+                QueueLeaseKey::build_key(
+                    &topic_id,
+                    &msg_id.partition,
+                    &msg_id.offset,
+                    consumer_group,
+                ),
                 &QueueLeaseRow {
                     expiry: scheduled_at,
                     dlq: false,
@@ -224,7 +229,7 @@ fn lease_available_msgs(
 
         batch.insert_row(
             &state.metadata_tables,
-            QueueLeaseRow::key_for(topic_id, &msg_id, consumer_group),
+            QueueLeaseKey::build_key(&topic_id, &msg_id.partition, &msg_id.offset, consumer_group),
             &QueueLeaseRow {
                 expiry,
                 dlq: false,
@@ -258,15 +263,23 @@ pub(crate) fn compact_cursor(
 ) -> Result<()> {
     loop {
         let check_id = MsgId::new(partition, cursor.offset);
-        match QueueLeaseRow::fetch(
-            &state.metadata_tables,
-            QueueLeaseRow::key_for(topic_id, &check_id, consumer_group),
-        )? {
+        let key = QueueLeaseKey::build_key(
+            &topic_id,
+            &check_id.partition,
+            &check_id.offset,
+            consumer_group,
+        );
+        match QueueLeaseRow::fetch(&state.metadata_tables, key)? {
             Some(lease) if lease.is_acked() => {
-                batch.remove(
+                batch.remove_row::<QueueLeaseRow, _>(
                     &state.metadata_tables,
-                    QueueLeaseRow::key_for(topic_id, &check_id, consumer_group).into_fjall_key(),
-                );
+                    QueueLeaseKey::build_key(
+                        &topic_id,
+                        &check_id.partition,
+                        &check_id.offset,
+                        consumer_group,
+                    ),
+                )?;
                 cursor.offset += 1;
             }
             // Advance past DLQ'd messages but keep their rows for redrive

--- a/crates/msgs/src/operations/queue/redrive_dlq.rs
+++ b/crates/msgs/src/operations/queue/redrive_dlq.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     State,
     entities::{ConsumerGroup, Partition, TopicName},
-    tables::{QueueLeaseRow, StreamLeaseRow, TopicRow},
+    tables::{QueueLeaseKey, QueueLeaseRow, StreamLeaseKey, StreamLeaseRow, TopicKey, TopicRow},
 };
 
 use super::super::{MsgsRaftState, MsgsRequest, QueueRedriveDlqResponse};
@@ -35,7 +35,7 @@ impl QueueRedriveDlqOperation {
         spawn_blocking_in_current_span(move || {
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &self.topic),
+                TopicKey::build_key(&self.namespace_id, &self.topic),
             )?
             .ok_or_else(|| Error::invalid_user_input("topic must exist"))?;
 
@@ -47,7 +47,7 @@ impl QueueRedriveDlqOperation {
 
                 let Some(mut cursor) = StreamLeaseRow::fetch(
                     &state.metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
+                    StreamLeaseKey::build_key(&topic_row.id, &partition, &self.consumer_group),
                 )?
                 else {
                     continue;
@@ -64,11 +64,15 @@ impl QueueRedriveDlqOperation {
                 let mut partition_redriven: u64 = 0;
                 for (msg_id, lease) in &leases {
                     if lease.is_dlq() {
-                        batch.remove(
+                        batch.remove_row::<QueueLeaseRow, _>(
                             &state.metadata_tables,
-                            QueueLeaseRow::key_for(topic_row.id, msg_id, &self.consumer_group)
-                                .into_fjall_key(),
-                        );
+                            QueueLeaseKey::build_key(
+                                &topic_row.id,
+                                &msg_id.partition,
+                                &msg_id.offset,
+                                &self.consumer_group,
+                            ),
+                        )?;
                         min_redriven =
                             Some(min_redriven.map_or(msg_id.offset, |m| m.min(msg_id.offset)));
                         partition_redriven += 1;
@@ -80,7 +84,7 @@ impl QueueRedriveDlqOperation {
                     cursor.offset = new_offset;
                     batch.insert_row(
                         &state.metadata_tables,
-                        StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
+                        StreamLeaseKey::build_key(&topic_row.id, &partition, &self.consumer_group),
                         &cursor,
                     )?;
                 }

--- a/crates/msgs/src/operations/stream/commit.rs
+++ b/crates/msgs/src/operations/stream/commit.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     State,
     entities::{ConsumerGroup, Offset, TopicPartition},
-    tables::{StreamLeaseRow, TopicRow},
+    tables::{StreamLeaseKey, StreamLeaseRow, TopicKey, TopicRow},
 };
 
 use super::super::{MsgsRaftState, MsgsRequest, StreamCommitResponse};
@@ -45,13 +45,13 @@ impl StreamCommitOperation {
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &topic.topic),
+                TopicKey::build_key(&self.namespace_id, &topic.topic),
             )?
             .ok_or_else(|| Error::invalid_user_input("partition must exist"))?;
 
             let mut lease = StreamLeaseRow::fetch(
                 &state.metadata_tables,
-                StreamLeaseRow::key_for(topic_row.id, topic.partition, &self.consumer_group),
+                StreamLeaseKey::build_key(&topic_row.id, &topic.partition, &self.consumer_group),
             )?
             .ok_or_else(|| Error::invalid_user_input("lease not found"))?;
 
@@ -62,7 +62,7 @@ impl StreamCommitOperation {
 
             batch.insert_row(
                 &state.metadata_tables,
-                StreamLeaseRow::key_for(topic_row.id, topic.partition, &self.consumer_group),
+                StreamLeaseKey::build_key(&topic_row.id, &topic.partition, &self.consumer_group),
                 &lease,
             )?;
 

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -16,7 +16,7 @@ use crate::{
     entities::{
         ConsumerGroup, Offset, Partition, SeekPosition, TopicIn, TopicName, TopicPartition,
     },
-    tables::{MsgRow, StreamLeaseRow, TopicRow},
+    tables::{MsgRow, StreamLeaseKey, StreamLeaseRow, TopicRow},
 };
 
 use super::super::{MsgsRaftState, MsgsRequest, StreamReceiveResponse};
@@ -92,7 +92,11 @@ impl StreamReceiveOperation {
                 let topic = TopicPartition::new(self.topic.clone(), Partition::new(partition)?);
                 let (mut lease, is_new) = match StreamLeaseRow::fetch(
                     &state.metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, topic.partition, &self.consumer_group),
+                    StreamLeaseKey::build_key(
+                        &topic_row.id,
+                        &topic.partition,
+                        &self.consumer_group,
+                    ),
                 )? {
                     Some(lease) => (lease, false),
                     None => {
@@ -126,9 +130,9 @@ impl StreamReceiveOperation {
                     if is_new {
                         batch.insert_row(
                             &state.metadata_tables,
-                            StreamLeaseRow::key_for(
-                                topic_row.id,
-                                topic.partition,
+                            StreamLeaseKey::build_key(
+                                &topic_row.id,
+                                &topic.partition,
                                 &self.consumer_group,
                             ),
                             &lease,
@@ -159,7 +163,11 @@ impl StreamReceiveOperation {
 
                 batch.insert_row(
                     &state.metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, topic.partition, &self.consumer_group),
+                    StreamLeaseKey::build_key(
+                        &topic_row.id,
+                        &topic.partition,
+                        &self.consumer_group,
+                    ),
                     &lease,
                 )?;
 

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     State,
     entities::{ConsumerGroup, Offset, Partition, SeekPosition, TopicIn, TopicName},
-    tables::{MsgRow, StreamLeaseRow, TopicRow},
+    tables::{MsgRow, StreamLeaseKey, StreamLeaseRow, TopicKey, TopicRow},
 };
 
 use super::super::{MsgsRaftState, MsgsRequest, StreamSeekResponse};
@@ -64,7 +64,7 @@ impl StreamSeekOperation {
 
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &self.topic),
+                TopicKey::build_key(&self.namespace_id, &self.topic),
             )?
             .ok_or_else(|| Error::invalid_user_input("topic must exist"))?;
 
@@ -92,7 +92,7 @@ impl StreamSeekOperation {
 
                 batch.insert_row(
                     &state.metadata_tables,
-                    StreamLeaseRow::key_for(topic_row.id, partition, &self.consumer_group),
+                    StreamLeaseKey::build_key(&topic_row.id, &partition, &self.consumer_group),
                     &lease,
                 )?;
             }

--- a/crates/msgs/src/operations/topic_configure.rs
+++ b/crates/msgs/src/operations/topic_configure.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     State,
     entities::{MAX_PARTITION_COUNT, TopicName},
-    tables::TopicRow,
+    tables::{TopicKey, TopicRow},
 };
 
 use super::{MsgsRaftState, MsgsRequest, TopicConfigureResponse};
@@ -41,7 +41,7 @@ impl TopicConfigureOperation {
         spawn_blocking_in_current_span(move || {
             let mut topic_row = match TopicRow::fetch(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &self.topic),
+                TopicKey::build_key(&self.namespace_id, &self.topic),
             )? {
                 Some(topic_row) => topic_row,
                 None => TopicRow::new(self.topic.clone(), now, self.topic_id_random_bytes),
@@ -58,7 +58,7 @@ impl TopicConfigureOperation {
             let mut batch = state.db.batch();
             batch.insert_row(
                 &state.metadata_tables,
-                TopicRow::key_for(self.namespace_id, &self.topic),
+                TopicKey::build_key(&self.namespace_id, &self.topic),
                 &topic_row,
             )?;
             batch.commit().map_err(Error::from)?;

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -3,7 +3,7 @@ use diom_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use std::collections::HashMap;
 
 use diom_error::Result;
-use fjall_utils::{FjallKeyAble, TableKey, TableRow, WriteBatchExt};
+use fjall_utils::{FjallKeyAble, TableRow, WriteBatchExt};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -30,11 +30,16 @@ impl TableRow for TopicRow {
     const ROW_TYPE: u8 = RowType::Topic as u8;
 }
 
-impl TopicRow {
-    pub(crate) fn key_for(namespace_id: NamespaceId, topic: &TopicName) -> TableKey<Self> {
-        TableKey::init_key(Self::ROW_TYPE, &[namespace_id.as_bytes()], &[topic])
-    }
+#[derive(FjallKeyAble)]
+#[table_key(prefix = RowType::Topic)]
+pub(crate) struct TopicKey {
+    #[key(0)]
+    pub(crate) namespace_id: NamespaceId,
+    #[key(1)]
+    pub(crate) topic: TopicName,
+}
 
+impl TopicRow {
     pub(crate) fn new(name: TopicName, now: Timestamp, id_random_bytes: UuidV7RandomBytes) -> Self {
         Self {
             id: TopicId::new(now, id_random_bytes),
@@ -59,11 +64,12 @@ impl TopicRow {
         now: Timestamp,
         id_random_bytes: UuidV7RandomBytes,
     ) -> Result<Self> {
-        if let Some(row) = Self::fetch(metadata_tables, Self::key_for(namespace_id, topic))? {
+        let key = TopicKey::build_key(&namespace_id, topic);
+        if let Some(row) = Self::fetch(metadata_tables, key.clone())? {
             return Ok(row);
         }
         let row = Self::new(topic.clone(), now, id_random_bytes);
-        batch.insert_row(metadata_tables, Self::key_for(namespace_id, topic), &row)?;
+        batch.insert_row(metadata_tables, key, &row)?;
         Ok(row)
     }
 }
@@ -78,34 +84,6 @@ pub(crate) struct StreamLeaseRow {
 }
 
 impl StreamLeaseRow {
-    const CONSUMER_GROUP_OFFSET: usize =
-        size_of::<fjall_utils::TableKeyType>() + size_of::<TopicId>() + size_of::<Partition>();
-
-    pub(crate) fn consumer_group_from_key(key: &[u8]) -> Option<&str> {
-        std::str::from_utf8(key.get(Self::CONSUMER_GROUP_OFFSET..)?).ok()
-    }
-
-    /// Returns the key prefix for scanning all `StreamLeaseRow`s for a given topic.
-    pub(crate) fn topic_scan_prefix(topic_id: TopicId) -> Vec<u8> {
-        let mut prefix =
-            Vec::with_capacity(size_of::<fjall_utils::TableKeyType>() + size_of::<TopicId>());
-        prefix.push(Self::ROW_TYPE);
-        prefix.extend_from_slice(topic_id.as_bytes());
-        prefix
-    }
-
-    pub(crate) fn key_for(
-        topic_id: TopicId,
-        partition: Partition,
-        consumer_group: &ConsumerGroup,
-    ) -> TableKey<Self> {
-        TableKey::init_key(
-            Self::ROW_TYPE,
-            &[topic_id.as_bytes(), &partition.get().to_be_bytes()],
-            &[consumer_group],
-        )
-    }
-
     pub(crate) fn new() -> Result<Self> {
         Ok(Self {
             offset: 0,
@@ -117,6 +95,17 @@ impl StreamLeaseRow {
 
 impl TableRow for StreamLeaseRow {
     const ROW_TYPE: u8 = RowType::StreamLease as u8;
+}
+
+#[derive(FjallKeyAble)]
+#[table_key(prefix = RowType::StreamLease)]
+pub(crate) struct StreamLeaseKey {
+    #[key(0)]
+    pub(crate) topic_id: TopicId,
+    #[key(1)]
+    pub(crate) partition: Partition,
+    #[key(2)]
+    pub(crate) consumer_group: ConsumerGroup,
 }
 
 /// Per-message lease/ack tracking for queue semantics.
@@ -135,22 +124,6 @@ pub(crate) struct QueueLeaseRow {
 }
 
 impl QueueLeaseRow {
-    pub(crate) fn key_for(
-        topic_id: TopicId,
-        msg_id: &MsgId,
-        consumer_group: &ConsumerGroup,
-    ) -> TableKey<Self> {
-        TableKey::init_key(
-            Self::ROW_TYPE,
-            &[
-                topic_id.as_bytes(),
-                &msg_id.partition.get().to_be_bytes(),
-                &msg_id.offset.to_be_bytes(),
-            ],
-            &[consumer_group],
-        )
-    }
-
     /// Permanently acked — will never be re-delivered.
     pub(crate) fn acked() -> Self {
         Self {
@@ -179,7 +152,7 @@ impl QueueLeaseRow {
     ) -> Result<()> {
         batch.insert_row(
             keyspace,
-            Self::key_for(topic_id, msg_id, consumer_group),
+            QueueLeaseKey::build_key(&topic_id, &msg_id.partition, &msg_id.offset, consumer_group),
             &Self::acked(),
         )?;
         Ok(())
@@ -197,9 +170,6 @@ impl QueueLeaseRow {
         self.dlq
     }
 
-    // FIXME(@svix-gabriel): This manually parses the TableKey byte layout, which is
-    // fragile and tightly coupled to `TableKey::init_key`'s encoding. Should be replaced
-    // with a proper range/prefix scan API on TableRow.
     /// Returns all lease rows for a given (topic, partition, consumer_group) via prefix scan.
     pub(crate) fn scan_partition(
         keyspace: &impl fjall_utils::ReadableKeyspace,
@@ -207,31 +177,18 @@ impl QueueLeaseRow {
         partition: Partition,
         consumer_group: &ConsumerGroup,
     ) -> Result<Vec<(MsgId, Self)>> {
-        // Key layout: [ROW_TYPE:1B][topic_id:16B][partition:2B][offset:8B][consumer_group]
-        let mut prefix = Vec::with_capacity(1 + 16 + 2);
-        prefix.push(Self::ROW_TYPE);
-        prefix.extend_from_slice(topic_id.as_bytes());
-        prefix.extend_from_slice(&partition.get().to_be_bytes());
-
-        let cg_bytes = consumer_group.as_bytes();
+        let prefix = QueueLeaseKey::prefix_partition(&topic_id, &partition);
         let mut results = Vec::new();
 
         for guard in keyspace.prefix(&prefix) {
             let (key, val) = guard.into_inner()?;
-            let offset_start = 1 + 16 + 2;
-            let offset_end = offset_start + 8;
-            if key.len() < offset_end {
+            let cg = QueueLeaseKey::extract_consumer_group(&key)
+                .expect("valid QueueLeaseKey in metadata table");
+            if cg != *consumer_group {
                 continue;
             }
-            let offset_bytes: [u8; 8] = key[offset_start..offset_end]
-                .try_into()
-                .expect("checked length");
-            let offset = u64::from_be_bytes(offset_bytes);
-
-            let key_cg = &key[offset_end..];
-            if key_cg != cg_bytes {
-                continue;
-            }
+            let offset =
+                QueueLeaseKey::extract_offset(&key).expect("valid QueueLeaseKey in metadata table");
 
             let row = Self::from_fjall_value(val)?;
             results.push((MsgId::new(partition, offset), row));
@@ -245,6 +202,19 @@ impl TableRow for QueueLeaseRow {
     const ROW_TYPE: u8 = RowType::QueueLease as u8;
 }
 
+#[derive(FjallKeyAble)]
+#[table_key(prefix = RowType::QueueLease)]
+pub(crate) struct QueueLeaseKey {
+    #[key(0)]
+    pub(crate) topic_id: TopicId,
+    #[key(1)]
+    pub(crate) partition: Partition,
+    #[key(2)]
+    pub(crate) offset: Offset,
+    #[key(3)]
+    pub(crate) consumer_group: ConsumerGroup,
+}
+
 /// Per-consumer-group queue configuration
 #[derive(Serialize, Deserialize)]
 pub(crate) struct QueueConfigRow {
@@ -252,14 +222,17 @@ pub(crate) struct QueueConfigRow {
     pub dlq_topic: Option<TopicName>,
 }
 
-impl QueueConfigRow {
-    pub(crate) fn key_for(topic_id: TopicId, consumer_group: &ConsumerGroup) -> TableKey<Self> {
-        TableKey::init_key(Self::ROW_TYPE, &[topic_id.as_bytes()], &[consumer_group])
-    }
-}
-
 impl TableRow for QueueConfigRow {
     const ROW_TYPE: u8 = RowType::QueueConfig as u8;
+}
+
+#[derive(FjallKeyAble)]
+#[table_key(prefix = RowType::QueueConfig)]
+pub(crate) struct QueueConfigKey {
+    #[key(0)]
+    pub(crate) topic_id: TopicId,
+    #[key(1)]
+    pub(crate) consumer_group: ConsumerGroup,
 }
 
 #[derive(FjallKeyAble)]
@@ -288,18 +261,8 @@ impl MsgRow {
         topic_id: TopicId,
         partition: Partition,
     ) -> Result<Offset> {
-        let range = MsgKey::range(
-            MsgKey {
-                topic_id,
-                partition,
-                offset: Offset::MIN,
-            }..=MsgKey {
-                topic_id,
-                partition,
-                offset: Offset::MAX,
-            },
-        );
-        let item = keyspace.range(range).next_back();
+        let range = MsgKey::prefix_partition(&topic_id, &partition);
+        let item = keyspace.prefix(range).next_back();
         match item {
             Some(kv) => {
                 let key = kv.key()?;
@@ -355,14 +318,13 @@ impl TableRow for IdempotencyRow {
     const ROW_TYPE: u8 = RowType::Idempotency as u8;
 }
 
-impl IdempotencyRow {
-    pub(crate) fn key_for(namespace_id: NamespaceId, key: &MsgsIdempotencyKey) -> TableKey<Self> {
-        TableKey::init_key(
-            Self::ROW_TYPE,
-            &[namespace_id.as_bytes(), key.as_bytes()],
-            &[],
-        )
-    }
+#[derive(FjallKeyAble)]
+#[table_key(prefix = RowType::Idempotency)]
+pub(crate) struct IdempotencyKey {
+    #[key(0)]
+    pub(crate) namespace_id: NamespaceId,
+    #[key(1)]
+    pub(crate) key: MsgsIdempotencyKey,
 }
 
 #[cfg(test)]
@@ -378,10 +340,10 @@ mod tests {
         let topic_id = TopicId::new(Timestamp::UNIX_EPOCH, UuidV7RandomBytes::new_random());
         let partition = Partition::new(0).unwrap();
         let cg = ConsumerGroup::try_from("my-group").unwrap();
-        let key = StreamLeaseRow::key_for(topic_id, partition, &cg).into_fjall_key();
+        let key = StreamLeaseKey::build_key(&topic_id, &partition, &cg);
         assert_eq!(
-            StreamLeaseRow::consumer_group_from_key(&key),
-            Some("my-group")
+            &*StreamLeaseKey::extract_consumer_group(&key).unwrap(),
+            "my-group"
         );
     }
 }


### PR DESCRIPTION
This migration did expose some things missing with FjallKeyAble, namely

* The ability to generate prefix'd keys. Similar too, but slightly different than range queries.
* The ability to generate keys without Cloning underlying fields, e.g. a String.

The macro's been updated to accommodate both of these requirements.