### PR TITLE
cancel background tasks during tests

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -12,3 +12,5 @@ disallowed-macros = [
     # https://github.com/tokio-rs/tracing/issues/2448
     "tracing::enabled"
 ]
+
+too-many-arguments-threshold = 8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "tempfile",
  "test-utils",
  "tokio",
+ "tokio-util",
  "toml",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ sysinfo.workspace = true
 tap.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 toml.workspace = true
 tower.workspace = true
 tower-http.workspace = true

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -19,6 +19,7 @@ use openraft::{
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use tap::{Pipe, Tap, TapFallible, TapOptional};
+use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Span};
 
 use super::{NodeId, raft::TypeConfig};
@@ -312,10 +313,10 @@ async fn flush_worker(
     autoscale_duration: bool,
     sync_mode: SyncMode,
     fsync_mode: FsyncMode,
+    shutting_down: CancellationToken,
 ) {
     let mut pending = Vec::new();
     let mut done = false;
-    let shutting_down = crate::shutting_down_token();
     let mut duration_estimator = SimpleEstimator::<7>::new(duration_before_fsync);
     let mut last_estimate = duration_before_fsync;
     let mut ticker = tokio::time::interval(duration_before_fsync);
@@ -422,6 +423,7 @@ pub struct DiomLogs {
     metrics: Option<LogMetrics>,
     last_vote: Arc<Mutex<Option<Vote>>>,
     fsync_mode: FsyncMode,
+    cancellation_token: CancellationToken,
 }
 
 impl DiomLogs {
@@ -434,6 +436,7 @@ impl DiomLogs {
         autoscale_duration: bool,
         sync_mode: SyncMode,
         fsync_mode: FsyncMode,
+        cancellation_token: CancellationToken,
     ) -> anyhow::Result<Self> {
         let pb: std::path::PathBuf = path.into();
         let db = Database::builder(&pb).worker_threads(1).open()?;
@@ -456,6 +459,7 @@ impl DiomLogs {
             autoscale_duration,
             sync_mode,
             fsync_mode,
+            cancellation_token.clone(),
         ));
         Ok(Self {
             db,
@@ -466,6 +470,7 @@ impl DiomLogs {
             metrics: None,
             last_vote: Arc::new(Mutex::new(None)),
             fsync_mode,
+            cancellation_token,
         })
     }
 
@@ -747,7 +752,7 @@ impl DiomLogs {
     fn start_metrics(&self, metrics: LogMetrics) {
         let mut logs = self.clone();
         let db = self.db.clone();
-        let shutdown = crate::shutting_down_token();
+        let shutdown = self.cancellation_token.clone();
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_secs(60));
             while shutdown.run_until_cancelled(ticker.tick()).await.is_some() {
@@ -838,19 +843,23 @@ mod tests {
 
     use super::DiomLogs;
     use crate::cfg::{Dir, FsyncMode, SyncMode};
+    use diom_error::CanFailExt;
     use jiff::{Span, Timestamp};
     use tempfile::TempDir;
     use test_utils::TestResult;
+    use tokio_util::sync::CancellationToken;
 
     struct TestContext {
-        _workdir: TempDir,
+        workdir: Option<TempDir>,
         logs: DiomLogs,
+        cancellation_token: CancellationToken,
     }
 
     impl TestContext {
         fn new() -> Self {
             let workdir = tempfile::tempdir().unwrap();
             let logdir = Dir::new(&workdir).unwrap();
+            let token = CancellationToken::new();
             let logs = DiomLogs::new(
                 logdir,
                 0,
@@ -858,11 +867,22 @@ mod tests {
                 false,
                 SyncMode::Buffer,
                 FsyncMode::default(),
+                token.clone(),
             )
             .unwrap();
             Self {
-                _workdir: workdir,
+                workdir: Some(workdir),
                 logs,
+                cancellation_token: token,
+            }
+        }
+    }
+
+    impl Drop for TestContext {
+        fn drop(&mut self) {
+            self.cancellation_token.cancel();
+            if let Some(workdir) = self.workdir.take() {
+                workdir.close().can_fail("failure to close workdir")
             }
         }
     }

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -78,6 +78,7 @@ pub async fn initialize_raft(
         cfg.cluster.log_sync_interval_auto,
         cfg.cluster.log_sync_mode,
         cfg.fsync_mode,
+        crate::shutting_down_token(),
     )
     .context("setting up log store")?;
     let id: NodeId = logs
@@ -119,6 +120,7 @@ pub async fn initialize_raft(
         logs.clone(),
         id,
         time.clone(),
+        crate::shutting_down_token(),
     )
     .await?;
     let state_machine: StoreHandle = state_machine.into();
@@ -214,10 +216,12 @@ pub async fn initialize_raft(
 mod tests {
     use std::time::Duration;
 
+    use diom_error::CanFailExt;
     use diom_proto::InternalClient;
     use fjall::Database;
     use openraft::testing::log::StoreBuilder;
     use tempfile::TempDir;
+    use tokio_util::sync::CancellationToken;
 
     use crate::{AppState, cfg::ConfigurationInner};
 
@@ -230,13 +234,31 @@ mod tests {
     };
     use crate::cfg::{Dir, FsyncMode};
 
+    struct DiomStoreGuard {
+        tempdir: Option<TempDir>,
+        cancel: CancellationToken,
+    }
+
+    impl Drop for DiomStoreGuard {
+        fn drop(&mut self) {
+            self.cancel.cancel();
+            // wait a beat for it to catch up since cancellation is async and we're sync
+            std::thread::sleep(Duration::from_millis(10));
+            if let Some(tempdir) = self.tempdir.take() {
+                tempdir.close().can_fail("error cleaning up tempdir");
+            }
+        }
+    }
+
     struct DiomStoreBuilder;
 
     impl DiomStoreBuilder {
-        async fn setup() -> anyhow::Result<(TempDir, DiomLogs, StoreHandle)> {
+        async fn setup() -> anyhow::Result<(DiomStoreGuard, DiomLogs, StoreHandle)> {
             let workdir = tempfile::tempdir()?;
             let log_path = workdir.path().to_path_buf().join("logs");
             let log_path = Dir::new(log_path)?;
+            let token = CancellationToken::new();
+
             let logs = DiomLogs::new(
                 log_path,
                 1,
@@ -244,6 +266,7 @@ mod tests {
                 false,
                 crate::cfg::SyncMode::Buffer,
                 FsyncMode::default(),
+                token.clone(),
             )?;
 
             let data_path = workdir.path().join("data");
@@ -275,17 +298,24 @@ mod tests {
                 logs.clone(),
                 1.into(),
                 time,
+                token.clone(),
             )
             .await?;
 
-            Ok((workdir, logs, store.into()))
+            let guard = DiomStoreGuard {
+                tempdir: Some(workdir),
+                cancel: token,
+            };
+
+            Ok((guard, logs, store.into()))
         }
     }
 
-    impl StoreBuilder<TypeConfig, DiomLogs, StoreHandle, TempDir> for DiomStoreBuilder {
+    impl StoreBuilder<TypeConfig, DiomLogs, StoreHandle, DiomStoreGuard> for DiomStoreBuilder {
         async fn build(
             &self,
-        ) -> Result<(TempDir, DiomLogs, StoreHandle), openraft::StorageError<TypeConfig>> {
+        ) -> Result<(DiomStoreGuard, DiomLogs, StoreHandle), openraft::StorageError<TypeConfig>>
+        {
             Ok(Self::setup().await.unwrap())
         }
     }

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -25,6 +25,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tap::TapOptional;
 use tokio::sync::RwLock as TokioRwLock;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use super::{
@@ -185,6 +186,7 @@ pub struct Store {
     metrics: DbMetrics,
     persist_mode: PersistMode,
     snapshot_loading: TaskWatcher,
+    cancellation_token: CancellationToken,
 }
 
 trait SnapshotIdx {
@@ -219,6 +221,7 @@ impl Store {
         logs: DiomLogs,
         node_id: NodeId,
         time: Monotime,
+        cancellation_token: CancellationToken,
     ) -> anyhow::Result<Self> {
         let meta_keyspace =
             persistent_db.keyspace(METADATA_KEYSPACE, KeyspaceCreateOptions::default)?;
@@ -278,6 +281,7 @@ impl Store {
             metrics,
             persist_mode,
             snapshot_loading: TaskWatcher::default(),
+            cancellation_token,
         };
         this.load_information().await?;
         this.start_metrics();
@@ -315,8 +319,8 @@ impl Store {
         let stores = Arc::clone(&self.stores);
         let metrics = self.metrics.clone();
         let snapshot_directory = self.snapshot_directory.clone();
+        let shutdown = self.cancellation_token.clone();
         tokio::spawn(async move {
-            let shutdown = crate::shutting_down_token();
             let mut ticker = tokio::time::interval(Duration::from_secs(10));
             let mut last_fetched_size = std::time::Instant::now();
 


### PR DESCRIPTION
Right now, we leak the various `tokio::spawn`'d background tasks between tests because they only shut down when the process-wide cancellation token is canceled. This PR changes it so that instead of using the process-wide cancellation token, we thread through specific cancellation tokens (which are overridden in tests).