### PR TITLE
migrate release documentation into the repo

### DIFF
--- a/.github/workflows/mega-releaser.yml
+++ b/.github/workflows/mega-releaser.yml
@@ -8,17 +8,27 @@ permissions:
   packages: write # to stage stuff in GHCR
 
 jobs:
+  # Gate job: requests environment approval upfront so you don't wait until the end
+  gate:
+    environment: "release"
+    runs-on: "ubuntu-latest"
+    steps:
+      - run: echo "Release approved!"
+
   docker:
+    needs: [gate]
     uses: ./.github/workflows/docker-release.yml
     with:
       dry_run: false
     secrets: inherit
 
   java:
+    needs: [gate]
     uses: ./.github/workflows/java-release.yml
     secrets: inherit
 
   javascript:
+    needs: [gate]
     uses: ./.github/workflows/javascript-release.yml
     secrets: inherit
 
@@ -27,5 +37,6 @@ jobs:
   #  uses: ./.github/workflows/python-release.yml
 
   rust:
+    needs: [gate]
     uses: ./.github/workflows/rust-release.yml
     secrets: inherit

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,10 +6,10 @@
 * Libs/Rust: Revamp `ErrorKind` and error type methods
 
 ## Version 0.2.3
-* Rust SDK: expose `.is_retriable()` and `.kind()` on `diom::Error`
-* Rust SDK: do not leak feature `release_max_level_debug` into the tracing library
-* All SDKs: remove automatic retries
-* Several configuration values that were specified as millisecond durations are now explicitly checked for being non-zero at startup
+* Server: Several configuration values that were specified as millisecond durations are now explicitly checked for being non-zero at startup
+* Libs/Rust: expose `.is_retriable()` and `.kind()` on `diom::Error`
+* Libs/Rust: do not leak feature `release_max_level_debug` into the tracing library
+* Libs/All: remove automatic retries
 * Miscellaneous dependency bumps
 * Various improvements to release infrastructure
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@
 
 ## Version 0.2.3
 * Server: Several configuration values that were specified as millisecond durations are now explicitly checked for being non-zero at startup
-* Libs/Rust: expose `.is_retriable()` and `.kind()` on `diom::Error`
+* Libs/Rust: expose `.is_retryable()` and `.kind()` on `diom::Error`
 * Libs/Rust: do not leak feature `release_max_level_debug` into the tracing library
 * Libs/All: remove automatic retries
 * Miscellaneous dependency bumps

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,19 @@
+> [!NOTE]
+> These steps are aimed at a maintainer releasing a new version
+
+ 1. Determine the new version, following [semver](https://semver.org/) appropriately. Make sure you closely examine and understand all commits since the last release.
+ 2. Create a commit which bumps all versions (using `uv run tools/bump_version.py bump <NEW_VERSION>`). In the same commit, update `ChangeLog.md` to contain human-facing information about changes in the new version; especially make sure to call out any breaking changes. Ideally, people will have been adding notes to `ChangeLog.md` as they make substantive changes, so this step will just be organization. Get that commit reviewed and landed, and note the SHA once it's landed onto `main`.
+ 3. [Create a new GitHub Release](https://github.com/svix/diom/releases/new) pointing at the SHA from step 2. Mark it as a "draft". Copy the text from your `ChangeLog.md` entry into the release body under a `# Changes` header. Make sure to create a tag with an appropriate name (this should be your version number preceded by the character `v`; e.g., `v1.2.3`)
+ 4. Invoke the [release.yml workflow](https://github.com/svix/diom/actions/workflows/release.yml) with the tag name you created in Step 3. This will prompt other members of @svix/Maintainers to approve the release, and then will build various artifacts
+ 5. Invoke the [mega releaser workflow](https://github.com/svix/diom/actions/workflows/mega-releaser.yml) with the tag name you created in Step 3. It is normal for the Maven upload to take approximately 20 minutes.
+ 6. Create a new commit which adds an `## Unreleased` section to the top of `ChangeLog.md` for future commits to record information
+
+### Writing good Changelogs
+
+A ChangeLog shouldn't just be a list of git commit messages; it should summarize the most important things that end users and other developers need to know about a given release.
+
+Some miscellaneous rules:
+
+ - Each entry should be a &lt;h2&gt; (`##` in Markdown) beginning with the word "Version"
+ - Put server updates first, then libraries/clients, then miscellany
+ - Don't forget to thank new external contributors!

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,6 +14,6 @@ A ChangeLog shouldn't just be a list of git commit messages; it should summarize
 
 Some miscellaneous rules:
 
- - Each entry should be a &lt;h2&gt; (`##` in Markdown) beginning with the word "Version"
+ - Each entry should be a `<h2>` (`##` in Markdown) beginning with the word "Version"
  - Put server updates first, then libraries/clients, then miscellany
  - Don't forget to thank new external contributors!


### PR DESCRIPTION
This is taken from Notion and moved into a markdown file in the repo, which I think is a mildly more intuitive place for it

Also adds a `gate` step to the mega-releaser to try and cut down on the permissions prompts