### PR TITLE
Give slow openraft tests more time to run

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,4 +16,4 @@ path = "junit.xml"
 
 [[profile.ci.overrides]]
 filter = 'test(~openraft_slow)'
-slow-timeout = { period = "60s", terminate-after = 2}
+slow-timeout = { period = "90s", terminate-after = 2 }


### PR DESCRIPTION
Just timed out on main: https://github.com/svix/diom/actions/runs/24509095592/job/71635138829#step:8:910