### PR TITLE
fix(release): Change homebrew repo path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: true
-          repository: "svix/homebrew-svix"
+          repository: "svix/homebrew-diom"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae


### PR DESCRIPTION
I updated the repo name on dist-workspace here https://github.com/svix/diom/pull/1012/changes/ef1e9b2cd189ecb972160c4b1b97d5f4202d8948, however, I forgot to also update in the action