### PR TITLE
Bootstrap: support setting mulitple config scripts at once.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+* `bootstrap_cfg_path` is replaced by `bootstrap_cfg_paths` (an array). `bootstrap_cfg` (inline) and `bootstrap_cfg_paths` can now both be set; inline is applied first. `$DIOM_BOOTSTRAP_CFG_PATH` is replaced by `$DIOM_BOOTSTRAP_CFG_PATHS`.
+
 ## Version 0.2.1
 * Fix Rust build
 

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -4,8 +4,8 @@ The diom server accepts the following environment variables:
 |----------------------|-------------|
 | `$DIOM_ADMIN_TOKEN` | An auth token for admin access to Diom<br/><br/>It's useful for bootstrapping a new Diom cluster, or using it in CI pipelines or other automated testing environments where you need a stable, well-known token for testing or scripted setup.<br/><br/>If you're using it to bootstrap a new Diom cluster, it’s recommended that you only use it during bootstrapping, and remove this configuration once done. |
 | `$DIOM_BACKGROUND_CLEANUP_INTERVAL_MS` | How often to run background cleanup/garbage collection jobs<br/><br/>Correctness should never be affected by this, just wasted memory/disk. |
-| `$DIOM_BOOTSTRAP_CFG` | YAML bootstrap data. Takes precedence over `bootstrap_cfg_path` |
-| `$DIOM_BOOTSTRAP_CFG_PATH` | The path to a YAML bootstrap file |
+| `$DIOM_BOOTSTRAP_CFG` | Inline YAML bootstrap data, applied before any `bootstrap_cfg_paths`. |
+| `$DIOM_BOOTSTRAP_CFG_PATHS` | Paths to YAML bootstrap files, applied in order. |
 | `$DIOM_BOOTSTRAP_MAX_WAIT_TIME_MS` | Maximum time to wait for cluster initialization at startup<br/><br/>If this is unset, we will wait indefinitely. |
 | `$DIOM_CLUSTER_ADVERTISED_ADDRESS` | Address that other nodes should use to communicate with this one.<br/><br/>If not passed, we'll attempt to discover it at boot time. This cannot currently be changed after cluster initialization. |
 | `$DIOM_CLUSTER_AUTO_INITIALIZE` | Automatically initialize the cluster on bootup if we can't discover any peers and we don't have any existing state.<br/><br/>If you initialize all peers at exactly the same time, this can potentially cause errors. |

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -4,8 +4,8 @@ The diom server accepts the following environment variables:
 |----------------------|-------------|
 | `$DIOM_ADMIN_TOKEN` | An auth token for admin access to Diom<br/><br/>It's useful for bootstrapping a new Diom cluster, or using it in CI pipelines or other automated testing environments where you need a stable, well-known token for testing or scripted setup.<br/><br/>If you're using it to bootstrap a new Diom cluster, it’s recommended that you only use it during bootstrapping, and remove this configuration once done. |
 | `$DIOM_BACKGROUND_CLEANUP_INTERVAL_MS` | How often to run background cleanup/garbage collection jobs<br/><br/>Correctness should never be affected by this, just wasted memory/disk. |
-| `$DIOM_BOOTSTRAP_CFG` | Inline YAML bootstrap data, applied before any `bootstrap_cfg_paths`. |
-| `$DIOM_BOOTSTRAP_CFG_PATHS` | Paths to YAML bootstrap files, applied in order. |
+| `$DIOM_BOOTSTRAP_CFG` | Inline bootstrap script, applied before any `bootstrap_cfg_paths`. |
+| `$DIOM_BOOTSTRAP_CFG_PATHS` | Paths to bootstrap scripts, applied in order. |
 | `$DIOM_BOOTSTRAP_MAX_WAIT_TIME_MS` | Maximum time to wait for cluster initialization at startup<br/><br/>If this is unset, we will wait indefinitely. |
 | `$DIOM_CLUSTER_ADVERTISED_ADDRESS` | Address that other nodes should use to communicate with this one.<br/><br/>If not passed, we'll attempt to discover it at boot time. This cannot currently be changed after cluster initialization. |
 | `$DIOM_CLUSTER_AUTO_INITIALIZE` | Automatically initialize the cluster on bootup if we can't discover any peers and we don't have any existing state.<br/><br/>If you initialize all peers at exactly the same time, this can potentially cause errors. |

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -14,10 +14,10 @@
 # Correctness should never be affected by this, just wasted memory/disk.
 background_cleanup_interval_ms = 10000
 
