### PR TITLE
CI: Trigger staging deployments on push to main

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -48,8 +48,8 @@ jobs:
         if: ${{ !inputs.is_release }}
         run: |
           yq -i '.name = "diom-private"' infra/helm-diom/Chart.yaml
-          yq -i '.operator.image.repository = "ghcr.io/svix/diom-operator"' infra/helm-diom/values.yaml
-          yq -i '.cluster.image.repository = "ghcr.io/svix/diom-server"' infra/helm-diom/values.yaml
+          yq -i '.operator.image.repository = "ghcr.io/svix/diom-operator-private"' infra/helm-diom/values.yaml
+          yq -i '.cluster.image.repository = "ghcr.io/svix/diom-server-private"' infra/helm-diom/values.yaml
 
       - name: Package chart
         run: |

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -76,3 +76,16 @@ jobs:
       server_image_tag: sha-${{ github.sha }}
       operator_image_tag: sha-${{ github.sha }}
       is_release: false
+
+  staging-deploy:
+    needs: [docker_publish_operator, docker_publish_server, helm-publish]
+    runs-on: ubuntu-24.04
+    environment: diom-staging-deploy
+    steps:
+      - name: Dispatch deploy to diom-staging
+        run: |
+          gh api repos/svix/diom-staging/dispatches --method POST --input - <<EOF
+          {"event_type":"deploy-staging","client_payload":{"image_tag":"sha-${GITHUB_SHA}"}}
+          EOF
+        env:
+          GH_TOKEN: ${{ secrets.STAGING_DISPATCH_PAT }}

--- a/infra/helm-diom/charts/crds/crds/diomclusters.json
+++ b/infra/helm-diom/charts/crds/crds/diomclusters.json
@@ -949,6 +949,22 @@
                     "nullable": true,
                     "type": "string"
                   },
+                  "imagePullSecrets": {
+                    "description": "Optional image pull secret to use when pulling the Diom image.",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
                   "internodeSecret": {
                     "anyOf": [
                       {

--- a/infra/helm-diom/templates/cluster.yaml
+++ b/infra/helm-diom/templates/cluster.yaml
@@ -10,5 +10,9 @@ metadata:
     {{- include "diom-operator.labels" . | nindent 4 }}
 spec:
   image: {{ printf "%s:%s" .Values.cluster.image.repository .Values.cluster.image.tag }}
+  {{- with .Values.cluster.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- toYaml (omit .Values.cluster.spec "image") | nindent 2 }}
 {{- end }}

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -96,6 +96,10 @@ pub struct DiomClusterSpec {
     /// ```
     #[serde(default)]
     pub affinity: Option<Affinity>,
+
+    /// Optional image pull secret to use when pulling the Diom image.
+    #[serde(default)]
+    pub image_pull_secrets: Option<Vec<ImagePullSecret>>,
 }
 
 /// Storage configuration for a Diom cluster.
@@ -287,6 +291,11 @@ impl ValueOrSecretRef {
             },
         }
     }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct ImagePullSecret {
+    pub name: String,
 }
 
 fn replicas_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -4,9 +4,10 @@ use k8s_openapi::{
     api::{
         apps::v1::{StatefulSet, StatefulSetPersistentVolumeClaimRetentionPolicy, StatefulSetSpec},
         core::v1::{
-            Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction, ObjectFieldSelector,
-            PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSecurityContext, PodSpec,
-            PodTemplateSpec, Probe, VolumeMount, VolumeResourceRequirements,
+            Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction, LocalObjectReference,
+            ObjectFieldSelector, PersistentVolumeClaim, PersistentVolumeClaimSpec,
+            PodSecurityContext, PodSpec, PodTemplateSpec, Probe, VolumeMount,
+            VolumeResourceRequirements,
         },
     },
     apimachinery::pkg::{
@@ -96,6 +97,14 @@ fn build(ctx: &ClusterCtx) -> Result<StatefulSet> {
         node_selector: spec.node_selector.clone(),
         tolerations: spec.tolerations.clone(),
         affinity: spec.affinity.clone(),
+        image_pull_secrets: spec.image_pull_secrets.as_ref().map(|secrets| {
+            secrets
+                .iter()
+                .map(|s| LocalObjectReference {
+                    name: s.name.clone(),
+                })
+                .collect()
+        }),
         ..Default::default()
     };
 
@@ -525,6 +534,7 @@ mod tests {
             node_selector: None,
             tolerations: None,
             affinity: None,
+            image_pull_secrets: None,
         }
     }
 


### PR DESCRIPTION
Note that this also requires some changes to the CRD to allow
specifying `imagePullSecrets`. This has been wrapped in our
own type to avoid spamming the crd with the verbose k8s-openapi
descriptions.
