### PR TITLE
Add Rust SDK code samples to OpenAPI spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,7 @@ dependencies = [
  "diom-backend",
  "fs-err",
  "futures-lite",
+ "indexmap",
  "openapi-codegen",
  "schemars",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,7 +3654,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "openapi-codegen"
 version = "0.1.0"
-source = "git+https://github.com/svix/openapi-codegen?rev=9b5730943bbcedcce49347c9225a6cf840637e14#9b5730943bbcedcce49347c9225a6cf840637e14"
+source = "git+https://github.com/svix/openapi-codegen?rev=fecc6dc607c19cb9247f35849288725514cb4675#fecc6dc607c19cb9247f35849288725514cb4675"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ kube_quantity = "0.9.0"
 maplit = "1"
 mimalloc = { version = "0.1.48", features = ["v3"] }
 mime = "0.3"
-openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "9b5730943bbcedcce49347c9225a6cf840637e14" }
+openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "fecc6dc607c19cb9247f35849288725514cb4675" }
 openraft = { version = "=0.10.0-alpha.19", default-features = false, features = ["tracing-log", "anyhow", "serde", "tokio-rt"] }
 opentelemetry = { version = "0.31.0", features = ["metrics"] }
 opentelemetry-http = "0.31.0"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -30,6 +30,7 @@ async-process = { version = "2.5.0", features = ["tracing"] }
 diom-backend.workspace = true
 fs-err.workspace = true
 futures-lite = { version = "2.6.1", default-features = false }
+indexmap.workspace = true
 openapi-codegen.workspace = true
 # this feature enablement is required so declared field order
 # for structs used in the API is preserved into openapi.json

--- a/codegen/src/code_samples.rs
+++ b/codegen/src/code_samples.rs
@@ -1,0 +1,82 @@
+use std::{collections::BTreeSet, path::Path};
+
+use anyhow::Context as _;
+use fs_err as fs;
+use openapi_codegen::{CodegenLanguage, CodesampleTemplates, aide::openapi, generate_codesamples};
+
+pub(crate) fn add_to_spec(openapi: &mut openapi::OpenApi) -> anyhow::Result<()> {
+    let templates = load_templates()?;
+    let code_samples = async_io::block_on(generate_codesamples(
+        &*openapi,
+        templates,
+        BTreeSet::new(),
+        core::convert::identity,
+    ))
+    .context("generating code samples")?;
+
+    for operation in openapi
+        .paths
+        .as_mut()
+        .iter_mut()
+        .flat_map(|p| p.paths.values_mut())
+        .filter_map(|r| r.as_item_mut())
+        .flat_map(path_item_operations_mut)
+    {
+        let operation_id = operation
+            .operation_id
+            .as_ref()
+            .context("all operations must have an ID")?;
+
+        let Some(samples) = code_samples.get(operation_id) else {
+            continue;
+        };
+        let indexmap::map::Entry::Vacant(v) =
+            operation.extensions.entry("x-codeSamples".to_owned())
+        else {
+            tracing::warn!(
+                operation_id,
+                "original spec already contains code samples for this operation"
+            );
+            continue;
+        };
+
+        v.insert(serde_json::to_value(samples).unwrap());
+    }
+
+    Ok(())
+}
+
+fn load_templates() -> anyhow::Result<CodesampleTemplates> {
+    const TEMPLATES: &[(&str, &str, CodegenLanguage)] = &[("rust", "Rust", CodegenLanguage::Rust)];
+
+    let mut result = CodesampleTemplates::default();
+    for &(dir, label, lang) in TEMPLATES {
+        let filename = format!("api_call_sample.{}.jinja", lang.ext());
+        let source = fs::read_to_string(
+            Path::new("codegen")
+                .join("templates")
+                .join(dir)
+                .join(filename),
+        )?;
+        result.add_template(lang, label, source);
+    }
+
+    Ok(result)
+}
+
+fn path_item_operations_mut(
+    inner: &mut openapi::PathItem,
+) -> impl Iterator<Item = &mut openapi::Operation> {
+    [
+        &mut inner.get,
+        &mut inner.put,
+        &mut inner.post,
+        &mut inner.delete,
+        &mut inner.options,
+        &mut inner.head,
+        &mut inner.patch,
+        &mut inner.trace,
+    ]
+    .into_iter()
+    .flatten()
+}

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::Context as _;
 use openapi_codegen::{IncludeMode, api::Api};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
