### PR TITLE
Add context support to permission verification

### DIFF
--- a/crates/diom-authorization/src/context.rs
+++ b/crates/diom-authorization/src/context.rs
@@ -1,0 +1,37 @@
+use std::{collections::HashMap, sync::LazyLock};
+
+use crate::Permissions;
+
+#[derive(Clone, Copy)]
+pub struct Context<'a> {
+    pub role: &'a str,
+    pub map: &'a HashMap<String, String>,
+}
+
+impl<'a> Context<'a> {
+    pub fn new(permissions: &'a Permissions) -> Self {
+        Self {
+            role: permissions.role.as_str(),
+            map: &permissions.context,
+        }
+    }
+
+    /// Create a test context with no useful data in it.
+    pub fn empty_for_tests() -> Self {
+        static EMPTY_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
+        Self {
+            role: "__test_role",
+            map: &EMPTY_MAP,
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&str> {
+        if key == "role" {
+            Some(self.role)
+        } else if let Some(name) = key.strip_prefix("context.") {
+            self.map.get(name).map(|s| s.as_str())
+        } else {
+            None
+        }
+    }
+}

--- a/crates/diom-authorization/src/lib.rs
+++ b/crates/diom-authorization/src/lib.rs
@@ -9,10 +9,12 @@ use diom_id::{AuthTokenId, Module};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+mod context;
 mod pattern;
 mod verification;
 
 pub use self::{
+    context::Context,
     pattern::{KeyPattern, KeyPatternSegment, ModulePattern, NamespacePattern, ResourcePattern},
     verification::{Forbidden, verify_operation},
 };
@@ -139,8 +141,8 @@ impl AccessRule {
         self.resource.namespace.is_reserved()
     }
 
-    pub fn matches(&self, operation: &RequestedOperation<'_>) -> bool {
-        self.resource.matches(operation)
+    pub fn matches(&self, operation: &RequestedOperation<'_>, context: Context<'_>) -> bool {
+        self.resource.matches(operation, context)
             && self
                 .actions
                 .iter()

--- a/crates/diom-authorization/src/pattern.rs
+++ b/crates/diom-authorization/src/pattern.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de};
 
-use crate::RequestedOperation;
+use crate::{Context, RequestedOperation};
 
 #[derive(Clone, Debug, PartialEq, Eq, PersistableValue)]
 pub struct ResourcePattern {
@@ -66,10 +66,10 @@ pub enum KeyPatternSegment {
 }
 
 impl ResourcePattern {
-    pub fn matches(&self, op: &RequestedOperation<'_>) -> bool {
+    pub fn matches(&self, op: &RequestedOperation<'_>, context: Context<'_>) -> bool {
         self.module.matches(op.module)
             && self.namespace.matches(op.namespace)
-            && self.key.matches(op.key)
+            && self.key.matches(op.key, context)
     }
 }
 
@@ -202,7 +202,7 @@ impl KeyPattern {
         }
     }
 
-    fn matches(&self, key: Option<&str>) -> bool {
+    fn matches(&self, key: Option<&str>, context: Context<'_>) -> bool {
         let Some(key) = key else {
             return self.segments.is_empty() && self.trailing_any;
         };
@@ -216,7 +216,7 @@ impl KeyPattern {
                 return self.trailing_any;
             };
 
-            if !pat_seg.matches(key_seg) {
+            if !pat_seg.matches(key_seg, context) {
                 return false;
             }
         }
@@ -276,11 +276,10 @@ impl FromStr for KeyPattern {
 }
 
 impl KeyPatternSegment {
-    fn matches(&self, key_seg: &str) -> bool {
+    fn matches(&self, key_seg: &str, context: Context<'_>) -> bool {
         match self {
             Self::Fixed(s) => s == key_seg,
-            // FIXME: Add support for context stuff
-            Self::Placeholder(_) => false,
+            Self::Placeholder(p) => context.get(p).is_some_and(|c| c == key_seg),
         }
     }
 }

--- a/crates/diom-authorization/src/verification.rs
+++ b/crates/diom-authorization/src/verification.rs
@@ -1,16 +1,17 @@
-use crate::{AccessRule, AccessRuleEffect, RequestedOperation};
+use crate::{AccessRule, AccessRuleEffect, Context, RequestedOperation};
 
 pub struct Forbidden;
 
 pub fn verify_operation(
     operation: &RequestedOperation<'_>,
     rules: &[AccessRule],
+    context: Context<'_>,
 ) -> Result<(), Forbidden> {
     // Fallback if no rule matches: reject
     let mut result = Err(Forbidden);
 
     for rule in rules {
-        if rule.matches(operation) {
+        if rule.matches(operation, context) {
             match rule.effect {
                 AccessRuleEffect::Allow => {
                     // found an allow rule, so set the result accordingly.

--- a/crates/diom-authorization/tests/it/pattern_matching.rs
+++ b/crates/diom-authorization/tests/it/pattern_matching.rs
@@ -1,4 +1,6 @@
-use diom_authorization::{RequestedOperation, ResourcePattern};
+use std::collections::HashMap;
+
+use diom_authorization::{Context, RequestedOperation, ResourcePattern};
 use diom_id::Module;
 
 static EXAMPLE_OP_KV: RequestedOperation<'static> = RequestedOperation {
@@ -11,31 +13,31 @@ static EXAMPLE_OP_KV: RequestedOperation<'static> = RequestedOperation {
 #[test]
 fn test_default_namespace_exact_key_match() {
     let pat = "kv::foo/bar".parse::<ResourcePattern>().unwrap();
-    assert!(pat.matches(&EXAMPLE_OP_KV));
+    assert!(pat.matches(&EXAMPLE_OP_KV, Context::empty_for_tests()));
 }
 
 #[test]
 fn test_any_namespace_exact_key_match() {
     let pat = "kv:*:foo/bar".parse::<ResourcePattern>().unwrap();
-    assert!(pat.matches(&EXAMPLE_OP_KV));
+    assert!(pat.matches(&EXAMPLE_OP_KV, Context::empty_for_tests()));
 }
 
 #[test]
 fn test_default_namespace_any_key_match() {
     let pat = "kv::*".parse::<ResourcePattern>().unwrap();
-    assert!(pat.matches(&EXAMPLE_OP_KV));
+    assert!(pat.matches(&EXAMPLE_OP_KV, Context::empty_for_tests()));
 }
 
 #[test]
 fn test_any_namespace_any_key_match() {
     let pat = "kv:*:*".parse::<ResourcePattern>().unwrap();
-    assert!(pat.matches(&EXAMPLE_OP_KV));
+    assert!(pat.matches(&EXAMPLE_OP_KV, Context::empty_for_tests()));
 }
 
 #[test]
 fn test_module_glob_match() {
     let pat = "*::*".parse::<ResourcePattern>().unwrap();
-    assert!(pat.matches(&EXAMPLE_OP_KV));
+    assert!(pat.matches(&EXAMPLE_OP_KV, Context::empty_for_tests()));
 }
 
 #[test]
@@ -43,7 +45,10 @@ fn test_any_namespace_wrong_module() {
     for wrong_module in ["auth_token", "cache", "idempotency", "msgs"] {
         let pat_s = &format!("{wrong_module}::*");
         let pat = pat_s.parse::<ResourcePattern>().unwrap();
-        assert!(!pat.matches(&EXAMPLE_OP_KV), "{pat_s}");
+        assert!(
+            !pat.matches(&EXAMPLE_OP_KV, Context::empty_for_tests()),
+            "{pat_s}"
+        );
     }
 }
 
@@ -52,7 +57,10 @@ fn test_any_namespace_wrong_exact_key_pattern() {
     for wrong_key in ["foo/baz", "foox/bar", "foo/ba", "foo/bars", "foobar"] {
         let pat_s = format!("kv:*:{wrong_key}");
         let pat = pat_s.parse::<ResourcePattern>().unwrap();
-        assert!(!pat.matches(&EXAMPLE_OP_KV), "{pat_s}");
+        assert!(
+            !pat.matches(&EXAMPLE_OP_KV, Context::empty_for_tests()),
+            "{pat_s}"
+        );
     }
 }
 
@@ -61,7 +69,51 @@ fn test_missing_context() {
     let pat = "kv:*:foo/${context.bar}"
         .parse::<ResourcePattern>()
         .unwrap();
-    assert!(!pat.matches(&EXAMPLE_OP_KV));
+    assert!(!pat.matches(&EXAMPLE_OP_KV, Context::empty_for_tests()));
+}
+
+#[test]
+fn test_role_placeholder() {
+    let pat = "kv:*:foo/${role}".parse::<ResourcePattern>().unwrap();
+    let context = Context {
+        role: "bar",
+        map: &HashMap::new(),
+    };
+    assert!(pat.matches(&EXAMPLE_OP_KV, context));
+}
+
+#[test]
+fn test_role_placeholder_mismatch() {
+    let pat = "kv:*:foo/${role}".parse::<ResourcePattern>().unwrap();
+    let context = Context {
+        role: "notbar",
+        map: &HashMap::new(),
+    };
+    assert!(!pat.matches(&EXAMPLE_OP_KV, context));
+}
+
+#[test]
+fn test_context_placeholder() {
+    let pat = "kv:*:foo/${context.xyz}"
+        .parse::<ResourcePattern>()
+        .unwrap();
+    let context = Context {
+        role: "whocares",
+        map: &HashMap::from([("xyz".to_owned(), "bar".to_owned())]),
+    };
+    assert!(pat.matches(&EXAMPLE_OP_KV, context));
+}
+
+#[test]
+fn test_context_placeholder_mismatch() {
+    let pat = "kv:*:foo/${context.xyz}"
+        .parse::<ResourcePattern>()
+        .unwrap();
+    let context = Context {
+        role: "whocares",
+        map: &HashMap::from([("xyz".to_owned(), "barr".to_owned())]),
+    };
+    assert!(!pat.matches(&EXAMPLE_OP_KV, context));
 }
 
 static EXAMPLE_OP_AUTH_TOKEN: RequestedOperation<'static> = RequestedOperation {
@@ -74,13 +126,13 @@ static EXAMPLE_OP_AUTH_TOKEN: RequestedOperation<'static> = RequestedOperation {
 #[test]
 fn test_explicit_namespace_any_key_match() {
     let pat = "auth_token:my-ns:*".parse::<ResourcePattern>().unwrap();
-    assert!(pat.matches(&EXAMPLE_OP_AUTH_TOKEN));
+    assert!(pat.matches(&EXAMPLE_OP_AUTH_TOKEN, Context::empty_for_tests()));
 }
 
 #[test]
 fn test_any_namespace_any_key_match_2() {
     let pat = "auth_token:*:*".parse::<ResourcePattern>().unwrap();
-    assert!(pat.matches(&EXAMPLE_OP_AUTH_TOKEN));
+    assert!(pat.matches(&EXAMPLE_OP_AUTH_TOKEN, Context::empty_for_tests()));
 }
 
 #[test]
@@ -88,7 +140,10 @@ fn test_wrong_namespace() {
     for wrong_ns in ["myns", "my-", "-ns", "m", "my-ns-"] {
         let pat_s = format!("auth_token:{wrong_ns}:*");
         let pat = pat_s.parse::<ResourcePattern>().unwrap();
-        assert!(!pat.matches(&EXAMPLE_OP_AUTH_TOKEN), "{pat_s}");
+        assert!(
+            !pat.matches(&EXAMPLE_OP_AUTH_TOKEN, Context::empty_for_tests()),
+            "{pat_s}"
+        );
     }
 }
 
@@ -102,5 +157,5 @@ static EXAMPLE_OP_POLICY: RequestedOperation<'static> = RequestedOperation {
 #[test]
 fn test_module_glob_no_match_on_admin_api() {
     let pat = "*:*:*".parse::<ResourcePattern>().unwrap();
-    assert!(!pat.matches(&EXAMPLE_OP_POLICY));
+    assert!(!pat.matches(&EXAMPLE_OP_POLICY, Context::empty_for_tests()));
 }

--- a/crates/diom-authorization/tests/it/verification.rs
+++ b/crates/diom-authorization/tests/it/verification.rs
@@ -1,4 +1,4 @@
-use diom_authorization::{AccessRule, RequestedOperation, verify_operation};
+use diom_authorization::{AccessRule, Context, RequestedOperation, verify_operation};
 use diom_id::Module;
 use serde_json::json;
 
@@ -54,7 +54,7 @@ fn test_verify_cache_example() {
         action: "get",
     };
     // no rule matches (need at least the extra /)
-    assert!(verify_operation(&op, &rules).is_err());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_err());
 
     let op = RequestedOperation {
         module: Module::Cache,
@@ -63,7 +63,7 @@ fn test_verify_cache_example() {
         action: "get",
     };
     // simple match of first rule
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 
     let op = RequestedOperation {
         module: Module::Cache,
@@ -72,7 +72,7 @@ fn test_verify_cache_example() {
         action: "delete",
     };
     // no matching rule for action
-    assert!(verify_operation(&op, &rules).is_err());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_err());
 
     let op = RequestedOperation {
         module: Module::Cache,
@@ -81,7 +81,7 @@ fn test_verify_cache_example() {
         action: "delete",
     };
     // wildcard action allowed for this key
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 
     let op = RequestedOperation {
         module: Module::Cache,
@@ -90,7 +90,7 @@ fn test_verify_cache_example() {
         action: "get",
     };
     // match of first rule with ** matching empty string
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 
     let op = RequestedOperation {
         module: Module::Cache,
@@ -99,7 +99,7 @@ fn test_verify_cache_example() {
         action: "get",
     };
     // explicit deny rule matches
-    assert!(verify_operation(&op, &rules).is_err());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_err());
 
     let op = RequestedOperation {
         module: Module::Cache,
@@ -108,7 +108,7 @@ fn test_verify_cache_example() {
         action: "set",
     };
     // deny rule only affects Read, not List
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 
     let op = RequestedOperation {
         module: Module::Cache,
@@ -117,7 +117,7 @@ fn test_verify_cache_example() {
         action: "get",
     };
     // deny rule is exact-match, does not match here
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 
     let op = RequestedOperation {
         module: Module::Cache,
@@ -126,7 +126,7 @@ fn test_verify_cache_example() {
         action: "get",
     };
     // both cache rules only apply to the default namespace
-    assert!(verify_operation(&op, &rules).is_err());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_err());
 
     let op = RequestedOperation {
         module: Module::Msgs,
@@ -135,7 +135,7 @@ fn test_verify_cache_example() {
         action: "get",
     };
     // no matching rule for module
-    assert!(verify_operation(&op, &rules).is_err());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_err());
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn test_verify_kv_example() {
         action: "delete",
     };
     // matches the first rule
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 
     let op = RequestedOperation {
         module: Module::Kv,
@@ -158,7 +158,7 @@ fn test_verify_kv_example() {
         action: "get",
     };
     // matches the second rule
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 
     let op = RequestedOperation {
         module: Module::Kv,
@@ -167,7 +167,7 @@ fn test_verify_kv_example() {
         action: "delete",
     };
     // Create action is only available for xyz namespace
-    assert!(verify_operation(&op, &rules).is_err());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_err());
 
     let op = RequestedOperation {
         module: Module::Kv,
@@ -176,7 +176,7 @@ fn test_verify_kv_example() {
         action: "delete",
     };
     // same issue
-    assert!(verify_operation(&op, &rules).is_err());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_err());
 
     let op = RequestedOperation {
         module: Module::Kv,
@@ -185,7 +185,7 @@ fn test_verify_kv_example() {
         action: "get",
     };
     // Read action does work for arbitrary namespaces, including the default one
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 
     let op = RequestedOperation {
         module: Module::Kv,
@@ -194,5 +194,5 @@ fn test_verify_kv_example() {
         action: "set",
     };
     // Same for List action, and a different named namespace
-    assert!(verify_operation(&op, &rules).is_ok());
+    assert!(verify_operation(&op, &rules, Context::empty_for_tests()).is_ok());
 }

--- a/crates/diom-proto/src/msgpack_or_json.rs
+++ b/crates/diom-proto/src/msgpack_or_json.rs
@@ -12,7 +12,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use bytes::{BufMut as _, Bytes, BytesMut};
-use diom_authorization::{Permissions, verify_operation};
+use diom_authorization::{Context, Permissions, verify_operation};
 use diom_core::validation::{ValidationErrorBody, ValidationErrorItem, validation_errors};
 use http::{HeaderMap, HeaderValue, StatusCode, header};
 use serde::{Serialize, de::DeserializeOwned};
@@ -135,7 +135,7 @@ where
 
         if let Some(op) = value.operation()
             && let Some(perms) = permissions
-            && verify_operation(&op, &perms.access_rules).is_err()
+            && verify_operation(&op, &perms.access_rules, Context::new(&perms)).is_err()
         {
             return Err(MsgPackOrJsonRejection::Forbidden {
                 resource: op.resource_str(),


### PR DESCRIPTION
Fixes compilation of diom-core on its own.

Based on #996.
Closes #878.