### PR TITLE
right, you need a checkout before you can use in-repo actions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -49,6 +49,7 @@ jobs:
           - {label: "server", repo: svix/diom-server, target: prod}
           - {label: "cli", repo: svix/diom-cli, target: cliprod}
     steps:
+      - uses: actions/checkout@v6
       - name: "build and deploy ${{ matrix.package.label }}"
         uses: ./.github/actions/docker-build-release
         with:

--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment: release
     steps:
+      - uses: actions/checkout@v6
       - name: "build and deploy operator"
         uses: ./.github/actions/docker-build-release
         with:


### PR DESCRIPTION
I feel like `actionlint` could handle this one