-# Inline YAML bootstrap data, applied before any `bootstrap_cfg_paths`.
+# Inline bootstrap script, applied before any `bootstrap_cfg_paths`.
 # bootstrap_cfg =
 
-# Paths to YAML bootstrap files, applied in order.
+# Paths to bootstrap scripts, applied in order.
 bootstrap_cfg_paths = []
 
 # Maximum time to wait for cluster initialization at startup

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -14,11 +14,11 @@
 # Correctness should never be affected by this, just wasted memory/disk.
 background_cleanup_interval_ms = 10000
 
-# YAML bootstrap data. Takes precedence over `bootstrap_cfg_path`
+# Inline YAML bootstrap data, applied before any `bootstrap_cfg_paths`.
 # bootstrap_cfg =
 
-# The path to a YAML bootstrap file
-# bootstrap_cfg_path =
+# Paths to YAML bootstrap files, applied in order.
+bootstrap_cfg_paths = []
 
 # Maximum time to wait for cluster initialization at startup
 #

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -324,6 +324,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         },
         background_cleanup_interval: DurationMs::from_secs(10),
         bootstrap_cfg: None,
+        bootstrap_cfg_paths: vec![],
         bootstrap_cfg_path: None,
         sync_mode: SyncMode::Buffer,
         fsync_mode: FsyncMode::SyncData,

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -298,16 +298,18 @@ fn ensure_defaults(commands: &mut Vec<BootstrapCommand>) {
 }
 
 fn load_commands(
-    config_path: Option<&str>,
+    config_paths: &[String],
     config_content: Option<&str>,
 ) -> anyhow::Result<Vec<BootstrapCommand>> {
-    let content = match (config_content, config_path) {
-        (Some(content), _) => content.to_owned(),
-        (None, Some(path)) => fs::read_to_string(path)
-            .with_context(|| format!("opening bootstrap config {path:?}"))?,
-        (None, None) => String::new(),
-    };
-    let mut commands = parse_bootstrap(&content).context("parsing bootstrap config")?;
+    let mut commands = Vec::new();
+    if let Some(content) = config_content {
+        commands.extend(parse_bootstrap(content).context("parsing inline bootstrap config")?);
+    }
+    for path in config_paths {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("opening bootstrap config {path:?}"))?;
+        commands.extend(parse_bootstrap(&content).context("parsing bootstrap config")?);
+    }
     ensure_defaults(&mut commands);
     Ok(commands)
 }
@@ -345,10 +347,12 @@ pub async fn run(app_config: AppConfig, raft_state: RaftState) -> anyhow::Result
 
     wait_for_up(&app_config, &raft_state).await?;
 
