### PR TITLE
CLI: remove ansi escape code from schema example title

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased Changes
+* CLI: Remove 'underline bold' ansi escape code from schema examples on `--help` messages
 
 ### Breaking Changes
 * Libs/Rust: Revamp `ErrorKind` and error type methods

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased Changes
-* CLI: Remove 'underline bold' ansi escape code from schema examples on `--help` messages
+* CLI: Remove underlining from schema examples on `--help` messages due to portability issues
 
 ### Breaking Changes
 * Libs/Rust: Revamp `ErrorKind` and error type methods

--- a/codegen/templates/cli/api_resource.rs.jinja
+++ b/codegen/templates/cli/api_resource.rs.jinja
@@ -67,7 +67,7 @@ use super::{
 {%- endmacro -%}
 
 {%- macro render_schema_example(title, schema, api) -%}
-\x1b[1;4m{{ title }}:\x1b[0m
+{{ title }}:
 {
 {%- for field in schema.fields | selectattr("positional", "false") %}
   \"{{ field.name }}\": {% if field.example is defined %}\"{{ field.example }}\"{% else %}{{ get_type_example(field, api) }}{% endif %}{{ "," if not loop.last else "" }}

--- a/z-clients/cli/src/cmds/api/admin_auth_policy.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_policy.rs
@@ -24,12 +24,12 @@ pub enum AdminAuthPolicyCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\",
   \"description\": \"...\",
   \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}]
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"...\",
   \"created\": 1234567890123,
@@ -48,10 +48,10 @@ pub enum AdminAuthPolicyCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"success\": true
 }\n")]
@@ -67,10 +67,10 @@ pub enum AdminAuthPolicyCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"...\",
   \"description\": \"...\",
@@ -90,11 +90,11 @@ pub enum AdminAuthPolicyCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"limit\": 123,
   \"iterator\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"data\": [{\"id\": \"...\", \"description\": \"...\", \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}], \"created\": 1234567890123, \"updated\": 1234567890123}],
   \"iterator\": \"...\",

--- a/z-clients/cli/src/cmds/api/admin_auth_role.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_role.rs
@@ -24,14 +24,14 @@ pub enum AdminAuthRoleCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\",
   \"description\": \"...\",
   \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}],
   \"policies\": [\"...\"],
   \"context\": {\"key\": \"...\"}
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"...\",
   \"created\": 1234567890123,
@@ -49,10 +49,10 @@ pub enum AdminAuthRoleCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"success\": true
 }\n")]
@@ -68,10 +68,10 @@ pub enum AdminAuthRoleCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"...\",
   \"description\": \"...\",
@@ -93,11 +93,11 @@ pub enum AdminAuthRoleCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"limit\": 123,
   \"iterator\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"data\": [{\"id\": \"...\", \"description\": \"...\", \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}], \"policies\": [\"...\"], \"context\": {\"key\": \"...\"}, \"created\": 1234567890123, \"updated\": 1234567890123}],
   \"iterator\": \"...\",

--- a/z-clients/cli/src/cmds/api/admin_auth_token.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_token.rs
@@ -24,13 +24,13 @@ pub enum AdminAuthTokenCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"...\",
   \"role\": \"...\",
   \"expiry_ms\": 60000,
   \"enabled\": true
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"...\",
   \"token\": \"...\",
@@ -49,11 +49,11 @@ pub enum AdminAuthTokenCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\",
   \"expiry_ms\": 60000
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Expire {
@@ -68,10 +68,10 @@ pub enum AdminAuthTokenCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"...\",
   \"token\": \"...\",
@@ -90,10 +90,10 @@ pub enum AdminAuthTokenCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"success\": true
 }\n")]
@@ -109,11 +109,11 @@ pub enum AdminAuthTokenCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"limit\": 123,
   \"iterator\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"data\": [{\"id\": \"...\", \"name\": \"...\", \"created\": 1234567890123, \"updated\": 1234567890123, \"expiry\": 1234567890123, \"role\": \"...\", \"enabled\": true}],
   \"iterator\": \"...\",
@@ -132,13 +132,13 @@ pub enum AdminAuthTokenCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"id\": \"...\",
   \"name\": \"...\",
   \"expiry_ms\": 60000,
   \"enabled\": true
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Update {
@@ -153,9 +153,9 @@ pub enum AdminAuthTokenCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"role\": \"...\"
 }\n")]

