### PR TITLE
Rust: Don't require optional fields

### DIFF
--- a/codegen/templates/rust/types/macros.rs.jinja
+++ b/codegen/templates/rust/types/macros.rs.jinja
@@ -33,11 +33,15 @@
     {% endif -%}
     {% if field.type.is_bytes() -%}
         {% if not field.required or field.nullable -%}
+            default,
             with = "crate::serde_bytes_opt",
         {% else -%}
             with = "serde_bytes",
         {% endif -%}
     {% elif field.type.is_unix_timestamp_ms() -%}
+        {% if not field.required or field.nullable -%}
+            default,
+        {% endif -%}
         with = "crate::unix_timestamp_ms_serde
             {%- if not field.required or field.nullable %}::optional{% endif -%}
         ",
@@ -49,6 +53,7 @@
         {% set serde_with = "crate::duration_ms_serde" -%}
         {% if not field.required or field.nullable -%}
             {% set serde_with = serde_with ~ "::optional" -%}
+            default,
         {% endif -%}
         with = "{{ serde_with }}",
     {% endif -%}

--- a/z-clients/rust/src/lib.rs
+++ b/z-clients/rust/src/lib.rs
@@ -16,3 +16,82 @@ pub use self::{
         ServerError,
     },
 };
+
+#[cfg(test)]
+mod tests {
+    use crate::models::{
+        AdminAuthTokenCreateIn, AdminAuthTokenExpireIn, AdminAuthTokenUpdateIn, KvSetIn, MsgIn,
+        MsgQueueExtendLeaseIn, MsgQueueReceiveIn, MsgStreamReceiveIn, MsgStreamSeekIn,
+        RateLimitConfig, Retention,
+    };
+
+    #[test]
+    fn test_stream_receive_in_defaults() {
+        let v: MsgStreamReceiveIn = serde_json::from_str("{}").unwrap();
+        assert!(v.lease_duration.is_none());
+        assert!(v.batch_wait.is_none());
+    }
+
+    #[test]
+    fn test_queue_receive_in_defaults() {
+        let v: MsgQueueReceiveIn = serde_json::from_str("{}").unwrap();
+        assert!(v.lease_duration.is_none());
+        assert!(v.batch_wait.is_none());
+    }
+
+    #[test]
+    fn test_msg_in_defaults() {
+        let v: MsgIn = serde_json::from_str(r#"{"value": ""}"#).unwrap();
+        assert!(v.delay.is_none());
+    }
+
+    #[test]
+    fn test_kv_set_in_defaults() {
+        let v: KvSetIn = serde_json::from_str(r#"{"key": "k", "value": ""}"#).unwrap();
+        assert!(v.ttl.is_none());
+    }
+
+    #[test]
+    fn test_msg_queue_extend_lease_in_defaults() {
+        let v: MsgQueueExtendLeaseIn = serde_json::from_str(r#"{"msg_ids": []}"#).unwrap();
+        assert!(v.lease_duration.is_none());
+    }
+
+    #[test]
+    fn test_msg_stream_seek_in_defaults() {
+        let v: MsgStreamSeekIn = serde_json::from_str("{}").unwrap();
+        assert!(v.timestamp.is_none());
+    }
+
+    #[test]
+    fn test_admin_auth_token_create_in_defaults() {
+        let v: AdminAuthTokenCreateIn =
+            serde_json::from_str(r#"{"name": "n", "role": "r"}"#).unwrap();
+        assert!(v.expiry.is_none());
+    }
+
+    #[test]
+    fn test_admin_auth_token_update_in_defaults() {
+        let v: AdminAuthTokenUpdateIn = serde_json::from_str(r#"{"id": "x"}"#).unwrap();
+        assert!(v.expiry.is_none());
+    }
+
+    #[test]
+    fn test_admin_auth_token_expire_in_defaults() {
+        let v: AdminAuthTokenExpireIn = serde_json::from_str(r#"{"id": "x"}"#).unwrap();
+        assert!(v.expiry.is_none());
+    }
+
+    #[test]
+    fn test_retention_defaults() {
+        let v: Retention = serde_json::from_str("{}").unwrap();
+        assert!(v.period.is_none());
+    }
+
+    #[test]
+    fn test_rate_limit_config_defaults() {
+        let v: RateLimitConfig =
+            serde_json::from_str(r#"{"capacity": 10, "refill_amount": 1}"#).unwrap();
+        assert!(v.refill_interval.is_none());
+    }
+}

--- a/z-clients/rust/src/models/admin_auth_token_create_in.rs
+++ b/z-clients/rust/src/models/admin_auth_token_create_in.rs
@@ -11,6 +11,7 @@ pub struct AdminAuthTokenCreateIn {
     #[serde(
         rename = "expiry_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub expiry: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/admin_auth_token_expire_in.rs
+++ b/z-clients/rust/src/models/admin_auth_token_expire_in.rs
@@ -9,6 +9,7 @@ pub struct AdminAuthTokenExpireIn {
     #[serde(
         rename = "expiry_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub expiry: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/admin_auth_token_out.rs
+++ b/z-clients/rust/src/models/admin_auth_token_out.rs
@@ -14,6 +14,7 @@ pub struct AdminAuthTokenOut {
     pub updated: jiff::Timestamp,
 
     #[serde(
+        default,
         with = "crate::unix_timestamp_ms_serde::optional",
         skip_serializing_if = "Option::is_none"
     )]

--- a/z-clients/rust/src/models/admin_auth_token_update_in.rs
+++ b/z-clients/rust/src/models/admin_auth_token_update_in.rs
@@ -11,6 +11,7 @@ pub struct AdminAuthTokenUpdateIn {
     #[serde(
         rename = "expiry_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub expiry: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/cache_get_out.rs
+++ b/z-clients/rust/src/models/cache_get_out.rs
@@ -5,12 +5,14 @@ use serde::{Deserialize, Serialize};
 pub struct CacheGetOut {
     /// Time of expiry
     #[serde(
+        default,
         with = "crate::unix_timestamp_ms_serde::optional",
         skip_serializing_if = "Option::is_none"
     )]
     pub expiry: Option<jiff::Timestamp>,
 
     #[serde(
+        default,
         with = "crate::serde_bytes_opt",
         skip_serializing_if = "Option::is_none"
     )]

--- a/z-clients/rust/src/models/kv_get_out.rs
+++ b/z-clients/rust/src/models/kv_get_out.rs
@@ -5,12 +5,14 @@ use serde::{Deserialize, Serialize};
 pub struct KvGetOut {
     /// Time of expiry
     #[serde(
+        default,
         with = "crate::unix_timestamp_ms_serde::optional",
         skip_serializing_if = "Option::is_none"
     )]
     pub expiry: Option<jiff::Timestamp>,
 
     #[serde(
+        default,
         with = "crate::serde_bytes_opt",
         skip_serializing_if = "Option::is_none"
     )]

--- a/z-clients/rust/src/models/kv_set_in.rs
+++ b/z-clients/rust/src/models/kv_set_in.rs
@@ -12,6 +12,7 @@ pub struct KvSetIn {
     #[serde(
         rename = "ttl_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub ttl: Option<std::time::Duration>,
@@ -70,6 +71,7 @@ pub(crate) struct KvSetIn_ {
     #[serde(
         rename = "ttl_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub ttl: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/msg_in.rs
+++ b/z-clients/rust/src/models/msg_in.rs
@@ -22,6 +22,7 @@ pub struct MsgIn {
     #[serde(
         rename = "delay_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub delay: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/msg_queue_extend_lease_in.rs
+++ b/z-clients/rust/src/models/msg_queue_extend_lease_in.rs
@@ -11,6 +11,7 @@ pub struct MsgQueueExtendLeaseIn {
     #[serde(
         rename = "lease_duration_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub lease_duration: Option<std::time::Duration>,
@@ -50,6 +51,7 @@ pub(crate) struct MsgQueueExtendLeaseIn_ {
     #[serde(
         rename = "lease_duration_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub lease_duration: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/msg_queue_receive_in.rs
+++ b/z-clients/rust/src/models/msg_queue_receive_in.rs
@@ -12,6 +12,7 @@ pub struct MsgQueueReceiveIn {
     #[serde(
         rename = "lease_duration_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub lease_duration: Option<std::time::Duration>,
@@ -20,6 +21,7 @@ pub struct MsgQueueReceiveIn {
     #[serde(
         rename = "batch_wait_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub batch_wait: Option<std::time::Duration>,
@@ -71,6 +73,7 @@ pub(crate) struct MsgQueueReceiveIn_ {
     #[serde(
         rename = "lease_duration_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub lease_duration: Option<std::time::Duration>,
@@ -79,6 +82,7 @@ pub(crate) struct MsgQueueReceiveIn_ {
     #[serde(
         rename = "batch_wait_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub batch_wait: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/msg_stream_receive_in.rs
+++ b/z-clients/rust/src/models/msg_stream_receive_in.rs
@@ -14,6 +14,7 @@ pub struct MsgStreamReceiveIn {
     #[serde(
         rename = "lease_duration_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub lease_duration: Option<std::time::Duration>,
@@ -25,6 +26,7 @@ pub struct MsgStreamReceiveIn {
     #[serde(
         rename = "batch_wait_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub batch_wait: Option<std::time::Duration>,
@@ -85,6 +87,7 @@ pub(crate) struct MsgStreamReceiveIn_ {
     #[serde(
         rename = "lease_duration_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub lease_duration: Option<std::time::Duration>,
@@ -96,6 +99,7 @@ pub(crate) struct MsgStreamReceiveIn_ {
     #[serde(
         rename = "batch_wait_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub batch_wait: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/msg_stream_seek_in.rs
+++ b/z-clients/rust/src/models/msg_stream_seek_in.rs
@@ -15,6 +15,7 @@ pub struct MsgStreamSeekIn {
     pub position: Option<SeekPosition>,
 
     #[serde(
+        default,
         with = "crate::unix_timestamp_ms_serde::optional",
         skip_serializing_if = "Option::is_none"
     )]
@@ -68,6 +69,7 @@ pub(crate) struct MsgStreamSeekIn_ {
     pub position: Option<SeekPosition>,
 
     #[serde(
+        default,
         with = "crate::unix_timestamp_ms_serde::optional",
         skip_serializing_if = "Option::is_none"
     )]

--- a/z-clients/rust/src/models/queue_msg_out.rs
+++ b/z-clients/rust/src/models/queue_msg_out.rs
@@ -14,6 +14,7 @@ pub struct QueueMsgOut {
     pub timestamp: jiff::Timestamp,
 
     #[serde(
+        default,
         with = "crate::unix_timestamp_ms_serde::optional",
         skip_serializing_if = "Option::is_none"
     )]

--- a/z-clients/rust/src/models/rate_limit_check_out.rs
+++ b/z-clients/rust/src/models/rate_limit_check_out.rs
@@ -13,6 +13,7 @@ pub struct RateLimitCheckOut {
     #[serde(
         rename = "retry_after_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub retry_after: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/rate_limit_config.rs
+++ b/z-clients/rust/src/models/rate_limit_config.rs
@@ -13,6 +13,7 @@ pub struct RateLimitConfig {
     #[serde(
         rename = "refill_interval_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub refill_interval: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/rate_limit_get_remaining_out.rs
+++ b/z-clients/rust/src/models/rate_limit_get_remaining_out.rs
@@ -10,6 +10,7 @@ pub struct RateLimitGetRemainingOut {
     #[serde(
         rename = "retry_after_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub retry_after: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/retention.rs
+++ b/z-clients/rust/src/models/retention.rs
@@ -6,6 +6,7 @@ pub struct Retention {
     #[serde(
         rename = "period_ms",
         skip_serializing_if = "Option::is_none",
+        default,
         with = "crate::duration_ms_serde::optional"
     )]
     pub period: Option<std::time::Duration>,

--- a/z-clients/rust/src/models/stream_msg_out.rs
+++ b/z-clients/rust/src/models/stream_msg_out.rs
@@ -16,6 +16,7 @@ pub struct StreamMsgOut {
     pub timestamp: jiff::Timestamp,
 
     #[serde(
+        default,
         with = "crate::unix_timestamp_ms_serde::optional",
         skip_serializing_if = "Option::is_none"
     )]


### PR DESCRIPTION
Currently, certain optional fields with custom de-/serialization logic must be set to `null` when deserialized. Instead, have the templating logic add serde `default` where appropriate.