### PR TITLE
cluster: purge logs in the background

### DIFF
--- a/.github/test-report.sh
+++ b/.github/test-report.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+export DIOM_LOG_LEVEL=debug
+export DIOM_CLUSTER_LOG_LEVEL=debug
+
 cargo llvm-cov nextest --profile ci --no-clean
 status=$?
 

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -326,7 +326,7 @@ pub trait MonotonicTableRow: TableRow {
     /// Remove all keys in the given range
     ///
     /// Implemented via a loop; may take a long time
-    fn remove_keys_in_range<B: RangeBounds<Self::KeyType> + Send + Clone>(
+    fn remove_keys_in_range<B: RangeBounds<Self::KeyType> + Send + Clone + std::fmt::Debug>(
         db: &fjall::Database,
         keyspace: &fjall::Keyspace,
         bounds: B,

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -577,7 +577,7 @@ pub struct DiomLogs {
 impl DiomLogs {
     const DELETE_BATCH_SIZE: usize = 10_000;
 
-    pub fn new(
+    pub async fn new(
         path: Dir,
         commits_before_fsync: usize,
         duration_before_fsync: Duration,
@@ -613,7 +613,7 @@ impl DiomLogs {
         let (purge_tx, purge_rx) = tokio::sync::mpsc::channel(2);
         let purge_worker = PurgeWorker::new(db.clone(), log_keyspace.clone(), purge_rx);
         tokio::spawn(purge_worker.run());
-        Ok(Self {
+        let mut this = Self {
             db,
             log_keyspace,
             meta_keyspace,
@@ -625,7 +625,10 @@ impl DiomLogs {
             last_vote: Arc::new(Mutex::new(None)),
             fsync_mode,
             cancellation_token,
-        })
+        };
+        let state = this.get_log_state().await?;
+        this.purged_index = state.last_purged_log_id.map(|l| l.index);
+        Ok(this)
     }
 
     async fn read_metadata<T: Serialize + serde::de::DeserializeOwned + Send + Sync + 'static>(
@@ -1018,7 +1021,7 @@ mod tests {
     }
 
     impl TestContext {
-        fn new() -> Self {
+        async fn new() -> Self {
             let workdir = tempfile::tempdir().unwrap();
             let logdir = Dir::new(&workdir).unwrap();
             let token = CancellationToken::new();
@@ -1031,6 +1034,7 @@ mod tests {
                 FsyncMode::default(),
                 token.clone(),
             )
+            .await
             .unwrap();
             Self {
                 workdir: Some(workdir),
@@ -1051,7 +1055,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_log_timestamps() -> TestResult {
-        let context = TestContext::new();
+        let context = TestContext::new().await;
         #[allow(clippy::disallowed_methods)]
         let now = Timestamp::now();
         context

--- a/src/core/cluster/logs.rs
+++ b/src/core/cluster/logs.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::Debug,
     ops::{Bound, RangeBounds},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::Context;
@@ -454,7 +454,7 @@ impl FlushWorker {
                     let _guard =
                         tracing::info_span!("logs:flush_worker:flush", num_commits).entered();
                     tracing::trace!(?persist_mode, "flushing logs to disk");
-                    let start_persist = std::time::Instant::now();
+                    let start_persist = Instant::now();
                     db.persist(persist_mode).map_err(|err| {
                         tracing::error!(?err, "error flushing fjall");
                         BackgroundFsyncFailedError(err.to_string())
@@ -499,12 +499,74 @@ impl FlushWorker {
     }
 }
 
+struct PurgeWorker {
+    rx: tokio::sync::mpsc::Receiver<(Instant, LogId)>,
+    db: Database,
+    log_keyspace: Keyspace,
+}
+
+impl PurgeWorker {
+    const DELETE_BATCH_SIZE: usize = 10_000;
+
+    fn new(
+        db: Database,
+        log_keyspace: Keyspace,
+        rx: tokio::sync::mpsc::Receiver<(Instant, LogId)>,
+    ) -> Self {
+        Self {
+            db,
+            log_keyspace,
+            rx,
+        }
+    }
+
+    async fn run(mut self) {
+        while let Some((start_time, log_id)) = self.rx.recv().await {
+            if let Err(err) = self.purge_one(start_time, log_id).await {
+                tracing::error!(?err, "error while purging logs");
+            }
+        }
+        tracing::debug!("purge worker shutting down");
+    }
+
+    async fn purge_one(&self, start: Instant, log_id: LogId) -> anyhow::Result<()> {
+        // precondition; the LAST_PURGED_LOG_ID has already been set
+        let log_keyspace = self.log_keyspace.clone();
+        let db = self.db.clone();
+        spawn_blocking_in_current_span(move || -> anyhow::Result<()> {
+            let fjall_start = Instant::now();
+            // do the very slow purge. If we crash here, we might leak some rows
+            // in the database, but they'll be cleared on the next purge since
+            // we always start at 0.
+            let deleted = Log::remove_keys_in_range(
+                &db,
+                &log_keyspace,
+                ..=log_id.index,
+                Self::DELETE_BATCH_SIZE,
+                PersistMode::Buffer,
+            )?;
+            let fjall_purge_time = fjall_start.elapsed();
+            let total_purge_time = start.elapsed();
+            tracing::debug!(
+                ?total_purge_time,
+                ?fjall_purge_time,
+                deleted,
+                "deleted entries for purge"
+            );
+            Ok(())
+        })
+        .await?
+    }
+}
+
 #[derive(Clone)]
 pub struct DiomLogs {
     db: Database,
     meta_keyspace: Keyspace,
     log_keyspace: Keyspace,
     flush_tx: tokio::sync::mpsc::Sender<FlushMessage>,
+    purge_tx: tokio::sync::mpsc::Sender<(Instant, LogId)>,
+    purged_index: Option<u64>,
     log_cache: LogCache,
     metrics: Option<LogMetrics>,
     last_vote: Arc<Mutex<Option<Vote>>>,
@@ -548,11 +610,16 @@ impl DiomLogs {
             cancellation_token.clone(),
         );
         tokio::spawn(flush_worker.run());
+        let (purge_tx, purge_rx) = tokio::sync::mpsc::channel(2);
+        let purge_worker = PurgeWorker::new(db.clone(), log_keyspace.clone(), purge_rx);
+        tokio::spawn(purge_worker.run());
         Ok(Self {
             db,
             log_keyspace,
             meta_keyspace,
             flush_tx,
+            purge_tx,
+            purged_index: None,
             log_cache: LogCache::new(100),
             metrics: None,
             last_vote: Arc::new(Mutex::new(None)),
@@ -648,7 +715,7 @@ impl DiomLogs {
         callback: IOFlushed<TypeConfig>,
     ) -> anyhow::Result<()> {
         Span::current().record("num_entries", entries.len());
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         let num_entries = entries.len();
 
         let keyspace = self.log_keyspace.clone();
@@ -704,26 +771,32 @@ impl DiomLogs {
     }
 
     /// Purge logs upto log_id, inclusive
-    async fn purge_entries_(&self, log_id: LogId) -> anyhow::Result<()> {
+    async fn purge_entries_(&mut self, log_id: LogId) -> anyhow::Result<()> {
+        tracing::debug!(?log_id, "scheduling background purge of logs");
+
+        let start = Instant::now();
+
+        // synchronously purge the cache and set the flag
         self.log_cache.purge(log_id.index);
-        let meta_keyspace = self.meta_keyspace.clone();
-        let log_keyspace = self.log_keyspace.clone();
-        let db = self.db.clone();
-        spawn_blocking_in_current_span(move || -> anyhow::Result<()> {
-            let mut tx = db.batch().durability(Some(PersistMode::Buffer));
-            LAST_PURGED_LOG_ID.store_tx(&mut tx, &meta_keyspace, &log_id)?;
-            tx.commit()?;
-            let deleted = Log::remove_keys_in_range(
-                &db,
-                &log_keyspace,
-                ..=log_id.index,
-                Self::DELETE_BATCH_SIZE,
-                PersistMode::Buffer,
-            )?;
-            tracing::debug!(deleted, "deleted entries for purge");
-            Ok(())
+        self.purged_index = Some(log_id.index);
+
+        // first, set LAST_PURGED_LOG_ID so that if we crash and restart, we'll
+        // ignore any IDs that have been purged
+        spawn_blocking_in_current_span({
+            let db = self.db.clone();
+            let meta_keyspace = self.meta_keyspace.clone();
+            move || -> anyhow::Result<()> {
+                let mut tx = db.batch().durability(Some(PersistMode::Buffer));
+                LAST_PURGED_LOG_ID.store_tx(&mut tx, &meta_keyspace, &log_id)?;
+                tx.commit()?;
+                Ok(())
+            }
         })
-        .await?
+        .await??;
+
+        // now run the rest in a background task
+        self.purge_tx.send((start, log_id)).await?;
+        Ok(())
     }
 
     async fn get_log_state_(&mut self) -> anyhow::Result<openraft::LogState<TypeConfig>> {
@@ -763,12 +836,14 @@ impl DiomLogs {
             _ => {}
         }
 
+        let purged_index = self.purged_index.unwrap_or(0);
+
         // For some reason, RB isn't specified as Send in the trait, so we can't
         // use it directly across the boundary. ARGH!
         let send_range = match range.start_bound() {
-            Bound::Unbounded => 0..,
-            Bound::Included(i) => *i..,
-            Bound::Excluded(i) => (*i + 1)..,
+            Bound::Unbounded => purged_index..,
+            Bound::Included(i) => (*i).max(purged_index)..,
+            Bound::Excluded(i) => (*i + 1).max(purged_index)..,
         };
         // why isn't RB always Send? it's a goddamn range...
         let end = match range.end_bound() {

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -168,6 +168,7 @@ pub async fn initialize_raft(
         cfg.fsync_mode,
         crate::shutting_down_token(),
     )
+    .await
     .context("setting up log store")?;
     let id: NodeId = logs
         .get_node_id()
@@ -361,7 +362,8 @@ mod tests {
                 crate::cfg::SyncMode::Buffer,
                 FsyncMode::default(),
                 token.clone(),
-            )?;
+            )
+            .await?;
 
             let data_path = workdir.path().join("data");
             let e_data_path = workdir.path().join("edata");


### PR DESCRIPTION
we sometimes see nodes in staging block for an unreasonably long time (just now: 21 seconds).

I've tracked this down to the log purge task, which gets invoked by openraft with a `&mut` reference on the log store (which means it's blocking all other log operations). fjall is pretty slow to do batch deletes, especially until https://github.com/fjall-rs/fjall/issues/33 is done

This PR changes it so that instead of blocking for the whole delete process, we just block long enough to set the purged ID (both in memory and in fjall), then push the rest of the work off to a background worker. This drops the blocking time for a 6 million log items items on my local machine from 15s to 400µs. If we crash or otherwise fail to finish the purge, we'll leak those logs until the next purge, but we always start purges at index 0 so we'll eventually get 'em, and as long as we set the last purged log ID synchronously there should be no chance to rewind.

I'm intentionally using a small queue here to provide back-pressure; if for some reason we're doing a lot of these it's better to block than to build up an infinite backlog of work. Typically we should only do one per 15 minutes.