### PR TITLE
Don't use non-deterministic shuffling in msg.*.receive operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,7 @@ dependencies = [
  "jiff",
  "opentelemetry",
  "pastey",
+ "rand 0.10.1",
  "serde",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ pnet = "0.35"
 postcard = { version = "1", features = ["alloc"] }
 proc-macro2 = "1.0.78"
 quote = "1.0.15"
-rand = "0.10.1"
+rand = { version = "0.10.1", features = ["chacha"] }
 regex = "1.5.5"
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls", "hickory-dns", "stream", "http2"] }
 rmp-serde = "1.3.1"

--- a/crates/diom-operations/Cargo.toml
+++ b/crates/diom-operations/Cargo.toml
@@ -14,6 +14,7 @@ http-serde.workspace = true
 jiff.workspace = true
 opentelemetry.workspace = true
 pastey.workspace = true
+rand.workspace = true
 serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/diom-operations/src/context.rs
+++ b/crates/diom-operations/src/context.rs
@@ -6,4 +6,24 @@ pub struct OpContext {
     pub log_index: u64,
     /// The raft term. This is monotonically-increasing with every leadership change.
     pub term: u64,
+    /// Seed for deterministic random number generation inside `apply_real`.
+    ///
+    /// Generated once at request creation time and replicated through Raft,
+    /// so every replica derives the same sequence of random values.
+    pub rng_seed: u64,
+}
+
+impl OpContext {
+    /// Returns a deterministic RNG seeded from this context.
+    ///
+    /// Use this for any randomness needed inside `apply_real` instead of
+    /// calling `rand::rng()` directly.
+    ///
+    /// Uses `ChaCha8Rng` rather than `StdRng` because `StdRng`'s algorithm
+    /// may change between `rand` versions, which would break determinism
+    /// across nodes during rolling upgrades. `ChaCha8Rng` guarantees a
+    /// stable output for a given seed.
+    pub fn rng(&self) -> rand::rngs::ChaCha8Rng {
+        rand::SeedableRng::seed_from_u64(self.rng_seed)
+    }
 }

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -55,8 +55,14 @@ impl QueueReceiveOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size = self.batch_size))]
-    async fn apply_real(self, state: &State, now: Timestamp) -> Result<QueueReceiveResponseData> {
+    async fn apply_real(
+        self,
+        state: &State,
+        ctx: &diom_operations::OpContext,
+    ) -> Result<QueueReceiveResponseData> {
         let state = state.clone();
+        let mut rng = ctx.rng();
+        let now = ctx.timestamp;
 
         spawn_blocking_in_current_span(move || {
             let mut remaining = self.batch_size.get();
@@ -80,7 +86,7 @@ impl QueueReceiveOperation {
             let partitions = self
                 .partition
                 .map(|p| vec![p.get()])
-                .unwrap_or_else(|| topic_row.partitions_shuffled());
+                .unwrap_or_else(|| topic_row.partitions_shuffled(&mut rng));
 
             for partition_idx in partitions {
                 let partition = Partition::new(partition_idx)?;
@@ -299,6 +305,6 @@ impl MsgsRequest for QueueReceiveOperation {
         state: MsgsRaftState<'_>,
         ctx: &diom_operations::OpContext,
     ) -> QueueReceiveResponse {
-        QueueReceiveResponse::new(self.apply_real(state.msgs, ctx.timestamp).await)
+        QueueReceiveResponse::new(self.apply_real(state.msgs, ctx).await)
     }
 }

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -60,8 +60,14 @@ impl StreamReceiveOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size = self.batch_size))]
-    async fn apply_real(self, state: &State, now: Timestamp) -> Result<StreamReceiveResponseData> {
+    async fn apply_real(
+        self,
+        state: &State,
+        ctx: &diom_operations::OpContext,
+    ) -> Result<StreamReceiveResponseData> {
         let state = state.clone();
+        let mut rng = ctx.rng();
+        let now = ctx.timestamp;
 
         spawn_blocking_in_current_span(move || {
             let mut remaining = self.batch_size.get();
@@ -84,7 +90,7 @@ impl StreamReceiveOperation {
             let partitions = self
                 .partition
                 .map(|p| vec![p.get()])
-                .unwrap_or_else(|| topic_row.partitions_shuffled());
+                .unwrap_or_else(|| topic_row.partitions_shuffled(&mut rng));
 
             let mut no_lease_available = true;
 
@@ -213,6 +219,6 @@ impl MsgsRequest for StreamReceiveOperation {
         state: MsgsRaftState<'_>,
         ctx: &diom_operations::OpContext,
     ) -> StreamReceiveResponse {
-        StreamReceiveResponse::new(self.apply_real(state.msgs, ctx.timestamp).await)
+        StreamReceiveResponse::new(self.apply_real(state.msgs, ctx).await)
     }
 }

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -43,10 +43,10 @@ impl TopicRow {
         }
     }
 
-    pub(crate) fn partitions_shuffled(&self) -> Vec<u16> {
+    pub(crate) fn partitions_shuffled(&self, rng: &mut impl rand::Rng) -> Vec<u16> {
         use rand::seq::SliceRandom;
         let mut list: Vec<u16> = (0..self.partitions).collect();
-        list.shuffle(&mut rand::rng());
+        list.shuffle(rng);
         list
     }
 

--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -59,6 +59,7 @@ pub(super) async fn apply_request(
         timestamp: request.timestamp,
         log_index: log_id.index,
         term: log_id.leader_id.term,
+        rng_seed: request.rng_seed,
     };
 
     let request = Arc::unwrap_or_clone(request);

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -89,6 +89,10 @@ pub struct RequestWithContext {
     )]
     pub timestamp: Timestamp,
     pub context: Option<OperationRequestMetadata>,
+    /// Seed for deterministic RNG during apply. Generated at request creation,
+    /// replicated through Raft so every node uses the same seed.
+    #[serde(default = "rand::random")]
+    pub rng_seed: u64,
 }
 
 impl fmt::Display for RequestWithContext {
@@ -112,6 +116,7 @@ impl RequestWithContext {
             inner: req,
             timestamp,
             context: ctx,
+            rng_seed: rand::random(),
         }
     }
 


### PR DESCRIPTION
Curious if this will offend anybody, or is wrong in a subtle way I'm not realizing.

I noticed we used `shuffle_partitions` in a couple of msgs Operation apply step, which is a no-no.

We've had this problem before with UuidV7 generation, which we fixed by manually threading in a randomly generated value into the Operation struct.

Since this is a semi-common pattern we have to fallback to, my thoughts are that it's better to have a standardized way do "random" generation. The idea is - wire a randomly generated seed into the `OpContext` (which gets passed into Operation::apply). This way, operations can be written to use the Rng generator from the OpContext and get deterministic output when the OpContext is replayed.

If folks are cool w/this, I'll go back and change UuidV7 generation to also use the Rng in the OpContext, instead of manually threading in the random bits of the uuidv7.