### PR TITLE
Operator/Helm: Ephemeral storage configuration

### DIFF
--- a/infra/helm-diom/ChangeLog.md
+++ b/infra/helm-diom/ChangeLog.md
@@ -3,3 +3,4 @@
 ## Unreleased Changes
 * Consistently name operator pod `<release>-operator`
 * Add `operator.logFormat` and `operator.extraEnv` values
+* Add `cluster.spec.storage.ephemeral`

--- a/infra/helm-diom/README.md
+++ b/infra/helm-diom/README.md
@@ -95,6 +95,14 @@ cluster:
 | `cluster.spec.storage.logs.storageClass` | Storage class for the logs volume. | `""` |
 | `cluster.spec.storage.snapshots.size` | Size of the separate Raft snapshot volume. Should be at least as large as the persistent volume. | `""` |
 | `cluster.spec.storage.snapshots.storageClass` | Storage class for the snapshots volume. | `""` |
+| `cluster.spec.storage.ephemeral` | Optional separate volume for ephemeral database storage. When omitted, ephemeral data is stored in a subdirectory of the persistent volume.Options: `emptyDir`, `hostPath`, `genericEphemeral`, or `pvc`. | null |
+| `cluster.spec.storage.ephemeral.emptyDir` | An emptyDir volume. Recommended only for testing. Data is lost on pod restart. | `""` |
+| `cluster.spec.storage.ephemeral.emptyDir.sizeLimit` | Optional maximum size of the volume. | null |
+| `cluster.spec.storage.ephemeral.hostPath.path` | Absolute path on the host node to mount into the container. Data persists across pod restarts as long as the pod is rescheduled onto the same node. | `""` |
+| `cluster.spec.storage.ephemeral.genericEphemeral.size` | A generic ephemeral volume provisioned by a CSI driver. Recommended only for testing. Data is lost on pod restart. Required. | `""` |
+| `cluster.spec.storage.ephemeral.genericEphemeral.storageClass` | Storage class name. Uses the cluster default if not specified. | cluster default |
+| `cluster.spec.storage.ephemeral.pvc.size` | A persistent volume claim. Required. | `""` |
+| `cluster.spec.storage.ephemeral.pvc.storageClass` | Storage class name. Uses the cluster default if not specified. | cluster default |
 | `cluster.spec.imagePullPolicy` | Image pull policy (`Always`, `IfNotPresent`, `Never`). | `""` |
 | `cluster.spec.podAnnotations` | Additional annotations to add to pods. | `{}` |
 | `cluster.spec.nodeSelector` | Node selector labels for pod scheduling. | `{}` |

