### PR TITLE
Operator: Add default crypto provider

### DIFF
--- a/infra/operator/Cargo.toml
+++ b/infra/operator/Cargo.toml
@@ -28,6 +28,7 @@ futures-util.workspace = true
 k8s-openapi = { workspace = true, features = ["schemars"] }
 kube.workspace = true
 kube_quantity.workspace = true
+rustls = { workspace = true, features = ["aws_lc_rs"] }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -38,7 +39,6 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json", "registry"] }
 
 [dev-dependencies]
-rustls = { workspace = true, features = ["ring"] }
 temp-env = "0.3"
 test-utils = { path = "../../crates/test-utils" }
 

--- a/infra/operator/src/main.rs
+++ b/infra/operator/src/main.rs
@@ -7,6 +7,10 @@ use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _
 async fn main() -> anyhow::Result<()> {
     use kube::CustomResourceExt;
 
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
+
     if std::env::args().any(|a| a == "--print-crd") {
         print!("{}", serde_yaml::to_string(&DiomCluster::crd())?);
         return Ok(());

--- a/infra/operator/tests/it/common.rs
+++ b/infra/operator/tests/it/common.rs
@@ -181,7 +181,7 @@ impl TestContextBuilder {
 
     pub(crate) async fn build(self) -> TestContext {
         let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         if self.image == E2E_IMAGE {
             ensure_e2e_image_built();
         }

--- a/infra/operator/tests/it/main.rs
+++ b/infra/operator/tests/it/main.rs
@@ -3,3 +3,6 @@ mod common;
 
 #[cfg(feature = "operator-e2e")]
 mod e2e;
+
+#[cfg(feature = "operator-e2e")]
+mod startup;

--- a/infra/operator/tests/it/startup.rs
+++ b/infra/operator/tests/it/startup.rs
@@ -1,0 +1,9 @@
+use std::process::Command;
+
+#[test]
+fn binary_starts_without_panic() {
+    let bin = env!("CARGO_BIN_EXE_diom-operator");
+    let output = Command::new(bin).arg("--print-crd").output().unwrap();
+
+    assert!(output.status.success());
+}


### PR DESCRIPTION
Operator startup was failing after adding the `diom-backend` dependency due to multiple available crypto providers. So set one explicitly and add a test that ensures we can catch startup panics in the future.