### PR TITLE
minor improvements to the Dockerfile

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -93,6 +93,14 @@ jobs:
       target: prod
       file: ./Dockerfile
 
+  main-docker-cli-test-build:
+    needs: filter
+    if: needs.filter.outputs.main-docker == 'true'
+    uses: ./.github/workflows/docker-test-build.yml
+    with:
+      target: cli-prod
+      file: ./Dockerfile
+
   operator-docker-test-build:
     needs: filter
     if: needs.filter.outputs.operator-docker == 'true'

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -120,6 +120,8 @@ jobs:
       - javascript
       - python
       - main-docker-test-build
+      - main-docker-cli-test-build
+      - operator-docker-test-build
     # Always run so that this job is a stable required status check: if an
     # upstream job is skipped (e.g. due to path filters added in the future)
     # that is fine; we only fail if something actually failed or was cancelled.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 # Build environment
-FROM chef AS build
+FROM chef AS build-base
 
 ENV __BUST_DOCKER_BUILD_CACHE=2026-01-30
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
@@ -40,8 +40,11 @@ EOF
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer
-RUN cargo chef cook --release --package diom-server --features diom-backend/openapi --recipe-path recipe.json
 RUN cargo chef cook --release --package diom-cli --recipe-path recipe.json
+
+FROM build-base AS build-server
+
+RUN cargo chef cook --release --package diom-server --features diom-backend/openapi --recipe-path recipe.json
 
 # Build the server
 COPY . .
@@ -50,6 +53,15 @@ ARG CARGO_LOG
 ARG GITHUB_SHA
 ARG RELEASE_VERSION
 RUN cargo build --release --package diom-server --bin diom-server --features diom-backend/openapi --frozen
+
+FROM build-base AS build-cli
+
+# Build the CLI
+COPY . .
+
+ARG CARGO_LOG
+ARG GITHUB_SHA
+ARG RELEASE_VERSION
 RUN cargo build --release --package diom-cli --bin diom --frozen
 
 # shared base image with dependencies
@@ -97,8 +109,8 @@ WORKDIR /home/appuser
 EXPOSE 8624/tcp
 EXPOSE 8625/tcp
 
-COPY --chown=root:root --chmod=755 --from=build /app/target/release/diom-server /usr/local/bin/diom-server
-COPY --chown=root:root --chmod=755 --from=build /app/target/release/diom /usr/local/bin/diom
+COPY --chown=root:root --chmod=755 --from=build-server /app/target/release/diom-server /usr/local/bin/diom-server
+COPY --chown=root:root --chmod=755 --from=build-cli /app/target/release/diom /usr/local/bin/diom
 
 CMD ["/usr/local/bin/diom-server"]
 
@@ -108,6 +120,6 @@ FROM base AS cli-prod
 USER appuser
 WORKDIR /home/appuser
 
-COPY --chown=root:root --chmod=755 --from=build /app/target/release/diom /usr/local/bin/diom
+COPY --chown=root:root --chmod=755 --from=build-cli /app/target/release/diom /usr/local/bin/diom
 
 ENTRYPOINT ["/usr/local/bin/diom"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,4 +123,4 @@ EXPOSE 8625/tcp
 
 COPY --chown=root:root --chmod=755 --from=build-server /app/target/release/diom-server /usr/local/bin/diom-server
 
-CMD ["/usr/local/bin/diom-server"]
+ENTRYPOINT ["/usr/local/bin/diom-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,20 @@ RUN <<EOF
     chown -R appuser: /home/appuser
 EOF
 
+# CLI Production
+FROM base AS cli-prod
+
+USER appuser
+WORKDIR /home/appuser
+
+COPY --chown=root:root --chmod=755 --from=build-cli /app/target/release/diom /usr/local/bin/diom
+
+ENTRYPOINT ["/usr/local/bin/diom"]
+
 # Production
-FROM base AS prod
+FROM cli-prod AS prod
+
+USER root
 
 RUN <<EOF
     #!/bin/bash
@@ -110,16 +122,5 @@ EXPOSE 8624/tcp
 EXPOSE 8625/tcp
 
 COPY --chown=root:root --chmod=755 --from=build-server /app/target/release/diom-server /usr/local/bin/diom-server
-COPY --chown=root:root --chmod=755 --from=build-cli /app/target/release/diom /usr/local/bin/diom
 
 CMD ["/usr/local/bin/diom-server"]
-
-# CLI Production
-FROM base AS cli-prod
-
-USER appuser
-WORKDIR /home/appuser
-
-COPY --chown=root:root --chmod=755 --from=build-cli /app/target/release/diom /usr/local/bin/diom
-
-ENTRYPOINT ["/usr/local/bin/diom"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,6 @@ EOF
 
 COPY --from=planner /app/recipe.json recipe.json
 
-# Build dependencies - this is the caching Docker layer
-RUN cargo chef cook --release --package diom-cli --recipe-path recipe.json
-
 FROM build-base AS build-server
 
 RUN cargo chef cook --release --package diom-server --features diom-backend/openapi --recipe-path recipe.json
@@ -55,6 +52,9 @@ ARG RELEASE_VERSION
 RUN cargo build --release --package diom-server --bin diom-server --features diom-backend/openapi --frozen
 
 FROM build-base AS build-cli
+
+# Build dependencies - this is the caching Docker layer
+RUN cargo chef cook --release --package diom-cli --recipe-path recipe.json
 
 # Build the CLI
 COPY . .


### PR DESCRIPTION
changes:

 - split the base layers for cli and server builds so that cli-only builds don't have to bake the server
 - make the server a descendant of the cli so to reduce disk usage if you have both pulled
 - make both cli and server use ENTRYPOINT instead of CMD
 - add CI for CLI build, and make the CI for operator builds required