--- a/infra/helm-diom/charts/crds/crds/diomclusters.json
+++ b/infra/helm-diom/charts/crds/crds/diomclusters.json
@@ -1332,6 +1332,104 @@
                   "storage": {
                     "description": "Storage configuration.",
                     "properties": {
+                      "ephemeral": {
+                        "description": "Optional separate volume for ephemeral database storage.",
+                        "nullable": true,
+                        "oneOf": [
+                          {
+                            "required": [
+                              "emptyDir"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "hostPath"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "genericEphemeral"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "pvc"
+                            ]
+                          }
+                        ],
+                        "properties": {
+                          "emptyDir": {
+                            "description": "An emptyDir volume.\n\nRecommended only for testing. Data is lost on pod restart.",
+                            "properties": {
+                              "medium": {
+                                "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                "nullable": true,
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "genericEphemeral": {
+                            "description": "A generic ephemeral volume provisioned by a CSI driver.\n\nRecommended only for testing. Data is lost on pod restart.",
+                            "properties": {
+                              "size": {
+                                "description": "Storage size, e.g. \"10Gi\".",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "storageClass": {
+                                "description": "Storage class name. Uses the cluster default if not specified.",
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "size"
+                            ],
+                            "type": "object"
+                          },
+                          "hostPath": {
+                            "description": "A directory mounted directly from the host node.\n\nData persists across pod restarts as long as the pod is rescheduled onto the same node.",
+                            "properties": {
+                              "path": {
+                                "description": "Absolute path on the host node to mount into the container.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type of hostPath volume.",
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object"
+                          },
+                          "pvc": {
+                            "description": "A persistent volume claim.",
+                            "properties": {
+                              "size": {
+                                "description": "Storage size, e.g. \"10Gi\".",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "storageClass": {
+                                "description": "Storage class name. Uses the cluster default if not specified.",
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "size"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
                       "logs": {
                         "description": "Separate volume for Raft commit logs.\nRecommended for high-throughput deployments to avoid I/O contention\nwith the persistent DB.",
                         "nullable": true,
@@ -1352,7 +1450,7 @@
                         "type": "object"
                       },
                       "persistent": {
-                        "description": "Persistent database storage",
+                        "description": "Persistent database storage.",
                         "properties": {
                           "size": {
                             "description": "Storage size, e.g. \"10Gi\".",

--- a/infra/helm-diom/values.yaml
+++ b/infra/helm-diom/values.yaml
@@ -61,7 +61,6 @@ cluster:
     storage:
       persistent:
         size: 10Gi
-        # storageClass: ""
     # envVar: []
     # nodeSelector: {}
     # tolerations: []

--- a/infra/operator/ChangeLog.md
+++ b/infra/operator/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased Changes
+* Add default crypto provider
+* Add ephemeral storage configuration
 
 ## Version 0.2.0
 * Fix serialization of `OpenTelemetrySpec` fields to use camelCase

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -3,8 +3,8 @@
 
 use k8s_openapi::{
     api::core::v1::{
-        Affinity, EnvVar, EnvVarSource, HTTPGetAction, Probe, ResourceRequirements,
-        SecretKeySelector, Toleration, TopologySpreadConstraint,
+        Affinity, EmptyDirVolumeSource, EnvVar, EnvVarSource, HTTPGetAction, Probe,
+        ResourceRequirements, SecretKeySelector, Toleration, TopologySpreadConstraint,
     },
     apimachinery::pkg::api::resource::Quantity,
 };
@@ -108,11 +108,13 @@ pub struct DiomClusterSpec {
 /// Storage configuration for a Diom cluster.
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct DiomStorageSpec {
-    /// Persistent database storage
+    /// Persistent database storage.
     pub persistent: VolumeSpec,
 
-    // TODO: ephemeral DB storage — fjall ephemeral DB
-    // pub ephemeral: VolumeSpec,
+    /// Optional separate volume for ephemeral database storage.
+    #[serde(default)]
+    pub ephemeral: Option<EphemeralVolumeSpec>,
+
     /// Separate volume for Raft commit logs.
     /// Recommended for high-throughput deployments to avoid I/O contention
     /// with the persistent DB.
@@ -123,6 +125,47 @@ pub struct DiomStorageSpec {
     /// Must be at least as large as persistent + ephemeral DB combined.
     #[serde(default)]
     pub snapshots: Option<VolumeSpec>,
+}
+
+/// Ephemeral storage configuration.
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum EphemeralVolumeSpec {
+    /// An emptyDir volume.
+    ///
+    /// Recommended only for testing. Data is lost on pod restart.
+    EmptyDir(EmptyDirVolumeSource),
+    /// A directory mounted directly from the host node.
+    ///
+    /// Data persists across pod restarts as long as the pod is rescheduled onto the same node.
+    HostPath(HostPathSpec),
+    /// A generic ephemeral volume provisioned by a CSI driver.
+    ///
+    /// Recommended only for testing. Data is lost on pod restart.
+    GenericEphemeral(VolumeSpec),
+    /// A persistent volume claim.
+    Pvc(VolumeSpec),
+}
+
+/// Configuration for a hostPath volume.
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HostPathSpec {
+    /// Absolute path on the host node to mount into the container.
+    pub path: String,
+
+    /// Type of hostPath volume.
+    #[serde(rename = "type", default)]
+    pub path_type: Option<String>,
+}
+
+impl From<HostPathSpec> for k8s_openapi::api::core::v1::HostPathVolumeSource {
+    fn from(s: HostPathSpec) -> Self {
+        Self {
+            path: s.path,
+            type_: s.path_type,
+        }
+    }
 }
 
 /// Configuration for a single persistent volume.

--- a/infra/operator/src/resources/pvcs.rs
+++ b/infra/operator/src/resources/pvcs.rs
@@ -12,6 +12,7 @@ use kube_quantity::{ParseQuantityError, ParsedQuantity};
 
 use crate::{
     context::ClusterCtx,
+    crd::EphemeralVolumeSpec,
     error::{Error, Result},
 };
 
@@ -28,6 +29,10 @@ pub(crate) async fn reconcile(ctx: &ClusterCtx) -> Result<()> {
         nodes,
     )
     .await?;
+
+    if let Some(EphemeralVolumeSpec::Pvc(v)) = &storage.ephemeral {
+        reconcile_volume(ctx, "ephemeral", &v.size, v.storage_class.as_deref(), nodes).await?;
+    }
 
     if let Some(logs) = &storage.logs {
         reconcile_volume(

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -4,9 +4,10 @@ use k8s_openapi::{
     api::{
         apps::v1::{StatefulSet, StatefulSetPersistentVolumeClaimRetentionPolicy, StatefulSetSpec},
         core::v1::{
-            Container, ContainerPort, EnvVar, EnvVarSource, HTTPGetAction, LocalObjectReference,
-            ObjectFieldSelector, PersistentVolumeClaim, PersistentVolumeClaimSpec,
-            PodSecurityContext, PodSpec, PodTemplateSpec, VolumeMount, VolumeResourceRequirements,
+            Container, ContainerPort, EnvVar, EnvVarSource, EphemeralVolumeSource, HTTPGetAction,
+            LocalObjectReference, ObjectFieldSelector, PersistentVolumeClaim,
+            PersistentVolumeClaimSpec, PersistentVolumeClaimTemplate, PodSecurityContext, PodSpec,
+            PodTemplateSpec, Volume, VolumeMount, VolumeResourceRequirements,
         },
     },
     apimachinery::pkg::{
@@ -21,7 +22,7 @@ use kube::{
 
 use crate::{
     context::ClusterCtx,
-    crd::{DiomClusterSpec, INTRACLUSTER_PORT},
+    crd::{DiomClusterSpec, EphemeralVolumeSpec, INTRACLUSTER_PORT},
     error::{Error, Result},
     labels,
     resources::services,
@@ -30,8 +31,8 @@ use crate::{
 /// Path inside the container for the persistent DB.
 const PERSISTENT_DATA_PATH: &str = "/data/persistent";
 
-// TODO: path for ephemeral DB
-// const EPHEMERAL_DATA_PATH: &str = "/data/ephemeral";
+/// Path inside the container for the ephemeral DB (when a separate volume is configured).
+const EPHEMERAL_DATA_PATH: &str = "/data/ephemeral";
 
 /// Path inside the container for Raft commit logs (when a separate volume is configured).
 const LOGS_DATA_PATH: &str = "/data/logs";
@@ -76,6 +77,7 @@ fn build(ctx: &ClusterCtx) -> Result<StatefulSet> {
     let headless_svc = services::headless_svc_name(cluster_name);
 
     let env = build_env(spec, cluster_name, &headless_svc, &ctx.ns);
+    let pod_volumes = build_pod_volumes(spec);
     let volume_claim_templates = build_volume_claim_templates(spec);
     let volume_mounts = build_volume_mounts(spec);
     let container = build_container(spec, env, volume_mounts);
@@ -85,7 +87,11 @@ fn build(ctx: &ClusterCtx) -> Result<StatefulSet> {
 
     let pod_spec = PodSpec {
         containers: vec![container],
-        volumes: None,
+        volumes: if pod_volumes.is_empty() {
+            None
+        } else {
+            Some(pod_volumes)
+        },
         // appuser in the diom-server image is created with plain `useradd`, giving it UID/GID
         // 1000. fsGroup ensures mounted PVC directories are chowned to that group on attach.
         security_context: Some(PodSecurityContext {
@@ -190,6 +196,10 @@ fn build_env(
         ),
         env_var("DIOM_PERSISTENT_DB_PATH", PERSISTENT_DATA_PATH),
     ];
+
+    if spec.diom.storage.ephemeral.is_some() {
+        env.push(env_var("DIOM_EPHEMERAL_DB_PATH", EPHEMERAL_DATA_PATH));
+    }
 
     // Always set log and snapshot paths explicitly to avoid the Dockerfile defaults, which point
     // to ephemeral storage and cause crashes on pod restart if Raft references a missing snapshot.
@@ -304,12 +314,58 @@ fn build_container(
     }
 }
 
+fn build_pod_volumes(spec: &DiomClusterSpec) -> Vec<Volume> {
+    match &spec.diom.storage.ephemeral {
+        Some(EphemeralVolumeSpec::EmptyDir(e)) => vec![Volume {
+            name: "ephemeral".into(),
+            empty_dir: Some(e.clone()),
+            ..Default::default()
+        }],
+        Some(EphemeralVolumeSpec::HostPath(h)) => vec![Volume {
+            name: "ephemeral".into(),
+            host_path: Some(h.clone().into()),
+            ..Default::default()
+        }],
+        Some(EphemeralVolumeSpec::GenericEphemeral(v)) => {
+            let mut resources: BTreeMap<String, Quantity> = BTreeMap::new();
+            resources.insert("storage".into(), v.size.clone());
+            vec![Volume {
+                name: "ephemeral".into(),
+                ephemeral: Some(EphemeralVolumeSource {
+                    volume_claim_template: Some(PersistentVolumeClaimTemplate {
+                        spec: PersistentVolumeClaimSpec {
+                            access_modes: Some(vec!["ReadWriteOnce".into()]),
+                            storage_class_name: v.storage_class.clone(),
+                            resources: Some(VolumeResourceRequirements {
+                                requests: Some(resources),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                }),
+                ..Default::default()
+            }]
+        }
+        Some(EphemeralVolumeSpec::Pvc(_)) | None => vec![],
+    }
+}
+
 fn build_volume_claim_templates(spec: &DiomClusterSpec) -> Vec<PersistentVolumeClaim> {
     let mut templates = vec![pvc_template(
         "persistent",
         &spec.diom.storage.persistent.size,
         spec.diom.storage.persistent.storage_class.as_deref(),
     )];
+
+    if let Some(EphemeralVolumeSpec::Pvc(v)) = &spec.diom.storage.ephemeral {
+        templates.push(pvc_template(
+            "ephemeral",
+            &v.size,
+            v.storage_class.as_deref(),
+        ));
+    }
 
     if let Some(logs) = &spec.diom.storage.logs {
         templates.push(pvc_template(
@@ -336,6 +392,14 @@ fn build_volume_mounts(spec: &DiomClusterSpec) -> Vec<VolumeMount> {
         mount_path: PERSISTENT_DATA_PATH.into(),
         ..Default::default()
     }];
+
+    if spec.diom.storage.ephemeral.is_some() {
+        mounts.push(VolumeMount {
+            name: "ephemeral".into(),
+            mount_path: EPHEMERAL_DATA_PATH.into(),
+            ..Default::default()
+        });
+    }
 
     if spec.diom.storage.logs.is_some() {
         mounts.push(VolumeMount {
@@ -472,11 +536,13 @@ async fn wait_for_sts_deleted(sts_api: &kube::Api<StatefulSet>, name: &str) -> R
 mod tests {
     use super::*;
     use crate::crd::{
-        DiomSpec, DiomStorageSpec, OpenTelemetryProtocol, OpenTelemetrySpec, VolumeSpec,
+        DiomSpec, DiomStorageSpec, EphemeralVolumeSpec, HostPathSpec, OpenTelemetryProtocol,
+        OpenTelemetrySpec, VolumeSpec,
     };
     use k8s_openapi::{
         api::core::v1::{
-            PersistentVolumeClaim, PersistentVolumeClaimSpec, VolumeResourceRequirements,
+            EmptyDirVolumeSource, PersistentVolumeClaim, PersistentVolumeClaimSpec,
+            VolumeResourceRequirements,
         },
         apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
     };
@@ -492,6 +558,7 @@ mod tests {
                         size: Quantity("1Gi".to_string()),
                         storage_class: None,
                     },
+                    ephemeral: None,
                     logs: None,
                     snapshots: None,
                 },
@@ -640,5 +707,134 @@ mod tests {
 
         let empty = make_sts(vec![]);
         assert!(!volume_claim_templates_differ(&empty, &empty));
+    }
+
+    #[test]
+    fn test_ephemeral_storage_config() {
+        let mut spec = make_spec();
+
+        // None (default)
+        assert!(build_pod_volumes(&spec).is_empty());
+
+        let templates = build_volume_claim_templates(&spec);
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].metadata.name.as_deref(), Some("persistent"));
+
+        let mounts = build_volume_mounts(&spec);
+        assert!(!mounts.iter().any(|m| m.mount_path == EPHEMERAL_DATA_PATH));
+
+        assert!(
+            build_env(&spec, "test", "test-headless", "test-ns")
+                .into_iter()
+                .find(|e| e.name == "DIOM_EPHEMERAL_DB_PATH")
+                .is_none()
+        );
+
+        // emptyDir
+        spec.diom.storage.ephemeral = Some(EphemeralVolumeSpec::EmptyDir(EmptyDirVolumeSource {
+            size_limit: Some(Quantity("10Gi".into())),
+            ..Default::default()
+        }));
+        let vols = build_pod_volumes(&spec);
+        assert_eq!(vols.len(), 1);
+        assert_eq!(vols[0].name, "ephemeral");
+        assert!(vols[0].empty_dir.is_some());
+        assert_eq!(
+            vols[0].empty_dir.as_ref().unwrap().size_limit,
+            Some(Quantity("10Gi".into()))
+        );
+        assert!(
+            build_env(&spec, "test", "test-headless", "test-ns")
+                .into_iter()
+                .find(|e| e.name == "DIOM_EPHEMERAL_DB_PATH")
+                .is_some()
+        );
+
+        let templates = build_volume_claim_templates(&spec);
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].metadata.name.as_deref(), Some("persistent"));
+
+        let mounts = build_volume_mounts(&spec);
+        assert!(mounts.iter().any(|m| m.mount_path == EPHEMERAL_DATA_PATH));
+
+        assert!(
+            build_env(&spec, "test", "test-headless", "test-ns")
+                .into_iter()
+                .find(|e| e.name == "DIOM_EPHEMERAL_DB_PATH")
+                .is_some()
+        );
+
+        // hostPath
+        spec.diom.storage.ephemeral = Some(EphemeralVolumeSpec::HostPath(HostPathSpec {
+            path: "/mnt/nvme".into(),
+            path_type: None,
+        }));
+        let vols = build_pod_volumes(&spec);
+        assert_eq!(vols.len(), 1);
+        assert_eq!(vols[0].name, "ephemeral");
+        assert_eq!(vols[0].host_path.as_ref().unwrap().path, "/mnt/nvme");
+
+        let templates = build_volume_claim_templates(&spec);
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].metadata.name.as_deref(), Some("persistent"));
+
+        let mounts = build_volume_mounts(&spec);
+        assert!(mounts.iter().any(|m| m.mount_path == EPHEMERAL_DATA_PATH));
+
+        assert!(
+            build_env(&spec, "test", "test-headless", "test-ns")
+                .into_iter()
+                .find(|e| e.name == "DIOM_EPHEMERAL_DB_PATH")
+                .is_some()
+        );
+
+        // genericEphemeral
+        spec.diom.storage.ephemeral = Some(EphemeralVolumeSpec::GenericEphemeral(VolumeSpec {
+            size: Quantity("10Gi".into()),
+            storage_class: Some("local-nvme".into()),
+        }));
+        let vols = build_pod_volumes(&spec);
+        assert_eq!(vols.len(), 1);
+        assert_eq!(vols[0].name, "ephemeral");
+        assert!(vols[0].ephemeral.is_some());
+
+        let templates = build_volume_claim_templates(&spec);
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].metadata.name.as_deref(), Some("persistent"));
+
+        let mounts = build_volume_mounts(&spec);
+        assert!(mounts.iter().any(|m| m.mount_path == EPHEMERAL_DATA_PATH));
+
+        assert!(
+            build_env(&spec, "test", "test-headless", "test-ns")
+                .into_iter()
+                .find(|e| e.name == "DIOM_EPHEMERAL_DB_PATH")
+                .is_some()
+        );
+
+        // pvc
+        spec.diom.storage.ephemeral = Some(EphemeralVolumeSpec::Pvc(VolumeSpec {
+            size: Quantity("10Gi".into()),
+            storage_class: None,
+        }));
+        assert!(build_pod_volumes(&spec).is_empty());
+
+        let templates = build_volume_claim_templates(&spec);
+        assert_eq!(templates.len(), 2);
+        assert!(
+            templates
+                .iter()
+                .any(|t| t.metadata.name.as_deref() == Some("ephemeral"))
+        );
+
+        let mounts = build_volume_mounts(&spec);
+        assert!(mounts.iter().any(|m| m.mount_path == EPHEMERAL_DATA_PATH));
+
+        assert!(
+            build_env(&spec, "test", "test-headless", "test-ns")
+                .into_iter()
+                .find(|e| e.name == "DIOM_EPHEMERAL_DB_PATH")
+                .is_some()
+        );
     }
 }


### PR DESCRIPTION
Add support for configuring ephemeral storage. There are a variety
of ways to configure ephemeral volumes. I've tried to accommodate
all of them here.

Note: We could potentially name `EphemeralVolumeSpec` something
more generic and also use it for persistent storage configuration, but
that would potentially confuse the distinction between the two storage
variants, so for now persistent storage continues to only support 
persistent volume claims.

Fixes #1111 