### PR TITLE
Helm: Support configuring operator logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,15 @@ jobs:
           fi
   sdk-integration:
     uses: ./.github/workflows/sdk-integration.yml
+  helm-test:
+    name: Helm chart unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
+      - name: Run Helm unit tests
+        run: helm unittest ./infra/helm-diom
   check-crd:
     name: Check CRD JSON freshness
     runs-on: ubicloud-standard-4-ubuntu-2404

--- a/infra/helm-diom/ChangeLog.md
+++ b/infra/helm-diom/ChangeLog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased Changes
+* Consistently name operator pod `<release>-operator`
+* Add `operator.logFormat` and `operator.extraEnv` values

--- a/infra/helm-diom/README.md
+++ b/infra/helm-diom/README.md
@@ -35,6 +35,8 @@ The CRD is enabled by default. The chart will attempt to manage upgrades of the 
 | `operator.serviceAccount.annotations` | Annotations for the ServiceAccount. | `{}` |
 | `operator.rbac.create` | Create ClusterRole and ClusterRoleBinding for the operator. | `true` |
 | `operator.logLevel` | Operator log level (`info`, `debug`, `trace`). | `info` |
+| `operator.logFormat` | Operator log format (`default`, `json`). | `default` |
+| `operator.extraEnv` | Additional environment variables to add to the operator container. | `[]` |
 | `operator.podAnnotations` | Annotations to add to the operator pod. | `{}` |
 | `operator.resources` | Resource requests/limits for the operator pod. | request cpu: 100m, memory: 128Mi, no limits |
 | `operator.nodeSelector` | Node selector for the operator pod. | `{}` |

--- a/infra/helm-diom/templates/deployment.yaml
+++ b/infra/helm-diom/templates/deployment.yaml
@@ -37,8 +37,17 @@ spec:
             capabilities:
               drop: ["ALL"]
           env:
+            {{- with .Values.operator.logLevel }}
             - name: RUST_LOG
-              value: {{ .Values.operator.logLevel | quote }}
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.operator.logFormat }}
+            - name: LOG_FORMAT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.operator.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.operator.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/infra/helm-diom/tests/operator_extra_env_test.yaml
+++ b/infra/helm-diom/tests/operator_extra_env_test.yaml
@@ -1,0 +1,87 @@
+suite: operator environment variables
+templates:
+  - deployment.yaml
+tests:
+  - it: sets no env vars by default
+    set:
+      operator.image.tag: test
+      cluster.enabled: false
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.containers[0].env
+
+  - it: sets RUST_LOG when logLevel is configured
+    set:
+      operator.image.tag: test
+      cluster.enabled: false
+      operator.logLevel: info
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUST_LOG
+            value: "info"
+
+  - it: does not set RUST_LOG when logLevel is unset
+    set:
+      operator.image.tag: test
+      cluster.enabled: false
+      operator.logFormat: json
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUST_LOG
+
+  - it: sets LOG_FORMAT when logFormat is configured
+    set:
+      operator.image.tag: test
+      cluster.enabled: false
+      operator.logFormat: json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_FORMAT
+            value: "json"
+
+  - it: supports multiple extra env vars
+    set:
+      operator.image.tag: test
+      cluster.enabled: false
+      operator.extraEnv:
+        - name: FOO
+          value: bar
+        - name: BAZ
+          value: qux
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FOO
+            value: bar
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BAZ
+            value: qux
+
+  - it: supports valueFrom
+    set:
+      operator.image.tag: test
+      cluster.enabled: false
+      operator.extraEnv:
+        - name: MY_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: my-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: my-key

--- a/infra/helm-diom/values.yaml
+++ b/infra/helm-diom/values.yaml
@@ -27,7 +27,10 @@ operator:
   rbac:
     create: true
 
-  logLevel: info
+  # logLevel: info
+  # logFormat: default
+
+  extraEnv: []
 
   podAnnotations: {}
 
@@ -59,7 +62,7 @@ cluster:
       persistent:
         size: 10Gi
         # storageClass: ""
-    # extraEnv: []
+    # envVar: []
     # nodeSelector: {}
     # tolerations: []
     # probes:

--- a/justfile
+++ b/justfile
@@ -103,6 +103,11 @@ test-all: test test-sdks
 bench:
     cargo bench
 
+# Run Helm chart unit tests
+[working-directory('infra/helm-diom')]
+test-helm:
+    helm unittest .
+
 # Regenerate the CRD JSON and write it into the Helm chart
 [working-directory('infra/operator')]
 generate-crd:


### PR DESCRIPTION
Add options for it in Helm. Also adds some ome unit tests for this, which we can use as a starting point for other tests.