### PR TITLE
Upgrade openapi-codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,21 +64,6 @@ dependencies = [
 
 [[package]]
 name = "aide"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2477554ebf38aea815a9c4729100cfc32f766876c45b9c9c38ef221b9d1a703"
-dependencies = [
- "cfg-if",
- "indexmap 2.14.0",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "aide"
 version = "0.16.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "390515b47251185fa076ac92a7a582d9d383b03e13cef0c801e7670cf928229b"
@@ -87,8 +72,8 @@ dependencies = [
  "bytes",
  "cfg-if",
  "http",
- "indexmap 2.14.0",
- "schemars 1.2.1",
+ "indexmap",
+ "schemars",
  "serde",
  "serde_json",
  "serde_qs",
@@ -902,7 +887,7 @@ dependencies = [
 name = "codegen"
 version = "0.2.3"
 dependencies = [
- "aide 0.16.0-alpha.4",
+ "aide",
  "anyhow",
  "async-io",
  "async-process",
@@ -910,7 +895,7 @@ dependencies = [
  "fs-err",
  "futures-lite",
  "openapi-codegen",
- "schemars 1.2.1",
+ "schemars",
  "serde_json",
  "tracing",
  "tracing-subscriber",
@@ -1522,7 +1507,7 @@ dependencies = [
  "diom-core",
  "diom-id",
  "itertools 0.14.0",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
 ]
@@ -1532,7 +1517,7 @@ name = "diom-backend"
 version = "0.2.3"
 dependencies = [
  "addr",
- "aide 0.16.0-alpha.4",
+ "aide",
  "anyerror",
  "anyhow",
  "axum",
@@ -1565,7 +1550,7 @@ dependencies = [
  "hex",
  "http",
  "idna_adapter",
- "indexmap 2.14.0",
+ "indexmap",
  "itertools 0.14.0",
  "jiff",
  "jsonwebtoken",
@@ -1580,7 +1565,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "rmpv",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1676,7 +1661,7 @@ dependencies = [
  "pastey",
  "rand 0.10.1",
  "regex",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1702,7 +1687,7 @@ dependencies = [
 name = "diom-error"
 version = "0.2.3"
 dependencies = [
- "aide 0.16.0-alpha.4",
+ "aide",
  "axum",
  "diom-proto",
  "fjall",
@@ -1722,7 +1707,7 @@ dependencies = [
  "jiff",
  "rand 0.10.1",
  "rmp-serde",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "uuid",
 ]
@@ -1757,7 +1742,7 @@ dependencies = [
  "fjall",
  "fjall-utils",
  "jiff",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "tempfile",
  "tokio",
@@ -1778,7 +1763,7 @@ dependencies = [
  "jiff",
  "opentelemetry",
  "rand 0.10.1",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "sha2 0.11.0",
  "tempfile",
@@ -1796,7 +1781,7 @@ dependencies = [
  "diom-id",
  "fjall",
  "fjall-utils",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "tokio",
  "tracing",
@@ -1830,7 +1815,7 @@ dependencies = [
  "kube",
  "kube_quantity",
  "rustls",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1846,7 +1831,7 @@ dependencies = [
 name = "diom-proto"
 version = "0.2.3"
 dependencies = [
- "aide 0.16.0-alpha.4",
+ "aide",
  "axum",
  "bytes",
  "diom-authorization",
@@ -1855,7 +1840,7 @@ dependencies = [
  "mime",
  "reqwest",
  "rmp-serde",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2164,7 +2149,7 @@ dependencies = [
  "itertools 0.14.0",
  "postcard",
  "rand 0.10.1",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_bytes",
  "tap",
@@ -2437,7 +2422,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2880,17 +2865,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -3183,7 +3157,7 @@ checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
 dependencies = [
  "base64 0.22.1",
  "jiff",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
 ]
@@ -3248,7 +3222,7 @@ dependencies = [
  "jiff",
  "json-patch",
  "k8s-openapi",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde-value",
  "serde_json",
@@ -3680,19 +3654,19 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "openapi-codegen"
 version = "0.1.0"
-source = "git+https://github.com/svix/openapi-codegen?rev=6035af003ed000b1d15debde0219f0b2d3e5e85f#6035af003ed000b1d15debde0219f0b2d3e5e85f"
+source = "git+https://github.com/svix/openapi-codegen?rev=9b5730943bbcedcce49347c9225a6cf840637e14#9b5730943bbcedcce49347c9225a6cf840637e14"
 dependencies = [
- "aide 0.14.2",
+ "aide",
  "anyhow",
  "camino",
  "clap",
  "fs-err",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "itertools 0.14.0",
  "minijinja",
  "ron",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -4826,14 +4800,15 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "base64 0.22.1",
  "bitflags 2.11.1",
+ "once_cell",
  "serde",
  "serde_derive",
+ "typeid",
  "unicode-ident",
 ]
 
@@ -4991,43 +4966,17 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
- "indexmap 2.14.0",
+ "indexmap",
  "ref-cast",
- "schemars_derive 1.2.1",
+ "schemars_derive",
  "serde",
  "serde_json",
  "uuid",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5165,7 +5114,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -5224,7 +5173,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -5764,7 +5713,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -5833,7 +5782,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6013,6 +5962,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -6320,7 +6275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6346,7 +6301,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -6811,7 +6766,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6842,7 +6797,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -6861,7 +6816,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -6943,7 +6898,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.2",
  "hmac",
- "indexmap 2.14.0",
+ "indexmap",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ kube_quantity = "0.9.0"
 maplit = "1"
 mimalloc = { version = "0.1.48", features = ["v3"] }
 mime = "0.3"
-openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "6035af003ed000b1d15debde0219f0b2d3e5e85f" }
+openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "9b5730943bbcedcce49347c9225a6cf840637e14" }
 openraft = { version = "=0.10.0-alpha.19", default-features = false, features = ["tracing-log", "anyhow", "serde", "tokio-rt"] }
 opentelemetry = { version = "0.31.0", features = ["metrics"] }
 opentelemetry-http = "0.31.0"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 edition = "2024"
 publish = false
 
+[package.metadata.cargo-machete]
+ignored = [
+    # need to configure its Cargo features (see comment below)
+    "schemars",
+]
+
 [package.metadata.dist]
 dist = false
 

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeSet, fs, path::Path, process::ExitCode};
 
+use aide::openapi::OpenApi;
 use anyhow::Context as _;
-use openapi_codegen::{IncludeMode, api::Api, schemars::schema::Schema};
+use openapi_codegen::{IncludeMode, api::Api};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 mod go;
@@ -43,10 +44,6 @@ fn main() -> anyhow::Result<ExitCode> {
         fs::write("openapi.json", &openapi_json).context("writing openapi.json")?;
     }
 
-    // FIXME: No longer needed once aide is upgraded in openapi-codegen
-    let openapi: openapi_codegen::aide::openapi::OpenApi =
-        serde_json::from_str(&openapi_json).context("deserializing OpenAPI")?;
-
     let webhooks = get_webhooks(&openapi);
     let paths = openapi.paths.context("spec must not be empty")?;
     let components = &mut openapi.components.unwrap_or_default();
@@ -82,7 +79,7 @@ fn repo_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap()
 }
 
-fn get_webhooks(spec: &openapi_codegen::aide::openapi::OpenApi) -> Vec<String> {
+fn get_webhooks(spec: &OpenApi) -> Vec<String> {
     let mut referenced_components = BTreeSet::new();
 
     for (_, webhook) in &spec.webhooks {
@@ -95,8 +92,7 @@ fn get_webhooks(spec: &openapi_codegen::aide::openapi::OpenApi) -> Vec<String> {
                 && let Some(item) = body.as_item()
                 && let Some(json_content) = item.content.get("application/json")
                 && let Some(schema) = &json_content.schema
-                && let Schema::Object(obj) = &schema.json_schema
-                && let Some(reference) = &obj.reference
+                && let Some(reference) = schema.json_schema.as_value()["$ref"].as_str()
                 && let Some(component_name) = reference.split('/').next_back()
             {
                 referenced_components.insert(component_name.to_owned());

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminRoleConfigureIn.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminRoleConfigureIn.java
@@ -40,7 +40,7 @@ public class AdminRoleConfigureIn {
     @JsonProperty private String description;
     @JsonProperty private List<AccessRule> rules;
     @JsonProperty private List<String> policies;
-    @JsonProperty private Map<String,String> context;
+    @JsonProperty private Map<String, String> context;
     public AdminRoleConfigureIn() {}
 
     public AdminRoleConfigureIn id(String id) {
@@ -133,7 +133,7 @@ public class AdminRoleConfigureIn {
         this.policies = policies;
     }
 
-    public AdminRoleConfigureIn context(Map<String,String> context) {
+    public AdminRoleConfigureIn context(Map<String, String> context) {
         this.context = context;
         return this;
     }
@@ -151,11 +151,11 @@ public class AdminRoleConfigureIn {
      * @return context
      */
     @javax.annotation.Nullable
-    public Map<String,String> getContext() {
+    public Map<String, String> getContext() {
         return context;
     }
 
-    public void setContext(Map<String,String> context) {
+    public void setContext(Map<String, String> context) {
         this.context = context;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/AdminRoleOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/AdminRoleOut.java
@@ -40,7 +40,7 @@ public class AdminRoleOut {
     @JsonProperty private String description;
     @JsonProperty private List<AccessRule> rules;
     @JsonProperty private List<String> policies;
-    @JsonProperty private Map<String,String> context;
+    @JsonProperty private Map<String, String> context;
     @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant created;
     @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant updated;
     public AdminRoleOut() {}
@@ -135,7 +135,7 @@ public class AdminRoleOut {
         this.policies = policies;
     }
 
-    public AdminRoleOut context(Map<String,String> context) {
+    public AdminRoleOut context(Map<String, String> context) {
         this.context = context;
         return this;
     }
@@ -153,11 +153,11 @@ public class AdminRoleOut {
      * @return context
      */
     @javax.annotation.Nonnull
-    public Map<String,String> getContext() {
+    public Map<String, String> getContext() {
         return context;
     }
 
-    public void setContext(Map<String,String> context) {
+    public void setContext(Map<String, String> context) {
         this.context = context;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyCompleteIn.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyCompleteIn.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 public class IdempotencyCompleteIn {
     @JsonProperty private String namespace;
     @JsonProperty private byte[] response;
-    @JsonProperty private Map<String,String> context;
+    @JsonProperty private Map<String, String> context;
     @JsonProperty("ttl_ms") @JsonSerialize(using = DurationMsSerializer.class) @JsonDeserialize(using = DurationMsDeserializer.class) private Duration ttl;
     public IdempotencyCompleteIn() {}
 
@@ -80,7 +80,7 @@ public class IdempotencyCompleteIn {
         this.response = response;
     }
 
-    public IdempotencyCompleteIn context(Map<String,String> context) {
+    public IdempotencyCompleteIn context(Map<String, String> context) {
         this.context = context;
         return this;
     }
@@ -98,11 +98,11 @@ public class IdempotencyCompleteIn {
      * @return context
      */
     @javax.annotation.Nullable
-    public Map<String,String> getContext() {
+    public Map<String, String> getContext() {
         return context;
     }
 
-    public void setContext(Map<String,String> context) {
+    public void setContext(Map<String, String> context) {
         this.context = context;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyCompleteIn_.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyCompleteIn_.java
@@ -34,14 +34,14 @@ public class IdempotencyCompleteIn_ {
     @JsonProperty private String namespace;
     @JsonProperty private String key;
     @JsonProperty private byte[] response;
-    @JsonProperty private Map<String,String> context;
+    @JsonProperty private Map<String, String> context;
     @JsonProperty("ttl_ms") @JsonSerialize(using = DurationMsSerializer.class) @JsonDeserialize(using = DurationMsDeserializer.class) private Duration ttl;
 
     public IdempotencyCompleteIn_(
         String namespace,
         String key,
         byte[] response,
-        Map<String,String> context,
+        Map<String, String> context,
         Duration ttl
     ) {
         this.namespace = namespace;

--- a/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyCompleted.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/IdempotencyCompleted.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class IdempotencyCompleted {
     @JsonProperty private byte[] response;
-    @JsonProperty private Map<String,String> context;
+    @JsonProperty private Map<String, String> context;
     public IdempotencyCompleted() {}
 
     public IdempotencyCompleted response(byte[] response) {
@@ -59,7 +59,7 @@ public class IdempotencyCompleted {
         this.response = response;
     }
 
-    public IdempotencyCompleted context(Map<String,String> context) {
+    public IdempotencyCompleted context(Map<String, String> context) {
         this.context = context;
         return this;
     }
@@ -77,11 +77,11 @@ public class IdempotencyCompleted {
      * @return context
      */
     @javax.annotation.Nullable
-    public Map<String,String> getContext() {
+    public Map<String, String> getContext() {
         return context;
     }
 
-    public void setContext(Map<String,String> context) {
+    public void setContext(Map<String, String> context) {
         this.context = context;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/MsgIn.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/MsgIn.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class MsgIn {
     @JsonProperty private byte[] value;
-    @JsonProperty private Map<String,String> headers;
+    @JsonProperty private Map<String, String> headers;
     @JsonProperty private String key;
     @JsonProperty("delay_ms") @JsonSerialize(using = DurationMsSerializer.class) @JsonDeserialize(using = DurationMsDeserializer.class) private Duration delay;
     public MsgIn() {}
@@ -61,7 +61,7 @@ public class MsgIn {
         this.value = value;
     }
 
-    public MsgIn headers(Map<String,String> headers) {
+    public MsgIn headers(Map<String, String> headers) {
         this.headers = headers;
         return this;
     }
@@ -79,11 +79,11 @@ public class MsgIn {
      * @return headers
      */
     @javax.annotation.Nullable
-    public Map<String,String> getHeaders() {
+    public Map<String, String> getHeaders() {
         return headers;
     }
 
-    public void setHeaders(Map<String,String> headers) {
+    public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/QueueMsgOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/QueueMsgOut.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 public class QueueMsgOut {
     @JsonProperty("msg_id") private String msgId;
     @JsonProperty private byte[] value;
-    @JsonProperty private Map<String,String> headers;
+    @JsonProperty private Map<String, String> headers;
     @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant timestamp;
     @JsonProperty("scheduled_at") @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant scheduledAt;
     public QueueMsgOut() {}
@@ -81,7 +81,7 @@ public class QueueMsgOut {
         this.value = value;
     }
 
-    public QueueMsgOut headers(Map<String,String> headers) {
+    public QueueMsgOut headers(Map<String, String> headers) {
         this.headers = headers;
         return this;
     }
@@ -99,11 +99,11 @@ public class QueueMsgOut {
      * @return headers
      */
     @javax.annotation.Nonnull
-    public Map<String,String> getHeaders() {
+    public Map<String, String> getHeaders() {
         return headers;
     }
 
-    public void setHeaders(Map<String,String> headers) {
+    public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/StreamMsgOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/StreamMsgOut.java
@@ -39,7 +39,7 @@ public class StreamMsgOut {
     @JsonProperty private Long offset;
     @JsonProperty private String topic;
     @JsonProperty private byte[] value;
-    @JsonProperty private Map<String,String> headers;
+    @JsonProperty private Map<String, String> headers;
     @JsonProperty @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant timestamp;
     @JsonProperty("scheduled_at") @JsonSerialize(using = UnixTimestampMsSerializer.class) @JsonDeserialize(using = UnixTimestampMsDeserializer.class) private Instant scheduledAt;
     public StreamMsgOut() {}
@@ -101,7 +101,7 @@ public class StreamMsgOut {
         this.value = value;
     }
 
-    public StreamMsgOut headers(Map<String,String> headers) {
+    public StreamMsgOut headers(Map<String, String> headers) {
         this.headers = headers;
         return this;
     }
@@ -119,11 +119,11 @@ public class StreamMsgOut {
      * @return headers
      */
     @javax.annotation.Nonnull
-    public Map<String,String> getHeaders() {
+    public Map<String, String> getHeaders() {
         return headers;
     }
 
-    public void setHeaders(Map<String,String> headers) {
+    public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
 


### PR DESCRIPTION
Part of https://github.com/svix/monorepo-private/issues/12997. Had to upgrade openapi-codegen to schemars 1.0 to avoid regressing the spec. Further changes are going to be needed for positional parameters, but I figured I get this small improvement in before the weekend / vacation.