### PR TITLE
cluster: fix log message on leadership change to be more readable

### DIFF
--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -167,7 +167,7 @@ async fn leadership_changes(handle: RaftState) -> tokio::sync::broadcast::Receiv
                 |m| {
                     let mut l = last_leader.lock().unwrap();
                     if m.current_leader != *l {
-                        tracing::debug!(old_leader = ?l, new_leader = ?m, "leader has changed");
+                        tracing::debug!(old_leader = ?l, new_leader = ?m.current_leader, "leader has changed");
                         *l = m.current_leader;
                         if tx.send(m.current_leader).is_err() {
                             return true;

--- a/src/core/cluster/node.rs
+++ b/src/core/cluster/node.rs
@@ -88,9 +88,7 @@ impl Node {
     }
 }
 
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash, Serialize, Deserialize,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct NodeId {
     #[serde(with = "uuid::serde::simple")]
@@ -108,6 +106,12 @@ impl JsonSchema for NodeId {
 
     fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         String::json_schema(generator)
+    }
+}
+
+impl std::fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NodeId({})", self.inner.simple())
     }
 }
 


### PR DESCRIPTION
just something I noticed while playing with #1157; we were logging the whole state instead of the leader

also changes the NodeId Debug impl to be less verbose