### PR TITLE
logs: add a log on startup when loading a database

### DIFF
--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -175,9 +175,19 @@ impl DatabaseConfig {
         }
     }
 
-    fn database(dir: &Path, file: &str, time: Monotime) -> Result<fjall::Database> {
+    fn database(
+        dir: &Path,
+        file: &str,
+        time: Monotime,
+        label: &'static str,
+    ) -> Result<fjall::Database> {
         let dir = Dir::new(dir)?;
         let path = dir.join(file);
+        if path.exists() {
+            tracing::info!(path = %path.display(), "loading existing {} database", label);
+        } else {
+            tracing::debug!(path = %path.display(), "initializing new {} database", label);
+        }
         // FIXME: we should probably make the cache size a config.
         fjall::Database::builder(path)
             .cache_size(Self::default_cache_size())
@@ -200,6 +210,7 @@ impl DatabaseConfig {
             &db_config.path,
             db_config.filename.as_deref().unwrap_or("fjall_persistent"),
             time,
+            "persistent",
         )
     }
 
@@ -208,6 +219,7 @@ impl DatabaseConfig {
             &db_config.path,
             db_config.filename.as_deref().unwrap_or("fjall_ephemeral"),
             time,
+            "ephemeral",
         )
     }
 }


### PR DESCRIPTION
since #1013, we no longer get fjall's message that it's loading databases, so it can look like the system is hung if there's a large fjall log to replay. This adds an info-level message on startup when there's an existing database so that the user can know we're about to do something expensive.