### PR TITLE
cfg: parameterize db cache size and refactor how db configuration works

### DIFF
--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -184,11 +184,16 @@ startup_discovery_delay_ms = 10
 # other modules, and can be placed on less-durable storage, such as local instance storage
 [ephemeral_db]
 
-# Filename under the directory specified in `path`.
+# Amount of memory to reserve for the database layer's
+# caches for this database type.
 #
-# If not specified, uses a default value
-# based on the database type.
-# filename =
+# Can be specified as a bare value of bytes (e.g., 1024000), a unit-ed amount
+# (e.g., 1024MiB), or a percentage (e.g., 20%), which will be applied against
+# the current cgroup limit if present and the total system memory otherwise
+cache_size = "20%"
+
+# Filename under the directory specified in `path`.
+filename = "fjall_ephemeral"
 
 # Directory in which this database is stored
 path = "./db"
@@ -254,11 +259,16 @@ service_name = "diom"
 # should be placed on durable storage
 [persistent_db]
 
-# Filename under the directory specified in `path`.
+# Amount of memory to reserve for the database layer's
+# caches for this database type.
 #
-# If not specified, uses a default value
-# based on the database type.
-# filename =
+# Can be specified as a bare value of bytes (e.g., 1024000), a unit-ed amount
+# (e.g., 1024MiB), or a percentage (e.g., 20%), which will be applied against
+# the current cgroup limit if present and the total system memory otherwise
+cache_size = "20%"
+
+# Filename under the directory specified in `path`.
+filename = "fjall_persistent"
 
 # Directory in which this database is stored
 path = "./db"

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -5,7 +5,7 @@ use diom_backend::{
     Initialized,
     cfg::{
         ClusterConfiguration, ConfigurationInner, DatabaseConfig, Environment, FsyncMode,
-        LogFormat, LogLevel, OpenTelemetryConfig, OpenTelemetryProtocol, SyncMode,
+        LogFormat, LogLevel, MemorySize, OpenTelemetryConfig, OpenTelemetryProtocol, SyncMode,
     },
     core::cluster::{ClusterId, NodeId, proto::HealthResponse},
     run_with_listeners,
@@ -274,11 +274,13 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         listen_address: addr,
         ephemeral_db: DatabaseConfig {
             path: db_dir.clone(),
-            ..Default::default()
+            filename: "fjall_ephemeral".into(),
+            cache_size: MemorySize::fjall_default_cache(),
         },
         persistent_db: DatabaseConfig {
             path: db_dir,
-            ..Default::default()
+            filename: "fjall_persistent".into(),
+            cache_size: MemorySize::fjall_default_cache(),
         },
         log_level: LogLevel::Debug,
         log_format: LogFormat::Default,

--- a/example-configs/three-node-cluster/first.toml
+++ b/example-configs/three-node-cluster/first.toml
@@ -2,11 +2,19 @@ listen_address = "127.0.0.1:8624"
 jwt_secret = "insecure_cluster"
 jwt_algorithm = "HS256"
 environment = "dev"
-persistent_db.path = "./db-first/persistent"
-ephemeral_db.path = "./db-first/ephemeral"
 opentelemetry_address = "http://localhost:4317"
 opentelemetry_metrics_address = "http://localhost:9090/api/v1/otlp/v1/metrics"
 opentelemetry_metrics_protocol = "http"
+
+[persistent_db]
+path = "db-first"
+filename = "persistent"
+cache_size = "32MiB"
+
+[ephemeral_db]
+path = "db-first"
+filename = "ephemeral"
+cache_size = "32MiB"
 
 [cluster]
 secret = "hunter2"

--- a/example-configs/three-node-cluster/second.toml
+++ b/example-configs/three-node-cluster/second.toml
@@ -2,11 +2,19 @@ listen_address = "127.0.0.1:8626"
 jwt_secret = "insecure_cluster"
 jwt_algorithm = "HS256"
 environment = "dev"
-persistent_db.path = "./db-second/persistent"
-ephemeral_db.path = "./db-second/ephemeral"
 opentelemetry_address = "http://localhost:4317"
 opentelemetry_metrics_address = "http://localhost:9090/api/v1/otlp/v1/metrics"
 opentelemetry_metrics_protocol = "http"
+
+[persistent_db]
+path = "db-second"
+filename = "persistent"
+cache_size = "32MiB"
+
+[ephemeral_db]
+path = "db-second"
+filename = "ephemeral"
+cache_size = "32MiB"
 
 [cluster]
 secret = "hunter2"

--- a/example-configs/three-node-cluster/third.toml
+++ b/example-configs/three-node-cluster/third.toml
@@ -2,11 +2,19 @@ listen_address = "127.0.0.1:8628"
 jwt_secret = "insecure_cluster"
 jwt_algorithm = "HS256"
 environment = "dev"
-persistent_db.path = "./db-third/persistent"
-ephemeral_db.path = "./db-third/ephemeral"
 opentelemetry_address = "http://localhost:4317"
 opentelemetry_metrics_address = "http://localhost:9090/api/v1/otlp/v1/metrics"
 opentelemetry_metrics_protocol = "http"
+
+[persistent_db]
+path = "db-third"
+filename = "persistent"
+cache_size = "32MiB"
+
+[ephemeral_db]
+path = "db-third"
+filename = "ephemeral"
+cache_size = "32MiB"
 
 [cluster]
 secret = "hunter2"

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -2,7 +2,7 @@ use std::net::{Ipv6Addr, SocketAddr};
 
 use diom_core::types::DurationMs;
 
-use super::DatabaseConfig;
+use super::{DatabaseConfig, MemorySize};
 
 pub(super) fn default_true() -> bool {
     true
@@ -19,14 +19,16 @@ pub(super) fn cluster_listen_address() -> SocketAddr {
 pub(super) fn persistent_db() -> DatabaseConfig {
     DatabaseConfig {
         path: "./db".into(),
-        filename: None,
+        filename: "fjall_persistent".into(),
+        cache_size: default_database_size(),
     }
 }
 
 pub(super) fn ephemeral_db() -> DatabaseConfig {
     DatabaseConfig {
         path: "./db".into(),
-        filename: None,
+        filename: "fjall_ephemeral".into(),
+        cache_size: default_database_size(),
     }
 }
 
@@ -104,4 +106,8 @@ pub(super) fn cluster_replication_lag_threshold() -> u64 {
 
 pub(super) fn background_cleanup_interval() -> DurationMs {
     DurationMs::from_secs(10)
+}
+
+pub(super) fn default_database_size() -> MemorySize {
+    MemorySize::Percent(20)
 }

--- a/src/cfg/memory_size.rs
+++ b/src/cfg/memory_size.rs
@@ -1,0 +1,183 @@
+use std::{collections::HashMap, fmt, sync::LazyLock};
+
+use serde::de::{self, Visitor};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MemorySize {
+    Bytes(u64),
+    Percent(u8),
+}
+
+static SYSTEM_MEMORY: LazyLock<u64> = LazyLock::new(|| {
+    let mut sys = sysinfo::System::new_all();
+    sys.refresh_all();
+
+    if let Some(limit) = sys.cgroup_limits() {
+        limit.total_memory
+    } else {
+        sys.total_memory()
+    }
+});
+
+impl MemorySize {
+    pub fn as_bytes(&self) -> u64 {
+        match self {
+            Self::Percent(pct) => {
+                if *SYSTEM_MEMORY == 0 {
+                    tracing::warn!(
+                        pct,
+                        "unable to determine system memory, falling back from percentage to fixed size for cache"
+                    );
+                    Self::fjall_default_cache().as_bytes()
+                } else {
+                    (*pct as u64) * *SYSTEM_MEMORY / 100
+                }
+            }
+            Self::Bytes(bytes) => *bytes,
+        }
+    }
+
+    pub fn fjall_default_cache() -> Self {
+        Self::Bytes(32 * 1024 * 1024) // match fjall default of 32MB
+    }
+}
+
+impl serde::ser::Serialize for MemorySize {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Bytes(bval) => bval.to_string().serialize(serializer),
+            Self::Percent(pct) => format!("{pct}%").serialize(serializer),
+        }
+    }
+}
+
+static UNIT_SUFFIXES: LazyLock<HashMap<&'static str, u64>> = LazyLock::new(|| {
+    maplit::hashmap! {
+        "b" => 1,
+        "kb" => 1000,
+        "kib" => 1024,
+        "mb" => 1_000_000,
+        "mib" => 1024 * 1024,
+        "gb" => 1_000_000_000,
+        "gib" => 1024 * 1024 * 1024,
+        "tb" => 1_000_000_000_000,
+        "tib" => 1024 * 1024 * 1024 * 1024
+    }
+});
+
+struct MemorySizeVisitor;
+
+impl<'de> Visitor<'de> for MemorySizeVisitor {
+    type Value = MemorySize;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a valid byte size")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        // strip any whitespace
+        let v = v.replace(|c: char| c == '_' || c.is_ascii_whitespace(), "");
+        // look for the unit part
+        if let Some(unit_index) = v.find(|f: char| !f.is_ascii_digit()) {
+            let prefix = &v[..unit_index];
+            let suffix = &v[unit_index..];
+            if suffix == "%" {
+                let numeric_part: u8 = prefix
+                    .parse()
+                    .map_err(|_| de::Error::custom("prefix could not be parsed as an integer"))?;
+                Ok(MemorySize::Percent(numeric_part))
+            } else {
+                let Some(multiplier) = UNIT_SUFFIXES.get(suffix.to_lowercase().as_str()) else {
+                    return Err(de::Error::custom(format!(
+                        "suffix {suffix} is not recognized"
+                    )));
+                };
+                let numeric_part: u64 = prefix
+                    .parse()
+                    .map_err(|_| de::Error::custom("prefix could not be parsed as an integer"))?;
+                Ok(MemorySize::Bytes(numeric_part * *multiplier))
+            }
+        } else {
+            // great, they're all digits
+            let number: u64 = v
+                .parse()
+                .map_err(|_| de::Error::custom("could not be parsed as an integer"))?;
+            Ok(MemorySize::Bytes(number))
+        }
+    }
+}
+
+impl<'de> de::Deserialize<'de> for MemorySize {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(MemorySizeVisitor)
+    }
+}
+
+crate::from_str_via_serde!(MemorySize);
+
+#[cfg(test)]
+mod tests {
+    use super::MemorySize;
+    use std::str::FromStr;
+
+    const VECTORS: &[(&str, MemorySize)] = &[
+        ("1", MemorySize::Bytes(1)),
+        ("1_024_000", MemorySize::Bytes(1024000)),
+        ("1kb", MemorySize::Bytes(1000)),
+        ("1KiB", MemorySize::Bytes(1024)),
+        ("1mb", MemorySize::Bytes(1000000)),
+        ("1MiB", MemorySize::Bytes(1048576)),
+        ("1_024 KiB", MemorySize::Bytes(1048576)),
+        ("50%", MemorySize::Percent(50)),
+    ];
+
+    const INVALID_STRINGS: &[&str] = &[
+        "all of it",
+        "1 byte",
+        "1024MB and also some garbage",
+        "1.44MB",
+    ];
+
+    #[test]
+    fn test_fromstr() {
+        for (input, expected) in VECTORS {
+            let parsed: MemorySize = input.parse().expect("should parse");
+            assert_eq!(parsed, *expected);
+        }
+        for input in INVALID_STRINGS {
+            MemorySize::from_str(input).expect_err("should fail to parse");
+        }
+    }
+
+    #[test]
+    fn test_serde_deserialize() {
+        for (input, expected) in VECTORS {
+            let wrapped = serde_json::json! { input };
+            let parsed: MemorySize = serde_json::value::from_value(wrapped).expect("should parse");
+            assert_eq!(parsed, *expected);
+            let serialized = serde_json::to_string(&parsed).expect("should re-serialize");
+            let deserialized: MemorySize =
+                serde_json::from_str(&serialized).expect("should re-deserialize");
+            assert_eq!(deserialized, *expected);
+        }
+        for input in INVALID_STRINGS {
+            let wrapped = serde_json::json! { input };
+            serde_json::value::from_value::<MemorySize>(wrapped).expect_err("should fail to parse");
+        }
+    }
+
+    #[test]
+    fn test_as_bytes() {
+        assert_eq!(MemorySize::Bytes(2048).as_bytes(), 2048);
+        assert!(MemorySize::Percent(100).as_bytes() > 32 * 1024 * 1024);
+    }
+}

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -20,13 +20,14 @@ use crate::error::{Error, Result};
 mod defaults;
 mod dumpable_config;
 pub(crate) mod env_overridable;
