### PR TITLE
cluster: fix background tasks to update monotime

### DIFF
--- a/src/core/cluster/applier.rs
+++ b/src/core/cluster/applier.rs
@@ -53,6 +53,12 @@ pub(super) async fn apply_request(
         child_span.set_attribute("hashed_key", hash);
     }
 
+    tracing::trace!(
+        timestamp = %request.timestamp,
+        last_timestamp = %state_machine.time.now_utm(),
+        "applying request with new timestamp"
+    );
+
     state_machine.time.update_from_other(request.timestamp);
 
     let context = diom_operations::OpContext {

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -198,7 +198,6 @@ async fn wait_until_leader(
         };
         match value {
             Ok(Some(node)) if node == me => {
-                tracing::debug!("I believe I am the leader! Spawning background tasks");
                 return true;
             }
             Err(tokio::sync::broadcast::error::RecvError::Closed) => {
@@ -217,6 +216,7 @@ pub(super) async fn run_background_jobs_on_leader(
     let shutdown = crate::shutting_down_token();
     let mut chan = leadership_changes(handle.clone()).await;
     while wait_until_leader(handle.node_id, chan.resubscribe()).await {
+        tracing::info!("spawning leader-only background tasks");
         let mut runner = BackgroundJobRunner::new();
         runner.spawn_all(cfg.clone(), handle.clone()).await;
         loop {

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -753,9 +753,12 @@ impl diom_operations::OperationWriterBase for RaftState {
         &self,
         request: Self::Request,
     ) -> diom_operations::BackgroundResult<Self::Response> {
-        let now = self.state_machine.time.now_utm();
-        let request =
-            RequestWithContext::new(request, now, Some(opentelemetry::Context::current().into()));
+        let now = self.time.update_now();
+        let request = RequestWithContext::new(
+            request,
+            now.into(),
+            Some(opentelemetry::Context::current().into()),
+        );
         let request = Arc::new(request);
         match self.raft.client_write(request).await {
             Ok(resp) => {


### PR DESCRIPTION
at some point, things got changed so that leader-only background tasks no longer updated the monotonic timer (which makes the Tick job kind of useless!)