### PR TITLE
some more github actions fixes

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -67,7 +67,7 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-  release:
+  release-to-dockerhub:
     environment: release
     needs: [build]
     runs-on: ubuntu-24.04
@@ -76,6 +76,18 @@ jobs:
         uses: actions/checkout@v6
       - name: Install regctl
         uses: iarekylew00t/regctl-installer@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Recompute meta tags
         id: meta
         uses: docker/metadata-action@v6
@@ -91,8 +103,8 @@ jobs:
       - name: "Copy images"
         run: |
           for source in ${{ steps.meta.outputs.tags }}; do
-            # TODO: do this better
-            dest="$(echo tag | sed -e 's,${{ inputs.staging_image_repo }},${{ inputs.image_repo }}'),"
+            # shellcheck disable=SC2001
+            dest="$(echo "$source" | sed -e 's,${{ inputs.staging_image_repo }},${{ inputs.image_repo }},')"
             echo "Copying $source to $dest"
             regctl image copy "$source" "$dest"
           done

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -48,6 +48,7 @@ jobs:
       image_repo: svix/diom-server
       staging_image_repo: ghcr.io/svix/diom-server-staging
       version: ${{ needs.get-version.outputs.version }}
+      target: prod
       dry_run: ${{ inputs.dry_run || false }}
       cache-scope: docker-release-server
     secrets: inherit


### PR DESCRIPTION
changes:

 - renames the action to be more descriptive
 - re-adds the login steps
 - fixes two small typos in the copy step (which, amusingly, I didn't make when I did this for my personal project as an experiment!)
 - set the `target` when building the server so we don't get two copies of the CLI