--- a/z-clients/cli/src/cmds/api/cache.rs
+++ b/z-clients/cli/src/cmds/api/cache.rs
@@ -26,11 +26,11 @@ pub enum CacheCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"ttl_ms\": 60000
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Set {
@@ -47,11 +47,11 @@ pub enum CacheCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"consistency\": \"strong\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"expiry\": 1234567890123,
   \"value\": \"...\"
@@ -69,10 +69,10 @@ pub enum CacheCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"success\": true
 }\n")]

--- a/z-clients/cli/src/cmds/api/cache_namespace.rs
+++ b/z-clients/cli/src/cmds/api/cache_namespace.rs
@@ -24,11 +24,11 @@ pub enum CacheNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"some_namespace\",
   \"eviction_policy\": \"no-eviction\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"eviction_policy\": \"no-eviction\",
@@ -47,10 +47,10 @@ pub enum CacheNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"eviction_policy\": \"no-eviction\",

--- a/z-clients/cli/src/cmds/api/cluster_admin.rs
+++ b/z-clients/cli/src/cmds/api/cluster_admin.rs
@@ -24,7 +24,7 @@ pub enum ClusterAdminCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"cluster_id\": \"...\",
   \"cluster_name\": \"...\",
@@ -47,9 +47,9 @@ pub enum ClusterAdminCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"cluster_id\": \"...\"
 }\n")]
@@ -68,10 +68,10 @@ pub enum ClusterAdminCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"node_id\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"node_id\": \"...\"
 }\n")]
@@ -87,9 +87,9 @@ pub enum ClusterAdminCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"snapshot_time\": 1234567890123,
   \"snapshot_log_index\": 123,

--- a/z-clients/cli/src/cmds/api/health.rs
+++ b/z-clients/cli/src/cmds/api/health.rs
@@ -24,7 +24,7 @@ pub enum HealthCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"ok\": true
 }\n")]

--- a/z-clients/cli/src/cmds/api/idempotency.rs
+++ b/z-clients/cli/src/cmds/api/idempotency.rs
@@ -26,11 +26,11 @@ pub enum IdempotencyCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"lock_period_ms\": 60000
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Start {
@@ -46,13 +46,13 @@ pub enum IdempotencyCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"response\": \"...\",
   \"context\": {\"key\": \"...\"},
   \"ttl_ms\": 60000
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Complete {
@@ -68,10 +68,10 @@ pub enum IdempotencyCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Abort {

--- a/z-clients/cli/src/cmds/api/idempotency_namespace.rs
+++ b/z-clients/cli/src/cmds/api/idempotency_namespace.rs
@@ -24,10 +24,10 @@ pub enum IdempotencyNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
@@ -46,10 +46,10 @@ pub enum IdempotencyNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,

--- a/z-clients/cli/src/cmds/api/kv.rs
+++ b/z-clients/cli/src/cmds/api/kv.rs
@@ -26,13 +26,13 @@ pub enum KvCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"ttl_ms\": 60000,
   \"behavior\": \"upsert\",
   \"version\": 123
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"version\": 123
 }\n")]
@@ -50,11 +50,11 @@ pub enum KvCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"consistency\": \"strong\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"expiry\": 1234567890123,
   \"value\": \"...\",
@@ -73,11 +73,11 @@ pub enum KvCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"version\": 123
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"success\": true
 }\n")]

--- a/z-clients/cli/src/cmds/api/kv_namespace.rs
+++ b/z-clients/cli/src/cmds/api/kv_namespace.rs
@@ -24,10 +24,10 @@ pub enum KvNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
@@ -45,10 +45,10 @@ pub enum KvNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,

--- a/z-clients/cli/src/cmds/api/msgs.rs
+++ b/z-clients/cli/src/cmds/api/msgs.rs
@@ -29,12 +29,12 @@ pub enum MsgsCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"msgs\": [{\"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"key\": \"...\", \"delay_ms\": 60000}],
   \"idempotency_key\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"topics\": [{\"topic\": \"...\", \"start_offset\": 123, \"offset\": 123}]
 }\n")]

