### PR TITLE
Always enable uuid's v4 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "local-time", "fmt", "registry", "std"] }
 tracing-test = "0.2"
 url = { version = "2.2.2", features = ["serde"] }
-uuid = { version = "1.19.0", features = ["v7", "serde"] }
+uuid = { version = "1.19.0", features = ["v4", "v7", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 which = "8"
 yansi = "1.0.1"


### PR DESCRIPTION
Fixes compilation of diom-core on its own.