### PR TITLE
cluster: fix bootstrap running too early

### DIFF
--- a/crates/diom-core/src/types/non_zero_duration_ms.rs
+++ b/crates/diom-core/src/types/non_zero_duration_ms.rs
@@ -61,6 +61,14 @@ impl NonZeroDurationMs {
     pub const fn as_duration(&self) -> Duration {
         Duration::from_millis(self.as_millis())
     }
+
+    pub fn saturating_add(self, other: &NonZeroDurationMs) -> Self {
+        Self(self.0.saturating_add(other.0.into()))
+    }
+
+    pub fn saturating_mul(self, multiplier: NonZeroU64) -> Self {
+        Self(self.0.saturating_mul(multiplier))
+    }
 }
 
 impl From<NonZeroDurationMs> for Duration {

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc, time::Duration};
+use std::{fmt, num::NonZeroU64, sync::Arc, time::Duration};
 
 use super::{
     ClientWriteError, LogId, Node, NodeId, RaftError, discovery::Discovery,
@@ -24,6 +24,7 @@ use openraft::{RaftNetworkFactory, ServerState};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tap::TapFallible;
 use tokio::sync::mpsc::Sender;
 
 tokio::task_local! {
@@ -473,10 +474,7 @@ impl RaftState {
         Ok(())
     }
 
-    pub async fn is_up(&self) -> bool {
-        if self.state_machine.is_loading_snapshot() {
-            return false;
-        }
+    async fn has_known_leader(&self) -> bool {
         let Ok(state) = self
             .raft
             .with_raft_state(|s| s.server_state)
@@ -511,6 +509,49 @@ impl RaftState {
                 true
             }
         }
+    }
+
+    /// Check whether the cluster is ready to receive writes
+    pub async fn is_up(&self) -> bool {
+        if self.state_machine.is_loading_snapshot() {
+            return false;
+        }
+        if !self.has_known_leader().await {
+            return false;
+        }
+        if self
+            .raft
+            .with_raft_state(|s| s.membership_state.effective().nodes().count() == 1)
+            .await
+            .unwrap_or(false)
+        {
+            // if there's only one node, openraft doesn't bother heartbeating, so
+            // return true immediately
+            return true;
+        }
+        // wait to see if we get a heartbeat recorded
+        let duration = self
+            .cfg
+            .cluster
+            .heartbeat_interval
+            .saturating_mul(NonZeroU64::new(3).unwrap());
+        let Ok(last_applied) = self
+            .raft
+            .with_raft_state(|s| s.committed().map(|c| c.index()).unwrap_or(0))
+            .await
+        else {
+            return false;
+        };
+        self.raft
+            .wait(Some(duration.into()))
+            .committed_index_at_least(
+                Some(last_applied + 1),
+                "waiting for a write for proof-of-life",
+            )
+            .await
+            .inspect_err(|err| tracing::debug!(?err, "error waiting for log to be applied"))
+            .tap_ok(|_| tracing::debug!("at least one log was committed, we must be up"))
+            .is_ok()
     }
 
     pub async fn state(&self) -> anyhow::Result<ServerState> {


### PR DESCRIPTION
This was an interesting bug that could happen and cause a crash on startup.

Imagine a three node cluster with nodes A, B, and C.

Node A is the leader.
Node B shuts down
Node C becomes the leader (for whatever reason)
Node B starts up

At this point, `is_up` would return on Node B quickly because we still think it's a Follower of Node A. As soon as we start receiving traffic, we'll be proven wrong here. Instead, let's wait until our theoretical leader actually writes some logs to us before we call ourselves "up".