### PR TITLE
Show 'long' help on both --help and -h commands // Change order of sections  in --help messages

### DIFF
--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -96,7 +96,14 @@ pub enum {{ resource_type_name }}Commands {
             {{ op.description | to_doc_comment(style="rust") }}
         {% endif -%}
         {% if op.request_body_schema_name is defined or op.response_body_schema_name is defined -%}
-            #[command(after_long_help = "
+            #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+            #[command(after_help = "
             {%- if op.request_body_schema_name is defined -%}
                 {{- render_schema_example("Example body", api.types[op.request_body_schema_name], api) -}}
             {%- endif -%}
@@ -106,7 +113,7 @@ pub enum {{ resource_type_name }}Commands {
             {%- if op.response_body_schema_name is defined -%}
                 {{- render_schema_example("Example response", api.types[op.response_body_schema_name], api) -}}
             {%- endif -%}
-")]
+\n")]
         {% endif -%}
         {{ op.name | to_upper_camel_case }} {
             {% if op.request_body_schema_name is defined -%}

--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -95,14 +95,15 @@ pub enum {{ resource_type_name }}Commands {
         {% if op.description is defined -%}
             {{ op.description | to_doc_comment(style="rust") }}
         {% endif -%}
+        #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom {{ resource.name | replace(".", " ") }} {{ op.name }}{% if op.request_body_schema_name is defined %}{% for field in api.types[op.request_body_schema_name].fields | selectattr("positional") %} {{ field.name | upper }}{% endfor %} {...}{% endif %}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
         {% if op.request_body_schema_name is defined or op.response_body_schema_name is defined -%}
-            #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
             #[command(after_help = "
             {%- if op.request_body_schema_name is defined -%}
                 {{- render_schema_example("Example body", api.types[op.request_body_schema_name], api) -}}

--- a/z-clients/cli/src/cmds/api/admin_auth_policy.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_policy.rs
@@ -16,7 +16,14 @@ pub struct AdminAuthPolicyArgs {
 #[derive(Subcommand)]
 pub enum AdminAuthPolicyCommands {
     /// Create or update an access policy
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\",
   \"description\": \"...\",
@@ -26,24 +33,38 @@ pub enum AdminAuthPolicyCommands {
   \"id\": \"...\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Configure {
         admin_access_policy_configure_in:
             crate::json::JsonOf<diom::models::AdminAccessPolicyConfigureIn>,
     },
     /// Delete an access policy
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"success\": true
-}")]
+}\n")]
     Delete {
         admin_access_policy_delete_in: crate::json::JsonOf<diom::models::AdminAccessPolicyDeleteIn>,
     },
     /// Get an access policy by ID
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -53,12 +74,19 @@ pub enum AdminAuthPolicyCommands {
   \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}],
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Get {
         admin_access_policy_get_in: crate::json::JsonOf<diom::models::AdminAccessPolicyGetIn>,
     },
     /// List all access policies
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"limit\": 123,
   \"iterator\": \"...\"
@@ -68,7 +96,7 @@ pub enum AdminAuthPolicyCommands {
   \"iterator\": \"...\",
   \"prev_iterator\": \"...\",
   \"done\": true
-}")]
+}\n")]
     List {
         admin_access_policy_list_in:
             Option<crate::json::JsonOf<diom::models::AdminAccessPolicyListIn>>,

--- a/z-clients/cli/src/cmds/api/admin_auth_policy.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_policy.rs
@@ -17,12 +17,13 @@ pub struct AdminAuthPolicyArgs {
 pub enum AdminAuthPolicyCommands {
     /// Create or update an access policy
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-policy configure {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\",
@@ -40,12 +41,13 @@ pub enum AdminAuthPolicyCommands {
     },
     /// Delete an access policy
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-policy delete {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
@@ -58,12 +60,13 @@ pub enum AdminAuthPolicyCommands {
     },
     /// Get an access policy by ID
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-policy get {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
@@ -80,12 +83,13 @@ pub enum AdminAuthPolicyCommands {
     },
     /// List all access policies
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-policy list {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"limit\": 123,

--- a/z-clients/cli/src/cmds/api/admin_auth_role.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_role.rs
@@ -16,7 +16,14 @@ pub struct AdminAuthRoleArgs {
 #[derive(Subcommand)]
 pub enum AdminAuthRoleCommands {
     /// Create or update a role
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\",
   \"description\": \"...\",
@@ -28,23 +35,37 @@ pub enum AdminAuthRoleCommands {
   \"id\": \"...\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Configure {
         admin_role_configure_in: crate::json::JsonOf<diom::models::AdminRoleConfigureIn>,
     },
     /// Delete a role
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"success\": true
-}")]
+}\n")]
     Delete {
         admin_role_delete_in: crate::json::JsonOf<diom::models::AdminRoleDeleteIn>,
     },
     /// Get a role by ID
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -56,12 +77,19 @@ pub enum AdminAuthRoleCommands {
   \"context\": {\"key\": \"...\"},
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Get {
         admin_role_get_in: crate::json::JsonOf<diom::models::AdminRoleGetIn>,
     },
     /// List all roles
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"limit\": 123,
   \"iterator\": \"...\"
@@ -71,7 +99,7 @@ pub enum AdminAuthRoleCommands {
   \"iterator\": \"...\",
   \"prev_iterator\": \"...\",
   \"done\": true
-}")]
+}\n")]
     List {
         admin_role_list_in: Option<crate::json::JsonOf<diom::models::AdminRoleListIn>>,
     },

--- a/z-clients/cli/src/cmds/api/admin_auth_role.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_role.rs
@@ -17,12 +17,13 @@ pub struct AdminAuthRoleArgs {
 pub enum AdminAuthRoleCommands {
     /// Create or update a role
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-role configure {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\",
@@ -41,12 +42,13 @@ pub enum AdminAuthRoleCommands {
     },
     /// Delete a role
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-role delete {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
@@ -59,12 +61,13 @@ pub enum AdminAuthRoleCommands {
     },
     /// Get a role by ID
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-role get {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
@@ -83,12 +86,13 @@ pub enum AdminAuthRoleCommands {
     },
     /// List all roles
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-role list {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"limit\": 123,

--- a/z-clients/cli/src/cmds/api/admin_auth_token.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_token.rs
@@ -17,12 +17,13 @@ pub struct AdminAuthTokenArgs {
 pub enum AdminAuthTokenCommands {
     /// Create an auth token
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-token create {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"...\",
@@ -41,12 +42,13 @@ pub enum AdminAuthTokenCommands {
     },
     /// Expire an auth token
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-token expire {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\",
@@ -59,12 +61,13 @@ pub enum AdminAuthTokenCommands {
     },
     /// Rotate an auth token, invalidating the old one and issuing a new secret
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-token rotate {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
@@ -80,12 +83,13 @@ pub enum AdminAuthTokenCommands {
     },
     /// Delete an auth token
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-token delete {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
@@ -98,12 +102,13 @@ pub enum AdminAuthTokenCommands {
     },
     /// List auth tokens for a given owner
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-token list {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"limit\": 123,
@@ -120,12 +125,13 @@ pub enum AdminAuthTokenCommands {
     },
     /// Update an auth token's properties
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-token update {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\",
@@ -140,12 +146,13 @@ pub enum AdminAuthTokenCommands {
     },
     /// Return the role of the currently authenticated token
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom admin auth-token whoami {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m

--- a/z-clients/cli/src/cmds/api/admin_auth_token.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_token.rs
@@ -16,7 +16,14 @@ pub struct AdminAuthTokenArgs {
 #[derive(Subcommand)]
 pub enum AdminAuthTokenCommands {
     /// Create an auth token
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"...\",
   \"role\": \"...\",
@@ -28,23 +35,37 @@ pub enum AdminAuthTokenCommands {
   \"token\": \"...\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Create {
         admin_auth_token_create_in: crate::json::JsonOf<diom::models::AdminAuthTokenCreateIn>,
     },
     /// Expire an auth token
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\",
   \"expiry_ms\": 60000
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Expire {
         admin_auth_token_expire_in: crate::json::JsonOf<diom::models::AdminAuthTokenExpireIn>,
     },
     /// Rotate an auth token, invalidating the old one and issuing a new secret
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -53,23 +74,37 @@ pub enum AdminAuthTokenCommands {
   \"token\": \"...\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Rotate {
         admin_auth_token_rotate_in: crate::json::JsonOf<diom::models::AdminAuthTokenRotateIn>,
     },
     /// Delete an auth token
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"success\": true
-}")]
+}\n")]
     Delete {
         admin_auth_token_delete_in: crate::json::JsonOf<diom::models::AdminAuthTokenDeleteIn>,
     },
     /// List auth tokens for a given owner
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"limit\": 123,
   \"iterator\": \"...\"
@@ -79,12 +114,19 @@ pub enum AdminAuthTokenCommands {
   \"iterator\": \"...\",
   \"prev_iterator\": \"...\",
   \"done\": true
-}")]
+}\n")]
     List {
         admin_auth_token_list_in: Option<crate::json::JsonOf<diom::models::AdminAuthTokenListIn>>,
     },
     /// Update an auth token's properties
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"id\": \"...\",
   \"name\": \"...\",
@@ -92,17 +134,24 @@ pub enum AdminAuthTokenCommands {
   \"enabled\": true
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Update {
         admin_auth_token_update_in: crate::json::JsonOf<diom::models::AdminAuthTokenUpdateIn>,
     },
     /// Return the role of the currently authenticated token
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"role\": \"...\"
-}")]
+}\n")]
     Whoami {
         admin_auth_token_whoami_in:
             Option<crate::json::JsonOf<diom::models::AdminAuthTokenWhoamiIn>>,

--- a/z-clients/cli/src/cmds/api/cache.rs
+++ b/z-clients/cli/src/cmds/api/cache.rs
@@ -19,12 +19,13 @@ pub enum CacheCommands {
     Namespace(CacheNamespaceArgs),
     /// Cache Set
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cache set KEY VALUE {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -39,12 +40,13 @@ pub enum CacheCommands {
     },
     /// Cache Get
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cache get KEY {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -60,12 +62,13 @@ pub enum CacheCommands {
     },
     /// Cache Delete
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cache delete KEY {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\"

--- a/z-clients/cli/src/cmds/api/cache.rs
+++ b/z-clients/cli/src/cmds/api/cache.rs
@@ -18,20 +18,34 @@ pub struct CacheArgs {
 pub enum CacheCommands {
     Namespace(CacheNamespaceArgs),
     /// Cache Set
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"ttl_ms\": 60000
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Set {
         key: String,
         value: ByteString,
         cache_set_in: crate::json::JsonOf<diom::models::CacheSetIn>,
     },
     /// Cache Get
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"consistency\": \"strong\"
@@ -39,19 +53,26 @@ pub enum CacheCommands {
 {
   \"expiry\": 1234567890123,
   \"value\": \"...\"
-}")]
+}\n")]
     Get {
         key: String,
         cache_get_in: Option<crate::json::JsonOf<diom::models::CacheGetIn>>,
     },
     /// Cache Delete
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"success\": true
-}")]
+}\n")]
     Delete {
         key: String,
         cache_delete_in: Option<crate::json::JsonOf<diom::models::CacheDeleteIn>>,

--- a/z-clients/cli/src/cmds/api/cache_namespace.rs
+++ b/z-clients/cli/src/cmds/api/cache_namespace.rs
@@ -17,12 +17,13 @@ pub struct CacheNamespaceArgs {
 pub enum CacheNamespaceCommands {
     /// Configure cache namespace
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cache namespace configure {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\",
@@ -39,12 +40,13 @@ pub enum CacheNamespaceCommands {
     },
     /// Get cache namespace
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cache namespace get {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"

--- a/z-clients/cli/src/cmds/api/cache_namespace.rs
+++ b/z-clients/cli/src/cmds/api/cache_namespace.rs
@@ -16,7 +16,14 @@ pub struct CacheNamespaceArgs {
 #[derive(Subcommand)]
 pub enum CacheNamespaceCommands {
     /// Configure cache namespace
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\",
   \"eviction_policy\": \"no-eviction\"
@@ -26,12 +33,19 @@ pub enum CacheNamespaceCommands {
   \"eviction_policy\": \"no-eviction\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Configure {
         cache_configure_namespace_in: crate::json::JsonOf<diom::models::CacheConfigureNamespaceIn>,
     },
     /// Get cache namespace
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -40,7 +54,7 @@ pub enum CacheNamespaceCommands {
   \"eviction_policy\": \"no-eviction\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Get {
         cache_get_namespace_in: crate::json::JsonOf<diom::models::CacheGetNamespaceIn>,
     },

--- a/z-clients/cli/src/cmds/api/cluster_admin.rs
+++ b/z-clients/cli/src/cmds/api/cluster_admin.rs
@@ -17,12 +17,13 @@ pub struct ClusterAdminArgs {
 pub enum ClusterAdminCommands {
     /// Get information about the current cluster
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cluster-admin status\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
 {
   \"cluster_id\": \"...\",
@@ -39,12 +40,13 @@ pub enum ClusterAdminCommands {
     /// This operation may only be performed against a node which has not been
     /// initialized and is not currently a member of a cluster.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cluster-admin initialize {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -59,12 +61,13 @@ pub enum ClusterAdminCommands {
     /// This operation executes immediately and the node must be wiped and reset
     /// before it can safely be added to the cluster.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cluster-admin remove-node {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"node_id\": \"...\"
@@ -77,12 +80,13 @@ pub enum ClusterAdminCommands {
     },
     /// Force the cluster to take a snapshot immediately
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom cluster-admin force-snapshot {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m

--- a/z-clients/cli/src/cmds/api/cluster_admin.rs
+++ b/z-clients/cli/src/cmds/api/cluster_admin.rs
@@ -16,7 +16,14 @@ pub struct ClusterAdminArgs {
 #[derive(Subcommand)]
 pub enum ClusterAdminCommands {
     /// Get information about the current cluster
-    #[command(after_long_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
 {
   \"cluster_id\": \"...\",
   \"cluster_name\": \"...\",
@@ -25,18 +32,25 @@ pub enum ClusterAdminCommands {
   \"this_node_last_committed_timestamp\": 1234567890123,
   \"this_node_last_snapshot_id\": \"...\",
   \"nodes\": [{\"node_id\": \"...\", \"address\": \"...\", \"state\": \"leader\", \"last_committed_log_index\": 123, \"last_committed_term\": 123}]
-}")]
+}\n")]
     Status {},
     /// Initialize this node as the leader of a new cluster
     ///
     /// This operation may only be performed against a node which has not been
     /// initialized and is not currently a member of a cluster.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"cluster_id\": \"...\"
-}")]
+}\n")]
     Initialize {
         cluster_initialize_in: Option<crate::json::JsonOf<diom::models::ClusterInitializeIn>>,
     },
@@ -44,25 +58,39 @@ pub enum ClusterAdminCommands {
     ///
     /// This operation executes immediately and the node must be wiped and reset
     /// before it can safely be added to the cluster.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"node_id\": \"...\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"node_id\": \"...\"
-}")]
+}\n")]
     RemoveNode {
         cluster_remove_node_in: crate::json::JsonOf<diom::models::ClusterRemoveNodeIn>,
     },
     /// Force the cluster to take a snapshot immediately
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"snapshot_time\": 1234567890123,
   \"snapshot_log_index\": 123,
   \"snapshot_id\": \"...\"
-}")]
+}\n")]
     ForceSnapshot {
         cluster_force_snapshot_in:
             Option<crate::json::JsonOf<diom::models::ClusterForceSnapshotIn>>,

--- a/z-clients/cli/src/cmds/api/health.rs
+++ b/z-clients/cli/src/cmds/api/health.rs
@@ -16,10 +16,17 @@ pub struct HealthArgs {
 #[derive(Subcommand)]
 pub enum HealthCommands {
     /// Verify the server is up and running.
-    #[command(after_long_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
 {
   \"ok\": true
-}")]
+}\n")]
     Ping {},
     /// Intentionally return an error
     Error {},

--- a/z-clients/cli/src/cmds/api/health.rs
+++ b/z-clients/cli/src/cmds/api/health.rs
@@ -17,18 +17,27 @@ pub struct HealthArgs {
 pub enum HealthCommands {
     /// Verify the server is up and running.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom health ping\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
 {
   \"ok\": true
 }\n")]
     Ping {},
     /// Intentionally return an error
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom health error\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     Error {},
 }
 

--- a/z-clients/cli/src/cmds/api/idempotency.rs
+++ b/z-clients/cli/src/cmds/api/idempotency.rs
@@ -18,19 +18,33 @@ pub struct IdempotencyArgs {
 pub enum IdempotencyCommands {
     Namespace(IdempotencyNamespaceArgs),
     /// Start an idempotent request
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"lock_period_ms\": 60000
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Start {
         key: String,
         idempotency_start_in: crate::json::JsonOf<diom::models::IdempotencyStartIn>,
     },
     /// Complete an idempotent request with a response
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"response\": \"...\",
@@ -38,18 +52,25 @@ pub enum IdempotencyCommands {
   \"ttl_ms\": 60000
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Complete {
         key: String,
         idempotency_complete_in: crate::json::JsonOf<diom::models::IdempotencyCompleteIn>,
     },
     /// Abandon an idempotent request (remove lock without saving response)
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Abort {
         key: String,
         idempotency_abort_in: Option<crate::json::JsonOf<diom::models::IdempotencyAbortIn>>,

--- a/z-clients/cli/src/cmds/api/idempotency.rs
+++ b/z-clients/cli/src/cmds/api/idempotency.rs
@@ -19,12 +19,13 @@ pub enum IdempotencyCommands {
     Namespace(IdempotencyNamespaceArgs),
     /// Start an idempotent request
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom idempotency start KEY {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -38,12 +39,13 @@ pub enum IdempotencyCommands {
     },
     /// Complete an idempotent request with a response
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom idempotency complete KEY {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -59,12 +61,13 @@ pub enum IdempotencyCommands {
     },
     /// Abandon an idempotent request (remove lock without saving response)
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom idempotency abort KEY {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\"

--- a/z-clients/cli/src/cmds/api/idempotency_namespace.rs
+++ b/z-clients/cli/src/cmds/api/idempotency_namespace.rs
@@ -17,12 +17,13 @@ pub struct IdempotencyNamespaceArgs {
 pub enum IdempotencyNamespaceCommands {
     /// Configure idempotency namespace
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom idempotency namespace configure {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
@@ -38,12 +39,13 @@ pub enum IdempotencyNamespaceCommands {
     },
     /// Get idempotency namespace
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom idempotency namespace get {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"

--- a/z-clients/cli/src/cmds/api/idempotency_namespace.rs
+++ b/z-clients/cli/src/cmds/api/idempotency_namespace.rs
@@ -16,7 +16,14 @@ pub struct IdempotencyNamespaceArgs {
 #[derive(Subcommand)]
 pub enum IdempotencyNamespaceCommands {
     /// Configure idempotency namespace
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -24,13 +31,20 @@ pub enum IdempotencyNamespaceCommands {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Configure {
         idempotency_configure_namespace_in:
             crate::json::JsonOf<diom::models::IdempotencyConfigureNamespaceIn>,
     },
     /// Get idempotency namespace
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -38,7 +52,7 @@ pub enum IdempotencyNamespaceCommands {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Get {
         idempotency_get_namespace_in: crate::json::JsonOf<diom::models::IdempotencyGetNamespaceIn>,
     },

--- a/z-clients/cli/src/cmds/api/kv.rs
+++ b/z-clients/cli/src/cmds/api/kv.rs
@@ -18,7 +18,14 @@ pub struct KvArgs {
 pub enum KvCommands {
     Namespace(KvNamespaceArgs),
     /// KV Set
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"ttl_ms\": 60000,
@@ -27,14 +34,21 @@ pub enum KvCommands {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"version\": 123
-}")]
+}\n")]
     Set {
         key: String,
         value: ByteString,
         kv_set_in: Option<crate::json::JsonOf<diom::models::KvSetIn>>,
     },
     /// KV Get
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"consistency\": \"strong\"
@@ -43,20 +57,27 @@ pub enum KvCommands {
   \"expiry\": 1234567890123,
   \"value\": \"...\",
   \"version\": 123
-}")]
+}\n")]
     Get {
         key: String,
         kv_get_in: Option<crate::json::JsonOf<diom::models::KvGetIn>>,
     },
     /// KV Delete
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"version\": 123
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"success\": true
-}")]
+}\n")]
     Delete {
         key: String,
         kv_delete_in: Option<crate::json::JsonOf<diom::models::KvDeleteIn>>,

--- a/z-clients/cli/src/cmds/api/kv.rs
+++ b/z-clients/cli/src/cmds/api/kv.rs
@@ -19,12 +19,13 @@ pub enum KvCommands {
     Namespace(KvNamespaceArgs),
     /// KV Set
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom kv set KEY VALUE {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -42,12 +43,13 @@ pub enum KvCommands {
     },
     /// KV Get
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom kv get KEY {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -64,12 +66,13 @@ pub enum KvCommands {
     },
     /// KV Delete
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom kv delete KEY {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",

--- a/z-clients/cli/src/cmds/api/kv_namespace.rs
+++ b/z-clients/cli/src/cmds/api/kv_namespace.rs
@@ -16,7 +16,14 @@ pub struct KvNamespaceArgs {
 #[derive(Subcommand)]
 pub enum KvNamespaceCommands {
     /// Configure KV namespace
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -24,12 +31,19 @@ pub enum KvNamespaceCommands {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Configure {
         kv_configure_namespace_in: crate::json::JsonOf<diom::models::KvConfigureNamespaceIn>,
     },
     /// Get KV namespace
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -37,7 +51,7 @@ pub enum KvNamespaceCommands {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Get {
         kv_get_namespace_in: crate::json::JsonOf<diom::models::KvGetNamespaceIn>,
     },

--- a/z-clients/cli/src/cmds/api/kv_namespace.rs
+++ b/z-clients/cli/src/cmds/api/kv_namespace.rs
@@ -17,12 +17,13 @@ pub struct KvNamespaceArgs {
 pub enum KvNamespaceCommands {
     /// Configure KV namespace
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom kv namespace configure {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
@@ -37,12 +38,13 @@ pub enum KvNamespaceCommands {
     },
     /// Get KV namespace
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom kv namespace get {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"

--- a/z-clients/cli/src/cmds/api/msgs.rs
+++ b/z-clients/cli/src/cmds/api/msgs.rs
@@ -21,7 +21,14 @@ pub enum MsgsCommands {
     Stream(MsgsStreamArgs),
     Topic(MsgsTopicArgs),
     /// Publishes messages to a topic within a namespace.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"msgs\": [{\"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"key\": \"...\", \"delay_ms\": 60000}],
@@ -29,7 +36,7 @@ pub enum MsgsCommands {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"topics\": [{\"topic\": \"...\", \"start_offset\": 123, \"offset\": 123}]
-}")]
+}\n")]
     Publish {
         topic: String,
         msg_publish_in: crate::json::JsonOf<diom::models::MsgPublishIn>,

--- a/z-clients/cli/src/cmds/api/msgs.rs
+++ b/z-clients/cli/src/cmds/api/msgs.rs
@@ -22,12 +22,13 @@ pub enum MsgsCommands {
     Topic(MsgsTopicArgs),
     /// Publishes messages to a topic within a namespace.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs publish TOPIC {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",

--- a/z-clients/cli/src/cmds/api/msgs_namespace.rs
+++ b/z-clients/cli/src/cmds/api/msgs_namespace.rs
@@ -16,7 +16,14 @@ pub struct MsgsNamespaceArgs {
 #[derive(Subcommand)]
 pub enum MsgsNamespaceCommands {
     /// Configures a msgs namespace with the given name.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"retention\": {\"period_ms\": 60000}
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -25,14 +32,21 @@ pub enum MsgsNamespaceCommands {
   \"retention\": {\"period_ms\": 60000},
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Configure {
         name: String,
         msg_namespace_configure_in:
             Option<crate::json::JsonOf<diom::models::MsgNamespaceConfigureIn>>,
     },
     /// Gets a msgs namespace by name.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
@@ -40,7 +54,7 @@ pub enum MsgsNamespaceCommands {
   \"retention\": {\"period_ms\": 60000},
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Get {
         name: String,
         msg_namespace_get_in: Option<crate::json::JsonOf<diom::models::MsgNamespaceGetIn>>,

--- a/z-clients/cli/src/cmds/api/msgs_namespace.rs
+++ b/z-clients/cli/src/cmds/api/msgs_namespace.rs
@@ -17,12 +17,13 @@ pub struct MsgsNamespaceArgs {
 pub enum MsgsNamespaceCommands {
     /// Configures a msgs namespace with the given name.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs namespace configure NAME {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"retention\": {\"period_ms\": 60000}
@@ -40,12 +41,13 @@ pub enum MsgsNamespaceCommands {
     },
     /// Gets a msgs namespace by name.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs namespace get NAME {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
 }\n\n\x1b[1;4mExample response:\x1b[0m

--- a/z-clients/cli/src/cmds/api/msgs_queue.rs
+++ b/z-clients/cli/src/cmds/api/msgs_queue.rs
@@ -20,7 +20,14 @@ pub enum MsgsQueueCommands {
     /// Messages are individually leased for the specified duration. Multiple consumers can receive
     /// different messages from the same topic concurrently. Leased messages are skipped until they
     /// are acked or their lease expires.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"batch_size\": 123,
@@ -29,7 +36,7 @@ pub enum MsgsQueueCommands {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"msgs\": [{\"msg_id\": \"...\", \"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"timestamp\": 1234567890123, \"scheduled_at\": 1234567890123}]
-}")]
+}\n")]
     Receive {
         topic: String,
         consumer_group: String,
@@ -38,13 +45,20 @@ pub enum MsgsQueueCommands {
     /// Acknowledges messages by their opaque msg_ids.
     ///
     /// Acked messages are permanently removed from the queue and will never be re-delivered.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"msg_ids\": [\"...\"]
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Ack {
         topic: String,
         consumer_group: String,
@@ -54,14 +68,21 @@ pub enum MsgsQueueCommands {
     ///
     /// Consumers that need more processing time can call this before the lease expires to prevent the
     /// message from being re-delivered to another consumer.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"msg_ids\": [\"...\"],
   \"lease_duration_ms\": 60000
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     ExtendLease {
         topic: String,
         consumer_group: String,
@@ -71,7 +92,14 @@ pub enum MsgsQueueCommands {
     ///
     /// `retry_schedule` is a list of delays (in millis) between retries after a nack. Once exhausted,
     /// the message is moved to the DLQ (or forwarded to `dlq_topic` if set).
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"retry_schedule\": [123],
@@ -80,7 +108,7 @@ pub enum MsgsQueueCommands {
 {
   \"retry_schedule\": [123],
   \"dlq_topic\": \"...\"
-}")]
+}\n")]
     Configure {
         topic: String,
         consumer_group: String,
@@ -90,25 +118,39 @@ pub enum MsgsQueueCommands {
     ///
     /// Nacked messages will not be re-delivered by `queue/receive`. Use `queue/redrive-dlq` to
     /// move them back to the queue for reprocessing.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"msg_ids\": [\"...\"]
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Nack {
         topic: String,
         consumer_group: String,
         msg_queue_nack_in: crate::json::JsonOf<diom::models::MsgQueueNackIn>,
     },
     /// Moves all dead-letter queue messages back to the main queue for reprocessing.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     RedriveDlq {
         topic: String,
         consumer_group: String,

--- a/z-clients/cli/src/cmds/api/msgs_queue.rs
+++ b/z-clients/cli/src/cmds/api/msgs_queue.rs
@@ -21,12 +21,13 @@ pub enum MsgsQueueCommands {
     /// different messages from the same topic concurrently. Leased messages are skipped until they
     /// are acked or their lease expires.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs queue receive TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -46,12 +47,13 @@ pub enum MsgsQueueCommands {
     ///
     /// Acked messages are permanently removed from the queue and will never be re-delivered.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs queue ack TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -69,12 +71,13 @@ pub enum MsgsQueueCommands {
     /// Consumers that need more processing time can call this before the lease expires to prevent the
     /// message from being re-delivered to another consumer.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs queue extend-lease TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -93,12 +96,13 @@ pub enum MsgsQueueCommands {
     /// `retry_schedule` is a list of delays (in millis) between retries after a nack. Once exhausted,
     /// the message is moved to the DLQ (or forwarded to `dlq_topic` if set).
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs queue configure TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -119,12 +123,13 @@ pub enum MsgsQueueCommands {
     /// Nacked messages will not be re-delivered by `queue/receive`. Use `queue/redrive-dlq` to
     /// move them back to the queue for reprocessing.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs queue nack TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -139,12 +144,13 @@ pub enum MsgsQueueCommands {
     },
     /// Moves all dead-letter queue messages back to the main queue for reprocessing.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs queue redrive-dlq TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\"

--- a/z-clients/cli/src/cmds/api/msgs_stream.rs
+++ b/z-clients/cli/src/cmds/api/msgs_stream.rs
@@ -19,7 +19,14 @@ pub enum MsgsStreamCommands {
     ///
     /// Each consumer in the group reads from all partitions. Messages are locked by leases for the
     /// specified duration to prevent duplicate delivery within the same consumer group.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"batch_size\": 123,
@@ -29,7 +36,7 @@ pub enum MsgsStreamCommands {
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"msgs\": [{\"offset\": 123, \"topic\": \"...\", \"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"timestamp\": 1234567890123, \"scheduled_at\": 1234567890123}]
-}")]
+}\n")]
     Receive {
         topic: String,
         consumer_group: String,
@@ -39,13 +46,20 @@ pub enum MsgsStreamCommands {
     ///
     /// The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
     /// successfully processed offset; future receives will start after it.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"offset\": 123
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Commit {
         topic: String,
         consumer_group: String,
@@ -58,7 +72,14 @@ pub enum MsgsStreamCommands {
     /// `"earliest"` or `"latest"` and may be used with or without a partition suffix. The `timestamp`
     /// field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
     /// time.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"offset\": 123,
@@ -66,7 +87,7 @@ pub enum MsgsStreamCommands {
   \"timestamp\": 1234567890123
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Seek {
         topic: String,
         consumer_group: String,

--- a/z-clients/cli/src/cmds/api/msgs_stream.rs
+++ b/z-clients/cli/src/cmds/api/msgs_stream.rs
@@ -20,12 +20,13 @@ pub enum MsgsStreamCommands {
     /// Each consumer in the group reads from all partitions. Messages are locked by leases for the
     /// specified duration to prevent duplicate delivery within the same consumer group.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs stream receive TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -47,12 +48,13 @@ pub enum MsgsStreamCommands {
     /// The topic must be a partition-level topic (e.g. `ns:my-topic~3`). The offset is the last
     /// successfully processed offset; future receives will start after it.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs stream commit TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -73,12 +75,13 @@ pub enum MsgsStreamCommands {
     /// field accepts a Unix timestamp in milliseconds and seeks to the first message at or after that
     /// time.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs stream seek TOPIC CONSUMER_GROUP {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",

--- a/z-clients/cli/src/cmds/api/msgs_topic.rs
+++ b/z-clients/cli/src/cmds/api/msgs_topic.rs
@@ -18,14 +18,21 @@ pub enum MsgsTopicCommands {
     /// Configures the number of partitions for a topic.
     ///
     /// Partition count can only be increased, never decreased. The default for a new topic is 1.
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"partitions\": 123
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
   \"partitions\": 123
-}")]
+}\n")]
     Configure {
         topic: String,
         msg_topic_configure_in: crate::json::JsonOf<diom::models::MsgTopicConfigureIn>,

--- a/z-clients/cli/src/cmds/api/msgs_topic.rs
+++ b/z-clients/cli/src/cmds/api/msgs_topic.rs
@@ -19,12 +19,13 @@ pub enum MsgsTopicCommands {
     ///
     /// Partition count can only be increased, never decreased. The default for a new topic is 1.
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom msgs topic configure TOPIC {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",

--- a/z-clients/cli/src/cmds/api/rate_limit.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit.rs
@@ -18,7 +18,14 @@ pub struct RateLimitArgs {
 pub enum RateLimitCommands {
     Namespace(RateLimitNamespaceArgs),
     /// Rate Limiter Check and Consume
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
@@ -29,12 +36,19 @@ pub enum RateLimitCommands {
   \"allowed\": true,
   \"remaining\": 123,
   \"retry_after_ms\": 60000
-}")]
+}\n")]
     Limit {
         rate_limit_check_in: crate::json::JsonOf<diom::models::RateLimitCheckIn>,
     },
     /// Rate Limiter Get Remaining
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
@@ -43,19 +57,26 @@ pub enum RateLimitCommands {
 {
   \"remaining\": 123,
   \"retry_after_ms\": 60000
-}")]
+}\n")]
     GetRemaining {
         rate_limit_get_remaining_in: crate::json::JsonOf<diom::models::RateLimitGetRemainingIn>,
     },
     /// Rate Limiter Reset
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
   \"config\": {\"capacity\": 123, \"refill_amount\": 123, \"refill_interval_ms\": 60000}
 }\n\n\x1b[1;4mExample response:\x1b[0m
 {
-}")]
+}\n")]
     Reset {
         rate_limit_reset_in: crate::json::JsonOf<diom::models::RateLimitResetIn>,
     },

--- a/z-clients/cli/src/cmds/api/rate_limit.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit.rs
@@ -19,12 +19,13 @@ pub enum RateLimitCommands {
     Namespace(RateLimitNamespaceArgs),
     /// Rate Limiter Check and Consume
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom rate-limit limit {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -42,12 +43,13 @@ pub enum RateLimitCommands {
     },
     /// Rate Limiter Get Remaining
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom rate-limit get-remaining {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",
@@ -63,12 +65,13 @@ pub enum RateLimitCommands {
     },
     /// Rate Limiter Reset
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom rate-limit reset {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"namespace\": \"some_namespace\",

--- a/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
@@ -16,7 +16,14 @@ pub struct RateLimitNamespaceArgs {
 #[derive(Subcommand)]
 pub enum RateLimitNamespaceCommands {
     /// Configure rate limiter namespace
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -24,13 +31,20 @@ pub enum RateLimitNamespaceCommands {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Configure {
         rate_limit_configure_namespace_in:
             crate::json::JsonOf<diom::models::RateLimitConfigureNamespaceIn>,
     },
     /// Get rate limiter namespace
-    #[command(after_long_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(help_template = concat!(
+                "{about-with-newline}\n",
+                "{usage-heading} {usage}\n",
+                "{after-help}",
+                "\n",
+                "{all-args}",
+            ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
 }\n\n\x1b[1;4mExample response:\x1b[0m
@@ -38,7 +52,7 @@ pub enum RateLimitNamespaceCommands {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
-}")]
+}\n")]
     Get {
         rate_limit_get_namespace_in: crate::json::JsonOf<diom::models::RateLimitGetNamespaceIn>,
     },

--- a/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
@@ -17,12 +17,13 @@ pub struct RateLimitNamespaceArgs {
 pub enum RateLimitNamespaceCommands {
     /// Configure rate limiter namespace
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom rate-limit namespace configure {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"
@@ -38,12 +39,13 @@ pub enum RateLimitNamespaceCommands {
     },
     /// Get rate limiter namespace
     #[command(help_template = concat!(
-                "{about-with-newline}\n",
-                "{usage-heading} {usage}\n",
-                "{after-help}",
-                "\n",
-                "{all-args}",
-            ))]
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom rate-limit namespace get {...}\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
     #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
 {
   \"name\": \"some_namespace\"


### PR DESCRIPTION
- use `after_help` instead of `after_long_help`, this ensure that both `-h` and `--help` will output the same message.
- change the order of sections in `--help` messages to match svix-cli order proposed here https://github.com/svix/svix-webhooks/pull/2278