### PR TITLE
gha: Add Helm/Operator release jobs

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -1,0 +1,96 @@
+name: Docker Build Release
+
+on:
+  workflow_call:
+    inputs:
+      image_repo:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      dockerfile:
+        required: false
+        type: string
+        default: ./Dockerfile
+      target:
+        required: false
+        type: string
+        default: prod
+      context:
+        required: false
+        type: string
+        default: .
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  docker-build-release:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Derive Docker tags
+        id: docker_tags
+        run: |
+          VERSION="${{ inputs.version }}"
+          VERSION_BARE="${VERSION#v}"
+          IFS='.' read -r major minor patch <<< "$VERSION_BARE"
+          REPO="${{ inputs.image_repo }}"
+          TAGS="${REPO}:latest,${REPO}:v${major}.${minor}.${patch},${REPO}:v${major}.${minor},${REPO}:v${major}"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=${REPO}:latest" >> "$GITHUB_OUTPUT"
+          echo "Generated tags: ${TAGS}"
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: ${{ !inputs.dry_run }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image (scan only)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          target: ${{ inputs.target }}
+          push: false
+          tags: ${{ steps.docker_tags.outputs.tags }}
+          platforms: linux/amd64
+          load: true
+
+      - name: Scan image with Grype
+        id: scan
+        uses: anchore/scan-action@v6
+        with:
+          image: "${{ steps.docker_tags.outputs.latest_tag }}"
+          fail-build: true
+          severity-cutoff: high
+          only-fixed: true
+          output-file: grype.sarif
+
+      - name: Inspect SARIF report
+        if: ${{ !cancelled() && hashFiles('grype.sarif') != '' }}
+        run: cat ${{ steps.scan.outputs.sarif }}
+
+      - name: Build and push Docker image
+        if: ${{ !inputs.dry_run }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          target: ${{ inputs.target }}
+          push: true
+          tags: ${{ steps.docker_tags.outputs.tags }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,43 @@
+name: Docker Release
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
+
+jobs:
+  get-version:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Get version
+        id: version
+        run: echo "version=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+  docker-server:
+    name: release docker - server
+    needs: get-version
+    uses: ./.github/workflows/docker-build-release.yml
+    with:
+      image_repo: svix/diom-server
+      version: ${{ needs.get-version.outputs.version }}
+    secrets: inherit
+
+  docker-cli:
+    name: release docker - cli
+    needs: get-version
+    uses: ./.github/workflows/docker-build-release.yml
+    with:
+      image_repo: svix/diom-cli
+      version: ${{ needs.get-version.outputs.version }}
+      target: cli-prod
+    secrets: inherit

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -6,9 +6,15 @@ on:
       version:
         required: true
         type: string
-      image_tag:
+      operator_image_tag:
         required: true
         type: string
+      server_image_tag:
+        required: true
+        type: string
+      is_release:
+        type: boolean
+        default: false
 
 jobs:
   helm-publish:
@@ -32,7 +38,12 @@ jobs:
 
       - name: Set image tags
         run: |
-          sed -i 's/tag: ""/tag: "${{ inputs.image_tag }}"/g' infra/helm-diom/values.yaml
+          yq -i '.operator.image.tag = "${{ inputs.operator_image_tag }}"' infra/helm-diom/values.yaml
+          yq -i '.cluster.image.tag = "${{ inputs.server_image_tag }}"' infra/helm-diom/values.yaml
+
+      - name: Use private chart name if not a release build
+        if: ${{ !inputs.is_release }}
+        run: yq -i '.name = "diom-private"' infra/helm-diom/Chart.yaml
 
       - name: Package and push chart
         run: |

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,121 @@
+name: Helm Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: Version bump type
+        required: true
+        type: choice
+        options: [major, minor, patch]
+      dry_run:
+        description: Dry run (skip pushes)
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      bump_type:
+        required: true
+        type: string
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  compute-versions:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      new_helm_version: ${{ steps.versions.outputs.new_helm_version }}
+      new_helm_tag: ${{ steps.versions.outputs.new_helm_tag }}
+      operator_image_tag: ${{ steps.versions.outputs.operator_image_tag }}
+      server_image_tag: ${{ steps.versions.outputs.server_image_tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate inputs
+        run: |
+          if [[ ! "${{ inputs.bump_type }}" =~ ^(major|minor|patch)$ ]]; then
+            echo "::error::Invalid bump_type: ${{ inputs.bump_type }}"
+            exit 1
+          fi
+
+      - name: Compute versions
+        id: versions
+        run: |
+          bump_version() {
+            local version="${1#v}"
+            local bump_type="$2"
+            IFS='.' read -r major minor patch <<< "$version"
+            case "$bump_type" in
+              major) echo "v$((major + 1)).0.0" ;;
+              minor) echo "v${major}.$((minor + 1)).0" ;;
+              patch) echo "v${major}.${minor}.$((patch + 1))" ;;
+            esac
+          }
+
+          # Helm version
+          latest_helm=$(git tag --list 'helm/v*' | sed 's|^helm/||' | sort -V | tail -1)
+          latest_helm="${latest_helm:-v0.0.0}"
+          new_helm=$(bump_version "$latest_helm" "${{ inputs.bump_type }}")
+          echo "new_helm_version=${new_helm}" >> "$GITHUB_OUTPUT"
+          echo "new_helm_tag=helm/${new_helm}" >> "$GITHUB_OUTPUT"
+
+          # Operator image tag (latest operator/v* tag)
+          # TODO: remove before merging
+          latest_operator="v0.0.1"
+          latest_operator=$(git tag --list 'operator/v*' | sed 's|^operator/||' | sort -V | tail -1)
+          if [[ -z "$latest_operator" ]]; then
+            echo "::error::No operator/v* tags found. Run an operator release first."
+            exit 1
+          fi
+          echo "operator_image_tag=${latest_operator}" >> "$GITHUB_OUTPUT"
+
+          # Server image tag (latest v* tag)
+          # TODO: remove before merging
+          latest_server="v0.0.1"
+          latest_server=$(git tag --list 'v*' | sort -V | tail -1)
+          if [[ -z "$latest_server" ]]; then
+            echo "::error::No v* tags found. Run a server release first."
+            exit 1
+          fi
+          echo "server_image_tag=${latest_server}" >> "$GITHUB_OUTPUT"
+
+          echo "Helm: ${latest_helm} -> ${new_helm}"
+          echo "Operator image tag: ${latest_operator}"
+          echo "Server image tag: ${latest_server}"
+
+      - name: Push git tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.versions.outputs.new_helm_tag }}" -m "Helm chart release ${{ steps.versions.outputs.new_helm_version }}"
+          git push origin "${{ steps.versions.outputs.new_helm_tag }}"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "=== DRY RUN ==="
+          echo "Would release Helm chart: ${{ steps.versions.outputs.new_helm_tag }}"
+          echo "Operator image tag: ${{ steps.versions.outputs.operator_image_tag }}"
+          echo "Server image tag: ${{ steps.versions.outputs.server_image_tag }}"
+          echo "Would push to: oci://ghcr.io/svix/charts"
+
+  publish:
+    needs: compute-versions
+    if: ${{ !inputs.dry_run }}
+    uses: ./.github/workflows/helm-publish.yml
+    with:
+      version: ${{ needs.compute-versions.outputs.new_helm_version }}
+      operator_image_tag: ${{ needs.compute-versions.outputs.operator_image_tag }}
+      server_image_tag: ${{ needs.compute-versions.outputs.server_image_tag }}
+      is_release: true
+    secrets: inherit

