### PR TITLE
add missing permissions to mega-releaser script

### DIFF
--- a/.github/workflows/mega-releaser.yml
+++ b/.github/workflows/mega-releaser.yml
@@ -5,6 +5,7 @@ on: workflow_dispatch
 permissions:
   id-token: write
   contents: read
+  packages: write # to stage stuff in GHCR
 
 jobs:
   docker:


### PR DESCRIPTION
error: releaser was insufficiently mega