### PR TITLE
Fix error code for serde value errors from rmp-serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,12 +222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,7 +1488,6 @@ dependencies = [
  "aide 0.16.0-alpha.4",
  "anyerror",
  "anyhow",
- "assert_matches",
  "axum",
  "axum-extra",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_matches2"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15832d94c458da98cac0ffa6eca52cc19c2a3c6c951058500a5ae8f01f0fdf56"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1421,7 @@ dependencies = [
 name = "diom"
 version = "0.2.3"
 dependencies = [
+ "assert_matches2",
  "headers",
  "http",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ addr = "0.15"
 aide = { version = "=0.16.0-alpha.4", features = ["axum", "axum-json"] }
 anyerror = { version = "0.1.13", features = ["anyhow"] }
 anyhow = "1.0.56"
+assert_matches2 = "0.1.2"
 async-trait = "0.1.89"
 axum = { version = "0.8.8", features = ["macros", "http2"] }
 axum-extra = { version = "0.12", features = ["typed-header"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ validator.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
-assert_matches.workspace = true
 ctor.workspace = true
 dotenvy.workspace = true
 rand.workspace = true
@@ -126,7 +125,6 @@ addr = "0.15"
 aide = { version = "=0.16.0-alpha.4", features = ["axum", "axum-json"] }
 anyerror = { version = "0.1.13", features = ["anyhow"] }
 anyhow = "1.0.56"
-assert_matches = "1.5.0"
 async-trait = "0.1.89"
 axum = { version = "0.8.8", features = ["macros", "http2"] }
 axum-extra = { version = "0.12", features = ["typed-header"] }

--- a/crates/diom-proto/src/msgpack_or_json.rs
+++ b/crates/diom-proto/src/msgpack_or_json.rs
@@ -123,16 +123,17 @@ where
                 | rmp_serde::decode::Error::OutOfRange
                 | rmp_serde::decode::Error::LengthMismatch(_)
                 | rmp_serde::decode::Error::Uncategorized(_)
-                | rmp_serde::decode::Error::Syntax(_)
                 | rmp_serde::decode::Error::DepthLimitExceeded => {
                     MsgPackOrJsonRejection::InvalidEncoding {
                         msg: inner.to_string(),
                     }
                 }
-                rmp_serde::decode::Error::TypeMismatch(_) => MsgPackOrJsonRejection::InvalidData {
-                    location,
-                    msg: inner.to_string(),
-                },
+                rmp_serde::decode::Error::Syntax(_) | rmp_serde::decode::Error::TypeMismatch(_) => {
+                    MsgPackOrJsonRejection::InvalidData {
+                        location,
+                        msg: inner.to_string(),
+                    }
+                }
             }
         }
 

--- a/z-clients/java/src/test/java/com/svix/diom/IntegrationTest.java
+++ b/z-clients/java/src/test/java/com/svix/diom/IntegrationTest.java
@@ -116,7 +116,7 @@ class IntegrationTest {
         InvalidInputException e = assertThrows(InvalidInputException.class, () -> {
             client.kv().set("❤️", "whatever".getBytes(), new KvSetIn());
         });
-        assertEquals(e.getCode(), "invalid-encoding");
+        assertEquals(e.getCode(), "invalid-data");
         assertTrue(e.getDetail().startsWith("EntityKey must match the following pattern:"));
     }
 }

--- a/z-clients/rust/Cargo.toml
+++ b/z-clients/rust/Cargo.toml
@@ -41,6 +41,7 @@ tower-service.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+assert_matches2.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 
 [lints]

--- a/z-clients/rust/tests/integration.rs
+++ b/z-clients/rust/tests/integration.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
+use assert_matches2::assert_let;
 use diom::{
-    DiomClient, DiomOptions,
+    DiomClient, DiomOptions, ErrorKind,
     models::{CacheDeleteIn, CacheGetIn, CacheSetIn, KvDeleteIn, KvGetIn, KvSetIn},
 };
 
@@ -90,4 +91,19 @@ async fn test_cache_set_get_delete() {
     // Verify deleted
     let get_resp = client.cache().get(key, CacheGetIn::new()).await.unwrap();
     assert_eq!(get_resp.value, None);
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_invalid_input() {
+    let client = client();
+
+    let err = client
+        .kv()
+        .set("❤️".to_owned(), b"whatever".to_vec(), KvSetIn::new())
+        .await
+        .unwrap_err();
+
+    assert_let!(ErrorKind::InvalidInput(i) = err.kind());
+    assert_eq!(i.code(), "invalid-data");
 }


### PR DESCRIPTION
Something I noticed when writing the error test for Java (https://github.com/svix/diom/pull/1179).
Need to rebase that PR if this merges first, or the other way around.