### PR TITLE
Operator: Fix otel var naming

### DIFF
--- a/infra/helm-diom/charts/crds/crds/diomclusters.json
+++ b/infra/helm-diom/charts/crds/crds/diomclusters.json
@@ -1035,12 +1035,12 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "metrics_address": {
+                      "metricsAddress": {
                         "description": "The OpenTelemetry address to send metrics to if given.\n\nIf not specified, the server will attempt to fall back\nto `opentelemetry_address`.",
                         "nullable": true,
                         "type": "string"
                       },
-                      "metrics_protocol": {
+                      "metricsProtocol": {
                         "description": "OpenTelemetry metrics protocol\n\nBy default, metrics are sent via GRPC. Some metrics destinations, most\nnotably Prometheus, only support receiving metrics via HTTP.",
                         "enum": [
                           "grpc",

--- a/infra/helm-diom/templates/_helpers.tpl
+++ b/infra/helm-diom/templates/_helpers.tpl
@@ -9,16 +9,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 */}}
 {{- define "diom-operator.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- printf "%s-operator" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -206,6 +206,7 @@ impl fmt::Display for OpenTelemetryProtocol {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct OpenTelemetrySpec {
     /// The OpenTelemetry address to send events to if given.
     ///

--- a/infra/operator/tests/it/common.rs
+++ b/infra/operator/tests/it/common.rs
@@ -135,6 +135,8 @@ pub(crate) struct TestContextBuilder {
     replicas: i32,
     image: String,
     storage_size: String,
+    #[allow(clippy::disallowed_types)]
+    extra_spec: serde_json::Map<String, serde_json::Value>,
 }
 
 impl Default for TestContextBuilder {
@@ -143,6 +145,7 @@ impl Default for TestContextBuilder {
             replicas: 1,
             image: E2E_IMAGE.to_string(),
             storage_size: "10M".to_string(),
+            extra_spec: serde_json::Map::new(),
         }
     }
 }
@@ -165,6 +168,14 @@ impl TestContextBuilder {
 
     pub(crate) fn storage_size(mut self, size: impl Into<String>) -> Self {
         self.storage_size = size.into();
+        self
+    }
+
+    #[allow(clippy::disallowed_types)]
+    pub(crate) fn spec_fields(mut self, fields: serde_json::Value) -> Self {
+        if let serde_json::Value::Object(map) = fields {
+            self.extra_spec.extend(map);
+        }
         self
     }
 
@@ -249,6 +260,13 @@ impl TestContextBuilder {
         });
 
         let cluster_api: Api<DiomCluster> = Api::namespaced(client.clone(), "default");
+        let mut spec = serde_json::json!({
+            "image": self.image,
+            "imagePullPolicy": "Never",
+            "replicas": self.replicas,
+            "storage": { "persistent": { "size": self.storage_size } }
+        });
+        spec.as_object_mut().unwrap().extend(self.extra_spec);
         let cluster = cluster_api
             .create(
                 &PostParams::default(),
@@ -256,12 +274,7 @@ impl TestContextBuilder {
                     "apiVersion": "diom.svix.com/v1alpha1",
                     "kind": "DiomCluster",
                     "metadata": { "name": "test-cluster" },
-                    "spec": {
-                        "image": self.image,
-                        "imagePullPolicy": "Never",
-                        "replicas": self.replicas,
-                        "storage": { "persistent": { "size": self.storage_size } }
-                    }
+                    "spec": spec
                 }))
                 .unwrap(),
             )

--- a/infra/operator/tests/it/e2e.rs
+++ b/infra/operator/tests/it/e2e.rs
@@ -108,6 +108,56 @@ async fn test_degraded_on_bad_image() -> TestResult {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_spec_env_var_mapping() -> TestResult {
+    let env = TestContextBuilder::new()
+        .spec_fields(serde_json::json!({
+            "logLevel": "debug",
+            "logFormat": "json",
+            "bootstrap": "some-bootstrap-cfg",
+            "opentelemetry": {
+                "address": "grpc://otel:4317",
+                "metricsAddress": "http://otel:4318/v1/metrics",
+                "metricsProtocol": "http"
+            }
+        }))
+        .build()
+        .await;
+
+    let sts_json = serde_json::to_value(&env.sts).unwrap();
+    let container_env = sts_json["spec"]["template"]["spec"]["containers"][0]["env"]
+        .as_array()
+        .unwrap();
+    let get_env = |name: &str| {
+        container_env
+            .iter()
+            .find(|e| e["name"] == name)
+            .and_then(|e| e["value"].as_str())
+            .map(str::to_owned)
+    };
+
+    assert_eq!(get_env("DIOM_LOG_LEVEL").as_deref(), Some("debug"));
+    assert_eq!(get_env("DIOM_LOG_FORMAT").as_deref(), Some("json"));
+    assert_eq!(
+        get_env("DIOM_BOOTSTRAP_CFG").as_deref(),
+        Some("some-bootstrap-cfg")
+    );
+    assert_eq!(
+        get_env("DIOM_OPENTELEMETRY_ADDRESS").as_deref(),
+        Some("grpc://otel:4317")
+    );
+    assert_eq!(
+        get_env("DIOM_OPENTELEMETRY_METRICS_ADDRESS").as_deref(),
+        Some("http://otel:4318/v1/metrics")
+    );
+    assert_eq!(
+        get_env("DIOM_OPENTELEMETRY_METRICS_PROTOCOL").as_deref(),
+        Some("http")
+    );
+
+    Ok(())
+}
+
 // TODO: The default storage driver in kind doesn't support
 // storage resizing, so we can't currently validate that the PVCs
 // themselves have actually been resized.


### PR DESCRIPTION
Missing camelCase. Added test to try and catch this sort of thing. Also, made some changes to how the helm chart names the operator pod to avoid confusion.