### PR TITLE
Replace #[validate(range)] with stronger types

### DIFF
--- a/crates/diom-core/src/types/duration_ms.rs
+++ b/crates/diom-core/src/types/duration_ms.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     fmt,
+    num::NonZeroU64,
     ops::{Add, AddAssign, Mul},
     time::Duration,
 };
@@ -197,5 +198,67 @@ impl ValidateRange<u64> for DurationMs {
 
     fn less_than(&self, min: u64) -> Option<bool> {
         Some(*self < Self::from(min))
+    }
+}
+
+/// Non-zero variation of [`DurationMs`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct NonZeroDurationMs(NonZeroU64);
+
+impl NonZeroDurationMs {
+    pub fn get(self) -> DurationMs {
+        DurationMs(self.0.get())
+    }
+}
+
+impl From<NonZeroU64> for NonZeroDurationMs {
+    /// Assume the given value represents an integer number of milliseconds
+    /// and treat it as a `NonZeroDurationMs`.
+    #[inline]
+    fn from(millis: NonZeroU64) -> Self {
+        Self(millis)
+    }
+}
+
+impl fmt::Debug for NonZeroDurationMs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl Serialize for NonZeroDurationMs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for NonZeroDurationMs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let millis = NonZeroU64::deserialize(deserializer)?;
+        Ok(Self::from(millis))
+    }
+}
+
+impl JsonSchema for NonZeroDurationMs {
+    fn schema_name() -> Cow<'static, str> {
+        "NonZeroDurationMs".into()
+    }
+
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 1,
+            "x-subtype": "DurationMs",
+        })
+    }
+
+    fn inline_schema() -> bool {
+        true
     }
 }

--- a/crates/diom-core/src/types/mod.rs
+++ b/crates/diom-core/src/types/mod.rs
@@ -8,7 +8,9 @@ mod metadata;
 mod unix_timestamp_ms;
 
 pub use self::{
-    byte_string::ByteString, duration_ms::DurationMs, metadata::Metadata,
+    byte_string::ByteString,
+    duration_ms::{DurationMs, NonZeroDurationMs},
+    metadata::Metadata,
     unix_timestamp_ms::UnixTimestampMs,
 };
 

--- a/src/v1/endpoints/idempotency.rs
+++ b/src/v1/endpoints/idempotency.rs
@@ -1,7 +1,7 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use diom_authorization::RequestedOperation;
-use diom_core::types::{ByteString, DurationMs, EntityKey, Metadata, UnixTimestampMs};
+use diom_core::types::{ByteString, EntityKey, Metadata, NonZeroDurationMs, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt as _, ResultExt};
 use diom_id::Module;
@@ -59,8 +59,7 @@ pub struct IdempotencyStartIn {
     pub key: EntityKey,
     /// How long to hold the lock on start before releasing it.
     #[serde(rename = "lock_period_ms")]
-    #[validate(range(min = 1))]
-    pub lock_period: DurationMs,
+    pub lock_period: NonZeroDurationMs,
 }
 
 request_input!(IdempotencyStartIn, "start");
@@ -112,8 +111,7 @@ pub struct IdempotencyCompleteIn {
 
     /// How long to keep the idempotency response for.
     #[serde(rename = "ttl_ms")]
-    #[validate(range(min = 1))]
-    pub ttl: DurationMs,
+    pub ttl: NonZeroDurationMs,
 }
 
 request_input!(IdempotencyCompleteIn, "complete");
