### PR TITLE
gha: Add docker release jobs

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -1,0 +1,96 @@
+name: Docker Build Release
+
+on:
+  workflow_call:
+    inputs:
+      image_repo:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      dockerfile:
+        required: false
+        type: string
+        default: ./Dockerfile
+      target:
+        required: false
+        type: string
+        default: prod
+      context:
+        required: false
+        type: string
+        default: .
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  docker-build-release:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Derive Docker tags
+        id: docker_tags
+        run: |
+          VERSION="${{ inputs.version }}"
+          VERSION_BARE="${VERSION#v}"
+          IFS='.' read -r major minor patch <<< "$VERSION_BARE"
+          REPO="${{ inputs.image_repo }}"
+          TAGS="${REPO}:latest,${REPO}:v${major}.${minor}.${patch},${REPO}:v${major}.${minor},${REPO}:v${major}"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=${REPO}:latest" >> "$GITHUB_OUTPUT"
+          echo "Generated tags: ${TAGS}"
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: ${{ !inputs.dry_run }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image (scan only)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          target: ${{ inputs.target }}
+          push: false
+          tags: ${{ steps.docker_tags.outputs.tags }}
+          platforms: linux/amd64
+          load: true
+
+      - name: Scan image with Grype
+        id: scan
+        uses: anchore/scan-action@v6
+        with:
+          image: "${{ steps.docker_tags.outputs.latest_tag }}"
+          fail-build: true
+          severity-cutoff: high
+          only-fixed: true
+          output-file: grype.sarif
+
+      - name: Inspect SARIF report
+        if: ${{ !cancelled() && hashFiles('grype.sarif') != '' }}
+        run: cat ${{ steps.scan.outputs.sarif }}
+
+      - name: Build and push Docker image
+        if: ${{ !inputs.dry_run }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          target: ${{ inputs.target }}
+          push: true
+          tags: ${{ steps.docker_tags.outputs.tags }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,43 @@
+name: Docker Release
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
+
+jobs:
+  get-version:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Get version
+        id: version
+        run: echo "version=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+  docker-server:
+    name: release docker - server
+    needs: get-version
+    uses: ./.github/workflows/docker-build-release.yml
+    with:
+      image_repo: svix/diom-server
+      version: ${{ needs.get-version.outputs.version }}
+    secrets: inherit
+
+  docker-cli:
+    name: release docker - cli
+    needs: get-version
+    uses: ./.github/workflows/docker-build-release.yml
+    with:
+      image_repo: svix/diom-cli
+      version: ${{ needs.get-version.outputs.version }}
+      target: cli-prod
+    secrets: inherit


### PR DESCRIPTION
Publish both cli and server images to Docker Hub.

Note that this job doesn't reuse the docker-publish step we use for the private Docker builds. This is intentional, b/c those jobs use `sha-` images that I don't think are appropriate for public-facing image tags. These jobs instead are modeled after webhooks-private, which produces clean tags.