### PR TITLE
some more miscellaneous snapshot fixes

### DIFF
--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -162,7 +162,7 @@ name = "diom"
 # your data is large, then setting this value too small can mean that a snapshot can never
 # catch up because it'll take too long to replicate. Typically this should be around twice the
 # number of commits that you generate in the time it takes to replicate a full snapshot.
-replication_lag_threshold = 50000
+replication_lag_threshold = 100000
 
 # Timeout for replication requests.
 #

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -101,7 +101,7 @@ pub(super) const fn cluster_send_snapshot_timeout() -> NonZeroDurationMs {
 }
 
 pub(super) fn cluster_replication_lag_threshold() -> u64 {
-    50_000
+    100_000
 }
 
 pub(super) const fn background_cleanup_interval() -> NonZeroDurationMs {

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -289,6 +289,10 @@ async fn trigger_snapshot(
         tracing::warn!("refusing to snapshot a learner");
         return Ok(false);
     }
+    if handle.state_machine.is_loading_snapshot() {
+        tracing::warn!("refusing to snapshot while loading another snapshot");
+        return Ok(false);
+    }
 
     tracing::debug!("triggering background snapshot");
     if let Err(err) = handle.raft.trigger().snapshot().await {

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -502,6 +502,10 @@ impl Store {
                 tracing::trace!(filename = ?dent.file_name(), "preserving last_snapshot");
                 continue;
             }
+            if !dent.file_name().as_encoded_bytes().starts_with(b"diom-") {
+                tracing::trace!(filename = ?dent.file_name(), "ignoring non-snapshot file");
+                continue;
+            }
             tracing::debug!(filename = ?dent.file_name(), "deleting unused snapshot");
             tokio::fs::remove_file(dent.path()).await?;
         }


### PR DESCRIPTION
changes:

 - increases `cluster_replication_lag_threshold` default value a bit
 - refuses to do a background snapshot if we're in the process of loading someone else's snapshot
 - skips temporary files when cleaning up the snapshot dir

the last one is the kicker, I found a case where one of the nodes deleted an in-progress snapshot file (name starting with `.tmp`) and broke itself