+mod code_samples;
 mod go;
 mod java;
 mod javascript;
@@ -34,6 +35,7 @@ fn main() -> anyhow::Result<ExitCode> {
         .finish_api_with(&mut openapi, diom_backend::openapi::add_security_scheme);
 
     diom_backend::openapi::postprocess_spec(&mut openapi);
+    code_samples::add_to_spec(&mut openapi)?;
 
     let openapi_json = serde_json::to_string_pretty(&openapi)? + "\n";
 

--- a/codegen/templates/rust/api_call_sample.rs.jinja
+++ b/codegen/templates/rust/api_call_sample.rs.jinja
@@ -1,0 +1,126 @@
+{% macro ident(name) -%}
+    {%- if name in ["ref", "type"] %}r#{% endif -%}
+    {{ name }}
+{%- endmacro -%}
+
+{% macro field_name(field, as_ident=true) -%}
+    {%- set field_name = field.name | to_snake_case -%}
+    {%- if field.type.is_duration_ms() %}
+        {%- if field_name is not endingwith "_ms" %}{% do panic("duration field must have _ms suffix") %}{% endif %}
+        {%- set field_name = field_name | strip_trailing_str("_ms") -%}
+    {%- endif -%}
+    {%- if as_ident -%}
+        {{ ident(field_name) }}
+    {%- else -%}
+        {{ field_name }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{% macro field_type(field) -%}
+    {% set field_ty = field.type.to_rust() -%}
+    {% if field.type.is_unix_timestamp_ms() -%}
+        {% set field_ty = "jiff::Timestamp" -%}
+    {% elif field.name is endingwith "_ms" -%}
+        {% set field_ty = "std::time::Duration" -%}
+    {% endif -%}
+    {% if not field.required or field.nullable -%}
+        {% set field_ty %}Option<{{ field_ty }}>{% endset -%}
+    {% endif -%}
+    {{ field_ty }}
+{%- endmacro -%}
+
+{% macro ident(name) -%}
+    {%- if name in ["ref", "type"] %}r#{% endif -%}
+    {{ name }}
+{%- endmacro -%}
+
+{% macro render_example_resource(resource) -%}
+{{ resource.name | to_upper_camel_case }}
+{%- if resource.kind == "string_enum" -%}
+    ::{{ resource.values[0] | to_upper_camel_case }}
+{%- elif resource.kind == "integer_enum" -%}
+    ::{{ resource.variants[0][0] | to_upper_camel_case }}
+{%- else -%}
+    {% set non_positional_fields = resource.fields | selectattr("positional", "false") -%}
+    ::new(
+    {%- set ctor_fields = non_positional_fields | selectattr("required") %}
+    {%- if ctor_fields | length > 1 %}
+    {%- for field in ctor_fields %}
+        {{ field_example(field) }},
+    {%- endfor %}
+    {% elif ctor_fields | length == 1 -%}
+        {{ field_example(ctor_fields[0]) }}
+    {%- endif -%}
+    )
+    {%- for field in non_positional_fields | selectattr("required", "false") %}
+        .with_{{ field_name(field, as_ident=false) }}({{ field_example(field) }})
+    {%- endfor -%}
+{% endif -%}
+{% endmacro -%}
+
+{% macro field_example(field) -%}
+    {%- if field.type.is_string() or field.type.is_uri() -%}
+        "sample string".to_owned()
+    {%- elif field.type.is_unix_timestamp_ms() -%}
+        "2026-04-20 12:00:00".parse()?
+    {%- elif field.type.is_duration_ms() -%}
+        Duration::from_secs(30)
+    {%- elif field.type.is_map() -%}
+        {%- if field.example is defined -%}
+            HashMap::from([
+            {%- for key, val in field.example | items -%}
+                (
+                    "{{ key }}".to_string(),
+                    "{{ val }}".to_string()
+                ){% if not loop.last %},{% endif -%}
+            {%- endfor -%}
+            ])
+        {%- else -%}
+        HashMap::new()
+        {%- endif -%}
+    {%- elif field.type.is_json_object() -%}
+        {%- if field.example is defined -%}
+            serde_json::json!({{ field.example }})
+        {%- else -%}
+            serde_json::json!({})
+        {%- endif -%}
+    {%- elif field.type.is_int_or_uint() -%}
+        {%- if field.example is defined -%}
+            {{ field.example | fix_serde_number_repr }}
+        {%- else -%}
+            1
+        {%- endif -%}
+    {%- elif field.type.is_schema_ref() -%}
+        {{ render_example_resource(field.type.inner_schema_ref_ty()) | indent(4) }}
+    {%- elif field.type.is_set() or field.type.is_list() -%}
+        vec![]
+    {%- elif field.type.is_bool() -%}
+        true
+    {%- else -%}
+        /* missing example def for field */
+    {%- endif -%}
+{% endmacro -%}
+
+{# build the resource path (for example: ingest.source) -#}
+{% set resource_path -%}
+    {% for resource_name in resource_parents -%}
+        .{{ resource_name | to_snake_case }}()
+    {% endfor -%}
+{% endset -%}
+
+{# output starts here -#}
+{% if operation.response_body_schema_name is defined %}let response = {% endif -%}
+diom{{ resource_path }}.{{ operation.name | to_snake_case }}
+{%- if operation.request_body_schema_name is defined -%}
+    (
+    {#- positional body parameters #}
+    {%- set body_schema = api.types[operation.request_body_schema_name] %}
+    {%- set positional_fields = body_schema.fields | selectattr("positional") %}
+    {%- for field in positional_fields %}
+        {{ field_example(field) }},
+    {%- endfor %}
+        {{ render_example_resource(req_body_ty) | indent(4) }},
+    )
+{%- else %}()
+{%- endif %}
+    .await?;

--- a/openapi.json
+++ b/openapi.json
@@ -74,6 +74,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cluster_admin()\n    .status()\n    .await?;"
+          }
         ]
       }
     },
@@ -150,6 +157,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cluster_admin()\n    .initialize(\n        ClusterInitializeIn::new(),\n    )\n    .await?;"
           }
         ]
       }
