### PR TITLE
logs: disable fsync latency estimation if commits_before_fsync == 1

### DIFF
--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -390,7 +390,7 @@ async fn flush_worker(
         .instrument(tracing::info_span!("logs:flush_worker"))
         .await;
 
-        if autoscale_duration && synced {
+        if autoscale_duration && synced && commits_before_fsync != 1 {
             let new_estimate = duration_estimator.estimate();
             if new_estimate < Duration::from_micros(1) {
                 tracing::debug!(?new_estimate, "ignoring obviously bogus fsync time")


### PR DESCRIPTION
if commits_before_fsync is 1, then we persist fjall on every commit so there's no point estimating how long it takes