### PR TITLE
Remove HTTP 204 specialization

### DIFF
--- a/z-clients/go/internal/proto/http_client.go
+++ b/z-clients/go/internal/proto/http_client.go
@@ -80,9 +80,6 @@ func ExecuteRequest[ReqBody any, ResBody any](
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode == 204 {
-		return nil, nil
-	}
 	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)

--- a/z-clients/java/src/main/java/com/svix/diom/HttpClient.java
+++ b/z-clients/java/src/main/java/com/svix/diom/HttpClient.java
@@ -184,10 +184,6 @@ public class HttpClient {
             throw new ConnectionException(opId, e);
         }
 
-        if (response.code() == 204) {
-            return null;
-        }
-
         ErrorBody errorBody;
         try {
             if (response.code() >= 200 && response.code() < 300) {

--- a/z-clients/javascript/src/request.ts
+++ b/z-clients/javascript/src/request.ts
@@ -117,9 +117,6 @@ export class DiomRequest {
   ): Promise<R> {
     const operationId = this.operationId();
     const response = await this.sendInner(ctx, operationId);
-    if (response.status === 204) {
-      return <R>null;
-    }
     const decoded = await readMsgpackResponse(response, operationId);
     return parseResponseBody(decoded);
   }


### PR DESCRIPTION
We don't ever return HTTP 204 from the Diom API.