### PR TITLE
check in no-op Dockerfile.rego policies

### DIFF
--- a/Dockerfile.rego
+++ b/Dockerfile.rego
@@ -1,0 +1,8 @@
+package docker
+
+# todo: actually write a policy once a version of buildx that can
+# interpret these .rego files is stable
+
+default allow := true
+
+decision := {"allow": allow}

--- a/infra/operator/Dockerfile.rego
+++ b/infra/operator/Dockerfile.rego
@@ -1,0 +1,8 @@
+package docker
+
+# todo: actually write a policy once a version of buildx that can
+# interpret these .rego files is stable
+
+default allow := true
+
+decision := {"allow": allow}


### PR DESCRIPTION
I have no way to verify this because there isn't a version of `docker-buildx` for my platform that reads these, but I think this is a minimal no-op

all this OPA stuff is nonsense and at some point we'll all get over the collective insanity of containerization and just go back to installing software from trusted, vetted, tested sources instead of having every application run in a cobbled-together tarball of nonsense, but today is not that day.