### PR TITLE
cfg: add --env-file flag for loading secrets from an envfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "diom-operations",
  "diom-proto",
  "diom-rate-limit",
+ "dotenvy",
  "fjall",
  "fjall-utils",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ zip.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 ctor.workspace = true
+dotenvy.workspace = true
 rand.workspace = true
 rmp-serde.workspace = true
 rmpv.workspace = true

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![forbid(unsafe_code)]
 
+use anyhow::Context as _;
 use clap::{Parser, Subcommand};
 use comfy_table::{Cell, Table};
 use diom_backend::{
@@ -28,6 +29,10 @@ struct Args {
     /// Path to a TOML configuration file
     #[clap(short = 'C', long)]
     config_path: Option<PathBuf>,
+
+    /// Path to a file of environment variable overrides to load in addition to .env
+    #[clap(long)]
+    env_file: Option<PathBuf>,
 
     #[clap(subcommand)]
     command: Option<Commands>,
@@ -127,9 +132,13 @@ fn dump_variables(path: Option<PathBuf>) -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    _ = dotenv();
-
     let args = Args::parse();
+
+    if let Some(env_file) = &args.env_file {
+        dotenvy::from_path(env_file).context("loading env file")?;
+    }
+
+    _ = dotenv();
 
     if let Some(Commands::Healthcheck { server_url }) = args.command {
         let server_url = if let Some(url) = server_url {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -1140,6 +1140,30 @@ persistent_db = { path = "/2", filename = "fjall_persistent" }
     }
 
     #[test]
+    fn test_env_file_nonexistent_errors() {
+        let err = dotenvy::from_path("/nonexistent/path/to/.env").unwrap_err();
+        assert!(
+            matches!(err, dotenvy::Error::Io(_)),
+            "expected an IO error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_env_file_config_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join("secrets.env");
+        std::fs::write(&env_path, "DIOM_LISTEN_ADDRESS=127.0.0.1:19999\n").unwrap();
+
+        dotenvy::from_path(&env_path).unwrap();
+
+        let config = load_toml(None).unwrap();
+        assert_eq!(
+            config.listen_address,
+            "127.0.0.1:19999".parse::<SocketAddr>().unwrap()
+        );
+    }
+
+    #[test]
     fn test_peer_addr_parsing() {
         let Ok(PeerAddr::SocketAddr(SocketAddr::V4(sa))) = "127.0.0.2:8624".parse() else {
             panic!("failed to parse v4 addr")


### PR DESCRIPTION
Adds a --env-file <PATH> CLI argument that loads environment variables from the given file before config is applied, giving users a dedicated place to keep secrets outside of the TOML config and instead of passing as env variables.

It kind of meaningless in how it works, as it actually sets the environment variables so it's the same as just setting the env vars directly, though we'll change that to load directly to config soon.