### PR TITLE
Implement timestamp based seeking for msgs.stream module

### DIFF
--- a/crates/diom-derive/src/dumpable_config.rs
+++ b/crates/diom-derive/src/dumpable_config.rs
@@ -133,19 +133,17 @@ pub(crate) fn derive_dumpable_config(input: DeriveInput) -> proc_macro2::TokenSt
             quote! {
                 self.#field.dump_fields(writer, prefix)?;
             }
+        } else if is_optional {
+            quote! {
+                crate::cfg::dumpable_config::dump_optional_field(
+                    #name,
+                    self.#field.as_ref(),
+                    writer,
+                )?;
+            }
         } else {
-            if is_optional {
-                quote! {
-                    crate::cfg::dumpable_config::dump_optional_field(
-                        #name,
-                        self.#field.as_ref(),
-                        writer,
-                    )?;
-                }
-            } else {
-                quote! {
-                    crate::cfg::dumpable_config::dump_field(#name, &self.#field, writer)?;
-                }
+            quote! {
+                crate::cfg::dumpable_config::dump_field(#name, &self.#field, writer)?;
             }
         };
 

--- a/crates/msgs/src/operations/stream/seek.rs
+++ b/crates/msgs/src/operations/stream/seek.rs
@@ -16,6 +16,7 @@ use super::super::{MsgsRaftState, MsgsRequest, StreamSeekResponse};
 pub enum SeekTarget {
     Offset(Offset),
     Position(SeekPosition),
+    Timestamp(UnixTimestampMs),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PersistableValue)]
@@ -81,6 +82,12 @@ impl StreamSeekOperation {
                         MsgRow::next_offset(&state.msg_table, topic_row.id, partition)?
                     }
                     SeekTarget::Offset(o) => *o,
+                    SeekTarget::Timestamp(ts) => MsgRow::first_offset_at_or_after(
+                        &state.msg_table,
+                        topic_row.id,
+                        partition,
+                        *ts,
+                    )?,
                 };
 
                 let lease = StreamLeaseRow {

--- a/crates/msgs/src/storage.rs
+++ b/crates/msgs/src/storage.rs
@@ -282,6 +282,51 @@ impl MsgRow {
         }
     }
 
+    /// Finds the offset of the first message whose timestamp is >= `target_ts`.
+    ///
+    /// Returns `next_offset` if every message is older than the target (or the
+    /// partition is empty), which positions the cursor at the tail — equivalent
+    /// to a "latest" seek.
+    ///
+    /// Uses binary search over offsets, leveraging the invariant that timestamps
+    /// increase monotonically with offsets.
+    #[tracing::instrument(skip_all, level = "debug")]
+    pub(crate) fn first_offset_at_or_after(
+        keyspace: &impl fjall_utils::ReadableKeyspace,
+        topic_id: TopicId,
+        partition: Partition,
+        target_ts: UnixTimestampMs,
+    ) -> Result<Offset> {
+        let high = Self::next_offset(keyspace, topic_id, partition)?;
+        if high == 0 {
+            return Ok(0);
+        }
+
+        let mut lo: Offset = 0;
+        let mut hi: Offset = high;
+
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+
+            let prefix = MsgKey::prefix_offset(&topic_id, &partition, &mid);
+            let ts = if let Some(entry) = keyspace.prefix(prefix).next() {
+                let k = entry.key()?;
+                Some(MsgKey::extract_timestamp(&k).expect("valid MsgKey in msg table"))
+            } else {
+                None
+            };
+
+            match ts {
+                Some(ts) if ts < target_ts => lo = mid + 1,
+                Some(_) => hi = mid,
+                // Offset has no entry (deleted by cleanup) — treat as older than target.
+                None => lo = mid + 1,
+            }
+        }
+
+        Ok(lo)
+    }
+
     /// Fetch a single message by offset, skipping it if expired.
     #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn fetch_by_offset(
