### PR TITLE
ci: Use ubicloud cache action in jobs that run on ubicloud runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: '1.95'
-      - uses: Swatinem/rust-cache@v2
+      - uses: ubicloud/rust-cache@v2
       - name: Install cargo-criterion
         run: cargo install cargo-criterion
       - name: Run benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           toolchain: ${{ env.ci_toolchain_rust }}
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: ubicloud/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Regerate openapi.json and SDKs


### PR DESCRIPTION
I think the codegen cache isn't actually working? Either way, even if it is it makes more sense to use this action, which includes some ubicloud-specific optimizations IIRC.