### PR TITLE
Use deterministic seed for shuffling in msg.*.receive operations

### DIFF
--- a/crates/msgs/src/operations/queue/receive.rs
+++ b/crates/msgs/src/operations/queue/receive.rs
@@ -81,7 +81,7 @@ impl QueueReceiveOperation {
             let partitions = self
                 .partition
                 .map(|p| vec![p.get()])
-                .unwrap_or_else(|| topic_row.partitions_shuffled());
+                .unwrap_or_else(|| topic_row.partitions_shuffled(now.as_millisecond() as u64));
 
             for partition_idx in partitions {
                 let partition = Partition::new(partition_idx)?;

--- a/crates/msgs/src/operations/stream/receive.rs
+++ b/crates/msgs/src/operations/stream/receive.rs
@@ -85,7 +85,7 @@ impl StreamReceiveOperation {
             let partitions = self
                 .partition
                 .map(|p| vec![p.get()])
-                .unwrap_or_else(|| topic_row.partitions_shuffled());
+                .unwrap_or_else(|| topic_row.partitions_shuffled(now.as_millisecond() as u64));
 
             let mut no_lease_available = true;
 

--- a/crates/msgs/src/tables.rs
+++ b/crates/msgs/src/tables.rs
@@ -48,10 +48,11 @@ impl TopicRow {
         }
     }
 
-    pub(crate) fn partitions_shuffled(&self) -> Vec<u16> {
-        use rand::seq::SliceRandom;
+    pub(crate) fn partitions_shuffled(&self, seed: u64) -> Vec<u16> {
+        use rand::{SeedableRng, seq::SliceRandom};
         let mut list: Vec<u16> = (0..self.partitions).collect();
-        list.shuffle(&mut rand::rng());
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        list.shuffle(&mut rng);
         list
     }
 


### PR DESCRIPTION
I noticed we used shuffle_partitions in a couple of msgs Operation apply step, which is a no-no.

We don't _always_ partition within these operations, and doing the shuffle outside of the apply step would entail another disk read, which I wanted to avoid.

Instead, we just use the timestamp (from the OpContext) to seed an RNG for shuffling. So we still get something random-enough, but deterministic and replicable across nodes.