### PR TITLE
Release CI: ask for access to environment at the start of the run.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,12 +91,23 @@ jobs:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
 
+  # Gate job: requests environment approval upfront so you don't wait until the end
+  gate:
+    needs:
+      - plan
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    environment: "release"
+    runs-on: "ubuntu-22.04"
+    steps:
+      - run: echo "Release approved for ${{ needs.plan.outputs.tag }}"
+
   # Build and packages all the platform-specific things
   build-local-artifacts:
     name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
+      - gate
     if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') || inputs.tag == 'dry-run' }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
At the moment it asks it at the end, asking at the start is nicer as it means we don't have to watch it and wait until the end to approve it.

We do it with a simple gate that just asks for the approval at the start.