### PR TITLE
Enable str_to_string clippy lint in lower crates

### DIFF
--- a/crates/diom-core/src/fifo_cache.rs
+++ b/crates/diom-core/src/fifo_cache.rs
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn get_returns_inserted_value() {
         let mut cache = FifoCache::new(10);
-        cache.put("a".to_string(), 1);
+        cache.put("a".to_owned(), 1);
         assert_eq!(cache.get("a", Duration::from_secs(60)), Some(&1));
     }
 
@@ -72,16 +72,16 @@ mod tests {
     #[test]
     fn get_returns_none_after_ttl_expires() {
         let mut cache = FifoCache::new(10);
-        cache.put("a".to_string(), 1);
+        cache.put("a".to_owned(), 1);
         assert_eq!(cache.get("a", Duration::ZERO), None);
     }
 
     #[test]
     fn evicts_oldest_when_at_capacity() {
         let mut cache = FifoCache::new(2);
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_owned(), 1);
+        cache.put("b".to_owned(), 2);
+        cache.put("c".to_owned(), 3);
         assert_eq!(cache.get("a", Duration::from_secs(60)), None);
         assert_eq!(cache.get("b", Duration::from_secs(60)), Some(&2));
         assert_eq!(cache.get("c", Duration::from_secs(60)), Some(&3));
@@ -90,11 +90,11 @@ mod tests {
     #[test]
     fn update_refreshes_value_and_eviction_order() {
         let mut cache = FifoCache::new(2);
-        cache.put("a".to_string(), 1);
-        cache.put("b".to_string(), 2);
+        cache.put("a".to_owned(), 1);
+        cache.put("b".to_owned(), 2);
         // Re-insert "a" — it should now be evicted last
-        cache.put("a".to_string(), 10);
-        cache.put("c".to_string(), 3);
+        cache.put("a".to_owned(), 10);
+        cache.put("c".to_owned(), 3);
         // "b" is now the oldest live entry and should be evicted
         assert_eq!(cache.get("b", Duration::from_secs(60)), None);
         assert_eq!(cache.get("a", Duration::from_secs(60)), Some(&10));

--- a/crates/diom-core/src/lib.rs
+++ b/crates/diom-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::str_to_string)]
+
 use std::sync::LazyLock;
 
 pub mod backoff;

--- a/crates/diom-derive/src/dumpable_config.rs
+++ b/crates/diom-derive/src/dumpable_config.rs
@@ -32,7 +32,7 @@ impl DumpableField {
                     && let syn::Lit::Str(lit) = &lit.lit
                 {
                     let value = lit.value();
-                    docstring.push(value.trim_start().to_string())
+                    docstring.push(value.trim_start().to_owned())
                 }
             } else if attr.path().is_ident("dumpable_config") {
                 attr.parse_nested_meta(|meta| {

--- a/crates/diom-derive/src/lib.rs
+++ b/crates/diom-derive/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::str_to_string)]
+
 use quote::quote;
 use syn::{DeriveInput, ItemFn, parse_macro_input};
 

--- a/crates/diom-error/src/lib.rs
+++ b/crates/diom-error/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::str_to_string)]
+
 use std::{error, fmt, panic::Location};
 
 use aide::OperationOutput;

--- a/crates/diom-id/src/lib.rs
+++ b/crates/diom-id/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::str_to_string)]
+
 use std::{fmt, marker::PhantomData};
 
 use diom_core::{PersistableValue, types::AsMillisecond};

--- a/crates/diom-proto/src/lib.rs
+++ b/crates/diom-proto/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::str_to_string)]
+
 mod error;
 mod internal_client;
 mod msgpack;


### PR DESCRIPTION
[Why restrict this?](https://rust-lang.github.io/rust-clippy/master/?search=str_to_s)

> The `to_string` method is also used on other types to convert them to a string. When called on a `&str` it turns the `&str` into the owned variant `String`, which can be more specifically expressed with `.to_owned()`.

I'll do the higher-up crates of our dependency graph in more PRs and ultimately turn this into a workspace-wide lint.