### PR TITLE
codegen: Some template code refactors

### DIFF
--- a/codegen/templates/javascript/types/macros.ts.jinja
+++ b/codegen/templates/javascript/types/macros.ts.jinja
@@ -3,7 +3,7 @@
     {% if field.description is defined -%}
         {{ field.description | with_javadoc_deprecation(field.deprecated) | to_doc_comment(style="js") | indent(5) }}
     {% endif -%}
-    {% set field_lhs = field_name(field)  -%}
+    {% set field_lhs = field_name(field) -%}
     {% if not field.required %}{% set field_lhs %}{{ field_lhs }}?{% endset %}{% endif -%}
     {% if field.type.is_bytes() -%}
         {% set ty = "Uint8Array" -%}

--- a/codegen/templates/python/types/macros.py.jinja
+++ b/codegen/templates/python/types/macros.py.jinja
@@ -3,8 +3,8 @@
     {%- if field_name != field.name %}
         {%- do panic("diom API does not use non-snake_case field names") %}
     {%- endif %}
-    {%- if field_name is endingwith "_ms" -%}
-        {%- if not (field.type.is_u64() or field.type.is_duration_ms() or field.type.is_unix_timestamp_ms()) %}{% do panic("_ms type should be uint64, current type is " ~ field.type) %}{% endif -%}
+    {%- if field.type.is_duration_ms() -%}
+        {%- if field_name is not endingwith "_ms" %}{% do panic("duration field must have _ms suffix") %}{% endif %}
         {%- set field_name = field_name | strip_trailing_str("_ms") -%}
     {%- endif -%}
     {{ field_name }}
@@ -13,7 +13,7 @@
     {% set field_ty = field.type.to_python() -%}
     {% if field.type.is_unix_timestamp_ms() -%}
         {% set field_ty = "UnixTimestampMs" -%}
-    {% elif field.name is endingwith "_ms" -%}
+    {% elif field.type.is_duration_ms() -%}
         {% set field_ty = "TimeDeltaMs" -%}
     {% endif -%}
     {{ field_ty }}

--- a/codegen/templates/rust/types/macros.rs.jinja
+++ b/codegen/templates/rust/types/macros.rs.jinja
@@ -4,8 +4,8 @@
 {%- endmacro -%}
 {% macro field_name(field, as_ident=true) -%}
     {%- set field_name = field.name | to_snake_case -%}
-    {%- if field_name is endingwith "_ms" -%}
-        {%- if not (field.type.is_u64() or field.type.is_duration_ms() or field.type.is_unix_timestamp_ms()) %}{% do panic("_ms type should be uint64, current type is " ~ field.type) %}{% endif -%}
+    {%- if field.type.is_duration_ms() %}
+        {%- if field_name is not endingwith "_ms" %}{% do panic("duration field must have _ms suffix") %}{% endif %}
         {%- set field_name = field_name | strip_trailing_str("_ms") -%}
     {%- endif -%}
     {%- if as_ident -%}
@@ -45,7 +45,7 @@
     {% if not field.required or field.nullable -%}
         skip_serializing_if = "Option::is_none",
     {% endif -%}
-    {% if (field.name | to_snake_case) is endingwith "_ms" -%}
+    {% if field.type.is_duration_ms() -%}
         {% set serde_with = "crate::duration_ms_serde" -%}
         {% if not field.required or field.nullable -%}
             {% set serde_with = serde_with ~ "::optional" -%}


### PR DESCRIPTION
Use the proper subtype information instead of `_ms` field suffix for Py, Rust.