### PR TITLE
CI: Publish Helm to private chart on merge to main

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -9,6 +9,9 @@ on:
       image_tag:
         required: true
         type: string
+      is_release:
+        type: boolean
+        default: false
 
 jobs:
   helm-publish:
@@ -33,6 +36,11 @@ jobs:
       - name: Set image tags
         run: |
           sed -i 's/tag: ""/tag: "${{ inputs.image_tag }}"/g' infra/helm-diom/values.yaml
+
+      - name: Use private chart name if not a release build
+        if: ${{ inputs.is_release == 'false' }}
+        run: |
+          sed -i 's/name: diom/name: diom-private/' infra/helm-diom/Chart.yaml
 
       - name: Package and push chart
         run: |

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -63,3 +63,15 @@ jobs:
       contents: read
       packages: write
       security-events: write
+
+  helm_publish:
+    needs: ci
+    uses: ./.github/workflows/helm-publish.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    with:
+      version: 0.0.0-${{ github.sha }}
+      image_tag: sha-${{ github.sha }}
+      is_release: false


### PR DESCRIPTION
This is intended to publish a private Helm chart to GHCR for use in test envs.