### PR TITLE
Unquote `PRERELEASE_FLAG` from release workflow host step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,8 @@ jobs:
           # If we're editing a release in place, we need to upload things ahead of time
           gh release upload "${{ needs.plan.outputs.tag }}" artifacts/*
 
-          gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" "$PRERELEASE_FLAG" --draft=false
+          # shellcheck disable=SC2086
+          gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --draft=false
 
   publish-homebrew-formula:
     # figure out if we can set this w/o `allow-dirty = ["ci"]` in dist-workspace.toml


### PR DESCRIPTION
One of the shellcheck warnings that I fixed here https://github.com/svix/diom/pull/1012/commits/432514fe74be73f98b5b7b50251e743a730e9013 ended up breaking the command to create the release