### PR TITLE
Always enable tokio's time feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,7 @@ tap = "1"
 tempfile = "3.24.0"
 test-utils.path = "crates/test-utils"
 thiserror = "2.0.18"
-tokio = { version = "1.24.2", features = ["rt", "rt-multi-thread", "signal", "fs"] }
+tokio = { version = "1.24.2", features = ["rt", "rt-multi-thread", "signal", "time", "fs"] }
 tokio-util = "0.7"
 toml = { version = "1.0.3", default-features = false, features = ["parse", "serde", "display"] }
 tower = "0.5.1"


### PR DESCRIPTION
When running `cargo check` on a specific sub-crate, it might not have been activated by dependencies before this. I saw a weird rust-analyzer error before adding this.