### PR TITLE
Mega releaser: make explicit rather than implicit.

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -7,11 +7,11 @@ on:
         description: Dry run (skip pushes)
         type: boolean
         default: false
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
 
 jobs:
   get-version:

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -2,11 +2,7 @@ name: Java Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 permissions:
   id-token: write

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -2,11 +2,7 @@ name: JavaScript Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 permissions:
   id-token: write

--- a/.github/workflows/mega-releaser.yml
+++ b/.github/workflows/mega-releaser.yml
@@ -2,9 +2,28 @@ name: Mega Releaser
 
 on: workflow_dispatch
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
-  kick-off:
-    name: Kick-off Releases
-    runs-on: ubuntu-latest
-    steps:
-      - run: /bin/true
+  docker:
+    uses: ./.github/workflows/docker-release.yml
+    with:
+      dry_run: false
+    secrets: inherit
+
+  java:
+    uses: ./.github/workflows/java-release.yml
+    secrets: inherit
+
+  javascript:
+    uses: ./.github/workflows/javascript-release.yml
+    secrets: inherit
+
+  python:
+    uses: ./.github/workflows/python-release.yml
+
+  rust:
+    uses: ./.github/workflows/rust-release.yml
+    secrets: inherit

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -2,11 +2,7 @@ name: Python Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -2,11 +2,7 @@ name: Rust Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
First of all, it's cleaner, we don't want mega to succeed if the rest fail.
Second of all, it means that we only need to approve the workflow once instead of once per library.