@@ -228,6 +242,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cluster_admin()\n    .remove_node(\n        ClusterRemoveNodeIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -304,6 +325,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cluster_admin()\n    .force_snapshot(\n        ClusterForceSnapshotIn::new(),\n    )\n    .await?;"
           }
         ]
       }
@@ -382,6 +410,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cluster_admin()\n    .force_election(\n        ClusterForceElectionIn::new(),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -458,6 +493,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_token()\n    .create(\n        AdminAuthTokenCreateIn::new(\n            \"sample string\".to_owned(),\n            \"sample string\".to_owned(),\n        )\n            .with_expiry(Duration::from_secs(30))\n            .with_enabled(true),\n    )\n    .await?;"
           }
         ]
       }
@@ -536,6 +578,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_token()\n    .expire(\n        AdminAuthTokenExpireIn::new(\"sample string\".to_owned())\n            .with_expiry(Duration::from_secs(30)),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -612,6 +661,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_token()\n    .rotate(\n        AdminAuthTokenRotateIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -690,6 +746,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_token()\n    .delete(\n        AdminAuthTokenDeleteIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -766,6 +829,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_token()\n    .list(\n        AdminAuthTokenListIn::new()\n            .with_limit(1)\n            .with_iterator(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -844,6 +914,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_token()\n    .update(\n        AdminAuthTokenUpdateIn::new(\"sample string\".to_owned())\n            .with_name(\"sample string\".to_owned())\n            .with_expiry(Duration::from_secs(30))\n            .with_enabled(true),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -920,6 +997,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_token()\n    .whoami(\n        AdminAuthTokenWhoamiIn::new(),\n    )\n    .await?;"
           }
         ]
       }
