### PR TITLE
Helm: Prepare release 0.1.1

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -3,21 +3,12 @@ name: Helm Publish to GHCR
 on:
   workflow_call:
     inputs:
-      version:
-        required: false
-        type: string
-        description: 'Override the version specified in Chart.yaml (only used for private deployments)'
-      operator_image_tag:
-        required: true
-        type: string
-      server_image_tag:
-        required: true
-        type: string
       is_release:
         type: boolean
         default: false
       dry_run:
         type: boolean
+        default: false
 
 jobs:
   helm-publish:
@@ -39,25 +30,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set image tags
-        run: |
-          yq -i '.cluster.image.tag = "${{ inputs.server_image_tag }}"' infra/helm-diom/values.yaml
-          yq -i '.operator.image.tag = "${{ inputs.operator_image_tag }}"' infra/helm-diom/values.yaml
-
       - name: Mangle charts for private deploys
         if: ${{ !inputs.is_release }}
         run: |
+          # Change image repositories
           yq -i '.name = "diom-private"' infra/helm-diom/Chart.yaml
           yq -i '.operator.image.repository = "ghcr.io/svix/diom-operator-private"' infra/helm-diom/values.yaml
           yq -i '.cluster.image.repository = "ghcr.io/svix/diom-server-private"' infra/helm-diom/values.yaml
 
-      - name: Package chart
+          # Change image tags
+          yq -i '.cluster.image.tag = "sha-${{ github.sha }}"' infra/helm-diom/values.yaml
+          yq -i '.operator.image.tag = "sha-${{ github.sha }}"' infra/helm-diom/values.yaml
+
+          helm package ./infra/helm-diom --version "0.0.0-${{ github.sha }}"
+
+      - name: Package release chart
+        if: ${{ inputs.is_release }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            helm package ./infra/helm-diom --version ${{ inputs.version }}
-          else
-            helm package ./infra/helm-diom
-          fi
+          helm package ./infra/helm-diom
 
       - name: Push chart
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -3,27 +3,11 @@ name: Helm Release
 on:
   workflow_dispatch:
     inputs:
-      operator_image_tag:
-        description: "(Optional) Override operator image tag"
-        type: string
-        default: ''
-      server_image_tag:
-        description: "(Optional) Override server image tag"
-        type: string
-        default: ''
       dry_run:
         type: boolean
         default: false
   workflow_call:
     inputs:
-      operator_image_tag:
-        required: false
-        type: string
-        default: ''
-      server_image_tag:
-        required: false
-        type: string
-        default: ''
       dry_run:
         type: boolean
         default: false
@@ -37,35 +21,20 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Read versions from Cargo.toml
+      - name: Read versions from values.yaml
         id: versions
         run: |
-          if [ -n "${{ inputs.operator_image_tag }}" ]; then
-            OPERATOR_TAG="${{ inputs.operator_image_tag }}"
-          else
-            OPERATOR_TAG=$(cargo metadata --manifest-path infra/operator/Cargo.toml --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "diom-operator") | .version')
-          fi
-          if [ -n "${{ inputs.server_image_tag }}" ]; then
-            SERVER_TAG="${{ inputs.server_image_tag }}"
-          else
-            SERVER_TAG=$(cargo metadata --manifest-path server/Cargo.toml --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "diom-server") | .version')
-          fi
-          echo "operator_image_tag=${OPERATOR_TAG}" >> "$GITHUB_OUTPUT"
-          echo "server_image_tag=${SERVER_TAG}" >> "$GITHUB_OUTPUT"
-      - name: Dry run summary
-        if: ${{ inputs.dry_run }}
-        run: |
-          echo "=== DRY RUN ==="
-          echo "Would release helm chart with:"
-          echo "  operator image tag: ${{ steps.versions.outputs.operator_image_tag }}"
-          echo "  server image tag:   ${{ steps.versions.outputs.server_image_tag }}"
+          OPERATOR_TAG=$(yq '.operator.image.tag' infra/helm-diom/values.yaml)
+          SERVER_TAG=$(yq '.cluster.image.tag' infra/helm-diom/values.yaml)
+          echo "Releasing helm chart with:"
+          echo "  operator image tag: ${OPERATOR_TAG}"
+          echo "  server image tag:   ${SERVER_TAG}"
 
   publish:
     needs: read-versions
+    if: ${{ !inputs.dry_run }}
     uses: ./.github/workflows/helm-publish.yml
     with:
-      operator_image_tag: ${{ needs.read-versions.outputs.operator_image_tag }}
-      server_image_tag: ${{ needs.read-versions.outputs.server_image_tag }}
       is_release: true
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -72,9 +72,6 @@ jobs:
       contents: read
       packages: write
     with:
-      version: 0.0.0-${{ github.sha }}
-      server_image_tag: sha-${{ github.sha }}
-      operator_image_tag: sha-${{ github.sha }}
       is_release: false
 
   staging-deploy:

--- a/infra/helm-diom/ChangeLog.md
+++ b/infra/helm-diom/ChangeLog.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased Changes
+
+## Version 0.1.1
 * Consistently name operator pod `<release>-operator`
 * Add `operator.logFormat` and `operator.extraEnv` values
 * Add `cluster.spec.storage.ephemeral`
+* Default operator version 0.2.1
+* Default diom-server version 0.2.4

--- a/infra/helm-diom/Chart.yaml
+++ b/infra/helm-diom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diom
 description: Helm chart for Diom clusters
 type: application
-version: 0.1.0
+version: 0.1.1
 
 dependencies:
   - name: crds

--- a/infra/helm-diom/values.yaml
+++ b/infra/helm-diom/values.yaml
@@ -13,8 +13,7 @@ operator:
   image:
     repository: svix/diom-operator
     pullPolicy: IfNotPresent
-    # Overrides the image tag. Defaults to the chart's appVersion.
-    tag: ""
+    tag: "0.2.1"
 
   imagePullSecrets: []
 
@@ -52,7 +51,7 @@ cluster:
   image:
     repository: svix/diom-server
     # tag is required when cluster.enabled=true.
-    tag: ""
+    tag: "0.2.4"
   spec:
     replicas: 3
     service:


### PR DESCRIPTION
Also simplifies Helm release process a bit. For simplicity, we're now just going to hard-code the proper tags for the operator and diom-server versions in values.yaml directly. They will only be overwritten if doing a non-release publication.

Based on #1210