### PR TITLE
Implement "just in time" Msg expiration in msg module

### DIFF
--- a/crates/fjall-utils/src/fjall_key_able.rs
+++ b/crates/fjall-utils/src/fjall_key_able.rs
@@ -3,6 +3,8 @@ use std::{
     ops::{Bound, RangeBounds},
 };
 
+use diom_core::types::UnixTimestampMs;
+
 use crate::{TableKey, TableRow};
 
 /// Marks a struct as a key used in Fjall queries, and generates a bunch
@@ -217,6 +219,31 @@ macro_rules! impl_key_component_int {
 // as the order of those types when converted to big endian bytes
 // doesn't match the intrinsic order of the types
 impl_key_component_int!(u16, u32, u64, u128);
+
+impl KeyComponent for UnixTimestampMs {
+    const FIXED_SIZE: bool = true;
+    const BYTE_SIZE: usize = u64::BYTE_SIZE;
+    type Ref<'a> = UnixTimestampMs;
+
+    fn key_len(&self) -> usize {
+        Self::BYTE_SIZE
+    }
+
+    fn write_to_key(&self, buf: &mut [u8]) -> usize {
+        self.as_millisecond().write_to_key(buf)
+    }
+
+    fn read_from_key(buf: &[u8]) -> Result<(Self, usize), Cow<'static, str>> {
+        let (millis, len) = u64::read_from_key(buf)?;
+        let ts = UnixTimestampMs::try_from_millisecond(millis as i64)
+            .ok_or(Cow::Borrowed("invalid timestamp"))?;
+        Ok((ts, len))
+    }
+
+    fn read_ref_from_key(buf: &[u8]) -> Result<(Self::Ref<'_>, usize), Cow<'static, str>> {
+        Self::read_from_key(buf)
+    }
+}
 
 impl KeyComponent for String {
     const FIXED_SIZE: bool = false;

--- a/crates/msgs/src/metrics.rs
+++ b/crates/msgs/src/metrics.rs
@@ -377,6 +377,7 @@ mod tests {
                 MsgKey {
                     topic_id: topic_row.id,
                     partition,
+                    timestamp: UnixTimestampMs::UNIX_EPOCH,
                     offset,
                 },
                 &row,

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -234,6 +234,7 @@ fn write_msg_batch(
                 MsgKey {
                     topic_id,
                     partition,
+                    timestamp: now,
                     offset,
                 },
                 &msg,

--- a/crates/msgs/src/operations/queue/nack.rs
+++ b/crates/msgs/src/operations/queue/nack.rs
@@ -26,6 +26,7 @@ pub struct QueueNackOperation {
     consumer_group: ConsumerGroup,
     msg_ids: Vec<MsgId>,
     dlq_topic_id_random_bytes: UuidV7RandomBytes,
+    retention_period: Option<DurationMs>,
 }
 
 impl QueueNackOperation {
@@ -34,6 +35,7 @@ impl QueueNackOperation {
         topic: TopicName,
         consumer_group: ConsumerGroup,
         msg_ids: Vec<MsgId>,
+        retention_period: Option<DurationMs>,
     ) -> Self {
         Self {
             namespace_id,
@@ -41,6 +43,7 @@ impl QueueNackOperation {
             consumer_group,
             msg_ids,
             dlq_topic_id_random_bytes: UuidV7RandomBytes::new_random(),
+            retention_period,
         }
     }
 
@@ -53,6 +56,11 @@ impl QueueNackOperation {
         let state = state.clone();
 
         spawn_blocking_in_current_span(move || {
+            let expiry_cutoff = self
+                .retention_period
+                .map(|rp| now.saturating_sub(rp))
+                .unwrap_or(UnixTimestampMs::UNIX_EPOCH);
+
             let nack_count = self.msg_ids.len() as u64;
             let topic_row = TopicRow::fetch(
                 &state.metadata_tables,
@@ -116,6 +124,7 @@ impl QueueNackOperation {
                         &self.consumer_group,
                         now,
                         self.dlq_topic_id_random_bytes,
+                        expiry_cutoff,
                     )?;
                     dlq_count += 1;
                 } else {
@@ -161,14 +170,14 @@ fn forward_to_dlq(
     consumer_group: &ConsumerGroup,
     now: UnixTimestampMs,
     dlq_topic_id_random_bytes: UuidV7RandomBytes,
+    expiry_cutoff: UnixTimestampMs,
 ) -> Result<()> {
-    let original = MsgRow::fetch(
+    let original = MsgRow::fetch_by_offset(
         &state.msg_table,
-        MsgKey {
-            topic_id: source_topic_id,
-            partition: msg_id.partition,
-            offset: msg_id.offset,
-        },
+        source_topic_id,
+        msg_id.partition,
+        msg_id.offset,
+        expiry_cutoff,
     )?
     .ok_or_else(|| Error::internal("nacked message not found"))?;
 
@@ -190,6 +199,7 @@ fn forward_to_dlq(
         MsgKey {
             topic_id: dlq_topic_row.id,
             partition: dlq_partition,
+            timestamp: now,
             offset: dlq_offset,
         },
         &MsgRow {

--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -13,7 +13,7 @@ use tracing::Span;
 
 use crate::{
     State,
-    entities::{ConsumerGroup, MsgId, Partition, TopicIn, TopicName},
+    entities::{ConsumerGroup, MsgId, Offset, Partition, TopicIn, TopicName},
     tables::{MsgRow, QueueLeaseKey, QueueLeaseRow, StreamLeaseKey, StreamLeaseRow, TopicRow},
 };
 
@@ -29,6 +29,7 @@ pub struct QueueReceiveOperation {
     #[serde(rename = "lease_duration_ms")]
     lease_duration: DurationMs,
     topic_id_random_bytes: UuidV7RandomBytes,
+    retention_period: Option<DurationMs>,
 }
 
 impl QueueReceiveOperation {
@@ -38,6 +39,7 @@ impl QueueReceiveOperation {
         consumer_group: ConsumerGroup,
         batch_size: NonZeroU16,
         lease_duration: DurationMs,
+        retention_period: Option<DurationMs>,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => (tp.topic, Some(tp.partition)),
@@ -51,6 +53,7 @@ impl QueueReceiveOperation {
             batch_size,
             lease_duration,
             topic_id_random_bytes: UuidV7RandomBytes::new_random(),
+            retention_period,
         })
     }
 
@@ -67,6 +70,10 @@ impl QueueReceiveOperation {
             let mut all_msgs: Vec<QueueReceiveMsg> = Vec::with_capacity(remaining.into());
 
             let expiry = now + self.lease_duration;
+            let expiry_cutoff = self
+                .retention_period
+                .map(|rp| now.saturating_sub(rp))
+                .unwrap_or(UnixTimestampMs::UNIX_EPOCH);
 
             let mut batch = state.db.batch();
 
@@ -113,20 +120,20 @@ impl QueueReceiveOperation {
                         partition,
                         scan_offset,
                         remaining,
+                        expiry_cutoff,
                     )?;
 
                     if msgs.is_empty() {
                         break;
                     }
 
-                    let msgs_len = msgs.len() as u64;
+                    let last_offset = msgs.last().expect("non-empty").0;
 
                     let n = lease_available_msgs(
                         &state,
                         &mut batch,
                         &mut all_msgs,
                         msgs,
-                        scan_offset,
                         partition,
                         topic_row.id,
                         &self.consumer_group,
@@ -135,7 +142,7 @@ impl QueueReceiveOperation {
                     )?;
                     remaining = remaining.saturating_sub(n);
 
-                    scan_offset += msgs_len;
+                    scan_offset = last_offset + 1;
                 }
 
                 // Compact cursor: advance past contiguous acked messages
@@ -179,8 +186,7 @@ fn lease_available_msgs(
     state: &State,
     batch: &mut fjall::OwnedWriteBatch,
     all_msgs: &mut Vec<QueueReceiveMsg>,
-    msgs: Vec<MsgRow>,
-    scan_offset: u64,
+    msgs: Vec<(Offset, MsgRow)>,
     partition: Partition,
     topic_id: TopicId,
     consumer_group: &ConsumerGroup,
@@ -189,8 +195,7 @@ fn lease_available_msgs(
 ) -> Result<u16> {
     let mut count = 0;
 
-    for (i, msg) in msgs.into_iter().enumerate() {
-        let offset = scan_offset + i as u64;
+    for (offset, msg) in msgs {
         let msg_id = MsgId::new(partition, offset);
 
         let existing_lease = QueueLeaseRow::fetch(

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -32,6 +32,7 @@ pub struct StreamReceiveOperation {
     lease_duration: DurationMs,
     default_starting_position: SeekPosition,
     topic_id_random_bytes: UuidV7RandomBytes,
+    retention_period: Option<DurationMs>,
 }
 
 impl StreamReceiveOperation {
@@ -42,6 +43,7 @@ impl StreamReceiveOperation {
         batch_size: NonZeroU16,
         lease_duration: DurationMs,
         default_starting_position: SeekPosition,
+        retention_period: Option<DurationMs>,
     ) -> Result<Self> {
         let (topic, partition) = match topic {
             TopicIn::TopicPartition(tp) => (tp.topic, Some(tp.partition)),
@@ -56,6 +58,7 @@ impl StreamReceiveOperation {
             lease_duration,
             default_starting_position,
             topic_id_random_bytes: UuidV7RandomBytes::new_random(),
+            retention_period,
         })
     }
 
@@ -71,6 +74,10 @@ impl StreamReceiveOperation {
             let mut remaining = self.batch_size.get();
             let mut all_msgs: Vec<StreamReceiveMsg> = Vec::with_capacity(remaining as usize);
             let expiry = now + self.lease_duration;
+            let expiry_cutoff = self
+                .retention_period
+                .map(|rp| now.saturating_sub(rp))
+                .unwrap_or(UnixTimestampMs::UNIX_EPOCH);
 
             let mut batch = state.db.batch();
 
@@ -128,6 +135,7 @@ impl StreamReceiveOperation {
                     topic.partition,
                     lease.offset,
                     remaining,
+                    expiry_cutoff,
                 )?;
 
                 if msgs.is_empty() {
@@ -147,23 +155,17 @@ impl StreamReceiveOperation {
 
                 lease.expiry = expiry;
 
-                // FIXME(@svix-gabriel) - I should just be able to reference msgs.last.offset.
-                // this'll require a larger change though.
-                lease.end_offset = lease.offset + msgs.len() as u64 - 1;
+                lease.end_offset = msgs.last().expect("non-empty").0;
                 remaining -= msgs.len() as u16;
 
-                all_msgs.extend(
-                    msgs.into_iter()
-                        .enumerate()
-                        .map(|(i, msg)| StreamReceiveMsg {
-                            value: msg.value,
-                            timestamp: msg.timestamp,
-                            headers: msg.headers,
-                            offset: lease.offset + i as u64,
-                            topic: topic.clone(),
-                            scheduled_at: msg.scheduled_at,
-                        }),
-                );
+                all_msgs.extend(msgs.into_iter().map(|(offset, msg)| StreamReceiveMsg {
+                    value: msg.value,
+                    timestamp: msg.timestamp,
+                    headers: msg.headers,
+                    offset,
+                    topic: topic.clone(),
+                    scheduled_at: msg.scheduled_at,
+                }));
 
                 batch.insert_row(
                     &state.metadata_tables,

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -251,6 +251,8 @@ pub(crate) struct MsgKey {
     pub(crate) partition: Partition,
     #[key(2)]
     pub(crate) offset: Offset,
+    #[key(3)]
+    pub(crate) timestamp: UnixTimestampMs,
 }
 
 #[derive(Serialize, Deserialize, PersistableValue)]
@@ -280,6 +282,27 @@ impl MsgRow {
         }
     }
 
+    /// Fetch a single message by offset, skipping it if expired.
+    #[tracing::instrument(skip_all, level = "debug")]
+    pub(crate) fn fetch_by_offset(
+        keyspace: &impl fjall_utils::ReadableKeyspace,
+        topic_id: TopicId,
+        partition: Partition,
+        offset: Offset,
+        expiry_cutoff: UnixTimestampMs,
+    ) -> Result<Option<Self>> {
+        let prefix = MsgKey::prefix_offset(&topic_id, &partition, &offset);
+        for entry in keyspace.prefix(prefix) {
+            let (_, val) = entry.into_inner_if(|k| {
+                MsgKey::extract_timestamp(k).expect("valid MsgKey in msg table") >= expiry_cutoff
+            })?;
+            if let Some(v) = val {
+                return Ok(Some(Self::from_fjall_value(v)?));
+            }
+        }
+        Ok(None)
+    }
+
     #[tracing::instrument(skip_all, level = "debug", fields(batch_size))]
     pub(crate) fn fetch_range(
         keyspace: &fjall::Keyspace,
@@ -287,23 +310,31 @@ impl MsgRow {
         partition: Partition,
         offset: Offset,
         batch_size: u16,
-    ) -> Result<Vec<Self>> {
+        expiry_cutoff: UnixTimestampMs,
+    ) -> Result<Vec<(Offset, Self)>> {
         let mut results = Vec::with_capacity(batch_size as usize);
         let range = MsgKey::range(
             MsgKey {
                 topic_id,
                 partition,
                 offset,
+                timestamp: expiry_cutoff,
             }..MsgKey {
                 topic_id,
                 partition,
                 offset: offset + batch_size as u64,
+                timestamp: UnixTimestampMs::UNIX_EPOCH,
             },
         );
         for entry in keyspace.range(range) {
-            let val = entry.value()?;
-            let msg = Self::from_fjall_value(val)?;
-            results.push(msg);
+            let (key, val) = entry.into_inner_if(|k| {
+                MsgKey::extract_timestamp(k).expect("valid MsgKey in msg table") >= expiry_cutoff
+            })?;
+            if let Some(val) = val {
+                let msg_offset = MsgKey::extract_offset(&key).expect("valid MsgKey in msg table");
+                let msg = Self::from_fjall_value(val)?;
+                results.push((msg_offset, msg));
+            }
         }
 
         tracing::Span::current().record("msgs_found", results.len());
@@ -351,5 +382,76 @@ mod tests {
             &*StreamLeaseKey::extract_consumer_group(&key).unwrap(),
             "my-group"
         );
+    }
+
+    #[test]
+    fn fetch_range_filters_expired_messages() {
+        use std::collections::HashMap;
+
+        use diom_id::TopicId;
+        use fjall_utils::WriteBatchExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = fjall::Database::builder(dir.path())
+            .temporary(true)
+            .open()
+            .unwrap();
+        let ks = db
+            .keyspace("msgs", fjall::KeyspaceCreateOptions::default)
+            .unwrap();
+        let topic_id = TopicId::new(UnixTimestampMs::UNIX_EPOCH, UuidV7RandomBytes::new_random());
+        let partition = Partition::new(0).unwrap();
+
+        let t1 = UnixTimestampMs::try_from_millisecond(1000).unwrap();
+        let t2 = UnixTimestampMs::try_from_millisecond(2000).unwrap();
+        let t3 = UnixTimestampMs::try_from_millisecond(3000).unwrap();
+
+        for (ts, offset) in [(t1, 0), (t2, 1), (t3, 2)] {
+            let mut batch = db.batch();
+            batch
+                .insert_row(
+                    &ks,
+                    MsgKey {
+                        topic_id,
+                        partition,
+                        timestamp: ts,
+                        offset,
+                    },
+                    &MsgRow {
+                        value: b"msg".into(),
+                        headers: HashMap::new(),
+                        timestamp: ts,
+                        scheduled_at: None,
+                    },
+                )
+                .unwrap();
+            batch.commit().unwrap();
+        }
+
+        // No expiry: all 3 messages returned
+        let msgs =
+            MsgRow::fetch_range(&ks, topic_id, partition, 0, 10, UnixTimestampMs::UNIX_EPOCH)
+                .unwrap();
+        assert_eq!(msgs.len(), 3, "no expiry should return all messages");
+
+        // Cutoff at 1500: only t2 and t3 survive
+        let cutoff = UnixTimestampMs::try_from_millisecond(1500).unwrap();
+        let msgs = MsgRow::fetch_range(&ks, topic_id, partition, 0, 10, cutoff).unwrap();
+        assert_eq!(msgs.len(), 2, "cutoff should filter out the oldest message");
+
+        // Cutoff past all: nothing returned
+        let cutoff = UnixTimestampMs::try_from_millisecond(5000).unwrap();
+        let msgs = MsgRow::fetch_range(&ks, topic_id, partition, 0, 10, cutoff).unwrap();
+        assert_eq!(msgs.len(), 0, "cutoff past all should return nothing");
+
+        // fetch_by_offset: non-expired
+        let msg = MsgRow::fetch_by_offset(&ks, topic_id, partition, 1, UnixTimestampMs::UNIX_EPOCH)
+            .unwrap();
+        assert!(msg.is_some());
+
+        // fetch_by_offset: expired
+        let cutoff = UnixTimestampMs::try_from_millisecond(1500).unwrap();
+        let msg = MsgRow::fetch_by_offset(&ks, topic_id, partition, 0, cutoff).unwrap();
+        assert!(msg.is_none(), "expired message should not be returned");
     }
 }

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -303,6 +303,7 @@ async fn stream_receive(
         data.batch_size,
         data.lease_duration,
         data.default_starting_position,
+        namespace.config.retention_period,
     )?;
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 
@@ -512,6 +513,7 @@ async fn queue_receive(
         data.consumer_group,
         data.batch_size,
         data.lease_duration,
+        namespace.config.retention_period,
     )?;
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 
@@ -710,8 +712,13 @@ async fn queue_nack(
         .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
-    let operation =
-        QueueNackOperation::new(namespace.id, data.topic, data.consumer_group, data.msg_ids);
+    let operation = QueueNackOperation::new(
+        namespace.id,
+        data.topic,
+        data.consumer_group,
+        data.msg_ids,
+        namespace.config.retention_period,
+    );
     repl.client_write(operation).await.or_internal_error()?.0?;
 
     Ok(MsgPackOrJson(MsgQueueNackOut {}))

--- a/tests/it/msgs/mod.rs
+++ b/tests/it/msgs/mod.rs
@@ -1,6 +1,7 @@
 mod namespace;
 mod publish;
 mod queue;
+mod retention;
 mod scheduled;
 mod stream_receive;
 mod stream_seek;

--- a/tests/it/msgs/retention.rs
+++ b/tests/it/msgs/retention.rs
@@ -1,0 +1,265 @@
+use std::time::Duration;
+
+use serde_json::json;
+use test_utils::{
+    JsonFastAndLoose as _, StatusCode, TestResult,
+    server::{TestContext, start_server},
+};
+
+#[tokio::test]
+async fn queue_receive_skips_expired_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.configure")
+        .json(json!({
+            "name": "ns-retention-q",
+            "retention": { "period_ms": 5000 }
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-retention-q",
+            "topic": "t1",
+            "msgs": [
+                { "value": "old".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    time.fast_forward(Duration::from_secs(6));
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-retention-q",
+            "topic": "t1",
+            "msgs": [
+                { "value": "new".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "namespace": "ns-retention-q",
+            "topic": "t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 1, "should only get the non-expired message");
+    assert_eq!(msgs[0]["value"], json!("new".as_bytes()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn stream_receive_skips_expired_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.configure")
+        .json(json!({
+            "name": "ns-retention-s",
+            "retention": { "period_ms": 5000 }
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-retention-s",
+            "topic": "t1",
+            "msgs": [
+                { "value": "old".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    time.fast_forward(Duration::from_secs(6));
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-retention-s",
+            "topic": "t1",
+            "msgs": [
+                { "value": "new".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-retention-s",
+            "topic": "t1",
+            "consumer_group": "cg",
+            "default_starting_position": "earliest",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(msgs.len(), 1, "should only get the non-expired message");
+    assert_eq!(msgs[0]["value"], json!("new".as_bytes()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn no_retention_returns_all_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.configure")
+        .json(json!({ "name": "ns-no-retention" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-no-retention",
+            "topic": "t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    time.fast_forward(Duration::from_secs(3600));
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-no-retention",
+            "topic": "t1",
+            "msgs": [
+                { "value": "b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    let response = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "namespace": "ns-no-retention",
+            "topic": "t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(
+        msgs.len(),
+        2,
+        "without retention, all messages should be returned"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn retention_partial_expiry() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.configure")
+        .json(json!({
+            "name": "ns-partial",
+            "retention": { "period_ms": 10_000 }
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-partial",
+            "topic": "t1",
+            "msgs": [
+                { "value": "early-1".as_bytes(), "key": "k1" },
+                { "value": "early-2".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Advance 7 seconds (within retention)
+    time.fast_forward(Duration::from_secs(7));
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-partial",
+            "topic": "t1",
+            "msgs": [
+                { "value": "later".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Advance 5 more seconds -- first batch is now 12s old (expired), second is 5s old (valid)
+    time.fast_forward(Duration::from_secs(5));
+
+    let response = client
+        .post("v1.msgs.queue.receive")
+        .json(json!({
+            "namespace": "ns-partial",
+            "topic": "t1",
+            "consumer_group": "cg",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = response["msgs"].assert_array();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "only the non-expired message should be returned"
+    );
+    assert_eq!(msgs[0]["value"], json!("later".as_bytes()));
+
+    Ok(())
+}


### PR DESCRIPTION
This functionally implements msg expiration by filtering out msgs that have expired. We do this by inserting the monotonic timestamp in the msg key, and filter out expired rows when querying the "table".

Originally, I tried putting the timestamp before the offset in the key (so the msg key structure was `... | timestamp | offset`, but this caused stream.receive and queue.receive to tank in performance. When I switched the order to `| ... | offset | timestamp`, the performance regression went away.

The implementation was slightly trickier than I was expecting, since I had to account for changes to offset math since we're now potentially fetching fewer messages than would be assumed by pure offset math.

I did do a local pre and post change benchmark, and things look good

**Pre change**
```
    Running `target/release/diom benchmark --filter msgs. --concurrency 20 --batch-size 10 --iterations 2000`
Running benchmark: 2000 iterations · batch_size 10

  [00:00:42] msgs.stream.publish (batch=10) (conc=20)         [########################################]   40000/40000                                                                          
  [00:00:46] msgs.stream.receive (batch=10) (conc=20)         [########################################]   40000/40000                                                                          
  [00:00:43] msgs.queue.publish (batch=10) (conc=20)          [########################################]   40000/40000                                                                          
  [00:00:57] msgs.queue.receive (batch=10) (conc=20)          [########################################]   40000/40000                                                                          

╭──────────────────────────────────────────┬─────────────┬─────────┬────────┬───────┬───────┬───────┬────────┬────────┬────────┬────────┬───────────┬──────────────╮
│ op                                       ┆ concurrency ┆ ops/sec ┆ mean   ┆ ±     ┆ min   ┆ p50   ┆ p75    ┆ p99    ┆ p99.9  ┆ max    ┆ bytes/sec ┆ entities/sec │
╞══════════════════════════════════════════╪═════════════╪═════════╪════════╪═══════╪═══════╪═══════╪════════╪════════╪════════╪════════╪═══════════╪══════════════╡
│ msgs.queue.publish (batch=10)            ┆ 20          ┆ 923     ┆ 10.8ms ┆ 5.7ms ┆ 2.7ms ┆ 9.6ms ┆ 13.6ms ┆ 34.7ms ┆ 45.9ms ┆ 60.3ms ┆ 26.18 MB  ┆ 9230         │
│ msgs.queue.receive (batch=10) - ack      ┆ 20          ┆ 1416    ┆ 7.1ms  ┆ 1.9ms ┆ 2.3ms ┆ 6.9ms ┆ 8.1ms  ┆ 12.0ms ┆ 16.5ms ┆ 53.5ms ┆ --        ┆ 14160        │
│ msgs.queue.receive (batch=10) - receive  ┆ 20          ┆ 1363    ┆ 7.3ms  ┆ 2.0ms ┆ 2.5ms ┆ 7.2ms ┆ 8.4ms  ┆ 12.4ms ┆ 18.7ms ┆ 53.7ms ┆ 38.65 MB  ┆ 13630        │
│ msgs.stream.publish (batch=10)           ┆ 20          ┆ 950     ┆ 10.5ms ┆ 6.0ms ┆ 2.7ms ┆ 8.8ms ┆ 13.0ms ┆ 34.4ms ┆ 48.6ms ┆ 88.4ms ┆ 26.94 MB  ┆ 9500         │
│ msgs.stream.receive (batch=10) - commit  ┆ 20          ┆ 1729    ┆ 5.8ms  ┆ 1.5ms ┆ 2.3ms ┆ 5.5ms ┆ 6.8ms  ┆ 9.8ms  ┆ 12.4ms ┆ 21.6ms ┆ --        ┆ 17290        │
│ msgs.stream.receive (batch=10) - receive ┆ 20          ┆ 1693    ┆ 5.9ms  ┆ 1.5ms ┆ 2.5ms ┆ 5.6ms ┆ 6.9ms  ┆ 9.9ms  ┆ 11.9ms ┆ 21.5ms ┆ 48.01 MB  ┆ 16930        │
│ (COMBINED)                               ┆             ┆ 1305.6  ┆ 7.7ms  ┆       ┆ 2.3ms ┆       ┆        ┆        ┆        ┆ 88.4ms ┆ --        ┆              │
╰──────────────────────────────────────────┴─────────────┴─────────┴────────┴───────┴───────┴───────┴────────┴────────┴────────┴────────┴───────────┴──────────────╯
```

**Post Change**
```
╭──────────────────────────────────────────┬─────────────┬─────────┬────────┬───────┬───────┬───────┬────────┬────────┬────────┬─────────┬───────────┬──────────────╮
│ op                                       ┆ concurrency ┆ ops/sec ┆ mean   ┆ ±     ┆ min   ┆ p50   ┆ p75    ┆ p99    ┆ p99.9  ┆ max     ┆ bytes/sec ┆ entities/sec │
╞══════════════════════════════════════════╪═════════════╪═════════╪════════╪═══════╪═══════╪═══════╪════════╪════════╪════════╪═════════╪═══════════╪══════════════╡
│ msgs.queue.publish (batch=10)            ┆ 20          ┆ 954     ┆ 10.5ms ┆ 5.4ms ┆ 2.6ms ┆ 9.1ms ┆ 12.7ms ┆ 32.2ms ┆ 44.0ms ┆ 52.1ms  ┆ 27.05 MB  ┆ 9540         │
│ msgs.queue.receive (batch=10) - ack      ┆ 20          ┆ 1425    ┆ 7.0ms  ┆ 2.0ms ┆ 2.4ms ┆ 6.8ms ┆ 8.2ms  ┆ 12.1ms ┆ 16.9ms ┆ 45.1ms  ┆ --        ┆ 14250        │
│ msgs.queue.receive (batch=10) - receive  ┆ 20          ┆ 1369    ┆ 7.3ms  ┆ 2.0ms ┆ 2.5ms ┆ 7.2ms ┆ 8.5ms  ┆ 12.4ms ┆ 17.5ms ┆ 43.2ms  ┆ 38.80 MB  ┆ 13690        │
│ msgs.stream.publish (batch=10)           ┆ 20          ┆ 934     ┆ 10.7ms ┆ 6.1ms ┆ 3.1ms ┆ 8.9ms ┆ 13.2ms ┆ 33.6ms ┆ 48.6ms ┆ 105.9ms ┆ 26.50 MB  ┆ 9340         │
│ msgs.stream.receive (batch=10) - commit  ┆ 20          ┆ 1864    ┆ 5.4ms  ┆ 1.4ms ┆ 2.3ms ┆ 5.0ms ┆ 6.2ms  ┆ 9.3ms  ┆ 12.4ms ┆ 22.2ms  ┆ --        ┆ 18640        │
│ msgs.stream.receive (batch=10) - receive ┆ 20          ┆ 1814    ┆ 5.5ms  ┆ 1.4ms ┆ 2.4ms ┆ 5.2ms ┆ 6.3ms  ┆ 9.4ms  ┆ 12.0ms ┆ 22.0ms  ┆ 51.44 MB  ┆ 18140        │
│ (COMBINED)                               ┆             ┆ 1343.4  ┆ 7.4ms  ┆       ┆ 2.3ms ┆       ┆        ┆        ┆        ┆ 105.9ms ┆ --        ┆              │
╰──────────────────────────────────────────┴─────────────┴─────────┴────────┴───────┴───────┴───────┴────────┴────────┴────────┴─────────┴───────────┴──────────────╯
```