@@ -425,9 +470,118 @@ mod tests {
     use super::*;
     use crate::entities::{ConsumerGroup, Partition};
 
+    fn ts(millis: i64) -> UnixTimestampMs {
+        UnixTimestampMs::try_from_millisecond(millis).unwrap()
+    }
+
+    /// Helper: insert a message at a given offset and timestamp.
+    fn insert_msg(
+        db: &fjall::Database,
+        ks: &fjall::Keyspace,
+        topic_id: TopicId,
+        partition: Partition,
+        offset: u64,
+        timestamp: UnixTimestampMs,
+    ) {
+        use fjall_utils::WriteBatchExt as _;
+        let mut batch = db.batch();
+        batch
+            .insert_row(
+                ks,
+                MsgKey {
+                    topic_id,
+                    partition,
+                    offset,
+                    timestamp,
+                },
+                &MsgRow {
+                    value: b"msg".into(),
+                    headers: HashMap::new(),
+                    timestamp,
+                    scheduled_at: None,
+                },
+            )
+            .unwrap();
+        batch.commit().unwrap();
+    }
+
+    #[test]
+    fn first_offset_at_or_after_binary_search() {
+        use TopicId;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = fjall::Database::builder(dir.path())
+            .temporary(true)
+            .open()
+            .unwrap();
+        let ks = db
+            .keyspace("msgs", fjall::KeyspaceCreateOptions::default)
+            .unwrap();
+        let topic_id = TopicId::new(ts(0), UuidV7RandomBytes::new_random());
+        let p = Partition::new(0).unwrap();
+
+        // Empty partition returns 0
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(5000)).unwrap(),
+            0
+        );
+
+        // Insert messages: offset 0 @ t=1000, 1 @ t=2000, 2 @ t=3000, 3 @ t=5000
+        insert_msg(&db, &ks, topic_id, p, 0, ts(1000));
+        insert_msg(&db, &ks, topic_id, p, 1, ts(2000));
+        insert_msg(&db, &ks, topic_id, p, 2, ts(3000));
+        insert_msg(&db, &ks, topic_id, p, 3, ts(5000));
+
+        // Before all -> offset 0
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(0)).unwrap(),
+            0
+        );
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(500)).unwrap(),
+            0
+        );
+
+        // Exact match on first -> offset 0
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(1000)).unwrap(),
+            0
+        );
+
+        // Between t=1000 and t=2000 -> offset 1
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(1500)).unwrap(),
+            1
+        );
+
+        // Exact match on middle-> offset 2
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(3000)).unwrap(),
+            2
+        );
+
+        // Between t=3000 and t=5000 -> offset 3
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(4000)).unwrap(),
+            3
+        );
+
+        // Exact match on last -> offset 3
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(5000)).unwrap(),
+            3
+        );
+
+        // After all-> next_offset (4)
+        assert_eq!(
+            MsgRow::first_offset_at_or_after(&ks, topic_id, p, ts(9999)).unwrap(),
+            4
+        );
+    }
+
     #[test]
     fn test_consumer_group_from_key() {
-        use diom_id::TopicId;
+        use TopicId;
         let topic_id = TopicId::new(UnixTimestampMs::UNIX_EPOCH, UuidV7RandomBytes::new_random());
         let partition = Partition::new(0).unwrap();
         let cg = ConsumerGroup::try_from("my-group").unwrap();
@@ -442,7 +596,7 @@ mod tests {
     fn fetch_range_filters_expired_messages() {
         use std::collections::HashMap;
 
-        use diom_id::TopicId;
+        use TopicId;
         use fjall_utils::WriteBatchExt as _;
 
         let dir = tempfile::tempdir().unwrap();

--- a/openapi.json
+++ b/openapi.json
@@ -4096,7 +4096,7 @@
           "Msgs"
         ],
         "summary": "Stream Seek",
-        "description": "Repositions a consumer group's read cursor on a topic.\n\nProvide exactly one of `offset` or `position`. When using `offset`, the topic must include a\npartition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `\"earliest\"` or\n`\"latest\"` and may be used with or without a partition suffix.",
+        "description": "Repositions a consumer group's read cursor on a topic.\n\nProvide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic\nmust include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts\n`\"earliest\"` or `\"latest\"` and may be used with or without a partition suffix. The `timestamp`\nfield accepts a Unix timestamp in milliseconds and seeks to the first message at or after that\ntime.",
         "operationId": "v1.msgs.stream.seek",
         "requestBody": {
           "content": {
@@ -7541,6 +7541,13 @@
           },
           "position": {
             "$ref": "#/components/schemas/SeekPosition",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0,
+            "x-subtype": "UnixTimestampMs",
             "nullable": true
           }
         },

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -373,6 +373,7 @@ struct MsgStreamSeekIn {
     pub consumer_group: ConsumerGroup,
     pub offset: Option<Offset>,
     pub position: Option<SeekPosition>,
+    pub timestamp: Option<UnixTimestampMs>,
 }
 
 request_input!(MsgStreamSeekIn, "stream.seek");
@@ -382,9 +383,11 @@ struct MsgStreamSeekOut {}
 
 /// Repositions a consumer group's read cursor on a topic.
 ///
-/// Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-/// partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-/// `"latest"` and may be used with or without a partition suffix.
+/// Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+/// must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+/// `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+/// field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+/// time.
 #[aide_annotate(op_id = "v1.msgs.stream.seek")]
 async fn stream_seek(
     State(state): State<AppState>,
@@ -396,12 +399,13 @@ async fn stream_seek(
         .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
-    let target = match (data.offset, data.position) {
-        (Some(offset), None) => SeekTarget::Offset(offset),
-        (None, Some(position)) => SeekTarget::Position(position),
+    let target = match (data.offset, data.position, data.timestamp) {
+        (Some(offset), None, None) => SeekTarget::Offset(offset),
+        (None, Some(position), None) => SeekTarget::Position(position),
+        (None, None, Some(timestamp)) => SeekTarget::Timestamp(timestamp),
         _ => {
             return Err(Error::invalid_user_input(
-                "exactly one of 'offset' or 'position' must be provided",
+                "exactly one of 'offset', 'position', or 'timestamp' must be provided",
             ));
         }
     };

--- a/tests/it/msgs/stream_seek.rs
+++ b/tests/it/msgs/stream_seek.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::disallowed_types)] // serde_json::Value ok for tests
+use std::time::Duration;
+
 use serde_json::json;
 use test_utils::{
     JsonFastAndLoose as _, StatusCode, TestResult,
@@ -540,6 +543,465 @@ async fn seek_clears_lease() -> TestResult {
         2,
         "seek should clear lease and allow re-receive"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_to_timestamp_skips_older_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.configure")
+        .json(json!({ "name": "ns-seek-ts" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group
+    client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-seek-ts",
+            "topic": "t1",
+            "msgs": [
+                { "value": "old-a".as_bytes(), "key": "k1" },
+                { "value": "old-b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Need a time gap for seeking to make sense
+    time.fast_forward(Duration::from_secs(10));
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-seek-ts",
+            "topic": "t1",
+            "msgs": [
+                { "value": "new-a".as_bytes(), "key": "k1" },
+                { "value": "new-b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive all messages to discover the timestamp boundary
+    let r1 = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r1["msgs"].assert_array();
+    assert_eq!(msgs.len(), 4);
+    // The third message (index 2) is the first "new" one
+    let new_msg_ts = msgs[2]["timestamp"].assert_u64();
+
+    let partition_topic = msgs[0]["topic"].assert_str();
+    let last_offset = msgs[3]["offset"].assert_u64();
+    client
+        .post("v1.msgs.stream.commit")
+        .json(json!({
+            "namespace": "ns-seek-ts",
+            "topic": partition_topic,
+            "consumer_group": "cg1",
+            "offset": last_offset,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Seek to the timestamp of the new messages
+    client
+        .post("v1.msgs.stream.seek")
+        .json(json!({
+            "namespace": "ns-seek-ts",
+            "topic": "t1",
+            "consumer_group": "cg1",
+            "timestamp": new_msg_ts,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should only get the 2 new messages
+    let r2 = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs2 = r2["msgs"].assert_array();
+    assert_eq!(
+        msgs2.len(),
+        2,
+        "seek to timestamp should skip older messages"
+    );
+    assert_eq!(msgs2[0]["value"], json!("new-a".as_bytes()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_to_timestamp_before_all_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.configure")
+        .json(json!({ "name": "ns-seek-ts-early" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Register consumer group
+    client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts-early",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-seek-ts-early",
+            "topic": "t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive and commit past all
+    let r1 = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts-early",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let msgs = r1["msgs"].assert_array();
+    let partition_topic = msgs[0]["topic"].assert_str();
+    let last_offset = msgs[1]["offset"].assert_u64();
+    client
+        .post("v1.msgs.stream.commit")
+        .json(json!({
+            "namespace": "ns-seek-ts-early",
+            "topic": partition_topic,
+            "consumer_group": "cg1",
+            "offset": last_offset,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Seek to timestamp 0 (before all messages)
+    client
+        .post("v1.msgs.stream.seek")
+        .json(json!({
+            "namespace": "ns-seek-ts-early",
+            "topic": "t1",
+            "consumer_group": "cg1",
+            "timestamp": 0,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should replay all messages
+    let r2 = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts-early",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(
+        r2["msgs"].assert_array().len(),
+        2,
+        "seeking to timestamp 0 should replay all messages"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_to_timestamp_after_all_messages() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.configure")
+        .json(json!({ "name": "ns-seek-ts-future" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish messages (creates the topic)
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-seek-ts-future",
+            "topic": "t1",
+            "msgs": [
+                { "value": "a".as_bytes(), "key": "k1" },
+                { "value": "b".as_bytes(), "key": "k1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Seek to a far-future timestamp
+    client
+        .post("v1.msgs.stream.seek")
+        .json(json!({
+            "namespace": "ns-seek-ts-future",
+            "topic": "t1",
+            "consumer_group": "cg1",
+            "timestamp": 253402207200000_u64,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should get nothing
+    let r1 = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts-future",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    assert_eq!(
+        r1["msgs"].assert_array().len(),
+        0,
+        "seeking past all messages should return nothing"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn seek_to_timestamp_on_specific_partition_only_replays_that_partition() -> TestResult {
+    let TestContext {
+        client,
+        handle: _handle,
+        time,
+        ..
+    } = start_server().await;
+
+    client
+        .post("v1.msgs.namespace.configure")
+        .json(json!({ "name": "ns-seek-ts-one-part" }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Configure 2 partitions
+    client
+        .post("v1.msgs.topic.configure")
+        .json(json!({
+            "namespace": "ns-seek-ts-one-part",
+            "topic": "t1",
+            "partitions": 2,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Seek consumer group to earliest on all partitions
+    client
+        .post("v1.msgs.stream.seek")
+        .json(json!({
+            "namespace": "ns-seek-ts-one-part",
+            "topic": "t1",
+            "consumer_group": "cg1",
+            "position": "earliest",
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Publish old messages to both partitions (different keys route to different partitions)
+    // With 2 partitions, "k-p0" and "k-p1" should land on different partitions
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-seek-ts-one-part",
+            "topic": "t1",
+            "msgs": [
+                { "value": "old-p0".as_bytes(), "key": "k-p0" },
+                { "value": "old-p1".as_bytes(), "key": "k-p1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    time.fast_forward(Duration::from_secs(10));
+
+    // Publish new messages to both partitions
+    client
+        .post("v1.msgs.publish")
+        .json(json!({
+            "namespace": "ns-seek-ts-one-part",
+            "topic": "t1",
+            "msgs": [
+                { "value": "new-p0".as_bytes(), "key": "k-p0" },
+                { "value": "new-p1".as_bytes(), "key": "k-p1" },
+            ],
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive all messages to discover partition topics and timestamps
+    let r1 = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts-one-part",
+            "topic": "t1",
+            "consumer_group": "cg1",
+            "batch_size": 100,
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let all_msgs = r1["msgs"].assert_array();
+    assert!(all_msgs.len() >= 2, "should have messages from partitions");
+
+    // Group messages by partition topic
+    let mut partitions: std::collections::HashMap<String, Vec<&serde_json::Value>> =
+        std::collections::HashMap::new();
+    for m in all_msgs {
+        let pt = m["topic"].assert_str().to_string();
+        partitions.entry(pt).or_default().push(m);
+    }
+
+    // We need at least 2 partitions with messages for this test to be meaningful
+    // If hash routing put everything on one partition, the test isn't useful
+    if partitions.len() < 2 {
+        unreachable!("we misconfigured the partition keys");
+    }
+
+    // Pick two different partition topics
+    let mut part_iter = partitions.iter();
+    let (target_pt, target_msgs) = part_iter.next().unwrap();
+    let (other_pt, _) = part_iter.next().unwrap();
+
+    // Find the timestamp of the "new" message on the target partition
+    let target_new_ts = target_msgs
+        .iter()
+        .map(|m| m["timestamp"].assert_u64())
+        .max()
+        .unwrap();
+
+    // Commit all messages on both partitions
+    for (pt, msgs) in &partitions {
+        let last_offset = msgs.iter().map(|m| m["offset"].assert_u64()).max().unwrap();
+        client
+            .post("v1.msgs.stream.commit")
+            .json(json!({
+                "namespace": "ns-seek-ts-one-part",
+                "topic": pt,
+                "consumer_group": "cg1",
+                "offset": last_offset,
+            }))
+            .await?
+            .expect(StatusCode::OK);
+    }
+
+    // Verify nothing left to consume
+    let r_empty = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts-one-part",
+            "topic": "t1",
+            "consumer_group": "cg1",
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(r_empty["msgs"].assert_array().len(), 0);
+
+    // Seek ONLY the target partition to the new timestamp
+    client
+        .post("v1.msgs.stream.seek")
+        .json(json!({
+            "namespace": "ns-seek-ts-one-part",
+            "topic": target_pt,
+            "consumer_group": "cg1",
+            "timestamp": target_new_ts,
+        }))
+        .await?
+        .expect(StatusCode::OK);
+
+    // Receive — should only get the new message(s) from the target partition.
+    // The other partition should remain fully consumed (no messages returned).
+    let r2 = client
+        .post("v1.msgs.stream.receive")
+        .json(json!({
+            "namespace": "ns-seek-ts-one-part",
+            "topic": "t1",
+            "consumer_group": "cg1",
+            "batch_size": 100,
+        }))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+
+    let replayed = r2["msgs"].assert_array();
+    assert!(
+        !replayed.is_empty(),
+        "target partition should have replayed messages"
+    );
+    for m in replayed {
+        assert_eq!(
+            m["topic"].assert_str(),
+            target_pt,
+            "only the targeted partition should have replayed messages, not {other_pt}"
+        );
+    }
 
     Ok(())
 }

--- a/z-clients/cli/src/cmds/api/msgs_stream.rs
+++ b/z-clients/cli/src/cmds/api/msgs_stream.rs
@@ -53,14 +53,17 @@ pub enum MsgsStreamCommands {
     },
     /// Repositions a consumer group's read cursor on a topic.
     ///
-    /// Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-    /// partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-    /// `"latest"` and may be used with or without a partition suffix.
+    /// Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+    /// must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+    /// `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+    /// field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+    /// time.
     #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"offset\": 123,
-  \"position\": \"earliest\"
+  \"position\": \"earliest\",
+  \"timestamp\": 1234567890123
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
 }")]

--- a/z-clients/go/internal/apis/msgs_stream.go
+++ b/z-clients/go/internal/apis/msgs_stream.go
@@ -74,9 +74,11 @@ func (msgsStream MsgsStream) Commit(
 
 // Repositions a consumer group's read cursor on a topic.
 //
-// Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-// partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-// `"latest"` and may be used with or without a partition suffix.
+// Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+// must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+// `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+// field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+// time.
 func (msgsStream MsgsStream) Seek(
 	ctx context.Context,
 	topic string,
@@ -89,6 +91,7 @@ func (msgsStream MsgsStream) Seek(
 		ConsumerGroup: consumerGroup,
 		Offset:        msgStreamSeekIn.Offset,
 		Position:      msgStreamSeekIn.Position,
+		Timestamp:     msgStreamSeekIn.Timestamp,
 	}
 
 	return diom_proto.ExecuteRequest[diom_models.MsgStreamSeekIn_, diom_models.MsgStreamSeekOut](

--- a/z-clients/go/internal/models/msg_stream_seek_in.go
+++ b/z-clients/go/internal/models/msg_stream_seek_in.go
@@ -2,16 +2,22 @@ package diom_models
 
 // This file is @generated DO NOT EDIT
 
+import (
+	diom_types "diom.com/go/diom/internal/types"
+)
+
 type MsgStreamSeekIn struct {
-	Namespace *string       `msgpack:"namespace,omitempty"`
-	Offset    *uint64       `msgpack:"offset,omitempty"`
-	Position  *SeekPosition `msgpack:"position,omitempty"`
+	Namespace *string               `msgpack:"namespace,omitempty"`
+	Offset    *uint64               `msgpack:"offset,omitempty"`
+	Position  *SeekPosition         `msgpack:"position,omitempty"`
+	Timestamp *diom_types.Timestamp `msgpack:"timestamp,omitempty"`
 }
 
 type MsgStreamSeekIn_ struct {
-	Namespace     *string       `msgpack:"namespace,omitempty"`
-	Topic         string        `msgpack:"topic"`
-	ConsumerGroup string        `msgpack:"consumer_group"`
-	Offset        *uint64       `msgpack:"offset,omitempty"`
-	Position      *SeekPosition `msgpack:"position,omitempty"`
+	Namespace     *string               `msgpack:"namespace,omitempty"`
+	Topic         string                `msgpack:"topic"`
+	ConsumerGroup string                `msgpack:"consumer_group"`
+	Offset        *uint64               `msgpack:"offset,omitempty"`
+	Position      *SeekPosition         `msgpack:"position,omitempty"`
+	Timestamp     *diom_types.Timestamp `msgpack:"timestamp,omitempty"`
 }

--- a/z-clients/java/src/main/java/com/svix/diom/apis/MsgsStream.java
+++ b/z-clients/java/src/main/java/com/svix/diom/apis/MsgsStream.java
@@ -110,9 +110,11 @@ public class MsgsStream {
     /**
 * Repositions a consumer group's read cursor on a topic.
 * 
-* Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-* partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-* `"latest"` and may be used with or without a partition suffix.
+* Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+* must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+* `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+* field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+* time.
 */
     public MsgStreamSeekOut seek(
         String topic,
@@ -125,7 +127,8 @@ public class MsgsStream {
             topic,
             consumerGroup,
             msgStreamSeekIn.getOffset(),
-            msgStreamSeekIn.getPosition()
+            msgStreamSeekIn.getPosition(),
+            msgStreamSeekIn.getTimestamp()
         );
 
         return this.client.executeRequest(
@@ -140,9 +143,11 @@ public class MsgsStream {
     /**
 * Repositions a consumer group's read cursor on a topic.
 * 
-* Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-* partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-* `"latest"` and may be used with or without a partition suffix.
+* Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+* must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+* `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+* field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+* time.
 */
     public MsgStreamSeekOut seek(
         String topic,

--- a/z-clients/java/src/main/java/com/svix/diom/models/MsgStreamSeekIn.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/MsgStreamSeekIn.java
@@ -39,6 +39,7 @@ public class MsgStreamSeekIn {
     @JsonProperty private String namespace;
     @JsonProperty private Long offset;
     @JsonProperty private SeekPosition position;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant timestamp;
     public MsgStreamSeekIn() {}
 
     public MsgStreamSeekIn namespace(String namespace) {
@@ -96,5 +97,24 @@ public class MsgStreamSeekIn {
 
     public void setPosition(SeekPosition position) {
         this.position = position;
+    }
+
+    public MsgStreamSeekIn timestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    /**
+    * Get timestamp
+    *
+     * @return timestamp
+     */
+    @javax.annotation.Nullable
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
     }
 }

--- a/z-clients/java/src/main/java/com/svix/diom/models/MsgStreamSeekIn_.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/MsgStreamSeekIn_.java
@@ -36,19 +36,22 @@ public class MsgStreamSeekIn_ {
     @JsonProperty("consumer_group") private String consumerGroup;
     @JsonProperty private Long offset;
     @JsonProperty private SeekPosition position;
+    @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant timestamp;
 
     public MsgStreamSeekIn_(
         String namespace,
         String topic,
         String consumerGroup,
         Long offset,
-        SeekPosition position
+        SeekPosition position,
+        Instant timestamp
     ) {
         this.namespace = namespace;
         this.topic = topic;
         this.consumerGroup = consumerGroup;
         this.offset = offset;
         this.position = position;
+        this.timestamp = timestamp;
     }
 
     /**

--- a/z-clients/javascript/src/apis/msgsStream.ts
+++ b/z-clients/javascript/src/apis/msgsStream.ts
@@ -82,9 +82,11 @@ export class MsgsStream {
     }/**
 * Repositions a consumer group's read cursor on a topic.
 * 
-* Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-* partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-* `"latest"` and may be used with or without a partition suffix.
+* Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+* must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+* `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+* field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+* time.
 */
     public seek(
         topic: string,

--- a/z-clients/javascript/src/models/msgStreamSeekIn.ts
+++ b/z-clients/javascript/src/models/msgStreamSeekIn.ts
@@ -8,6 +8,7 @@ export interface MsgStreamSeekIn {
     namespace?: string | null;
     offset?: number | null;
     position?: SeekPosition | null;
+    timestamp?: Date | null;
 }
 
 export interface MsgStreamSeekIn_ {
@@ -16,6 +17,7 @@ export interface MsgStreamSeekIn_ {
     consumerGroup: string;
     offset?: number | null;
     position?: SeekPosition | null;
+    timestamp?: Date | null;
 }
 
 export const MsgStreamSeekInSerializer = {
@@ -27,6 +29,7 @@ export const MsgStreamSeekInSerializer = {
             consumerGroup: object['consumer_group'],
             offset: object['offset'],
             position: object['position'] != null ? SeekPositionSerializer._fromJsonObject(object['position']): undefined,
+            timestamp: object['timestamp'] ? new Date(Number(object['timestamp'])) : null,
         };
     },
 
@@ -38,6 +41,7 @@ export const MsgStreamSeekInSerializer = {
             'consumer_group': self.consumerGroup,
             'offset': self.offset,
             'position': self.position != null ? SeekPositionSerializer._toJsonObject(self.position) : undefined,
+            'timestamp': self.timestamp != null ? self.timestamp.getTime() : undefined,
         };
     }
 }

--- a/z-clients/python/diom/apis/msgs_stream.py
+++ b/z-clients/python/diom/apis/msgs_stream.py
@@ -75,15 +75,18 @@ class MsgsStreamAsync(ApiBase):
     ) -> MsgStreamSeekOut:
         """Repositions a consumer group's read cursor on a topic.
 
-        Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-        partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-        `"latest"` and may be used with or without a partition suffix."""
+        Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+        must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+        `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+        field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+        time."""
         body = _MsgStreamSeekIn(
             namespace=msg_stream_seek_in.namespace,
             topic=topic,
             consumer_group=consumer_group,
             offset=msg_stream_seek_in.offset,
             position=msg_stream_seek_in.position,
+            timestamp=msg_stream_seek_in.timestamp,
         ).model_dump(exclude_none=True)
 
         response = await self._request_asyncio(
@@ -154,15 +157,18 @@ class MsgsStream(ApiBase):
     ) -> MsgStreamSeekOut:
         """Repositions a consumer group's read cursor on a topic.
 
-        Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-        partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-        `"latest"` and may be used with or without a partition suffix."""
+        Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+        must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+        `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+        field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+        time."""
         body = _MsgStreamSeekIn(
             namespace=msg_stream_seek_in.namespace,
             topic=topic,
             consumer_group=consumer_group,
             offset=msg_stream_seek_in.offset,
             position=msg_stream_seek_in.position,
+            timestamp=msg_stream_seek_in.timestamp,
         ).model_dump(exclude_none=True)
 
         response = self._request_sync(

--- a/z-clients/python/diom/models/msg_stream_seek_in.py
+++ b/z-clients/python/diom/models/msg_stream_seek_in.py
@@ -1,6 +1,7 @@
 # this file is @generated
 
 from ..internal.base_model import BaseModel
+from ..internal.types import UnixTimestampMs
 
 from .seek_position import SeekPosition
 
@@ -11,6 +12,8 @@ class MsgStreamSeekIn(BaseModel):
     offset: int | None = None
 
     position: SeekPosition | None = None
+
+    timestamp: UnixTimestampMs | None = None
 
 
 class _MsgStreamSeekIn(BaseModel):
@@ -23,3 +26,5 @@ class _MsgStreamSeekIn(BaseModel):
     offset: int | None = None
 
     position: SeekPosition | None = None
+
+    timestamp: UnixTimestampMs | None = None

--- a/z-clients/rust/src/api/msgs_stream.rs
+++ b/z-clients/rust/src/api/msgs_stream.rs
@@ -61,9 +61,11 @@ impl<'a> MsgsStream<'a> {
 
     /// Repositions a consumer group's read cursor on a topic.
     ///
-    /// Provide exactly one of `offset` or `position`. When using `offset`, the topic must include a
-    /// partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts `"earliest"` or
-    /// `"latest"` and may be used with or without a partition suffix.
+    /// Provide exactly one of `offset`, `position`, or `timestamp`. When using `offset`, the topic
+    /// must include a partition suffix (e.g. `ns:my-topic~0`). The `position` field accepts
+    /// `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
+    /// field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
+    /// time.
     pub async fn seek(
         &self,
         topic: String,
@@ -76,6 +78,7 @@ impl<'a> MsgsStream<'a> {
             consumer_group,
             offset: msg_stream_seek_in.offset,
             position: msg_stream_seek_in.position,
+            timestamp: msg_stream_seek_in.timestamp,
         };
 
         crate::request::Request::new(http::Method::POST, "/api/v1.msgs.stream.seek")

--- a/z-clients/rust/src/models/msg_stream_seek_in.rs
+++ b/z-clients/rust/src/models/msg_stream_seek_in.rs
@@ -13,6 +13,12 @@ pub struct MsgStreamSeekIn {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<SeekPosition>,
+
+    #[serde(
+        with = "crate::unix_timestamp_ms_serde::optional",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp: Option<jiff::Timestamp>,
 }
 
 impl MsgStreamSeekIn {
@@ -21,6 +27,7 @@ impl MsgStreamSeekIn {
             namespace: None,
             offset: None,
             position: None,
+            timestamp: None,
         }
     }
 
@@ -36,6 +43,11 @@ impl MsgStreamSeekIn {
 
     pub fn with_position(mut self, value: impl Into<Option<SeekPosition>>) -> Self {
         self.position = value.into();
+        self
+    }
+
+    pub fn with_timestamp(mut self, value: impl Into<Option<jiff::Timestamp>>) -> Self {
+        self.timestamp = value.into();
         self
     }
 }
@@ -54,4 +66,10 @@ pub(crate) struct MsgStreamSeekIn_ {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<SeekPosition>,
+
+    #[serde(
+        with = "crate::unix_timestamp_ms_serde::optional",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp: Option<jiff::Timestamp>,
 }


### PR DESCRIPTION
This adds the ability to seek on a topic or it's partitions using a timestamp, rather than a specific offset or "earliest"/"latest".

That's... pretty much it. Timestamp based seeking isn't as performant as offset based seeking, because of how messages' are keyed internally in fjall (where the offset comes before the timestamp in the key).

That said, the implementation shouldn't be too slow. Since timestamps are monotonically increasing like offsets, we can effectively do a binary search to find the offset, given the timestamp we're interested in.