### PR TITLE
Clean up formatting of tracing event macros

### DIFF
--- a/crates/kv/src/kvcontroller.rs
+++ b/crates/kv/src/kvcontroller.rs
@@ -313,10 +313,10 @@ impl KvController {
                 tracing::warn!(
                     keyspace = self.keyspace_name,
                     elapsed = ?start.elapsed(),
-                    "clear_expired is running significantly behind"
+                    "clear_expired is running significantly behind",
                 );
             }
-            tracing::trace!(timestamp=%now, "scheduling a job to clear items expired before");
+            tracing::trace!(timestamp = %now, "scheduling a job to clear items expired before");
             thunk().await?;
         }
         Ok(())
@@ -347,11 +347,15 @@ impl KvController {
                 return Ok(cleared);
             };
 
-            tracing::trace!(first_key=?first, last_key=?last, "about to prune some expired keys");
+            tracing::trace!(
+                first_key = ?first,
+                last_key = ?last,
+                "about to prune some expired keys",
+            );
 
             let start_batch = Instant::now();
-            let num_this_batch =
-                tracing::debug_span!("clear_expired_in_raft:remove_chunk").in_scope(|| {
+            let num_this_batch = tracing::debug_span!("clear_expired_in_raft:remove_chunk")
+                .in_scope(|| {
                     let mut batch = db.batch();
                     let mut num_this_batch = 0;
 
@@ -359,10 +363,9 @@ impl KvController {
                         cleared += 1;
                         num_this_batch += 1;
                         let k = item.key()?;
-                        let namespace_id = ExpirationKey::extract_namespace_id(&k)
-                            .map_err(Error::internal)?;
-                        let main_key =
-                            ExpirationKey::extract_key(&k).map_err(Error::internal)?;
+                        let namespace_id =
+                            ExpirationKey::extract_namespace_id(&k).map_err(Error::internal)?;
+                        let main_key = ExpirationKey::extract_key(&k).map_err(Error::internal)?;
                         batch.remove_row::<KvPairRow, _>(
                             &keyspace,
                             KvPairKey::build_key(&namespace_id, main_key),
@@ -373,7 +376,11 @@ impl KvController {
                     batch.commit()?;
                     Ok::<_, Error>(num_this_batch)
                 })?;
-            tracing::trace!(num_this_batch, elapsed=?start_batch.elapsed(), "cleared a batch of items");
+            tracing::trace!(
+                num_this_batch,
+                elapsed = ?start_batch.elapsed(),
+                "cleared a batch of items",
+            );
 
             if cleared > 0 {
                 tracing::debug!(cleared, "cleared some keys");
@@ -381,7 +388,8 @@ impl KvController {
                 tracing::trace!("no expired keys");
             }
             Ok(cleared)
-        }).await??;
+        })
+        .await??;
 
         tracing::Span::current().record("cleared", cleared);
 

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -179,12 +179,12 @@ async fn check_initialized(
         .send()
         .await?;
     if response.status() != 200 {
-        tracing::debug!(status=%response.status(), "server returned an error");
+        tracing::debug!(status = %response.status(), "server returned an error");
         return Ok(None);
     }
     let body: HealthResponse = response.json().await?;
     if body.server_state.is_candidate() {
-        tracing::warn!(state=?body.server_state, "booted, but just a candidate");
+        tracing::warn!(state = ?body.server_state, "booted, but just a candidate");
         return Ok(None);
     }
     if let Some(cluster_id) = body.cluster_id {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -170,9 +170,9 @@ impl DatabaseConfig {
         let dir = Dir::new(&self.path)?;
         let path = dir.join(&self.filename);
         if path.exists() {
-            tracing::info!(path = %path.display(), "loading existing {} database", label);
+            tracing::info!(path = %path.display(), "loading existing {label} database");
         } else {
-            tracing::debug!(path = %path.display(), "initializing new {} database", label);
+            tracing::debug!(path = %path.display(), "initializing new {label} database");
         }
         let cache_size = self.cache_size;
         fjall::Database::builder(path)

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -138,9 +138,10 @@ async fn append_entries(
     MsgPack(body): MsgPack<AppendEntriesRequest<TypeConfig>>,
 ) -> impl IntoResponse {
     tracing::trace!(
-        num_entries=body.entries.len(),
-        leader_commit=?body.leader_commit,
-        "appending some entries to the log");
+        num_entries = body.entries.len(),
+        leader_commit = ?body.leader_commit,
+        "appending some entries to the log",
+    );
     state.raft.append_entries(body).await.pipe(rpc_response)
 }
 
@@ -150,7 +151,7 @@ async fn vote(
     MsgPack(body): MsgPack<VoteRequest<TypeConfig>>,
 ) -> impl IntoResponse {
     tracing::trace!(
-        vote=?body.vote,
+        vote = ?body.vote,
         "recording a vote",
     );
     state.raft.vote(body).await.pipe(rpc_response)
@@ -221,7 +222,11 @@ async fn discover(
                     if let Ok(peer) = n.clone().try_into() {
                         Some((*nid, peer))
                     } else {
-                        tracing::warn!(node_id = ?nid, node = ?n, "could not construct peer address for node");
+                        tracing::warn!(
+                            node_id = ?nid,
+                            node = ?n,
+                            "could not construct peer address for node",
+                        );
                         None
                     }
                 })

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -167,7 +167,7 @@ async fn leadership_changes(handle: RaftState) -> tokio::sync::broadcast::Receiv
                 |m| {
                     let mut l = last_leader.lock().unwrap();
                     if m.current_leader != *l {
-                        tracing::debug!(old_leader=?l, new_leader=?m, "leader has changed");
+                        tracing::debug!(old_leader = ?l, new_leader = ?m, "leader has changed");
                         *l = m.current_leader;
                         if tx.send(m.current_leader).is_err() {
                             return true;

--- a/src/core/cluster/discovery.rs
+++ b/src/core/cluster/discovery.rs
@@ -56,8 +56,8 @@ impl Discovery {
         })
     }
 
-    async fn poll_node(&self, s: &PeerAddr) -> Option<DiscoverResponse> {
-        let url = s
+    async fn poll_node(&self, peer: &PeerAddr) -> Option<DiscoverResponse> {
+        let url = peer
             .as_base_url()
             .join("/repl/discover")
             .expect("discovery URL should be valid");
@@ -65,14 +65,14 @@ impl Discovery {
             .get(url)
             .send()
             .await
-            .tap_err(|err| tracing::warn!(peer=?s, ?err, "unable to poll seed node"))
+            .tap_err(|err| tracing::warn!(?peer, ?err, "unable to poll seed node"))
             .ok()?
             .error_for_status()
-            .tap_err(|err| tracing::warn!(peer=?s, ?err, "got invalid HTTP response from seed"))
+            .tap_err(|err| tracing::warn!(?peer, ?err, "got invalid HTTP response from seed"))
             .ok()?
             .msgpack()
             .await
-            .tap_err(|err| tracing::warn!(peer=?s, ?err, "unable to read response body from seed"))
+            .tap_err(|err| tracing::warn!(?peer, ?err, "unable to read response body from seed"))
             .ok()
     }
 
@@ -104,7 +104,8 @@ impl Discovery {
         cluster_id: ClusterId,
         peers: Vec<(PeerAddr, NodeId, DiscoverClusterResponse)>,
     ) -> anyhow::Result<()> {
-        tracing::info!(?cluster_id, peers = ?peers.iter().map(|n| &n.0).collect::<Vec<_>>(), "joining running cluster");
+        let peers_dbg = || peers.iter().map(|n| &n.0).collect::<Vec<_>>();
+        tracing::info!(?cluster_id, peers = ?peers_dbg(), "joining running cluster");
         let Some((leader_addr, leader_node_id, leader_cluster)) = peers
             .into_iter()
             .find_or_first(|p| p.2.state == ServerState::Leader)

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -381,7 +381,7 @@ impl RaftState {
         let mut write_type = WriteType::Local;
         let (response, log_id) = match self.raft.client_write(Arc::clone(&request)).await {
             Ok(resp) => {
-                tracing::trace!(log_id=?resp.log_id(), "request applied to log");
+                tracing::trace!(log_id = ?resp.log_id(), "request applied to log");
                 (resp.data, resp.log_id)
             }
             Err(err) => {
@@ -488,7 +488,7 @@ impl RaftState {
             false
         } else {
             let Some(leader) = self.raft.current_leader().await else {
-                tracing::warn!(my_state=?state, "no current leader known");
+                tracing::warn!(my_state = ?state, "no current leader known");
                 return false;
             };
             if !self
@@ -750,7 +750,7 @@ impl diom_operations::OperationWriterBase for RaftState {
         let request = Arc::new(request);
         match self.raft.client_write(request).await {
             Ok(resp) => {
-                tracing::trace!(log_id=?resp.log_id(), "request applied to log");
+                tracing::trace!(log_id = ?resp.log_id(), "request applied to log");
                 Ok(resp.data)
             }
             Err(err) => {

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -36,7 +36,11 @@ pub(super) fn build_client(
             HeaderValue::from_str(&header_value).context("invalid interserver secret")?;
         headers.insert(header::AUTHORIZATION, header_value);
     }
-    tracing::debug!(connect_timeout = ?cfg.cluster.connection_timeout, ?request_timeout, "initializing interserver client");
+    tracing::debug!(
+        connect_timeout = ?cfg.cluster.connection_timeout,
+        ?request_timeout,
+        "initializing interserver client",
+    );
     let client = reqwest::Client::builder()
         .connect_timeout(cfg.cluster.connection_timeout.into())
         .pipe(|client| {
@@ -108,7 +112,7 @@ impl NetworkClient {
                 &crate::Error::internal("no has no known addresses"),
             )));
         };
-        tracing::trace!(%url, target=?self.target, "sending internal RPC");
+        tracing::trace!(%url, target = ?self.target, "sending internal RPC");
 
         let response = self
             .client
@@ -136,12 +140,12 @@ impl NetworkClient {
             })?
             .send()
             .await
-            .map_err(|e| {
-                tracing::warn!(err=?e, "error sending message to peer");
-                if e.is_connect() {
-                    RPCError::Unreachable(Unreachable::new(&e))
+            .map_err(|err| {
+                tracing::warn!(?err, "error sending message to peer");
+                if err.is_connect() {
+                    RPCError::Unreachable(Unreachable::new(&err))
                 } else {
-                    RPCError::Network(NetworkError::new(&e))
+                    RPCError::Network(NetworkError::new(&err))
                 }
             })?
             .error_for_status()
@@ -325,7 +329,7 @@ pub(crate) async fn detect_address(
 
     let cluster_addr = cfg.cluster.listen_address;
     if !is_unspecified(&cluster_addr) {
-        tracing::debug!(addr=?cluster_addr, "using configured cluster listen_address");
+        tracing::debug!(addr = ?cluster_addr, "using configured cluster listen_address");
         return Ok(PeerAddr::SocketAddr(cluster_addr));
     }
 

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -52,7 +52,7 @@ pub(crate) async fn initialize_cluster(
         .log_index_at_least(Some(1), "waiting for someone to become the leader")
         .await?;
     let new_id = ClusterId::generate();
-    tracing::info!(cluster_id=%new_id, "cluster initialized, setting cluster_id");
+    tracing::info!(cluster_id = %new_id, "cluster initialized, setting cluster_id");
     #[allow(clippy::disallowed_methods)]
     raft.client_write(Arc::new(RequestWithContext::new(
         Request::ClusterInternal(SetClusterUuidOperation(new_id).into()),
@@ -61,7 +61,7 @@ pub(crate) async fn initialize_cluster(
     )))
     .await
     .tap_err(|err| tracing::error!(?err, "failed to set initial cluster id"))?;
-    tracing::debug!(elapsed=?start.elapsed(), "initialization finished");
+    tracing::debug!(elapsed = ?start.elapsed(), "initialization finished");
     Ok(new_id)
 }
 

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -156,7 +156,8 @@ fn deserialize_keyspace<R: Read + Seek>(
         name = %keyspace.name(),
         path = %keyspace.path().display(),
         len = keyspace.len()?,
-        "clearing and then deserializing keyspace");
+        "clearing and then deserializing keyspace",
+    );
     // TODO: remove this slow path after
     // https://github.com/fjall-rs/fjall/issues/277 is fixed
     if keyspace.is_kv_separated() {
@@ -220,7 +221,7 @@ pub(crate) fn serialize_to_file<F: Write + Seek>(
             ..Default::default()
         };
         for keyspace_name in keyspaces {
-            tracing::debug!(keyspace=%keyspace_name, "serializing a keyspace");
+            tracing::debug!(keyspace = %keyspace_name, "serializing a keyspace");
             let options = keyspace_manifests
                 .keyspace_schemas
                 .options_for_keyspace(&keyspace_name);

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -366,7 +366,7 @@ impl Store {
             meta,
             path: snapshot_path.clone(),
         };
-        tracing::trace!(last_snapshot=?data, "setting last_snapshot");
+        tracing::trace!(last_snapshot = ?data, "setting last_snapshot");
         let data = spawn_blocking_in_current_span(move || -> anyhow::Result<LastSnapshot> {
             let mut tx = handle
                 .read()
@@ -388,9 +388,10 @@ impl Store {
 
     async fn record_ids_(&mut self) -> anyhow::Result<()> {
         tracing::trace!(
-            last_applied_log_id=?self.last_applied_log_id,
-            last_membership=?self.last_membership,
-            "storing id values");
+            last_applied_log_id = ?self.last_applied_log_id,
+            last_membership = ?self.last_membership,
+            "storing id values",
+        );
         let handle = self.stores.clone();
         let meta_keyspace = self.meta_keyspace.clone();
         let last_applied_log_id = self.last_applied_log_id;
@@ -428,7 +429,7 @@ impl Store {
         while let Some(dent) = dents.next_entry().await? {
             if let Some(preserve_path) = keep_path.file_name() {
                 if dent.file_name() == preserve_path {
-                    tracing::trace!(filename=?dent.file_name(), "preserving used snapshot");
+                    tracing::trace!(filename = ?dent.file_name(), "preserving used snapshot");
                     continue;
                 }
             } else {
@@ -437,10 +438,10 @@ impl Store {
             if let Some(preserve_name) = &last_file_name
                 && dent.file_name() == *preserve_name
             {
-                tracing::trace!(filename=?dent.file_name(), "preserving last_snapshot");
+                tracing::trace!(filename = ?dent.file_name(), "preserving last_snapshot");
                 continue;
             }
-            tracing::debug!(filename=?dent.file_name(), "deleting unused snapshot");
+            tracing::debug!(filename = ?dent.file_name(), "deleting unused snapshot");
             tokio::fs::remove_file(dent.path()).await?;
         }
         Ok(())
@@ -503,7 +504,7 @@ impl Store {
                     Response::Blank
                 }
                 EntryPayload::Normal(req) => {
-                    tracing::trace!(log_id=?item.log_id, request=%req, "applying user request");
+                    tracing::trace!(log_id = ?item.log_id, request=%req, "applying user request");
 
                     if req.inner.affects_persistent() {
                         touched_persistent = true;
@@ -760,7 +761,11 @@ impl StoredSnapshot {
         let path_c = path.clone();
         let file = spawn_blocking_in_current_span(move || -> anyhow::Result<std::fs::File> {
             let mut tf = tempfile().tempfile_in(directory)?;
-            tracing::debug!(final_path=%path_c.display(), temp_path = %tf.path().display(), "writing snapshot");
+            tracing::debug!(
+                final_path = %path_c.display(),
+                temp_path = %tf.path().display(),
+                "writing snapshot",
+            );
             serialized_state_machine::serialize_to_file(targets, tf.as_file_mut())?;
             tf.as_file_mut().sync_all()?;
             let mut f = tf.persist_noclobber(path_c)?;

--- a/src/core/cluster/streaming_snapshot.rs
+++ b/src/core/cluster/streaming_snapshot.rs
@@ -335,7 +335,7 @@ impl Sender {
                         let err: RPCError<TypeConfig, RaftError<TypeConfig, InstallSnapshotError>> =
                             err;
 
-                        tracing::warn!("failed to send InstallSnapshot RPC: {}", err);
+                        tracing::warn!("failed to send InstallSnapshot RPC: {err}");
 
                         match err {
                             RPCError::Timeout(_)
@@ -346,8 +346,7 @@ impl Sender {
                                 RaftError::APIError(snapshot_err) => match snapshot_err {
                                     InstallSnapshotError::SnapshotMismatch(mismatch) => {
                                         tracing::warn!(
-                                            "snapshot mismatch, reset offset and retry: mismatch: {}",
-                                            mismatch
+                                            "snapshot mismatch, reset offset and retry: mismatch: {mismatch}",
                                         );
                                         offset = 0;
                                     }
@@ -358,7 +357,7 @@ impl Sender {
                     }
                 },
                 Err(err) => {
-                    tracing::warn!("timeout sending InstallSnapshot RPC: {}", err);
+                    tracing::warn!("timeout sending InstallSnapshot RPC: {err}");
                     continue;
                 }
             };

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -54,7 +54,11 @@ impl Workers {
                     Ok(())
                 }
                 other => {
-                    tracing::debug!(job_name = W::NAME, res=?other, "background worker has finished");
+                    tracing::debug!(
+                        job_name = W::NAME,
+                        res = ?other,
+                        "background worker has finished",
+                    );
                     other
                 }
             }


### PR DESCRIPTION
Wouldn't it be great if rustfmt did this?