### PR TITLE
db: ensure that _schema is persisted

### DIFF
--- a/crates/fjall-utils/src/options.rs
+++ b/crates/fjall-utils/src/options.rs
@@ -153,6 +153,7 @@ impl SerializableKeyspaceCreateOptions {
             .map(fjall::Slice::from)
             .context("serializing schema")?;
         schema.insert(keyspace_name, serialized)?;
+        database.persist(fjall::PersistMode::Buffer)?;
         database
             .keyspace(keyspace_name, || self.into())
             .context("creating target keyspace")


### PR DESCRIPTION
only matters in very niche situations where the journal isn't flushed immediately afterward, but not _wrong_