### PR TITLE
db: add some more manual persistence calls during snapshot restoration

### DIFF
--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -180,6 +180,7 @@ fn deserialize_keyspace<R: Read + Seek>(
         } else {
             keyspace.clear()?;
         }
+        db.persist(fjall::PersistMode::SyncAll)?;
     }
     let mut key_buf = vec![];
     let mut value_buf = vec![];
@@ -202,7 +203,9 @@ fn deserialize_keyspace<R: Read + Seek>(
             i.write(&key_buf, &value_buf)?;
         }
         i.finish()?;
+        db.persist(fjall::PersistMode::Buffer)?;
     }
+    db.persist(fjall::PersistMode::SyncAll)?;
     Ok(())
 }
 


### PR DESCRIPTION
I'm still trying to track down these journal issues; I don't think think this is the direct source of them, but this should still improve resilience to weirdness if we crash at an inopportune moment.