### PR TITLE
Add Helm/Operator release jobs

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   docker-build-release:
     runs-on: ubuntu-24.04
+    environment: release
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,14 +1,21 @@
-name: Helm Publish
+name: Helm Publish to GHCR
 
 on:
   workflow_call:
     inputs:
       version:
+        required: false
+        type: string
+        description: 'Override the version specified in Chart.yaml (only used for private deployments)'
+      operator_image_tag:
         required: true
         type: string
-      image_tag:
+      server_image_tag:
         required: true
         type: string
+      is_release:
+        type: boolean
+        default: false
 
 jobs:
   helm-publish:
@@ -32,9 +39,21 @@ jobs:
 
       - name: Set image tags
         run: |
-          sed -i 's/tag: ""/tag: "${{ inputs.image_tag }}"/g' infra/helm-diom/values.yaml
+          yq -i '.cluster.image.tag = "${{ inputs.server_image_tag }}"' infra/helm-diom/values.yaml
+          yq -i '.operator.image.tag = "${{ inputs.operator_image_tag }}"' infra/helm-diom/values.yaml
+
+      - name: Mangle charts for private deploys
+        if: ${{ !inputs.is_release }}
+        run: |
+          yq -i '.name = "diom-private"' infra/helm-diom/Chart.yaml
+          yq -i '.operator.image.repository = "ghcr.io/svix/diom-operator"' infra/helm-diom/values.yaml
+          yq -i '.cluster.image.repository = "ghcr.io/svix/diom-server"' infra/helm-diom/values.yaml
 
       - name: Package and push chart
         run: |
-          helm package ./infra/helm-diom --version ${{ inputs.version }}
-          helm push diom-${{ inputs.version }}.tgz oci://ghcr.io/svix/charts
+          if [ -n "${{ inputs.version }}" ]; then
+            helm package ./infra/helm-diom --version ${{ inputs.version }}
+          else
+            helm package ./infra/helm-diom
+          fi
+          helm push diom*.tgz oci://ghcr.io/svix/charts

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,37 @@
+name: Helm Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      operator_image_tag:
+        required: true
+        type: string
+      server_image_tag:
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+      operator_image_tag:
+        required: false
+        type: string
+        default: ''
+      server_image_tag:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  publish:
+    uses: ./.github/workflows/helm-publish.yml
+    with:
+      operator_image_tag: ${{ inputs.operator_image_tag }}
+      server_image_tag: ${{ inputs.server_image_tag }}
+      is_release: true
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -63,3 +63,16 @@ jobs:
       contents: read
       packages: write
       security-events: write
+
+  helm-publish:
+    needs: ci
+    uses: ./.github/workflows/helm-publish.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    with:
+      version: 0.0.0-${{ github.sha }}
+      server_image_tag: sha-${{ github.sha }}
+      operator_image_tag: sha-${{ github.sha }}
+      is_release: false

--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -1,0 +1,45 @@
+name: Operator Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run (skip pushes)
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  operator-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(cargo metadata --manifest-path infra/operator/Cargo.toml --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "=== DRY RUN ==="
+          echo "Would release operator: ${{ steps.version.outputs.version }}"
+          echo "Would push Docker image: svix/diom-operator:${{ steps.version.outputs.version }}"
+
+  docker-build:
+    needs: operator-release
+    uses: ./.github/workflows/docker-build-release.yml
+    with:
+      image_repo: svix/diom-operator
+      version: ${{ needs.operator-release.outputs.version }}
+      dockerfile: ./infra/operator/Dockerfile
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit

--- a/infra/helm-diom/Chart.yaml
+++ b/infra/helm-diom/Chart.yaml
@@ -3,7 +3,6 @@ name: diom
 description: Helm chart for Diom clusters
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
 
 dependencies:
   - name: crds

--- a/infra/helm-diom/values.yaml
+++ b/infra/helm-diom/values.yaml
@@ -11,7 +11,7 @@ crds:
 
 operator:
   image:
-    repository: ghcr.io/svix/diom-operator
+    repository: svix/diom-operator
     pullPolicy: IfNotPresent
     # Overrides the image tag. Defaults to the chart's appVersion.
     tag: ""
@@ -47,7 +47,7 @@ cluster:
   enabled: true
   name: diom
   image:
-    repository: ghcr.io/svix/diom-server
+    repository: svix/diom-server
     # tag is required when cluster.enabled=true.
     tag: ""
   spec:


### PR DESCRIPTION
Add jobs for releasing the Helm chart (push to GHCR) and Operator
(push to Docker Hub). The versions of the chart and operator
should be commited in git _before_ calling these jobs.

When you run the Helm release job, you'll need to specify the proper
versions / image tags for Operator and Diom. These will be written
into the chart prior to packaging.

Also, added a step to publish Helm chart to private GHCR on pushes to 
main.
