### PR TITLE
Import UnixTimestampMs instead of using the qualified path

### DIFF
--- a/crates/auth-token/src/operations/configure_namespace.rs
+++ b/crates/auth-token/src/operations/configure_namespace.rs
@@ -1,4 +1,4 @@
-use diom_core::PersistableValue;
+use diom_core::{PersistableValue, types::UnixTimestampMs};
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -33,7 +33,7 @@ impl ConfigureAuthTokenNamespaceOperation {
     async fn apply_real(
         self,
         namespace_state: &diom_namespace::State,
-        now: diom_core::types::UnixTimestampMs,
+        now: UnixTimestampMs,
     ) -> Result<ConfigureAuthTokenNamespaceResponseData> {
         let op: CreateNamespace<AuthTokenConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;

--- a/crates/cache/src/operations/configure_namespace.rs
+++ b/crates/cache/src/operations/configure_namespace.rs
@@ -1,4 +1,4 @@
-use diom_core::PersistableValue;
+use diom_core::{PersistableValue, types::UnixTimestampMs};
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -41,7 +41,7 @@ impl ConfigureCacheOperation {
     async fn apply_real(
         self,
         namespace_state: &diom_namespace::State,
-        now: diom_core::types::UnixTimestampMs,
+        now: UnixTimestampMs,
     ) -> Result<ConfigureCacheResponseData> {
         let op: CreateNamespace<CacheConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;

--- a/crates/cache/src/operations/set.rs
+++ b/crates/cache/src/operations/set.rs
@@ -2,7 +2,7 @@ use super::{CacheRaftState, CacheRequest, SetResponse};
 use crate::CacheNamespace;
 use diom_core::{
     PersistableValue,
-    types::{ByteString, DurationMs},
+    types::{ByteString, DurationMs, UnixTimestampMs},
 };
 use diom_error::Result;
 use diom_id::NamespaceId;
@@ -38,7 +38,7 @@ impl SetOperation {
     async fn apply_real(
         self,
         state: &CacheRaftState<'_>,
-        now: diom_core::types::UnixTimestampMs,
+        now: UnixTimestampMs,
         log_index: u64,
     ) -> Result<()> {
         let expiry = self.ttl.map(|ttl| now + ttl);

--- a/crates/idempotency/src/operations/complete.rs
+++ b/crates/idempotency/src/operations/complete.rs
@@ -2,7 +2,7 @@ use super::{CompleteResponse, IdempotencyRaftState, IdempotencyRequest};
 use crate::{IdempotencyNamespace, storage::IdempotencyState};
 use diom_core::{
     PersistableValue,
-    types::{ByteString, DurationMs, Metadata},
+    types::{ByteString, DurationMs, Metadata, UnixTimestampMs},
 };
 use diom_error::Result;
 use diom_id::NamespaceId;
@@ -41,7 +41,7 @@ impl CompleteOperation {
     async fn apply_real(
         self,
         state: &IdempotencyRaftState<'_>,
-        now: diom_core::types::UnixTimestampMs,
+        now: UnixTimestampMs,
         log_index: u64,
     ) -> Result<()> {
         let expiry = now + self.ttl;

--- a/crates/idempotency/src/operations/configure_namespace.rs
+++ b/crates/idempotency/src/operations/configure_namespace.rs
@@ -1,4 +1,4 @@
-use diom_core::PersistableValue;
+use diom_core::{PersistableValue, types::UnixTimestampMs};
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -33,7 +33,7 @@ impl ConfigureIdempotencyOperation {
     async fn apply_real(
         self,
         namespace_state: &diom_namespace::State,
-        now: diom_core::types::UnixTimestampMs,
+        now: UnixTimestampMs,
     ) -> Result<ConfigureIdempotencyResponseData> {
         let op: CreateNamespace<IdempotencyConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;

--- a/crates/idempotency/src/operations/try_start.rs
+++ b/crates/idempotency/src/operations/try_start.rs
@@ -1,6 +1,9 @@
 use super::{IdempotencyRaftState, IdempotencyRequest, TryStartResponse};
 use crate::{IdempotencyNamespace, IdempotencyStartResult, storage::IdempotencyState};
-use diom_core::{PersistableValue, types::DurationMs};
+use diom_core::{
+    PersistableValue,
+    types::{DurationMs, UnixTimestampMs},
+};
 use diom_error::Result;
 use diom_id::NamespaceId;
 use diom_kv::kvcontroller::{KvModelIn, OperationBehavior};
@@ -33,7 +36,7 @@ impl TryStartOperation {
     async fn apply_real(
         self,
         state: &IdempotencyRaftState<'_>,
-        now: diom_core::types::UnixTimestampMs,
+        now: UnixTimestampMs,
         log_index: u64,
     ) -> Result<TryStartResponseData> {
         let expiry = now + self.lock_period;

--- a/crates/kv/src/operations/configure_namespace.rs
+++ b/crates/kv/src/operations/configure_namespace.rs
@@ -1,4 +1,4 @@
-use diom_core::PersistableValue;
+use diom_core::{PersistableValue, types::UnixTimestampMs};
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -33,7 +33,7 @@ impl ConfigureKvOperation {
     async fn apply_real(
         self,
         namespace_state: &diom_namespace::State,
-        now: diom_core::types::UnixTimestampMs,
+        now: UnixTimestampMs,
     ) -> Result<ConfigureKvResponseData> {
         let op: CreateNamespace<KeyValueConfig> = self.into();
         let out = op.apply_operation(namespace_state, now).await?;

--- a/crates/msgs/src/operations/configure_namespace.rs
+++ b/crates/msgs/src/operations/configure_namespace.rs
@@ -1,4 +1,4 @@
-use diom_core::PersistableValue;
+use diom_core::{PersistableValue, types::UnixTimestampMs};
 use diom_error::Result;
 use diom_id::UuidV7RandomBytes;
 use diom_namespace::{
@@ -30,7 +30,7 @@ impl ConfigureNamespaceOperation {
     async fn apply_real(
         self,
         namespace_state: &diom_namespace::State,
-        now: diom_core::types::UnixTimestampMs,
+        now: UnixTimestampMs,
     ) -> Result<ConfigureNamespaceResponseData> {
         let op = CreateNamespace::new(
             self.name,

--- a/crates/msgs/src/operations/publish.rs
+++ b/crates/msgs/src/operations/publish.rs
@@ -1,6 +1,10 @@
 use std::collections::BTreeMap;
 
-use diom_core::{PersistableValue, task::spawn_blocking_in_current_span, types::DurationMs};
+use diom_core::{
+    PersistableValue,
+    task::spawn_blocking_in_current_span,
+    types::{DurationMs, UnixTimestampMs},
+};
 use diom_error::{Error, Result};
 use diom_id::{NamespaceId, TopicId, UuidV7RandomBytes};
 use fjall::OwnedWriteBatch;
@@ -60,11 +64,7 @@ impl PublishOperation {
     }
 
     #[tracing::instrument(skip_all, level = "debug", fields(msg_count = self.msgs.len()))]
-    async fn apply_real(
-        self,
-        state: &State,
-        now: diom_core::types::UnixTimestampMs,
-    ) -> Result<PublishResponseData> {
+    async fn apply_real(self, state: &State, now: UnixTimestampMs) -> Result<PublishResponseData> {
         let state = state.clone();
 
         let results = spawn_blocking_in_current_span(move || {
@@ -210,7 +210,7 @@ fn write_msg_batch(
     topic_name: &TopicName,
     topic_id: TopicId,
     msgs_by_partition: BTreeMap<Partition, Vec<MsgIn>>,
-    now: diom_core::types::UnixTimestampMs,
+    now: UnixTimestampMs,
 ) -> Result<Vec<PublishedTopic>> {
     let mut results: Vec<PublishedTopic> = Vec::with_capacity(msgs_by_partition.len());
 


### PR DESCRIPTION
Type name is clear enough on its own. Follow-up to #979.