--- a/.github/workflows/mega-releaser.yml
+++ b/.github/workflows/mega-releaser.yml
@@ -1,6 +1,18 @@
 name: Mega Releaser
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: Version bump type
+        required: true
+        type: choice
+        options: [major, minor]
+      dry_run:
+        description: Dry run (skip pushes)
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   kick-off:
@@ -8,3 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: /bin/true
+
+  helm-release:
+    needs: kick-off
+    uses: ./.github/workflows/helm-release.yml
+    with:
+      bump_type: ${{ inputs.bump_type }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write

--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -1,0 +1,119 @@
+name: Operator Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: Version bump type
+        required: true
+        type: choice
+        options: [major, minor, patch]
+      dry_run:
+        description: Dry run (skip pushes)
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: operator-release
+  cancel-in-progress: false
+
+jobs:
+  operator-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    outputs:
+      new_version: ${{ steps.versions.outputs.new_version }}
+      new_tag: ${{ steps.versions.outputs.new_tag }}
+      helm_bump_type: ${{ steps.versions.outputs.helm_bump_type }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate inputs
+        run: |
+          if [[ ! "${{ inputs.bump_type }}" =~ ^(major|minor|patch)$ ]]; then
+            echo "::error::Invalid bump_type: ${{ inputs.bump_type }}"
+            exit 1
+          fi
+
+      - name: Compute versions
+        id: versions
+        run: |
+          bump_version() {
+            local version="${1#v}"
+            local bump_type="$2"
+            IFS='.' read -r major minor patch <<< "$version"
+            case "$bump_type" in
+              major) echo "v$((major + 1)).0.0" ;;
+              minor) echo "v${major}.$((minor + 1)).0" ;;
+              patch) echo "v${major}.${minor}.$((patch + 1))" ;;
+            esac
+          }
+
+          latest=$(git tag --list 'operator/v*' | sed 's|^operator/||' | sort -V | tail -1)
+          latest="${latest:-v0.0.0}"
+          new_version=$(bump_version "$latest" "${{ inputs.bump_type }}")
+          new_tag="operator/${new_version}"
+
+          echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
+          echo "new_tag=${new_tag}" >> "$GITHUB_OUTPUT"
+
+          # Helm gets a major bump only if operator is a major bump
+          if [[ "${{ inputs.bump_type }}" == "major" ]]; then
+            echo "helm_bump_type=major" >> "$GITHUB_OUTPUT"
+          else
+            echo "helm_bump_type=minor" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Operator: ${latest} -> ${new_version}"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "=== DRY RUN ==="
+          echo "Would release operator: ${{ steps.versions.outputs.new_tag }}"
+          echo "Would push Docker image: svix/diom-operator:${{ steps.versions.outputs.new_version }}"
+
+  docker-build:
+    needs: operator-release
+    uses: ./.github/workflows/docker-build-release.yml
+    with:
+      image_repo: svix/diom-operator
+      version: ${{ needs.operator-release.outputs.new_version }}
+      dockerfile: ./infra/operator/Dockerfile
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  push-tag:
+    needs: [docker-build, operator-release]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Push git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ needs.operator-release.outputs.new_tag }}" -m "Operator release ${{ needs.operator-release.outputs.new_version }}"
+          git push origin "${{ needs.operator-release.outputs.new_tag }}"
+
+  helm-release:
+    needs: [push-tag, operator-release]
+    uses: ./.github/workflows/helm-release.yml
+    with:
+      bump_type: ${{ needs.operator-release.outputs.helm_bump_type }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write

--- a/infra/helm-diom/values.yaml
+++ b/infra/helm-diom/values.yaml
@@ -11,7 +11,7 @@ crds:
 
 operator:
   image:
-    repository: ghcr.io/svix/diom-operator
+    repository: svix/diom-operator
     pullPolicy: IfNotPresent
     # Overrides the image tag. Defaults to the chart's appVersion.
     tag: ""
@@ -47,7 +47,7 @@ cluster:
   enabled: true
   name: diom
   image:
-    repository: ghcr.io/svix/diom-server
+    repository: svix/diom-server
     # tag is required when cluster.enabled=true.
     tag: ""
   spec:


### PR DESCRIPTION
Add jobs for releasing / managing versions of the Helm chart and
Operator separately. I don't think it's realstic to somehow try and
keep the versions of these in sync with the backend in any way given
that both of these are likely to undergo a lot of change independent
of the code.

The operator release job maintains semver-compatible versioning for
the operator and after pushing the Docker image and the tag, calls the
Helm release job for its own release.

The Helm release job gathers current tags for diom and for the operator
and adds those directly to the chart before publishing.

I've also added hooks to the Mega Release job to also call the Helm
release job.
