### PR TITLE
server: change default port to 8624

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,3 +33,8 @@ node_modules/
 /clients
 !/clients/rust/
 !/clients/cli/
+
+/db/
+/example-configs/
+
+/logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,20 +52,8 @@ ARG RELEASE_VERSION
 RUN cargo build --release --package diom-server --bin diom-server --features diom-backend/openapi --frozen
 RUN cargo build --release --package diom-cli --bin diom --frozen
 
-# Production
-FROM docker.io/debian:trixie-slim AS prod
-
-RUN <<EOF
-    #!/bin/bash
-    set -euxo pipefail
-    mkdir -p /app
-    useradd appuser
-    chown -R appuser: /app
-    mkdir -p /home/appuser
-    chown -R appuser: /home/appuser
-    mkdir -p /storage
-    chown -R appuser: /storage
-EOF
+# shared base image with dependencies
+FROM docker.io/debian:trixie-slim AS base
 
 ENV __BUST_DOCKER_BUILD_CACHE=2026-01-30
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
@@ -77,6 +65,25 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/
         ca-certificates=20250419 \
         --no-install-recommends
     update-ca-certificates
+EOF
+
+RUN <<EOF
+    #!/bin/bash
+    set -euxo pipefail
+    mkdir -p /app
+    useradd appuser
+    chown -R appuser: /app
+    mkdir -p /home/appuser
+    chown -R appuser: /home/appuser
+EOF
+
+# Production
+FROM base AS prod
+
+RUN <<EOF
+    #!/bin/bash
+    mkdir -p /storage
+    chown -R appuser: /storage
 EOF
 
 ENV DIOM_PERSISTENT_DB_PATH="/storage/db"
@@ -87,7 +94,8 @@ ENV DIOM_CLUSTER_SNAPSHOT_PATH="/storage/snapshots"
 
 USER appuser
 WORKDIR /home/appuser
-EXPOSE 8050
+EXPOSE 8624/tcp
+EXPOSE 8625/tcp
 
 COPY --chown=root:root --chmod=755 --from=build /app/target/release/diom-server /usr/local/bin/diom-server
 COPY --chown=root:root --chmod=755 --from=build /app/target/release/diom /usr/local/bin/diom
@@ -95,27 +103,7 @@ COPY --chown=root:root --chmod=755 --from=build /app/target/release/diom /usr/lo
 CMD ["/usr/local/bin/diom-server"]
 
 # CLI Production
-FROM docker.io/debian:trixie-slim AS cli-prod
-
-RUN <<EOF
-    #!/bin/bash
-    set -euxo pipefail
-    useradd appuser
-    mkdir -p /home/appuser
-    chown -R appuser: /home/appuser
-EOF
-
-ENV __BUST_DOCKER_BUILD_CACHE=2026-01-30
-RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
-    #!/bin/bash
-    set -euxo pipefail
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update -q
-    apt-get install -y \
-        ca-certificates=20250419 \
-        --no-install-recommends
-    update-ca-certificates
-EOF
+FROM base AS cli-prod
 
 USER appuser
 WORKDIR /home/appuser

--- a/config.bench.toml
+++ b/config.bench.toml
@@ -1,6 +1,6 @@
 # This is a configuration used for benchmarking, not for general use
 
-listen_address = "0.0.0.0:8050"
+listen_address = "0.0.0.0:8624"
 log_level="info"
 environment = "dev"
 

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -32,7 +32,7 @@ environment = "dev"
 fsync_mode = "sync-data"
 
 # The address to listen on
-listen_address = "0.0.0.0:8050"
+listen_address = "[::]:8624"
 
 # The log format that all output will follow. Supported: default, json
 log_format = "default"
@@ -123,9 +123,8 @@ election_timeout_min_ms = 1500
 # Must not be less than `replication_request_timeout`.
 heartbeat_interval_ms = 500
 
