### PR TITLE
cluster: more snapshot work

### DIFF
--- a/crates/diom-core/src/types/non_zero_duration_ms.rs
+++ b/crates/diom-core/src/types/non_zero_duration_ms.rs
@@ -99,13 +99,6 @@ impl fmt::Display for NonZeroDurationMsParseErr {
 }
 
 impl std::error::Error for NonZeroDurationMsParseErr {
-    fn description(&self) -> &str {
-        match self {
-            Self::Zero => "value was unexpectedly zero",
-            Self::ParseIntError(_) => "error parsing value as integer number of millis",
-        }
-    }
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Zero => None,

--- a/crates/diom-operations/src/lib.rs
+++ b/crates/diom-operations/src/lib.rs
@@ -31,10 +31,6 @@ impl std::fmt::Display for BackgroundError {
 }
 
 impl std::error::Error for BackgroundError {
-    fn description(&self) -> &str {
-        "Error while writing from background job"
-    }
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self {
             Self::Other(e) => Some(e),

--- a/crates/diom-proto/src/msgpack_client.rs
+++ b/crates/diom-proto/src/msgpack_client.rs
@@ -43,10 +43,6 @@ impl std::fmt::Display for MsgpackResponseError {
 }
 
 impl std::error::Error for MsgpackResponseError {
-    fn description(&self) -> &str {
-        "error reading msgpack body"
-    }
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Network(e) => Some(e),

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -42,15 +42,7 @@ impl fmt::Display for ResponseParseError {
     }
 }
 
-impl std::error::Error for ResponseParseError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        "Invalid response from consensus system"
-    }
-}
+impl std::error::Error for ResponseParseError {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PersistableValue)]
 pub enum Request {

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -261,11 +261,7 @@ impl std::fmt::Display for BackgroundFsyncFailedError {
     }
 }
 
-impl std::error::Error for BackgroundFsyncFailedError {
-    fn description(&self) -> &str {
-        "background fsync failed"
-    }
-}
+impl std::error::Error for BackgroundFsyncFailedError {}
 
 struct SimpleEstimator<const COUNT: usize> {
     samples: [Option<Duration>; COUNT],

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::{LogId, Node, NodeId, proto, raft::TypeConfig};
 use anyhow::Context;
 use diom_proto::prelude::*;
-use http::{HeaderMap, HeaderValue, header};
+use http::{HeaderMap, HeaderValue, StatusCode, header};
 use openraft::{
     RaftNetworkFactory, RaftNetworkV2,
     error::{NetworkError, Unreachable},
@@ -22,6 +22,31 @@ use tap::Pipe;
 
 type RPCError<E = openraft::errors::Infallible> = openraft::error::RPCError<TypeConfig, E>;
 type RPCResult<T, E = openraft::errors::Infallible> = Result<T, RPCError<E>>;
+
+#[derive(Debug, Clone)]
+pub(super) struct BadStatusError(StatusCode);
+
+impl From<StatusCode> for BadStatusError {
+    fn from(value: StatusCode) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for BadStatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BadStatusError({})", self.0)
+    }
+}
+
+impl std::error::Error for BadStatusError {
+    fn description(&self) -> &str {
+        "a network request returned an invalid status code"
+    }
+
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
 
 pub(super) fn build_client(
     cfg: &Configuration,
@@ -168,32 +193,50 @@ impl NetworkClient {
                 } else {
                     RPCError::Network(NetworkError::new(&err))
                 }
-            })?
-            .error_for_status()
-            .map_err(|e| {
-                tracing::warn!(status = ?e.status(), "error from responding server");
+            })?;
+
+        let status = response.status();
+
+        let body = match status {
+            s if s.is_success() => response.msgpack().await.map_err(|err| {
+                tracing::warn!(?err, ?status, "error deserializing response body");
+                self.metrics.record_request(
+                    self.target,
+                    ClusterRequestStatus::DeserializationError,
+                    start.elapsed(),
+                );
+                RPCError::Network(NetworkError::new(&err))
+            })?,
+            StatusCode::INTERNAL_SERVER_ERROR => {
+                let err_response = response.msgpack().await.map_err(|err| {
+                    tracing::warn!(?err, ?status, "error deserializing response body");
+                    self.metrics.record_request(
+                        self.target,
+                        ClusterRequestStatus::DeserializationError,
+                        start.elapsed(),
+                    );
+                    RPCError::Network(NetworkError::new(&err))
+                })?;
+                let error = openraft::error::RemoteError::new(self.target, err_response);
+                return Err(RPCError::RemoteError(error));
+            }
+            _ => {
+                tracing::warn!(?status, "error from responding server");
                 self.metrics.record_request(
                     self.target,
                     ClusterRequestStatus::OtherError,
                     start.elapsed(),
                 );
-                RPCError::Network(NetworkError::new(&e))
-            })?;
+                return Err(RPCError::Network(NetworkError::new(&BadStatusError::from(
+                    status,
+                ))));
+            }
+        };
 
         tracing::trace!(
-            status = ?response.status(),
+            ?status,
             duration = ?start.elapsed(),
             "response from peer server");
