### PR TITLE
rust: expose .kind() on errors

### DIFF
--- a/z-clients/rust/src/error.rs
+++ b/z-clients/rust/src/error.rs
@@ -163,6 +163,7 @@ struct ErrorImpl {
 
 /// The error type returned from the Diom API
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Could not make the intended request and fully receive the response.
     Network(NetworkError),

--- a/z-clients/rust/src/error.rs
+++ b/z-clients/rust/src/error.rs
@@ -82,6 +82,12 @@ impl Error {
         matches!(self.0.kind, ErrorKind::Other(_))
     }
 
+    #[must_use]
+    pub fn kind(&self) -> &ErrorKind {
+        &self.0.kind
+    }
+
+    #[must_use]
     pub fn is_retryable(&self) -> bool {
         match self.0.kind {
             ErrorKind::Network(_) | ErrorKind::Server(_) | ErrorKind::Timeout(_) => true,


### PR DESCRIPTION
doesn't seem that helpful to have a kind if you can't get it out again, right?

should we make `ErrorKind` non-exhaustive?