### PR TITLE
Clean up macros in api_call_sample.rs.jinja

### DIFF
--- a/codegen/templates/rust/api_call_sample.rs.jinja
+++ b/codegen/templates/rust/api_call_sample.rs.jinja
@@ -16,24 +16,6 @@
     {%- endif -%}
 {%- endmacro -%}
 
-{% macro field_type(field) -%}
-    {% set field_ty = field.type.to_rust() -%}
-    {% if field.type.is_unix_timestamp_ms() -%}
-        {% set field_ty = "jiff::Timestamp" -%}
-    {% elif field.name is endingwith "_ms" -%}
-        {% set field_ty = "std::time::Duration" -%}
-    {% endif -%}
-    {% if not field.required or field.nullable -%}
-        {% set field_ty %}Option<{{ field_ty }}>{% endset -%}
-    {% endif -%}
-    {{ field_ty }}
-{%- endmacro -%}
-
-{% macro ident(name) -%}
-    {%- if name in ["ref", "type"] %}r#{% endif -%}
-    {{ name }}
-{%- endmacro -%}
-
 {% macro render_example_resource(resource) -%}
 {{ resource.name | to_upper_camel_case }}
 {%- if resource.kind == "string_enum" -%}


### PR DESCRIPTION
Accidentally ended up with one unused, one duplicate macro. Ideally this template should be able to import from other files, but that's a separate change (in openapi-codegen).