-# The address to listen on for replication. Defaults to the main listen address,
-# but with the port incremented by 10000
-# listen_address =
+# The address to listen on for replication.
+listen_address = "[::]:8625"
 
 log_index_interval_ms = 600000
 

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -105,7 +105,7 @@ impl TestServerBuilder {
         let cfg = {
             let mut cfg = self.cfg;
             cfg.listen_address = addr;
-            cfg.cluster.listen_address = Some(repl_addr);
+            cfg.cluster.listen_address = repl_addr;
             cfg.cluster.advertised_address = Some(repl_addr.into());
             Arc::new(cfg)
         };
@@ -292,7 +292,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         bootstrap_max_wait_time: Some(DurationMs::from_secs(10)),
         cluster: ClusterConfiguration {
             advertised_address: None,
-            listen_address: Some(cluster_addr),
+            listen_address: cluster_addr,
             name: "diom-test".to_string(),
             snapshot_path: Some(snapshot_path),
             log_path: Some(log_path),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,34 @@
 x-diom-node: &diom-node
   build:
     context: .
+    target: prod
     dockerfile: Dockerfile
   image: "diom-server"
   ulimits:
     memlock: -1
   healthcheck:
-    test: ["CMD-SHELL", "diom healthcheck http://localhost:8050"]
+    test: ["CMD-SHELL", "diom healthcheck http://localhost:8624"]
     interval: 1s
     timeout: 1s
     retries: 600
   environment: &diom-node-env
-    DIOM_LISTEN_ADDRESS: "0.0.0.0:8050"
+    DIOM_LISTEN_ADDRESS: "0.0.0.0:8624"
     DIOM_ENVIRONMENT: "dev"
     # Cluster configuration
-    DIOM_CLUSTER_LISTEN_ADDRESS: "0.0.0.0:18050"
+    DIOM_CLUSTER_LISTEN_ADDRESS: "0.0.0.0:8625"
     # NOTE: the cluster is not secured with this configuration. Need to set a proper secret.
     DIOM_CLUSTER_SECRET: "insecure-cluster"
-    DIOM_CLUSTER_SEED_NODES: "diom-node-0:8050, diom-node-1:8050, diom-node-2:8050"
+    DIOM_CLUSTER_SEED_NODES: "diom-node-0:8625, diom-node-1:8625, diom-node-2:8625"
     # It's best practice to only enable it for node-0, but Diom also supports just turning it on for all.
     DIOM_CLUSTER_AUTO_INITIALIZE: false
+    # This token has superuser privileges on your cluster and should not be kept in plaintext
+    # in a production installation
+    DIOM_ADMIN_TOKEN: admin_insecure_abcdefghijlmnopqrstuvwxyz012345
 services:
   diom-node-0:
     !!merge <<: *diom-node
     ports:
-      - "8050:8050"
+      - "8624:8624"
     volumes:
       - diom-node-0:/storage
     environment:
@@ -32,14 +36,19 @@ services:
       DIOM_CLUSTER_AUTO_INITIALIZE: true
   diom-node-1:
     !!merge <<: *diom-node
+    depends_on:
+      - diom-node-0
     ports:
-      - "8051:8050"
+      - "18624:8624"
     volumes:
       - diom-node-1:/storage
   diom-node-2:
     !!merge <<: *diom-node
+    depends_on:
+      - diom-node-0
+      - diom-node-1
     ports:
-      - "8052:8050"
+      - "28624:8624"
     volumes:
       - diom-node-2:/storage
 # FIXME: should we add jaeger and the likes? Or maybe in another file.

--- a/infra/helm-diom/README.md
+++ b/infra/helm-diom/README.md
@@ -72,7 +72,7 @@ cluster:
 | `cluster.image.repository` | Diom server image repository. | `ghcr.io/svix/diom-server` |
 | `cluster.image.tag` | Diom server image tag. | Chart pre-populates current tag. |
 | `cluster.spec.replicas` | Number of Diom replicas. Should be an odd number. Recommended value is 3 for a cluster, or 1 for a single node. | `1` |
-| `cluster.spec.apiPort` | Port for the external API and service. | `8080` |
+| `cluster.spec.apiPort` | Port for the external API and service. | `8624` |
 | `cluster.spec.envVar` | Additional environment variables to inject into pods (list of `{name, value}`). | `[]` |
 | `cluster.spec.bootstrap` | Newline-delimited bootstrap script to run on cluster startup. | `""` |
 | `cluster.spec.logLevel` | The log level to run the service with. Supported: info, debug, trace. | `""` |

--- a/infra/helm-diom/charts/crds/crds/diomclusters.json
+++ b/infra/helm-diom/charts/crds/crds/diomclusters.json
@@ -791,7 +791,7 @@
                     "type": "object"
                   },
                   "apiPort": {
-                    "default": 8080,
+                    "default": 8624,
                     "description": "Port for the external API and service.",
                     "format": "uint16",
                     "maximum": 65535.0,

--- a/infra/operator/ingress.yaml
+++ b/infra/operator/ingress.yaml
@@ -17,4 +17,4 @@ spec:
               service:
                 name: diom
                 port:
-                  number: 8080
+                  number: 8624

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -13,8 +13,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-pub(crate) const DEFAULT_API_PORT: u16 = 8080;
-pub(crate) const INTRACLUSTER_PORT: u16 = 18080;
+pub(crate) const DEFAULT_API_PORT: u16 = 8624;
+pub(crate) const INTRACLUSTER_PORT: u16 = 8625;
 
 fn default_api_port() -> u16 {
     DEFAULT_API_PORT

--- a/scripts/start-diom-server.sh
+++ b/scripts/start-diom-server.sh
@@ -10,14 +10,14 @@ set -euo pipefail
 #
 # Environment variables:
 #   DIOM_ADMIN_TOKEN  Admin token (default: admin_abcdefghijlmnopqrstuvwxyz012345)
-#   DIOM_PORT         Port to listen on (default: 8050)
+#   DIOM_PORT         Port to listen on (default: 8624)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR/.."
 
 BINARY="${1:-$ROOT_DIR/target/release/diom-server}"
 DIOM_ADMIN_TOKEN="${DIOM_ADMIN_TOKEN:-admin_abcdefghijlmnopqrstuvwxyz012345}"
-PORT="${DIOM_PORT:-8050}"
+PORT="${DIOM_PORT:-8624}"
 PID_FILE="/tmp/diom-server.pid"
 
 if [[ ! -f "$BINARY" ]]; then
@@ -31,16 +31,16 @@ chmod +x "$BINARY"
 echo "==> Starting Diom server ($BINARY) on port $PORT..."
 
 DIOM_LISTEN_ADDRESS="0.0.0.0:$PORT" \
-DIOM_ENVIRONMENT=dev \
-DIOM_CLUSTER_AUTO_INITIALIZE=true \
-DIOM_ADMIN_TOKEN="$DIOM_ADMIN_TOKEN" \
+    DIOM_ENVIRONMENT=dev \
+    DIOM_CLUSTER_AUTO_INITIALIZE=true \
+    DIOM_ADMIN_TOKEN="$DIOM_ADMIN_TOKEN" \
     "$BINARY" &
 
-echo $! > "$PID_FILE"
+echo $! >"$PID_FILE"
 
 echo "==> Waiting for server to be ready..."
 for i in $(seq 1 60); do
-    if curl -sf "http://localhost:$PORT/api/v1.health.ping" > /dev/null 2>&1; then
+    if curl -sf "http://localhost:$PORT/api/v1.health.ping" >/dev/null 2>&1; then
         echo "Server is ready (pid $(cat "$PID_FILE"))"
         exit 0
     fi

--- a/scripts/test-sdk.sh
+++ b/scripts/test-sdk.sh
@@ -10,13 +10,13 @@ set -euo pipefail
 #
 # Environment variables:
 #   DIOM_TOKEN       Auth token for the running server (has a default)
-#   DIOM_SERVER_URL  Server URL (default: http://localhost:8050)
+#   DIOM_SERVER_URL  Server URL (default: http://localhost:8624)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR/.."
 
 export DIOM_TOKEN="${DIOM_TOKEN:-admin_abcdefghijlmnopqrstuvwxyz012345}"
-export DIOM_SERVER_URL="${DIOM_SERVER_URL:-http://localhost:8050}"
+export DIOM_SERVER_URL="${DIOM_SERVER_URL:-http://localhost:8624}"
 
 export DIOM_TOKEN="$DIOM_TOKEN"
 export DIOM_SERVER_URL="$DIOM_SERVER_URL"
@@ -52,7 +52,7 @@ run_java() {
 SDKS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        rust|python|javascript|go|java)
+        rust | python | javascript | go | java)
             SDKS+=("$1")
             shift
             ;;

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -1,4 +1,4 @@
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{Ipv6Addr, SocketAddr};
 
 use diom_core::types::DurationMs;
 
@@ -9,7 +9,11 @@ pub(super) fn default_true() -> bool {
 }
 
 pub(super) fn listen_address() -> SocketAddr {
-    (Ipv4Addr::UNSPECIFIED, 8050).into()
+    (Ipv6Addr::UNSPECIFIED, 8624).into()
+}
+
+pub(super) fn cluster_listen_address() -> SocketAddr {
+    (Ipv6Addr::UNSPECIFIED, 8625).into()
 }
 
 pub(super) fn persistent_db() -> DatabaseConfig {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -218,10 +218,9 @@ impl DatabaseConfig {
     skip_on_field_errors = true
 ))]
 pub struct ClusterConfiguration {
-    /// The address to listen on for replication. Defaults to the main listen address,
-    /// but with the port incremented by 10000
-    #[serde(default)]
-    pub listen_address: Option<SocketAddr>,
+    /// The address to listen on for replication.
+    #[serde(default = "defaults::cluster_listen_address")]
+    pub listen_address: SocketAddr,
 
     /// Human-facing name for this cluster.
     ///
@@ -435,14 +434,6 @@ impl ClusterConfiguration {
         } else {
             Dir::new(root.persistent_db.path.join("cluster_snapshots"))
         }
-    }
-
-    pub fn listen_address(&self, root: &ConfigurationInner) -> SocketAddr {
-        self.listen_address.unwrap_or_else(|| {
-            let port = root.listen_address.port() + 10000;
-            let ip = root.listen_address.ip();
-            SocketAddr::new(ip, port)
-        })
     }
 }
 
