### PR TITLE
fix: do not leak tracing feature release_max_level_debug into the rust client library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ toml = { version = "1.0.3", default-features = false, features = ["parse", "serd
 tower = "0.5.1"
 tower-http = { version = "0.6.1", features = ["catch-panic", "compression-full", "cors", "request-id", "trace"] }
 tower-service = "0.3.3"
-tracing = { version = "0.1.35", features = ["release_max_level_debug"] }
+tracing = "0.1.44"
 tracing-log = "0.2.0"
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "local-time", "fmt", "registry", "std"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,7 +24,7 @@ opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
 reqwest.workspace = true
 tokio.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-log.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true

--- a/z-clients/cli/Cargo.toml
+++ b/z-clients/cli/Cargo.toml
@@ -58,7 +58,7 @@ rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread"] }
-tracing.workspace = true
+tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-subscriber.workspace = true
 v_jsonescape = { version = "0.7.8", features = ["buf-min", "bytes-buf"] }
 yansi.workspace = true


### PR DESCRIPTION
We're getting panics on svix-webhooks with the `diom` crate included which appear to be due to a bug in `tracing-subscriber` when tracing's `max_level*` features are enabled. Stop leaking that feature into the Rust client library.