+mod memory_size;
 mod validators;
 
-pub use self::env_overridable::Variable;
 use self::{
     dumpable_config::DumpableConfig,
     env_overridable::{EnvOverridable, env_var},
 };
+pub use self::{env_overridable::Variable, memory_size::MemorySize};
 
 pub type Configuration = Arc<ConfigurationInner>;
 
@@ -102,15 +103,20 @@ impl Serialize for PeerAddr {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, EnvOverridable, Serialize, DumpableConfig)]
+#[derive(Clone, Debug, Deserialize, EnvOverridable, Serialize, DumpableConfig)]
 pub struct DatabaseConfig {
     /// Directory in which this database is stored
     pub path: PathBuf,
     /// Filename under the directory specified in `path`.
+    pub filename: String,
+    /// Amount of memory to reserve for the database layer's
+    /// caches for this database type.
     ///
-    /// If not specified, uses a default value
-    /// based on the database type.
-    pub filename: Option<String>,
+    /// Can be specified as a bare value of bytes (e.g., 1024000), a unit-ed amount
+    /// (e.g., 1024MiB), or a percentage (e.g., 20%), which will be applied against
+    /// the current cgroup limit if present and the total system memory otherwise
+    #[serde(default = "defaults::default_database_size")]
+    pub cache_size: MemorySize,
 }
 
 /// Wrapper around a path that we know to be an extant dir