@@ -1121,22 +1112,22 @@ persistent_db.path = "/2"
 
     #[test]
     fn test_peer_addr_parsing() {
-        let Ok(PeerAddr::SocketAddr(SocketAddr::V4(sa))) = "127.0.0.2:8050".parse() else {
+        let Ok(PeerAddr::SocketAddr(SocketAddr::V4(sa))) = "127.0.0.2:8624".parse() else {
             panic!("failed to parse v4 addr")
         };
-        assert_eq!(sa.port(), 8050);
+        assert_eq!(sa.port(), 8624);
         assert_eq!(*sa.ip(), Ipv4Addr::new(127, 0, 0, 2));
-        let Ok(PeerAddr::SocketAddr(SocketAddr::V6(sa))) = "[::1001:2%1234]:8050".parse() else {
+        let Ok(PeerAddr::SocketAddr(SocketAddr::V6(sa))) = "[::1001:2%1234]:8624".parse() else {
             panic!("failed to parse v6 addr");
         };
         assert_eq!(sa.scope_id(), 1234);
-        assert_eq!(sa.port(), 8050);
+        assert_eq!(sa.port(), 8624);
         assert_eq!(*sa.ip(), Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x1001, 0x2));
         assert_eq!(
-            "foobar:8050".parse::<PeerAddr>().expect("should parse"),
+            "foobar:8624".parse::<PeerAddr>().expect("should parse"),
             PeerAddr::HostnameAndPort {
                 hostname: "foobar".to_owned(),
-                port: 8050
+                port: 8624
             }
         );
         "  illegal-hostname:1"
@@ -1155,7 +1146,7 @@ persistent_db.path = "/2"
         let addrs = [
             PeerAddr::SocketAddr(SocketAddr::new(
                 IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
-                8050,
+                8624,
             )),
             PeerAddr::SocketAddr(SocketAddr::new(
                 IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)),

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -323,7 +323,7 @@ pub(crate) async fn detect_address(
         return Ok(addr.clone());
     }
 
-    let cluster_addr = cfg.cluster.listen_address(cfg);
+    let cluster_addr = cfg.cluster.listen_address;
     if !is_unspecified(&cluster_addr) {
         tracing::debug!(addr=?cluster_addr, "using configured cluster listen_address");
         return Ok(PeerAddr::SocketAddr(cluster_addr));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ async fn run_interserver(
 ) {
     let listener = axum_tcp_listener(
         listener,
-        cfg.cluster.listen_address(&cfg),
+        cfg.cluster.listen_address,
         conn_metrics.clone(),
         ConnectionType::Internal,
     )

--- a/z-clients/go/client.go
+++ b/z-clients/go/client.go
@@ -21,7 +21,7 @@ type Diom struct {
 }
 
 func New(token string, options *DiomOptions) (*Diom, error) {
-	httpClient := diom_proto.DefaultHttpClient("http://localhost:8050")
+	httpClient := diom_proto.DefaultHttpClient("http://localhost:8624")
 
 	if options != nil {
 		if options.ServerUrl != nil {

--- a/z-clients/javascript/src/request.ts
+++ b/z-clients/javascript/src/request.ts
@@ -60,7 +60,7 @@ export type DiomRequestContext = {
 >;
 
 export function makeRequestContext(token: string, options: DiomOptions) {
-  const baseUrl = options.serverUrl ?? "http://localhost:8050";
+  const baseUrl = options.serverUrl ?? "http://localhost:8624";
 
   if (options.retryScheduleInMs) {
     return {

--- a/z-clients/python/diom/internal/http_client.py
+++ b/z-clients/python/diom/internal/http_client.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 import attr
 
-DEFAULT_SERVER_URL = "http://localhost:8050"
+DEFAULT_SERVER_URL = "http://localhost:8624"
 
 
 @attr.s(auto_attribs=True)

--- a/z-clients/rust/src/client.rs
+++ b/z-clients/rust/src/client.rs
@@ -7,7 +7,7 @@ use crate::connector::{Connector, make_connector};
 
 const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const DEFAULT_URL: &str = "http://localhost:8050";
+pub const DEFAULT_URL: &str = "http://localhost:8624";
 
 pub struct DiomOptions {
     pub debug: bool,


### PR DESCRIPTION
Changes:

 - default port from 8050 to 8624
 - default intracluster port from 18050 to 8625
 - makes dockerfile build faster by sharing a layer and ignoring some more files
 - fixes docker-compose.yml to use the right docker target so that it works again
 - runs shfmt on the bash files (automatically by my editor when I edited them, heh)