### PR TITLE
tools: Don't update Rust dependencies to fix up Cargo.lock

### DIFF
--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -36,7 +36,7 @@ POST_BUMP_COMMANDS = [
     # Python
     "cd z-clients/python/ && uv sync",
     # Rust
-    "cargo update --workspace",
+    "cargo generate-lockfile --offline",
     # JavaScript
     "cd z-clients/javascript && npm i --package-lock-only"
 ]


### PR DESCRIPTION
Same idea as #1078, but using a command with minimal side effects (ideally none, but that seems to not be true under certain circumstances).

I tested it and it doesn't update dependencies unnecessarily here as it stands right now.