### PR TITLE
Add benchmarks for scheduled queue

### DIFF
--- a/benchmarks/benches/queue.rs
+++ b/benchmarks/benches/queue.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use criterion::{
-    BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
+    BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
 use diom::models::{
     MsgIn, MsgNamespaceConfigureIn, MsgPublishIn, MsgQueueAckIn, MsgQueueReceiveIn,
@@ -20,12 +20,16 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
         .build()
         .unwrap();
 
-    let mut make_msg_batch = |size: usize| {
+    let mut make_msg_batch = |size: usize, delay: Option<Duration>| {
         (0..size)
             .map(|_| {
                 let mut val = vec![0u8; 256];
                 rng.fill(&mut val[..]);
-                MsgIn::new(val)
+                let msg = MsgIn::new(val);
+                match delay {
+                    Some(d) => msg.with_delay(d),
+                    None => msg,
+                }
             })
             .collect::<Vec<_>>()
     };
@@ -45,7 +49,7 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             for _ in 0..100 {
                 client
                     .msgs()
-                    .publish(topic.clone(), MsgPublishIn::new(make_msg_batch(1000)))
+                    .publish(topic.clone(), MsgPublishIn::new(make_msg_batch(1000, None)))
                     .await
                     .unwrap();
             }
@@ -101,7 +105,7 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             for _ in 0..100 {
                 client
                     .msgs()
-                    .publish(topic.clone(), MsgPublishIn::new(make_msg_batch(1000)))
+                    .publish(topic.clone(), MsgPublishIn::new(make_msg_batch(1000, None)))
                     .await
                     .unwrap();
             }
@@ -119,6 +123,81 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
                             MsgQueueReceiveIn::new()
                                 .with_batch_size(100u16)
                                 .with_lease_duration(Duration::from_millis(100)),
+                        )
+                        .await
+                        .unwrap();
+                })
+            })
+        });
+    }
+
+    // Benchmark publish throughput with scheduled (delayed) messages.
+    {
+        let ns_name = "bench-queue-scheduled-publish";
+        let topic = format!("{ns_name}:bench-topic");
+
+        rt.block_on(async {
+            client
+                .msgs()
+                .namespace()
+                .configure(ns_name.to_owned(), MsgNamespaceConfigureIn::new())
+                .await
+                .unwrap();
+        });
+
+        group.bench_function("scheduled_publish_batch_100", |b| {
+            b.iter_batched(
+                || make_msg_batch(100, Some(Duration::from_secs(5))),
+                |msgs| {
+                    rt.block_on(async {
+                        client
+                            .msgs()
+                            .publish(topic.clone(), MsgPublishIn::new(msgs))
+                            .await
+                            .unwrap();
+                    })
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    // Benchmark receive against a topic where all messages have pending schedule leases.
+    // Each receive scans and skips the synthetic leases, measuring that overhead.
+    {
+        let ns_name = "bench-queue-scheduled-receive";
+        let topic = format!("{ns_name}:bench-topic");
+        let delay = Duration::from_secs(3600);
+
+        rt.block_on(async {
+            client
+                .msgs()
+                .namespace()
+                .configure(ns_name.to_owned(), MsgNamespaceConfigureIn::new())
+                .await
+                .unwrap();
+            for _ in 0..100 {
+                client
+                    .msgs()
+                    .publish(
+                        topic.clone(),
+                        MsgPublishIn::new(make_msg_batch(1000, Some(delay))),
+                    )
+                    .await
+                    .unwrap();
+            }
+        });
+
+        group.bench_function("scheduled_receive_pending_batch_100", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    client
+                        .msgs()
+                        .queue()
+                        .receive(
+                            topic.clone(),
+                            "bench-cg".to_owned(),
+                            MsgQueueReceiveIn::new().with_batch_size(100u16),
                         )
                         .await
                         .unwrap();

--- a/benchmarks/benches/queue.rs
+++ b/benchmarks/benches/queue.rs
@@ -25,11 +25,7 @@ fn bench_queue<'a, M: Measurement>(ctx: BenchmarkContext, group: &mut BenchmarkG
             .map(|_| {
                 let mut val = vec![0u8; 256];
                 rng.fill(&mut val[..]);
-                let msg = MsgIn::new(val);
-                match delay {
-                    Some(d) => msg.with_delay(d),
-                    None => msg,
-                }
+                MsgIn::new(val).with_delay(delay)
             })
             .collect::<Vec<_>>()
     };

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -561,6 +561,10 @@ async fn queue_ack(
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<MsgQueueAckIn>,
 ) -> Result<MsgPackOrJson<MsgQueueAckOut>> {
+    if data.msg_ids.is_empty() {
+        return Ok(MsgPackOrJson(MsgQueueAckOut {}));
+    }
+
     let namespace: MsgsNamespace = state
         .namespace_state
         .fetch_namespace(data.namespace.as_ref())?
@@ -707,6 +711,10 @@ async fn queue_nack(
     Extension(repl): Extension<RaftState>,
     MsgPackOrJson(data): MsgPackOrJson<MsgQueueNackIn>,
 ) -> Result<MsgPackOrJson<MsgQueueNackOut>> {
+    if data.msg_ids.is_empty() {
+        return Ok(MsgPackOrJson(MsgQueueNackOut {}));
+    }
+
     let namespace: MsgsNamespace = state
         .namespace_state
         .fetch_namespace(data.namespace.as_ref())?

--- a/z-clients/cli/src/cmds/benchmark.rs
+++ b/z-clients/cli/src/cmds/benchmark.rs
@@ -184,6 +184,13 @@ impl BenchmarkArgs {
                 filter.as_ref(),
             )
             .await?;
+            bench_msgs_scheduled_queue(
+                Arc::clone(&bench_cfg),
+                batch_size,
+                &mut all_stats,
+                filter.as_ref(),
+            )
+            .await?;
         }
 
         eprintln!("\n");
@@ -807,6 +814,7 @@ async fn bench_cache(
 struct BenchMsgsPublish<'a> {
     bench_result: BenchResult,
     batch_size: u16,
+    delay: Option<Duration>,
     label: String,
     topics: &'a [String],
 }
@@ -816,9 +824,15 @@ impl<'a> BenchMsgsPublish<'a> {
         Self {
             bench_result: BenchResult::new().set_batch_size(batch_size),
             batch_size,
+            delay: None,
             label: label.to_owned(),
             topics,
         }
+    }
+
+    fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = Some(delay);
+        self
     }
 }
 
@@ -839,7 +853,11 @@ impl<'a> BenchShard for BenchMsgsPublish<'a> {
             .map(|_| {
                 let mut payload = vec![0u8; 2_834];
                 rng.fill(&mut payload[..]);
-                MsgIn::new(payload)
+                let msg = MsgIn::new(payload);
+                match self.delay {
+                    Some(d) => msg.with_delay(d),
+                    None => msg,
+                }
             })
             .collect();
 
@@ -1126,6 +1144,38 @@ async fn bench_msgs_queue(
     BenchMsgsPublish::new(&topics, "queue", batch_size)
         .bench_shards_concurrent(Arc::clone(&cfg), all_stats, filter)
         .await?;
+    BenchMsgsQueueReceive::new(&topics, &consumer_group, batch_size)
+        .bench_shards_concurrent(Arc::clone(&cfg), all_stats, filter)
+        .await?;
+    Ok(())
+}
+
+async fn bench_msgs_scheduled_queue(
+    cfg: Arc<BenchConfig>,
+    batch_size: u16,
+    all_stats: &mut Vec<Stats>,
+    filter: Option<&Pattern>,
+) -> Result<()> {
+    cfg.client
+        .msgs()
+        .namespace()
+        .configure("bench".to_string(), MsgNamespaceConfigureIn::new())
+        .await?;
+
+    let topics: Vec<String> = (0..cfg.concurrency)
+        .map(|shard_id| format!("bench:bench-scheduled-queue/topic/{shard_id}"))
+        .collect();
+    let consumer_group = Alphanumeric.sample_string(&mut rand::rng(), 16);
+
+    let delay = Duration::from_secs(1);
+
+    BenchMsgsPublish::new(&topics, "scheduled_queue", batch_size)
+        .with_delay(delay)
+        .bench_shards_concurrent(Arc::clone(&cfg), all_stats, filter)
+        .await?;
+
+    tokio::time::sleep(delay).await;
+
     BenchMsgsQueueReceive::new(&topics, &consumer_group, batch_size)
         .bench_shards_concurrent(Arc::clone(&cfg), all_stats, filter)
         .await?;

--- a/z-clients/cli/src/cmds/benchmark.rs
+++ b/z-clients/cli/src/cmds/benchmark.rs
@@ -853,11 +853,7 @@ impl<'a> BenchShard for BenchMsgsPublish<'a> {
             .map(|_| {
                 let mut payload = vec![0u8; 2_834];
                 rng.fill(&mut payload[..]);
-                let msg = MsgIn::new(payload);
-                match self.delay {
-                    Some(d) => msg.with_delay(d),
-                    None => msg,
-                }
+                MsgIn::new(payload).with_delay(self.delay)
             })
             .collect();
 


### PR DESCRIPTION
Results:

```
svix@Chromebook coyote-private % DIOM_ADMIN_TOKEN=admin_abcdefghijlmnopqrstuvwxyz012345 cargo run -p diom-cli -- benchmark http://localhost:8050 --filter 'msgs.scheduled*'

    Finished `dev` profile [unoptimized] target(s) in 0.10s
     Running `target/debug/diom benchmark 'http://localhost:8050' --filter 'msgs.scheduled*'`
Running benchmark: 1000 iterations · batch_size 1

  [00:00:09] msgs.scheduled_queue.publish (batch=1) (conc=4)  [########################################]    4000/4000

╭────────────────────────────────────────┬─────────────┬─────────┬───────┬──────────┬───────┬───────┬───────┬───────┬────────┬────────┬───────────┬──────────────╮
│ op                                     ┆ concurrency ┆ ops/sec ┆ mean  ┆ ±        ┆ min   ┆ p50   ┆ p75   ┆ p99   ┆ p99.9  ┆ max    ┆ bytes/sec ┆ entities/sec │
╞════════════════════════════════════════╪═════════════╪═════════╪═══════╪══════════╪═══════╪═══════╪═══════╪═══════╪════════╪════════╪═══════════╪══════════════╡
│ msgs.scheduled_queue.publish (batch=1) ┆ 4           ┆ 433     ┆ 4.6ms ┆ 1776.0µs ┆ 2.7ms ┆ 4.5ms ┆ 5.0ms ┆ 7.9ms ┆ 10.4ms ┆ 11.3ms ┆ 1.23 MB   ┆ 433          │
╰────────────────────────────────────────┴─────────────┴─────────┴───────┴──────────┴───────┴───────┴───────┴───────┴────────┴────────┴───────────┴──────────────╯
```