@@ -160,37 +166,17 @@ impl From<Dir> for PathBuf {
 }
 
 impl DatabaseConfig {
-    fn default_cache_size() -> u64 {
-        let mut sys = sysinfo::System::new_all();
-        sys.refresh_all();
-
-        let ret = sys.total_memory();
-        if ret == 0 {
-            // Default to fjall's current default (32 MiB)
-            32 * 1024 * 1024
-        } else {
-            // Fjall recommends 20-25% of the memory for cache.
-            // We can probably do more, but let's start with that.
-            ret / 5
-        }
-    }
-
-    fn database(
-        dir: &Path,
-        file: &str,
-        time: Monotime,
-        label: &'static str,
-    ) -> Result<fjall::Database> {
-        let dir = Dir::new(dir)?;
-        let path = dir.join(file);
+    pub fn database(&self, time: Monotime, label: &'static str) -> Result<fjall::Database> {
+        let dir = Dir::new(&self.path)?;
+        let path = dir.join(&self.filename);
         if path.exists() {
             tracing::info!(path = %path.display(), "loading existing {} database", label);
         } else {
             tracing::debug!(path = %path.display(), "initializing new {} database", label);
         }
-        // FIXME: we should probably make the cache size a config.
+        let cache_size = self.cache_size;
         fjall::Database::builder(path)
-            .cache_size(Self::default_cache_size())
+            .cache_size(cache_size.as_bytes())
             .manual_journal_persist(true)
             .with_compaction_filter_factories(Arc::new(move |keyspace| match keyspace {
                 diom_msgs::METADATA_KEYSPACE => Some(Arc::new(
@@ -203,24 +189,6 @@ impl DatabaseConfig {
                 tracing::error!(?err, "error building database");
                 err.into()
             })
-    }
-
-    pub fn persistent(db_config: &DatabaseConfig, time: Monotime) -> Result<fjall::Database> {
-        Self::database(
-            &db_config.path,
-            db_config.filename.as_deref().unwrap_or("fjall_persistent"),
-            time,
-            "persistent",
-        )
-    }
-
-    pub fn ephemeral(db_config: &DatabaseConfig, time: Monotime) -> Result<fjall::Database> {
-        Self::database(
-            &db_config.path,
-            db_config.filename.as_deref().unwrap_or("fjall_ephemeral"),
-            time,
-            "ephemeral",
-        )
     }
 }
 
@@ -969,9 +937,10 @@ impl EnvOverridable for Option<JwtKey> {
     }
 }
 
+#[macro_export]
 macro_rules! from_str_via_serde {
     ($ty:ty) => {
-        impl FromStr for $ty {
+        impl std::str::FromStr for $ty {
             type Err = serde::de::value::Error;
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 <Self as serde::Deserialize>::deserialize(serde::de::value::StrDeserializer::new(s))
@@ -1131,16 +1100,19 @@ mod tests {
     fn test_db() {
         let raw_config = r#"
 ephemeral_db = { path = "/1", filename = "test1" }
-persistent_db.path = "/2"
+persistent_db = { path = "/2", filename = "fjall_persistent" }
 "#;
 
         let config = load_toml(Some(raw_config)).unwrap();
 
         assert_eq!(config.ephemeral_db.path, "/1".to_string());
-        assert_eq!(config.ephemeral_db.filename, Some("test1".to_string()));
+        assert_eq!(config.ephemeral_db.filename, "test1".to_string());
 
         assert_eq!(config.persistent_db.path, "/2".to_string());
-        assert!(config.persistent_db.filename.is_none());
+        assert_eq!(
+            config.persistent_db.filename,
+            "fjall_persistent".to_string()
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use tower_http::{
 };
 
 use crate::{
-    cfg::{Configuration, DatabaseConfig},
+    cfg::Configuration,
     core::{
         cluster::RaftState,
         metrics::{ConnectionMetrics, ConnectionType, RequestMetrics},
@@ -224,10 +224,14 @@ async fn run_internal(
 
 impl AppState {
     fn new(cfg: Configuration, time: Monotime, internal_client: InternalClient) -> Self {
-        let persistent_db =
-            DatabaseConfig::persistent(&cfg.persistent_db, time.clone()).expect("persistent db");
-        let ephemeral_db =
-            DatabaseConfig::ephemeral(&cfg.ephemeral_db, time.clone()).expect("ephemeral db");
+        let persistent_db = cfg
+            .persistent_db
+            .database(time.clone(), "persistent")
+            .expect("should be able to initialize persistent database");
+        let ephemeral_db = cfg
+            .ephemeral_db
+            .database(time.clone(), "ephemeral")
+            .expect("should be able to initialize ephemeral database");
 
         let dbs = Databases::new(persistent_db, ephemeral_db);
         let ro_dbs = dbs.readonly();


### PR DESCRIPTION
Changes:

 - allows the user to specify the memory cache size for each database in the config in an ergonomic fashion
 - makes the actual filename explicit in the default config instead of a surprise mystery
 - when using percentage-based cache size, base it on the cgroup memory limit instead of the system memory limit, if possible