-    let commands = load_commands(
-        app_config.bootstrap_cfg_path.as_deref(),
-        app_config.bootstrap_cfg.as_deref(),
-    )?;
+    let mut paths = app_config.bootstrap_cfg_paths.clone();
+    if let Some(path) = &app_config.bootstrap_cfg_path {
+        tracing::warn!("`bootstrap_cfg_path` is deprecated; use `bootstrap_cfg_paths` instead");
+        paths.push(path.clone());
+    }
+    let commands = load_commands(&paths, app_config.bootstrap_cfg.as_deref())?;
 
     tracing::debug!(
         num_commands = commands.len(),

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -542,7 +542,7 @@ pub struct ConfigurationInner {
     #[dumpable_config(nest)]
     pub cluster: ClusterConfiguration,
 
-    /// Paths to YAML bootstrap files, applied in order.
+    /// Paths to bootstrap scripts, applied in order.
     #[serde(default)]
     pub bootstrap_cfg_paths: Vec<String>,
 
@@ -552,7 +552,7 @@ pub struct ConfigurationInner {
     #[dumpable_config(skip)]
     pub bootstrap_cfg_path: Option<String>,
 
-    /// Inline YAML bootstrap data, applied before any `bootstrap_cfg_paths`.
+    /// Inline bootstrap script, applied before any `bootstrap_cfg_paths`.
     #[serde(default)]
     pub bootstrap_cfg: Option<String>,
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -542,11 +542,17 @@ pub struct ConfigurationInner {
     #[dumpable_config(nest)]
     pub cluster: ClusterConfiguration,
 
-    /// The path to a YAML bootstrap file
+    /// Paths to YAML bootstrap files, applied in order.
     #[serde(default)]
+    pub bootstrap_cfg_paths: Vec<String>,
+
+    /// Deprecated: use `bootstrap_cfg_paths` instead.
+    #[serde(default)]
+    #[env_overridable(skip)]
+    #[dumpable_config(skip)]
     pub bootstrap_cfg_path: Option<String>,
 
-    /// YAML bootstrap data. Takes precedence over `bootstrap_cfg_path`
+    /// Inline YAML bootstrap data, applied before any `bootstrap_cfg_paths`.
     #[serde(default)]
     pub bootstrap_cfg: Option<String>,
 

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -68,7 +68,7 @@ async fn assert_bootstrap_namespaces(client: &TestClient) -> TestResult {
 #[tokio::test]
 async fn test_bootstrap_file_based() -> TestResult {
     let test_server = TestServerBuilder::with_default_config()
-        .tap_cfg(|cfg| cfg.bootstrap_cfg_path = Some("tests/it/static/bootstrap.test".to_string()))
+        .tap_cfg(|cfg| cfg.bootstrap_cfg_paths = vec!["tests/it/static/bootstrap.test".to_string()])
         .build()
         .await;
     assert_bootstrap_namespaces(&test_server.client).await
@@ -82,4 +82,46 @@ async fn test_bootstrap_env_var_based() -> TestResult {
         .build()
         .await;
     assert_bootstrap_namespaces(&test_server.client).await
+}
+
+#[tokio::test]
+async fn test_bootstrap_deprecated_file_path() -> TestResult {
+    let test_server = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| cfg.bootstrap_cfg_path = Some("tests/it/static/bootstrap.test".to_string()))
+        .build()
+        .await;
+    assert_bootstrap_namespaces(&test_server.client).await
+}
+
+#[tokio::test]
+async fn test_bootstrap_multiple_sources() -> TestResult {
+    let inline = include_str!("static/bootstrap.test").to_string();
+    let test_server = TestServerBuilder::with_default_config()
+        .tap_cfg(|cfg| {
+            cfg.bootstrap_cfg = Some(inline);
+            cfg.bootstrap_cfg_paths = vec!["tests/it/static/bootstrap2.test".to_string()];
+        })
+        .build()
+        .await;
+    assert_bootstrap_namespaces(&test_server.client).await?;
+
+    let kv3 = test_server
+        .client
+        .post("v1.kv.namespace.get")
+        .json(json!({"name": "kv3"}))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(kv3["name"], "kv3");
+
+    let cache2 = test_server
+        .client
+        .post("v1.cache.namespace.get")
+        .json(json!({"name": "cache2"}))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(cache2["name"], "cache2");
+
+    Ok(())
 }

--- a/tests/it/bootstrap.rs
+++ b/tests/it/bootstrap.rs
@@ -95,16 +95,32 @@ async fn test_bootstrap_deprecated_file_path() -> TestResult {
 
 #[tokio::test]
 async fn test_bootstrap_multiple_sources() -> TestResult {
-    let inline = include_str!("static/bootstrap.test").to_string();
+    let inline = r#"kv namespace configure {"name":"kv_inline"}"#.to_string();
     let test_server = TestServerBuilder::with_default_config()
         .tap_cfg(|cfg| {
             cfg.bootstrap_cfg = Some(inline);
-            cfg.bootstrap_cfg_paths = vec!["tests/it/static/bootstrap2.test".to_string()];
+            cfg.bootstrap_cfg_paths = vec![
+                "tests/it/static/bootstrap.test".to_string(),
+                "tests/it/static/bootstrap2.test".to_string(),
+            ];
         })
         .build()
         .await;
+
+    // Verify inline source
+    let kv_inline = test_server
+        .client
+        .post("v1.kv.namespace.get")
+        .json(json!({"name": "kv_inline"}))
+        .await?
+        .expect(StatusCode::OK)
+        .json();
+    assert_eq!(kv_inline["name"], "kv_inline");
+
+    // Verify bootstrap.test (file source 1)
     assert_bootstrap_namespaces(&test_server.client).await?;
 
+    // Verify bootstrap2.test (file source 2)
     let kv3 = test_server
         .client
         .post("v1.kv.namespace.get")

--- a/tests/it/static/bootstrap2.test
+++ b/tests/it/static/bootstrap2.test
@@ -1,0 +1,2 @@
+kv namespace configure {"name":"kv3"}
+cache namespace configure {"name":"cache2"}


### PR DESCRIPTION
We previously only supported on script or inline, now we support both inline and multiple scripts at once. This is intended to make it easier to bootstrap multiple different unrelated components at once, as well as bootstrapping potentially sensitive information.