### PR TITLE
fix: potential cluster initialization bug

### DIFF
--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -38,7 +38,6 @@ pub(crate) async fn initialize_cluster(
     cluster: BTreeMap<NodeId, Node>,
 ) -> anyhow::Result<ClusterId> {
     let start = Instant::now();
-    let voters = cluster.keys().copied().collect::<Vec<_>>();
     match raft.initialize(cluster).await {
         Ok(_) => {}
         Err(RaftError::APIError(InitializeError::NotAllowed(_))) => {
@@ -50,7 +49,7 @@ pub(crate) async fn initialize_cluster(
         }
     };
     raft.wait(None)
-        .voter_ids(voters, "waiting for cluster to bootstrap")
+        .log_index_at_least(Some(1), "waiting for someone to become the leader")
         .await?;
     let new_id = ClusterId::generate();
     tracing::info!(cluster_id=%new_id, "cluster initialized, setting cluster_id");


### PR DESCRIPTION
noticed this while playing with the docker-compose file; if another node joins just after the first node finishes the openraft bootstrapping but before it runs the `cluster_id` command, things get hinky because we were checking voter_ids.

Instead of waiting for the voter_ids to become stable (which is racy), just wait until the vote is recorded to the log.