@@ -150,7 +148,7 @@ async fn idempotency_start(
         .fetch_namespace(data.namespace.as_ref())?
         .ok_or_not_found()?;
 
-    let operation = TryStartOperation::new(namespace, data.key.to_string(), data.lock_period);
+    let operation = TryStartOperation::new(namespace, data.key.to_string(), data.lock_period.get());
     let response = repl.client_write(operation).await.or_internal_error()?.0?;
 
     Ok(MsgPackOrJson(response.result.into()))
@@ -173,7 +171,7 @@ async fn idempotency_complete(
         data.key.to_string(),
         data.response,
         data.context,
-        data.ttl,
+        data.ttl.get(),
     );
     repl.client_write(operation).await.or_internal_error()?.0?;
 

--- a/src/v1/endpoints/kv.rs
+++ b/src/v1/endpoints/kv.rs
@@ -1,7 +1,7 @@
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use diom_authorization::RequestedOperation;
-use diom_core::types::{ByteString, Consistency, DurationMs, EntityKey, UnixTimestampMs};
+use diom_core::types::{ByteString, Consistency, EntityKey, NonZeroDurationMs, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt, ResultExt};
 use diom_id::Module;
@@ -53,8 +53,7 @@ pub struct KvSetIn {
 
     /// Time to live in milliseconds
     #[serde(rename = "ttl_ms")]
-    #[validate(range(min = 1))]
-    pub ttl: Option<DurationMs>,
+    pub ttl: Option<NonZeroDurationMs>,
 
     #[serde(default)]
     pub behavior: OperationBehavior,
@@ -142,7 +141,7 @@ async fn kv_set(
         namespace,
         data.key,
         data.value,
-        data.ttl,
+        data.ttl.map(NonZeroDurationMs::get),
         data.behavior,
         data.version,
     );

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -1,7 +1,9 @@
+use std::num::NonZeroU64;
+
 use aide::axum::{ApiRouter, routing::post_with};
 use axum::{Extension, extract::State};
 use diom_authorization::RequestedOperation;
-use diom_core::types::{DurationMs, EntityKey, UnixTimestampMs};
+use diom_core::types::{DurationMs, EntityKey, NonZeroDurationMs, UnixTimestampMs};
 use diom_derive::aide_annotate;
 use diom_error::{OptionExt, ResultExt};
 use diom_id::Module;
@@ -47,7 +49,7 @@ impl From<RateLimitConfig> for TokenBucket {
         TokenBucket {
             bucket_size: val.capacity,
             refill_rate: val.refill_amount,
-            refill_interval: val.refill_interval,
+            refill_interval: val.refill_interval.get(),
         }
     }
 }
@@ -64,12 +66,11 @@ pub struct RateLimitConfig {
 
     /// Interval in milliseconds between refills (minimum 1 millisecond)
     #[serde(rename = "refill_interval_ms", default = "default_interval_ms")]
-    #[validate(range(min = 1))]
-    pub refill_interval: DurationMs,
+    pub refill_interval: NonZeroDurationMs,
 }
 
-fn default_interval_ms() -> DurationMs {
-    1000.into()
+fn default_interval_ms() -> NonZeroDurationMs {
+    const { NonZeroU64::new(1000).unwrap() }.into()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -54,7 +54,7 @@ impl From<RateLimitConfig> for TokenBucket {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RateLimitConfig {
     /// Maximum capacity of the bucket
     pub capacity: NonZeroU64,
@@ -83,7 +83,6 @@ pub struct RateLimitCheckIn {
     pub tokens: u64,
 
     /// Rate limiter configuration
-    #[validate(nested)]
     pub config: RateLimitConfig,
 }
 
@@ -114,7 +113,6 @@ pub struct RateLimitGetRemainingIn {
     pub key: EntityKey,
 
     /// Rate limiter configuration
-    #[validate(nested)]
     pub config: RateLimitConfig,
 }
 
@@ -206,7 +204,6 @@ pub struct RateLimitResetIn {
     pub key: EntityKey,
 
     /// Rate limiter configuration
-    #[validate(nested)]
     pub config: RateLimitConfig,
 }
 

--- a/src/v1/endpoints/rate_limit.rs
+++ b/src/v1/endpoints/rate_limit.rs
@@ -47,8 +47,8 @@ macro_rules! request_input {
 impl From<RateLimitConfig> for TokenBucket {
     fn from(val: RateLimitConfig) -> Self {
         TokenBucket {
-            bucket_size: val.capacity,
-            refill_rate: val.refill_amount,
+            bucket_size: val.capacity.get(),
+            refill_rate: val.refill_amount.get(),
             refill_interval: val.refill_interval.get(),
         }
     }
@@ -57,12 +57,10 @@ impl From<RateLimitConfig> for TokenBucket {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, JsonSchema)]
 pub struct RateLimitConfig {
     /// Maximum capacity of the bucket
-    #[validate(range(min = 1))]
-    pub capacity: u64,
+    pub capacity: NonZeroU64,
 
     /// Number of tokens to add per refill interval
-    #[validate(range(min = 1))]
-    pub refill_amount: u64,
+    pub refill_amount: NonZeroU64,
 
     /// Interval in milliseconds between refills (minimum 1 millisecond)
     #[serde(rename = "refill_interval_ms", default = "default_interval_ms")]


### PR DESCRIPTION
… in the API. `#[validate(range)` continues to be used for the config, at least for now.

After this, only one custom validation function for `AccessRule` lists remains, after that we'll be able to remove `ValidationErrorBody`, which I want to do for https://github.com/svix/diom/issues/302.