### PR TITLE
cluster: do not block as much for snapshots

### DIFF
--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -119,7 +119,7 @@ impl<'a, B: Write + Seek> KeyspaceSerializer<'a, B> {
             storage_type = ?self.storage_type,
             keyspace_name = self.keyspace_name,
             path = %keyspace.path().display(),
-            len = keyspace.len()?,
+            approximate_len = keyspace.approximate_len(),
             "serializing keyspace"
         );
         for guard in snapshot.iter(keyspace) {

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -212,6 +212,8 @@ static LAST_SNAPSHOT: FjallFixedKey<LastSnapshot> = FjallFixedKey::new("last_sna
 static LAST_MEMBERSHIP: FjallFixedKey<StoredMembership> = FjallFixedKey::new("last_membership");
 static CLUSTER_UUID: FjallFixedKey<ClusterId> = FjallFixedKey::new("cluster_uuid");
 
+type SnapshotTarget = (StorageType, Database, fjall::Snapshot, Vec<String>);
+
 impl Store {
     pub async fn new(
         persistent_db: Database,
@@ -639,10 +641,6 @@ impl Store {
         })
     }
 
-    fn prep_snapshot_builder_(&mut self) {
-        self.snapshot_idx += 1;
-    }
-
     #[tracing::instrument(skip_all)]
     async fn get_current_snapshot_(&mut self) -> anyhow::Result<Option<Snapshot>> {
         // clone to avoid holding a lock over an await point
@@ -664,6 +662,60 @@ impl Store {
             tracing::trace!("found no last_snapshot");
             Ok(None)
         }
+    }
+
+    async fn snapshot_phase_1(&mut self) -> anyhow::Result<(SnapshotMeta, Vec<SnapshotTarget>)> {
+        self.snapshot_idx += 1;
+        let last_log_id = self.last_applied_log_id;
+        let last_membership = self.last_membership.clone();
+
+        let snapshot_id = if let Some(last) = last_log_id {
+            format!("{}-{}-{}", last.leader_id, last.index, self.snapshot_idx)
+        } else {
+            format!("x-x-{}", self.snapshot_idx)
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id,
+            last_membership,
+            snapshot_id,
+        };
+
+        let handle = self.stores.clone();
+
+        fn list_keyspaces(db: &Database) -> Vec<String> {
+            db.list_keyspace_names()
+                .into_iter()
+                .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
+                .map(|s| s.to_string())
+                .collect()
+        }
+
+        let targets = spawn_blocking_in_current_span(move || {
+            // this is the only time we lock the underlying databases,
+            // and it should just be for the duration of a fjall snapshot
+            let store = handle.write();
+            let dbs = &store.databases;
+
+            vec![
+                (
+                    StorageType::Persistent,
+                    dbs.persistent.clone(),
+                    dbs.persistent.snapshot(),
+                    list_keyspaces(&dbs.persistent),
+                ),
+                (
+                    StorageType::Ephemeral,
+                    dbs.ephemeral.clone(),
+                    dbs.ephemeral.snapshot(),
+                    list_keyspaces(&dbs.ephemeral),
+                ),
+            ]
+        })
+        .await
+        .context("failed to generate snapshot targets")?;
+
+        Ok((meta, targets))
     }
 }
 
@@ -808,7 +860,6 @@ pub struct StoreSnapshotHandle {
     // a handle to the actual StoreHandle
     inner: Arc<TokioRwLock<Store>>,
     // keep our own references to these (cheaply-copyable) items
-    stores: Arc<RwLock<Stores>>,
     metrics: DbMetrics,
     snapshot_directory: PathBuf,
 }
@@ -821,59 +872,13 @@ impl RaftSnapshotBuilder<TypeConfig> for StoreSnapshotHandle {
 
 impl StoreSnapshotHandle {
     async fn build_snapshot_(&mut self) -> anyhow::Result<Snapshot> {
-        // lock the underlying store while we pull out some fields atomically
-        let guard = self.inner.write().await;
-        let last_log_id = guard.last_applied_log_id;
-        let last_membership = guard.last_membership.clone();
-
-        let snapshot_id = if let Some(last) = last_log_id {
-            format!("{}-{}-{}", last.leader_id, last.index, guard.snapshot_idx)
-        } else {
-            format!("x-x-{}", guard.snapshot_idx)
-        };
-
-        let meta = SnapshotMeta {
-            last_log_id,
-            last_membership,
-            snapshot_id,
-        };
-
         let start = std::time::Instant::now();
 
-        let handle = self.stores.clone();
-
-        fn list_keyspaces(db: &Database) -> Vec<String> {
-            db.list_keyspace_names()
-                .into_iter()
-                .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
-                .map(|s| s.to_string())
-                .collect()
-        }
-
-        let targets = spawn_blocking_in_current_span(move || {
-            let store = handle.write();
-            let dbs = &store.databases;
-
-            vec![
-                (
-                    StorageType::Persistent,
-                    dbs.persistent.clone(),
-                    dbs.persistent.snapshot(),
-                    list_keyspaces(&dbs.persistent),
-                ),
-                (
-                    StorageType::Ephemeral,
-                    dbs.ephemeral.clone(),
-                    dbs.ephemeral.snapshot(),
-                    list_keyspaces(&dbs.ephemeral),
-                ),
-            ]
-        })
-        .await
-        .context("failed to generate snapshot targets")?;
-
-        // release the lock while we actually serialize the keyspace
-        drop(guard);
+        // lock the underlying store while we pull out some fields atomically
+        let (meta, targets) = {
+            let mut guard = self.inner.write().await;
+            guard.snapshot_phase_1().await
+        }?;
 
         let snapshot = StoredSnapshot::new(&meta, &self.snapshot_directory, targets)
             .await
@@ -881,10 +886,10 @@ impl StoreSnapshotHandle {
 
         let path = snapshot.path.clone();
 
-        let size =
-            spawn_blocking_in_current_span(move || std::fs::metadata(&path).map(|m| m.len()))
-                .await?
-                .context("getting size of snapshot")?;
+        let size = tokio::fs::metadata(&path)
+            .await
+            .map(|m| m.len())
+            .context("getting size of snapshot")?;
 
         let runtime = start.elapsed();
         let path = snapshot.path.clone();
@@ -893,7 +898,7 @@ impl StoreSnapshotHandle {
             ?path,
             last_log_id = ?meta.last_log_id(),
             size,
-            runtime = ?runtime,
+            ?runtime,
             "finished generating a snapshot");
 
         self.metrics.record_snapshot(size, runtime);
@@ -942,16 +947,13 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
         // briefly lock
-        let mut guard = self.inner.write().await;
-        guard.prep_snapshot_builder_();
-        let stores = Arc::clone(&guard.stores);
-        let metrics = guard.metrics.clone();
-        let snapshot_directory = guard.snapshot_directory.clone();
-        drop(guard);
+        let (metrics, snapshot_directory) = {
+            let guard = self.inner.read().await;
+            (guard.metrics.clone(), guard.snapshot_directory.clone())
+        };
 
         StoreSnapshotHandle {
             inner: self.inner.clone(),
-            stores,
             metrics,
             snapshot_directory,
         }

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -888,8 +888,8 @@ impl StoreSnapshotHandle {
 
         let size = tokio::fs::metadata(&path)
             .await
-            .map(|m| m.len())
-            .context("getting size of snapshot")?;
+            .context("getting size of snapshot")?
+            .len();
 
         let runtime = start.elapsed();
         let path = snapshot.path.clone();

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -665,72 +665,6 @@ impl Store {
             Ok(None)
         }
     }
-
-    async fn build_snapshot_(&self) -> anyhow::Result<Snapshot> {
-        let last_log_id = self.last_applied_log_id;
-        let last_membership = self.last_membership.clone();
-
-        let snapshot_id = if let Some(last) = last_log_id {
-            format!("{}-{}-{}", last.leader_id, last.index, self.snapshot_idx)
-        } else {
-            format!("x-x-{}", self.snapshot_idx)
-        };
-
-        let meta = SnapshotMeta {
-            last_log_id,
-            last_membership,
-            snapshot_id,
-        };
-
-        let start = std::time::Instant::now();
-
-        let handle = self.stores.clone();
-
-        fn list_keyspaces(db: &Database) -> Vec<String> {
-            db.list_keyspace_names()
-                .into_iter()
-                .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
-                .map(|s| s.to_string())
-                .collect()
-        }
-
-        let targets = spawn_blocking_in_current_span(move || {
-            let store = handle.write();
-            let dbs = &store.databases;
-
-            vec![
-                (
-                    StorageType::Persistent,
-                    dbs.persistent.clone(),
-                    dbs.persistent.snapshot(),
-                    list_keyspaces(&dbs.persistent),
-                ),
-                (
-                    StorageType::Ephemeral,
-                    dbs.ephemeral.clone(),
-                    dbs.ephemeral.snapshot(),
-                    list_keyspaces(&dbs.ephemeral),
-                ),
-            ]
-        })
-        .await
-        .context("failed to generate snapshot targets")?;
-
-        let snapshot = StoredSnapshot::new(&meta, &self.snapshot_directory, targets)
-            .await
-            .context("failed to build snapshot")?;
-
-        let path = snapshot.path.clone();
-
-        let size =
-            spawn_blocking_in_current_span(move || std::fs::metadata(&path).map(|m| m.len()))
-                .await?
-                .context("getting size of snapshot")?;
-
-        self.metrics.record_snapshot(size, start.elapsed());
-
-        Ok(Snapshot { meta, snapshot })
-    }
 }
 
 // Wrapper around a snapshot that has been written to disk and has both a filename
@@ -871,28 +805,109 @@ impl StoredSnapshot {
 }
 
 pub struct StoreSnapshotHandle {
+    // a handle to the actual StoreHandle
     inner: Arc<TokioRwLock<Store>>,
+    // keep our own references to these (cheaply-copyable) items
+    stores: Arc<RwLock<Stores>>,
+    metrics: DbMetrics,
+    snapshot_directory: PathBuf,
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for StoreSnapshotHandle {
     async fn build_snapshot(&mut self) -> StorageResult<Snapshot> {
-        // build the snapshot with a read lock so we don't block writes
-        let snapshot = self
-            .inner
-            .read()
+        self.build_snapshot_().await.map_err(io_err)
+    }
+}
+
+impl StoreSnapshotHandle {
+    async fn build_snapshot_(&mut self) -> anyhow::Result<Snapshot> {
+        // lock the underlying store while we pull out some fields atomically
+        let guard = self.inner.write().await;
+        let last_log_id = guard.last_applied_log_id;
+        let last_membership = guard.last_membership.clone();
+
+        let snapshot_id = if let Some(last) = last_log_id {
+            format!("{}-{}-{}", last.leader_id, last.index, guard.snapshot_idx)
+        } else {
+            format!("x-x-{}", guard.snapshot_idx)
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id,
+            last_membership,
+            snapshot_id,
+        };
+
+        let start = std::time::Instant::now();
+
+        let handle = self.stores.clone();
+
+        fn list_keyspaces(db: &Database) -> Vec<String> {
+            db.list_keyspace_names()
+                .into_iter()
+                .filter(|s| s.as_bytes() != METADATA_KEYSPACE.as_bytes())
+                .map(|s| s.to_string())
+                .collect()
+        }
+
+        let targets = spawn_blocking_in_current_span(move || {
+            let store = handle.write();
+            let dbs = &store.databases;
+
+            vec![
+                (
+                    StorageType::Persistent,
+                    dbs.persistent.clone(),
+                    dbs.persistent.snapshot(),
+                    list_keyspaces(&dbs.persistent),
+                ),
+                (
+                    StorageType::Ephemeral,
+                    dbs.ephemeral.clone(),
+                    dbs.ephemeral.snapshot(),
+                    list_keyspaces(&dbs.ephemeral),
+                ),
+            ]
+        })
+        .await
+        .context("failed to generate snapshot targets")?;
+
+        // release the lock while we actually serialize the keyspace
+        drop(guard);
+
+        let snapshot = StoredSnapshot::new(&meta, &self.snapshot_directory, targets)
             .await
-            .build_snapshot_()
-            .await
-            .map_err(io_err)?;
-        // but set the last_snapshot_ field with a write lock to serialize
+            .context("failed to build snapshot")?;
+
+        let path = snapshot.path.clone();
+
+        let size =
+            spawn_blocking_in_current_span(move || std::fs::metadata(&path).map(|m| m.len()))
+                .await?
+                .context("getting size of snapshot")?;
+
+        let runtime = start.elapsed();
+        let path = snapshot.path.clone();
+
+        tracing::debug!(
+            ?path,
+            last_log_id = ?meta.last_log_id(),
+            size,
+            runtime = ?runtime,
+            "finished generating a snapshot");
+
+        self.metrics.record_snapshot(size, runtime);
+
+        // set the last_snapshot_ field with a write lock to serialize
         self.inner
             .write()
             .await
-            .set_last_snapshot_(snapshot.meta.clone(), snapshot.snapshot.path.clone())
+            .set_last_snapshot_(meta.clone(), path)
             .await
             .context("failed to set last snapshot")
             .map_err(io_err)?;
-        Ok(snapshot)
+
+        Ok(Snapshot { meta, snapshot })
     }
 }
 
@@ -926,9 +941,19 @@ impl RaftStateMachine<TypeConfig> for StoreHandle {
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
-        self.inner.write().await.prep_snapshot_builder_();
+        // briefly lock
+        let mut guard = self.inner.write().await;
+        guard.prep_snapshot_builder_();
+        let stores = Arc::clone(&guard.stores);
+        let metrics = guard.metrics.clone();
+        let snapshot_directory = guard.snapshot_directory.clone();
+        drop(guard);
+
         StoreSnapshotHandle {
             inner: self.inner.clone(),
+            stores,
+            metrics,
+            snapshot_directory,
         }
     }
 


### PR DESCRIPTION
The previous way I was doing snapshots ended up holding a read lock on the RwLock for the duration of the snapshot; this is dumb, because `apply_` requires a write lock, so we block apply for way too long.

The locks are now much more explicit in the code and the handle's rwlock shouldn't ever be held during the slow part of snapshot-building now.