### PR TITLE
add a header with the log_id of the last change committed in a request

### DIFF
--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -179,12 +179,10 @@ impl KvController {
                 }
             }
 
-            let new_version = global_counter + 1;
-
             let new_model = KvModel {
                 value: model.value,
                 expiry: model.expiry,
-                version: new_version,
+                version: global_counter,
             };
 
             match behavior {
@@ -229,7 +227,7 @@ impl KvController {
             };
 
             Ok(KvSetResult {
-                version: new_version,
+                version: global_counter,
             })
         })
         .await?

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -21,9 +21,14 @@ use itertools::Itertools;
 use jiff::Timestamp;
 use maplit::btreeset;
 use openraft::{RaftNetworkFactory, ServerState};
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::sync::mpsc::Sender;
+
+tokio::task_local! {
+    pub(super) static APPLIED_LOG_ID: Mutex<Option<LogId>>;
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponseParseError {
@@ -374,10 +379,10 @@ impl RaftState {
         );
         let request = Arc::new(request);
         let mut write_type = WriteType::Local;
-        let response = match self.raft.client_write(Arc::clone(&request)).await {
+        let (response, log_id) = match self.raft.client_write(Arc::clone(&request)).await {
             Ok(resp) => {
                 tracing::trace!(log_id=?resp.log_id(), "request applied to log");
-                resp.data
+                (resp.data, resp.log_id)
             }
             Err(err) => {
                 if let Some(forward_to_leader) = err.forward_to_leader() {
@@ -395,7 +400,7 @@ impl RaftState {
                                 request: Arc::unwrap_or_clone(request),
                             })
                             .await
-                            .map(|r| r.response)
+                            .map(|r| (r.response, r.log_id))
                             .map_err(|e| anyhow::anyhow!(e))?
                     } else {
                         tracing::error!(
@@ -408,6 +413,14 @@ impl RaftState {
                 }
             }
         };
+        let _ = APPLIED_LOG_ID.try_with(|val| {
+            let mut opt = val.lock();
+            *opt = Some(if let Some(existing) = *opt {
+                existing.max(log_id)
+            } else {
+                log_id
+            });
+        });
         self.metrics.record_write(write_type, start.elapsed());
         let module_response = <O::Response as OperationResponse>::ResponseParent::try_from(
             response,

--- a/src/core/cluster/middleware.rs
+++ b/src/core/cluster/middleware.rs
@@ -1,0 +1,16 @@
+use super::handle::APPLIED_LOG_ID;
+use axum::{extract::Request, middleware::Next, response::Response};
+use parking_lot::Mutex;
+
+pub(crate) fn capture_log_id(request: Request, next: Next) -> impl Future<Output = Response> {
+    APPLIED_LOG_ID.scope(Mutex::new(None), async {
+        let mut response = next.run(request).await;
+        if let Some(log_id) = APPLIED_LOG_ID.with(|val| *val.lock()) {
+            // TODO: also include the leader ID and term
+            response
+                .headers_mut()
+                .insert("Diom-Mutation-Version", log_id.index.into());
+        }
+        response
+    })
+}

--- a/src/core/cluster/mod.rs
+++ b/src/core/cluster/mod.rs
@@ -6,6 +6,7 @@ mod background;
 mod discovery;
 mod handle;
 mod logs;
+pub(crate) mod middleware;
 pub(crate) mod network;
 mod node;
 mod operations;

--- a/src/core/cluster/node.rs
+++ b/src/core/cluster/node.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use http::HeaderValue;
 use opentelemetry::{KeyValue, Value};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -144,5 +145,12 @@ impl From<NodeId> for Value {
 impl From<NodeId> for KeyValue {
     fn from(value: NodeId) -> Self {
         KeyValue::new("node_id", value)
+    }
+}
+
+impl From<NodeId> for HeaderValue {
+    fn from(value: NodeId) -> Self {
+        // node IDs are serialized as 32 hex characters and trivially satisfy HeaderValue
+        HeaderValue::from_str(&value.to_string()).unwrap()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,7 @@ pub async fn run_with_listeners(
         .layer((
             trace_layer(),
             CatchPanicLayer::custom(handle_panic),
+            middleware::from_fn(core::cluster::middleware::capture_log_id),
             middleware::from_fn(diom_proto::capture_accept_hdr),
             CorsLayer::new()
                 .allow_origin(Any)

--- a/tests/it/common.rs
+++ b/tests/it/common.rs
@@ -1,0 +1,123 @@
+use diom_backend::cfg::PeerAddr;
+use serde_json::json;
+use test_utils::{
+    JsonFastAndLoose, StatusCode, TestClient, TestResponse, TestResult,
+    server::{TestContext, TestServerBuilder, start_server},
+};
+
+async fn kv_set(
+    client: &TestClient,
+    key: &str,
+    value: &str,
+    behavior: &str,
+) -> TestResult<TestResponse> {
+    client
+        .post("v1.kv.set")
+        .json(json!({
+            "key": key,
+            "value": value.as_bytes(),
+            "behavior": behavior
+        }))
+        .await
+        .map_err(Into::into)
+}
+
+#[allow(clippy::disallowed_types)] // serde_json::Value okay for tests
+async fn kv_get(client: &TestClient, key: &str) -> TestResult<TestResponse> {
+    client
+        .post("v1.kv.get")
+        .json(json!({
+            "key": key
+        }))
+        .await?
+        .ensure(StatusCode::OK)
+        .map_err(Into::into)
+}
+
+async fn test_mutation_header(client: &TestClient) -> TestResult {
+    let response = kv_set(client, "foo", "var", "upsert").await?;
+    let value = response
+        .headers()
+        .get("Diom-Mutation-Version")
+        .expect("header should be set");
+    let initial_index: u64 = value
+        .to_str()
+        .expect("value should start out a a str")
+        .parse()
+        .expect("value should be a u64");
+    tracing::debug!("initial index is {initial_index}");
+
+    let response = kv_set(client, "foo", "bar", "upsert").await?;
+    let new_index: u64 = response
+        .headers()
+        .get("Diom-Mutation-Version")
+        .expect("header should still be set on second request")
+        .to_str()
+        .expect("value should start out a str")
+        .parse()
+        .expect("value should be a u64");
+    tracing::debug!("second request index is {new_index}");
+    assert!(new_index > initial_index);
+
+    let response = kv_get(client, "foo").await?;
+    assert!(
+        response.headers().get("Diom-Mutation-Version").is_none(),
+        "Diom-Mutation-Version should not be set on get requests"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_diom_mutation_header_single_node() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+    test_mutation_header(&client).await
+}
+
+#[tokio::test]
+async fn test_diom_mutation_header_cluster() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        repl_addr,
+        ..
+    } = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.cluster.auto_initialize = true;
+        })
+        .build()
+        .await;
+
+    let TestContext {
+        client: second_client,
+        handle: _second_handle,
+        ..
+    } = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.cluster.seed_nodes = vec![PeerAddr::from(repl_addr)];
+            cfg.cluster.auto_initialize = false;
+        })
+        .build()
+        .await;
+    let cluster_status = client
+        .get("v1.cluster-admin.status")
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(cluster_status["nodes"].assert_array().len(), 2);
+
+    let (leader_client, follower_client) = if cluster_status["this_node_state"] == "leader" {
+        (&client, &second_client)
+    } else {
+        (&second_client, &client)
+    };
+
+    test_mutation_header(leader_client).await?;
+    test_mutation_header(follower_client).await?;
+
+    Ok(())
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -3,6 +3,7 @@ mod auth_token;
 mod bootstrap;
 mod cache;
 mod cluster_admin;
+mod common;
 mod idempotency;
 mod jwt_auth;
 mod kv;


### PR DESCRIPTION
this is an extension of the OCC feature for kv which adds a header recording the last log_id of a committed transaction in a request. this can be used to implement linearization for external clients if we're clever about it.