-
-        let body = response.msgpack().await.map_err(|err| {
-            tracing::warn!(?err, "error deserializing response status");
-            self.metrics.record_request(
-                self.target,
-                ClusterRequestStatus::DeserializationError,
-                start.elapsed(),
-            );
-            RPCError::Network(NetworkError::new(&err))
-        })?;
 
         self.metrics
             .record_request(self.target, ClusterRequestStatus::Success, start.elapsed());
@@ -259,6 +302,10 @@ impl NetworkClient {
     > {
         self.send_request_with_timeout("/repl/raft/stream-snapshot", rpc, option.soft_ttl())
             .await
+    }
+
+    pub(super) fn target(&self) -> NodeId {
+        self.target
     }
 }
 

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -38,15 +38,7 @@ impl std::fmt::Display for BadStatusError {
     }
 }
 
-impl std::error::Error for BadStatusError {
-    fn description(&self) -> &str {
-        "a network request returned an invalid status code"
-    }
-
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+impl std::error::Error for BadStatusError {}
 
 pub(super) fn build_client(
     cfg: &Configuration,
@@ -217,6 +209,11 @@ impl NetworkClient {
                     );
                     RPCError::Network(NetworkError::new(&err))
                 })?;
+                self.metrics.record_request(
+                    self.target,
+                    ClusterRequestStatus::OtherError,
+                    start.elapsed(),
+                );
                 let error = openraft::error::RemoteError::new(self.target, err_response);
                 return Err(RPCError::RemoteError(error));
             }

--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -554,8 +554,6 @@ impl Store {
         // clean up the snapshot directory
         self.set_last_snapshot_(meta.clone(), snapshot.path.clone())
             .await?;
-        self.delete_unused_snapshots(snapshot.path.as_path())
-            .await?;
         Ok(())
     }
 

--- a/src/core/cluster/streaming_snapshot.rs
+++ b/src/core/cluster/streaming_snapshot.rs
@@ -265,6 +265,12 @@ impl Sender {
             )
         };
 
+        tracing::info!(
+            target_node_id = %net.target(),
+            snapshot_id = snapshot.meta.snapshot_id,
+            "starting send of snapshot"
+        );
+
         let mut offset = 0;
         let end = snapshot
             .snapshot


### PR DESCRIPTION
The main thing here is that the network client for the install_snapshot RPC needs to actually parse out the error, because the snapshot installer is the only thing where the caller actually _reads_ the error body sent back by the RPC server. Specifically, if a node is restarted in the middle of loading a snapshot, it uses this to signal to the other peer node to restart snapshot transmission. If this message isn't parsed correctly, the other node ends up in an infinite loop trying to send the same end-of-file segment over and over again until you restart them all.

Our implementation (`rpc_response` in `app.rs`) only emits 500's when there's an underlying response; we do emit some other status codes (e.g., if we receive a request to a node that's shutting down or booting).

Other fixes:

 - Some more logging
 - Remove a duplicated call to `delete_unused_snapshots`

I'm going to make this work, dangit