@@ -998,6 +1082,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_role()\n    .configure(\n        AdminRoleConfigureIn::new(\n            \"sample string\".to_owned(),\n            \"sample string\".to_owned(),\n        )\n            .with_rules(vec![])\n            .with_policies(vec![])\n            .with_context(HashMap::new()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -1074,6 +1165,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_role()\n    .delete(\n        AdminRoleDeleteIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1152,6 +1250,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_role()\n    .get(\n        AdminRoleGetIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -1228,6 +1333,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_role()\n    .list(\n        AdminRoleListIn::new()\n            .with_limit(1)\n            .with_iterator(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1306,6 +1418,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_policy()\n    .configure(\n        AdminAccessPolicyConfigureIn::new(\n            \"sample string\".to_owned(),\n            \"sample string\".to_owned(),\n        )\n            .with_rules(vec![]),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -1382,6 +1501,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_policy()\n    .delete(\n        AdminAccessPolicyDeleteIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1460,6 +1586,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_policy()\n    .get(\n        AdminAccessPolicyGetIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -1536,6 +1669,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.admin()\n    .auth_policy()\n    .list(\n        AdminAccessPolicyListIn::new()\n            .with_limit(1)\n            .with_iterator(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -2316,6 +2456,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cache()\n    .set(\n        \"sample string\".to_owned(),\n        vec![],\n        CacheSetIn::new(Duration::from_secs(30))\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -2392,6 +2539,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cache()\n    .get(\n        \"sample string\".to_owned(),\n        CacheGetIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_consistency(Consistency::Strong),\n    )\n    .await?;"
           }
         ]
       }
@@ -2470,6 +2624,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cache()\n    .namespace()\n    .configure(\n        CacheConfigureNamespaceIn::new(\"sample string\".to_owned())\n            .with_eviction_policy(EvictionPolicy::NoEviction),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -2546,6 +2707,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cache()\n    .namespace()\n    .get(\n        CacheGetNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -2624,6 +2792,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.cache()\n    .delete(\n        \"sample string\".to_owned(),\n        CacheDeleteIn::new()\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -2700,6 +2875,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.kv()\n    .set(\n        \"sample string\".to_owned(),\n        vec![],\n        KvSetIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_ttl(Duration::from_secs(30))\n            .with_behavior(OperationBehavior::Upsert)\n            .with_version(1),\n    )\n    .await?;"
           }
         ]
       }
@@ -2778,6 +2960,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.kv()\n    .get(\n        \"sample string\".to_owned(),\n        KvGetIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_consistency(Consistency::Strong),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -2854,6 +3043,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.kv()\n    .namespace()\n    .configure(\n        KvConfigureNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -2932,6 +3128,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.kv()\n    .namespace()\n    .get(\n        KvGetNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -3008,6 +3211,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.kv()\n    .delete(\n        \"sample string\".to_owned(),\n        KvDeleteIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_version(1),\n    )\n    .await?;"
           }
         ]
       }
