### PR TITLE
sdks: Consistently escape and quote (only) detail field when printing errors

### DIFF
--- a/z-clients/go/internal/proto/error.go
+++ b/z-clients/go/internal/proto/error.go
@@ -2,6 +2,7 @@ package diom_proto
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/vmihailenco/msgpack/v5"
 )
@@ -89,11 +90,11 @@ func (e *OtherError) Unwrap() error {
 }
 
 func errorResponse(code string, detail string, location *string) string {
-	result := fmt.Sprintf("code=\"%s\"", code)
+	result := fmt.Sprintf("code=%s", code)
 	if location != nil {
-		result += fmt.Sprintf(" location=\"%s\"", *location)
+		result += fmt.Sprintf(" location=%s", *location)
 	}
-	result += fmt.Sprintf(" detail=\"%s\"", detail)
+	result += fmt.Sprintf(" detail=\"%s\"", strings.ReplaceAll(detail, "\"", "\\\""))
 
 	return result
 }

--- a/z-clients/javascript/src/error.ts
+++ b/z-clients/javascript/src/error.ts
@@ -57,10 +57,10 @@ export class OtherError extends DiomError {
 function errorResponseMessage(code: string, detail: string, location?: string): string {
   let result = `code=${code}`;
   if (location !== undefined) {
-    result += ` location="${location}"`;
+    result += ` location=${location}`;
   }
   const d = detail.replaceAll('"', '\\"');
-  result += ` detail=${d}`;
+  result += ` detail="${d}"`;
 
   return result
 }

--- a/z-clients/rust/src/error.rs
+++ b/z-clients/rust/src/error.rs
@@ -355,9 +355,9 @@ impl fmt::Display for ErrorResponse {
             detail,
             location,
         } = self;
-        write!(f, "code={code:?}")?;
+        write!(f, "code={code}")?;
         if let Some(location) = location {
-            write!(f, " location={location:?}")?;
+            write!(f, " location={location}")?;
         }
         write!(f, " detail={detail:?}")
     }


### PR DESCRIPTION
Re. https://github.com/svix/diom/pull/1179#discussion_r3189020365