### PR TITLE
Python release: change back to not using mega releaser.

### DIFF
--- a/.github/workflows/mega-releaser.yml
+++ b/.github/workflows/mega-releaser.yml
@@ -22,8 +22,9 @@ jobs:
     uses: ./.github/workflows/javascript-release.yml
     secrets: inherit
 
-  python:
-    uses: ./.github/workflows/python-release.yml
+  # See commit message, Python trusted publishing is broken with sub workflows
+  # python:
+  #  uses: ./.github/workflows/python-release.yml
 
   rust:
     uses: ./.github/workflows/rust-release.yml

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -3,6 +3,11 @@ name: Python Release
 on:
   workflow_dispatch:
   workflow_call:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   build:


### PR DESCRIPTION
Reusable workflows are not currently supported by pypi, so we have to change it back to be a dependency run, which I believe should work.

https://github.com/pypi/warehouse/issues/11096