@@ -3086,6 +3296,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.rate_limit()\n    .limit(\n        RateLimitCheckIn::new(\n            \"sample string\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"sample string\".to_owned())\n            .with_tokens(1),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -3162,6 +3379,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.rate_limit()\n    .get_remaining(\n        RateLimitGetRemainingIn::new(\n            \"sample string\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3240,6 +3464,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.rate_limit()\n    .reset(\n        RateLimitResetIn::new(\n            \"sample string\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -3316,6 +3547,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.rate_limit()\n    .namespace()\n    .configure(\n        RateLimitConfigureNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3394,6 +3632,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.rate_limit()\n    .namespace()\n    .get(\n        RateLimitGetNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -3470,6 +3715,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.idempotency()\n    .start(\n        \"sample string\".to_owned(),\n        IdempotencyStartIn::new(Duration::from_secs(30))\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3548,6 +3800,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.idempotency()\n    .complete(\n        \"sample string\".to_owned(),\n        IdempotencyCompleteIn::new(\n            vec![],\n            Duration::from_secs(30),\n        )\n            .with_namespace(\"sample string\".to_owned())\n            .with_context(HashMap::new()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -3624,6 +3883,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.idempotency()\n    .abort(\n        \"sample string\".to_owned(),\n        IdempotencyAbortIn::new()\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3702,6 +3968,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.idempotency()\n    .namespace()\n    .configure(\n        IdempotencyConfigureNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -3778,6 +4051,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.idempotency()\n    .namespace()\n    .get(\n        IdempotencyGetNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3856,6 +4136,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .namespace()\n    .configure(\n        \"sample string\".to_owned(),\n        MsgNamespaceConfigureIn::new()\n            .with_retention(Retention::new()\n                .with_period(Duration::from_secs(30))),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -3932,6 +4219,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .namespace()\n    .get(\n        \"sample string\".to_owned(),\n        MsgNamespaceGetIn::new(),\n    )\n    .await?;"
           }
         ]
       }
@@ -4010,6 +4304,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .publish(\n        \"sample string\".to_owned(),\n        MsgPublishIn::new(vec![])\n            .with_namespace(\"sample string\".to_owned())\n            .with_idempotency_key(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -4086,6 +4387,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .stream()\n    .receive(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgStreamReceiveIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_batch_size(1)\n            .with_lease_duration(Duration::from_secs(30))\n            .with_default_starting_position(SeekPosition::Earliest)\n            .with_batch_wait(Duration::from_secs(30)),\n    )\n    .await?;"
           }
         ]
       }
@@ -4164,6 +4472,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .stream()\n    .commit(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgStreamCommitIn::new(1)\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -4240,6 +4555,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .stream()\n    .seek(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgStreamSeekIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_offset(1)\n            .with_position(SeekPosition::Earliest)\n            .with_timestamp(\"2026-04-20 12:00:00\".parse()?),\n    )\n    .await?;"
           }
         ]
       }
@@ -4318,6 +4640,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .stream()\n    .cancel_lease(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgStreamCancelLeaseIn::new()\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -4394,6 +4723,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .queue()\n    .receive(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueReceiveIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_batch_size(1)\n            .with_lease_duration(Duration::from_secs(30))\n            .with_batch_wait(Duration::from_secs(30)),\n    )\n    .await?;"
           }
         ]
       }
@@ -4472,6 +4808,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .queue()\n    .ack(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueAckIn::new(vec![])\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -4548,6 +4891,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .queue()\n    .extend_lease(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueExtendLeaseIn::new(vec![])\n            .with_namespace(\"sample string\".to_owned())\n            .with_lease_duration(Duration::from_secs(30)),\n    )\n    .await?;"
           }
         ]
       }
@@ -4626,6 +4976,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .queue()\n    .configure(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueConfigureIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_retry_schedule(vec![])\n            .with_dlq_topic(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -4702,6 +5059,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .queue()\n    .nack(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueNackIn::new(vec![])\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -4780,6 +5144,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .queue()\n    .redrive_dlq(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueRedriveDlqIn::new()\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -4857,6 +5228,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.msgs()\n    .topic()\n    .configure(\n        \"sample string\".to_owned(),\n        MsgTopicConfigureIn::new(1)\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+          }
         ]
       }
     },
@@ -4924,6 +5302,13 @@
           {
             "HTTPBearer": []
           }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.health()\n    .ping()\n    .await?;"
+          }
         ]
       }
     },
@@ -4983,6 +5368,13 @@
         "security": [
           {
             "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "diom.health()\n    .error()\n    .await?;"
           }
         ]
       }


### PR DESCRIPTION
Took a while due to weird hacks in openapi codegen that I had to understand / modify for diom first, but I'm pretty happy about the result (I also tried [`prettyplease`](https://docs.rs/prettyplease/) formatting like we do in webhooks, but it was actually worse).