### PR TITLE
cfg: allow disabling storing otel context in raft logs

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -14,6 +14,7 @@ The diom server accepts the following environment variables:
 | `$DIOM_CLUSTER_DISCOVERY_TIMEOUT_MS` | Timeout for the entire discovery process |
 | `$DIOM_CLUSTER_ELECTION_TIMEOUT_MAX_MS` | The minimum time to let an election run for.<br/><br/>This should be set to at least 5x the RTT of your farthest-apart nodes and must not be less than `cluster_election_timeout_max`. |
 | `$DIOM_CLUSTER_ELECTION_TIMEOUT_MIN_MS` | The minimum time to let an election run for.<br/><br/>This should be set to at least 4x the RTT of your farthest-apart nodes, and must not be less than `heartbeat_interval_ms`. |
+| `$DIOM_CLUSTER_FORWARD_OPENTELEMETRY_CONTEXT` | Store an openetelemetry context in logs, for tracing.<br/><br/>This will make it possible to trace individual requests through the Raft layer, but greatly increases the size of raft logs, and may result in confusing traces when there are multiple nodes in a cluster. |
 | `$DIOM_CLUSTER_HEARTBEAT_INTERVAL_MS` | How often to send heartbeats.<br/><br/>This controls how fast lost leaders can be detected. Must not be less than `replication_request_timeout`. |
 | `$DIOM_CLUSTER_LISTEN_ADDRESS` | The address to listen on for replication. |
 | `$DIOM_CLUSTER_LOG_INDEX_INTERVAL_MS` | How often to write commit log indexes<br/><br/>This controls the granularity for purging of old logs, and should not be set to a value smaller than 1 second or larger than one hour |

--- a/config.bench.toml
+++ b/config.bench.toml
@@ -3,14 +3,15 @@
 listen_address = "0.0.0.0:8624"
 log_level="info"
 environment = "dev"
-
-opentelemetry_metrics_use_http=true
-opentelemetry_service_name="diom"
-opentelemetry_address="http://localhost:4317"
-opentelemetry_metrics_address="http://localhost:9090/api/v1/otlp/v1/metrics"
-opentelemetry_sample_ratio=0.001
 # for the primary data, write to the OS but do not fsync
 sync_mode = "buffer"
+
+[opentelemetry]
+address = "http://localhost:4317"
+metrics_address = "http://localhost:9090/api/v1/otlp/v1/metrics"
+metrics_protocol = "http"
+service_name = "diom"
+sample_ratio=0.001
 
 [cluster]
 # for the logs, also don't fsync; just flush to the OS every commit

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -89,6 +89,13 @@ election_timeout_max_ms = 3500
 # and must not be less than `heartbeat_interval_ms`.
 election_timeout_min_ms = 1500
 
+# Store an openetelemetry context in logs, for tracing.
+#
+# This will make it possible to trace individual requests through the Raft layer, but greatly
+# increases the size of raft logs, and may result in confusing traces when there are multiple
+# nodes in a cluster.
+forward_opentelemetry_context = false
+
 # How often to send heartbeats.
 #
 # This controls how fast lost leaders can be detected.

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -325,6 +325,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
             shut_down_on_go_away: true,
             replication_lag_threshold: 1_000_000,
             send_snapshot_timeout: NonZeroDurationMs::from_secs(3).unwrap(),
+            forward_opentelemetry_context: false,
         },
         background_cleanup_interval: NonZeroDurationMs::from_secs(10).unwrap(),
         bootstrap_cfg: None,

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -416,6 +416,14 @@ pub struct ClusterConfiguration {
     ///
     /// If not passed, will use the application-wide `log_level`.
     pub log_level: Option<LogLevel>,
+
+    #[serde(default)]
+    /// Store an openetelemetry context in logs, for tracing.
+    ///
+    /// This will make it possible to trace individual requests through the Raft layer, but greatly
+    /// increases the size of raft logs, and may result in confusing traces when there are multiple
+    /// nodes in a cluster.
+    pub forward_opentelemetry_context: bool,
 }
 
 impl ClusterConfiguration {

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -374,11 +374,11 @@ impl RaftState {
     {
         let inner: Request = op.into().into();
         let now = self.time.update_now();
-        let ctx = if self.cfg.cluster.forward_opentelemetry_context {
-            Some(opentelemetry::Context::current().into())
-        } else {
-            None
-        };
+        let ctx = self
+            .cfg
+            .cluster
+            .forward_opentelemetry_context
+            .then(|| opentelemetry::Context::current().into());
         let request = RequestWithContext::new(inner, now.into(), ctx);
         let (response, _) = self.client_write_inner(request, DEFAULT_HOP_TTL).await?;
         let module_response = <O::Response as OperationResponse>::ResponseParent::try_from(
@@ -824,11 +824,11 @@ impl diom_operations::OperationWriterBase for RaftState {
         request: Self::Request,
     ) -> diom_operations::BackgroundResult<Self::Response> {
         let now = self.time.update_now();
-        let ctx = if self.cfg.cluster.forward_opentelemetry_context {
-            Some(opentelemetry::Context::current().into())
-        } else {
-            None
-        };
+        let ctx = self
+            .cfg
+            .cluster
+            .forward_opentelemetry_context
+            .then(|| opentelemetry::Context::current().into());
         let request = RequestWithContext::new(request, now.into(), ctx);
         let request = Arc::new(request);
         match self.raft.client_write(request).await {

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -374,11 +374,12 @@ impl RaftState {
     {
         let inner: Request = op.into().into();
         let now = self.time.update_now();
-        let request = RequestWithContext::new(
-            inner,
-            now.into(),
-            Some(opentelemetry::Context::current().into()),
-        );
+        let ctx = if self.cfg.cluster.forward_opentelemetry_context {
+            Some(opentelemetry::Context::current().into())
+        } else {
+            None
+        };
+        let request = RequestWithContext::new(inner, now.into(), ctx);
         let (response, _) = self.client_write_inner(request, DEFAULT_HOP_TTL).await?;
         let module_response = <O::Response as OperationResponse>::ResponseParent::try_from(
             response,
@@ -823,11 +824,12 @@ impl diom_operations::OperationWriterBase for RaftState {
         request: Self::Request,
     ) -> diom_operations::BackgroundResult<Self::Response> {
         let now = self.time.update_now();
-        let request = RequestWithContext::new(
-            request,
-            now.into(),
-            Some(opentelemetry::Context::current().into()),
-        );
+        let ctx = if self.cfg.cluster.forward_opentelemetry_context {
+            Some(opentelemetry::Context::current().into())
+        } else {
+            None
+        };
+        let request = RequestWithContext::new(request, now.into(), ctx);
         let request = Arc::new(request);
         match self.raft.client_write(request).await {
             Ok(resp) => {


### PR DESCRIPTION
for small requests, the big opentelemetry string/string hashmap can be more than half of the log size. It's really only useful when doing single-node performance investigation anyway.