### PR TITLE
Build only the CLI package as part of dist release

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,3 +25,5 @@ tap = "svix/homebrew-diom"
 publish-jobs = ["homebrew"]
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
+# Don't build the entire workspace, only the CLI package.
+precise-builds = true


### PR DESCRIPTION
https://axodotdev.github.io/cargo-dist/book/reference/config.html#precise-builds

Ref. https://svixhq.slack.com/archives/C0A72988962/p1776437882562549