### PR TITLE
Logging: disable fjall and openraft logs by default.

### DIFF
--- a/server/src/otel.rs
+++ b/server/src/otel.rs
@@ -26,10 +26,10 @@ pub(crate) fn setup_tracing(
         let level = cfg.log_level.to_string();
         let var = [
             format!("diom={level}"),
-            format!("fjall={level}"),
             format!("fjall_utils={level}"),
             format!("tower_http={level}"),
-            format!("openraft={level}"),
+            "fjall=warn".to_string(),
+            "openraft=warn".to_string(),
             "opentelemetry_sdk=ERROR".to_string(),
         ];
 


### PR DESCRIPTION
They are just noise for Diom users, and Diom developers can just explicitly set RUST_LOG if they want to see them.