### PR TITLE
include more details in benchmark progress

### DIFF
--- a/z-clients/cli/src/cmds/benchmark.rs
+++ b/z-clients/cli/src/cmds/benchmark.rs
@@ -540,6 +540,7 @@ trait BenchShard {
         let iterations = cfg.iterations;
         let label = format!("{} (conc={})", self.test_name(), cfg.concurrency);
         let pb = new_bar(label, concurrency * iterations);
+        pb.set_message("running benchmark");
         let barrier = Arc::new(Barrier::new(concurrency as usize));
         let progress = Arc::new(AtomicU64::new(0));
         let handles = (0..concurrency).map(|shard_id| {
@@ -555,8 +556,9 @@ trait BenchShard {
         });
 
         let joined_handles = try_join_all(handles).await?.into_iter();
-        pb.finish();
+        pb.set_message("analyzing...");
         self.finalize_result_stats(Arc::clone(&cfg), joined_handles, all_stats)?;
+        pb.finish();
 
         Ok(())
     }


### PR DESCRIPTION
adds a message at the end of the progress bar with the current phase so you can see when it switches to "analyzing" (a.k.a merging the histograms).

Demo:

[![asciicast](https://asciinema.org/a/keWMV2sONpGZJUal.svg)](https://asciinema.org/a/keWMV2sONpGZJUal)