### PR TITLE
Small touchups to FjallKeyAble macro and tests

### DIFF
--- a/crates/diom-derive/src/fjall_key.rs
+++ b/crates/diom-derive/src/fjall_key.rs
@@ -263,9 +263,17 @@ fn gen_prefix_method(_prefix: &Expr, fields: &[KeyField]) -> TokenStream {
 
     quote! {
         #[doc = #doc]
-        pub fn #method_name(#(#params),*) -> ::std::vec::Vec<u8> {
+        pub fn #method_name(#(#params),*) -> ::fjall_utils::UserKey {
             let total_len = #len_expr;
-            let mut buf = ::std::vec![0u8; total_len];
+
+            let mut stack_buf = [0u8; 64];
+            let mut heap_buf;
+            let buf: &mut [u8] = if total_len <= stack_buf.len() {
+                &mut stack_buf[..total_len]
+            } else {
+                heap_buf = ::std::vec![0u8; total_len];
+                &mut heap_buf
+            };
             let mut pos = 0;
 
             buf[pos] = <Self as ::fjall_utils::FjallKeyAble>::PREFIX;
@@ -274,7 +282,7 @@ fn gen_prefix_method(_prefix: &Expr, fields: &[KeyField]) -> TokenStream {
             #(#writes)*
 
             ::std::debug_assert_eq!(pos, total_len);
-            buf
+            ::fjall_utils::UserKey::from(&*buf)
         }
     }
 }

--- a/crates/fjall-utils/src/fjall_key_able.rs
+++ b/crates/fjall-utils/src/fjall_key_able.rs
@@ -401,15 +401,22 @@ impl<M: diom_id::IdMarker> KeyComponent for diom_id::Id<M> {
 mod tests {
     use crate::FjallKeyAble;
 
+    #[repr(u8)]
+    enum RowType {
+        One = 1,
+        Two = 2,
+        Three = 3,
+    }
+
     #[derive(FjallKeyAble)]
-    #[table_key(prefix = 1)]
+    #[table_key(prefix = RowType::One)]
     struct ExampleSingleKey {
         #[key(0)]
         id: u32,
     }
 
     #[derive(FjallKeyAble)]
-    #[table_key(prefix = 2)]
+    #[table_key(prefix = RowType::Two)]
     struct ExampleCompositeKey {
         #[key(0)]
         id: u32,
@@ -509,7 +516,7 @@ mod tests {
     }
 
     #[derive(FjallKeyAble)]
-    #[table_key(prefix = 3)]
+    #[table_key(prefix = RowType::Three)]
     struct ExampleTripleKey {
         #[key(0)]
         a: u32,


### PR DESCRIPTION
Some small drive-by touch ups I noticed while working on a tech talk for the macro.

The tests used `prefix=1`, rather than the RowType::Variant pattern used elsewhere in code.

The `gen_prefix` methods weren't using stack allocated buffers where possible. We already used this pattern elsewhere when building the key.

Nothing here is a breaking change, w.r.t. to how keys are serialized on disk.