--- a/z-clients/cli/src/cmds/api/msgs_namespace.rs
+++ b/z-clients/cli/src/cmds/api/msgs_namespace.rs
@@ -24,10 +24,10 @@ pub enum MsgsNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"retention\": {\"period_ms\": 60000}
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"retention\": {\"period_ms\": 60000},
@@ -48,9 +48,9 @@ pub enum MsgsNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"retention\": {\"period_ms\": 60000},

--- a/z-clients/cli/src/cmds/api/msgs_queue.rs
+++ b/z-clients/cli/src/cmds/api/msgs_queue.rs
@@ -28,13 +28,13 @@ pub enum MsgsQueueCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"batch_size\": 123,
   \"lease_duration_ms\": 60000,
   \"batch_wait_ms\": 60000
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"msgs\": [{\"msg_id\": \"...\", \"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"timestamp\": 1234567890123, \"scheduled_at\": 1234567890123}]
 }\n")]
@@ -54,11 +54,11 @@ pub enum MsgsQueueCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"msg_ids\": [\"...\"]
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Ack {
@@ -78,12 +78,12 @@ pub enum MsgsQueueCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"msg_ids\": [\"...\"],
   \"lease_duration_ms\": 60000
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     ExtendLease {
@@ -103,12 +103,12 @@ pub enum MsgsQueueCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"retry_schedule\": [123],
   \"dlq_topic\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"retry_schedule\": [123],
   \"dlq_topic\": \"...\"
@@ -130,11 +130,11 @@ pub enum MsgsQueueCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"msg_ids\": [\"...\"]
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Nack {
@@ -151,10 +151,10 @@ pub enum MsgsQueueCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     RedriveDlq {

--- a/z-clients/cli/src/cmds/api/msgs_stream.rs
+++ b/z-clients/cli/src/cmds/api/msgs_stream.rs
@@ -27,14 +27,14 @@ pub enum MsgsStreamCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"batch_size\": 123,
   \"lease_duration_ms\": 60000,
   \"default_starting_position\": \"earliest\",
   \"batch_wait_ms\": 60000
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"msgs\": [{\"offset\": 123, \"topic\": \"...\", \"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"timestamp\": 1234567890123, \"scheduled_at\": 1234567890123}]
 }\n")]
@@ -55,11 +55,11 @@ pub enum MsgsStreamCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"offset\": 123
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Commit {
@@ -82,13 +82,13 @@ pub enum MsgsStreamCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"offset\": 123,
   \"position\": \"earliest\",
   \"timestamp\": 1234567890123
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Seek {

--- a/z-clients/cli/src/cmds/api/msgs_topic.rs
+++ b/z-clients/cli/src/cmds/api/msgs_topic.rs
@@ -26,11 +26,11 @@ pub enum MsgsTopicCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"partitions\": 123
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"partitions\": 123
 }\n")]

--- a/z-clients/cli/src/cmds/api/rate_limit.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit.rs
@@ -26,13 +26,13 @@ pub enum RateLimitCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
   \"tokens\": 123,
   \"config\": {\"capacity\": 123, \"refill_amount\": 123, \"refill_interval_ms\": 60000}
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"allowed\": true,
   \"remaining\": 123,
@@ -50,12 +50,12 @@ pub enum RateLimitCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
   \"config\": {\"capacity\": 123, \"refill_amount\": 123, \"refill_interval_ms\": 60000}
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"remaining\": 123,
   \"retry_after_ms\": 60000
@@ -72,12 +72,12 @@ pub enum RateLimitCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"namespace\": \"some_namespace\",
   \"key\": \"some_key\",
   \"config\": {\"capacity\": 123, \"refill_amount\": 123, \"refill_interval_ms\": 60000}
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Reset {

--- a/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
+++ b/z-clients/cli/src/cmds/api/rate_limit_namespace.rs
@@ -24,10 +24,10 @@ pub enum RateLimitNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,
@@ -46,10 +46,10 @@ pub enum RateLimitNamespaceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"name\": \"some_namespace\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"name\": \"some_namespace\",
   \"created\": 1234567890123,


### PR DESCRIPTION
@svix-jbrown suggested to remove this in https://github.com/svix/svix-webhooks/pull/2278#discussion_r3171432542 so we are more compatible with different terminals