### PR TITLE
Add more useful string examples to codesamples

### DIFF
--- a/codegen/templates/rust/api_call_sample.rs.jinja
+++ b/codegen/templates/rust/api_call_sample.rs.jinja
@@ -42,7 +42,12 @@
 
 {% macro field_example(field) -%}
     {%- if field.type.is_string() or field.type.is_uri() -%}
-        "sample string".to_owned()
+        {%- if field.example is defined -%}
+            "{{ field.example }}"
+        {%- else -%}
+            "sample string"
+        {%- endif -%}
+        .to_owned()
     {%- elif field.type.is_unix_timestamp_ms() -%}
         "2026-04-20 12:00:00".parse()?
     {%- elif field.type.is_duration_ms() -%}

--- a/crates/diom-authorization/src/api.rs
+++ b/crates/diom-authorization/src/api.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, fmt, str::FromStr};
 use diom_core::PersistableValue;
 use diom_id::Module;
 use itertools::Itertools as _;
-use schemars::JsonSchema;
+use schemars::{JsonSchema, json_schema};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
     pattern::{KeyPattern, NamespacePattern},
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, PersistableValue)]
 #[serde(transparent)]
 pub struct RoleId(pub String);
 
@@ -42,7 +42,24 @@ impl fmt::Display for RoleId {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema, PersistableValue)]
+impl JsonSchema for RoleId {
+    fn schema_name() -> Cow<'static, str> {
+        std::any::type_name::<Self>().into()
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        json_schema!({
+            "type": "string",
+            "example": "some_role_id",
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, PersistableValue)]
 #[serde(transparent)]
 pub struct AccessPolicyId(pub String);
 
@@ -55,6 +72,23 @@ impl AccessPolicyId {
 impl fmt::Display for AccessPolicyId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_str().fmt(f)
+    }
+}
+
+impl JsonSchema for AccessPolicyId {
+    fn schema_name() -> Cow<'static, str> {
+        std::any::type_name::<Self>().into()
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        json_schema!({
+            "type": "string",
+            "example": "some_access_policy",
+        })
     }
 }
 

--- a/crates/diom-id/src/lib.rs
+++ b/crates/diom-id/src/lib.rs
@@ -24,6 +24,11 @@ const V7_RANDOM_BYTES_LEN: usize = 10;
 pub struct UuidV7RandomBytes([u8; V7_RANDOM_BYTES_LEN]);
 
 impl UuidV7RandomBytes {
+    /// Return an arbitrary value used in example IDs.
+    pub fn example() -> Self {
+        Self([0xab, 0xcd, 0xde, 0xf2, 0x02, 0x29, 0xa2, 0x33, 0x20, 0x1f])
+    }
+
     pub fn new_random() -> Self {
         Self(rand::random())
     }

--- a/crates/diom-id/src/public.rs
+++ b/crates/diom-id/src/public.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize, de};
 use uuid::Uuid;
 
 use super::{Id, PublicIdMarker};
+use crate::UuidV7RandomBytes;
 
 /// serde wrapper for ID types that uses a verbose format (using `M`s prefix).
 #[derive(Clone, Copy, Debug)]
@@ -57,9 +58,16 @@ impl<M: PublicIdMarker> JsonSchema for Public<Id<M>> {
     }
 
     fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let example = Id::<M>::new(
+            "2026-04-20 12:00:00Z".parse::<jiff::Timestamp>().unwrap(),
+            UuidV7RandomBytes::example(),
+        )
+        .public();
+
         // FIXME: Add some more details
         json_schema!({
             "type": "string",
+            "example": example,
         })
     }
 

--- a/crates/msgs/src/entities.rs
+++ b/crates/msgs/src/entities.rs
@@ -12,7 +12,7 @@ use diom_core::{
 };
 use diom_error::Error;
 use fjall_utils::FjallKeyComponent;
-use schemars::JsonSchema;
+use schemars::{JsonSchema, json_schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use sha2::{Digest, Sha256};
 
@@ -147,8 +147,11 @@ impl JsonSchema for TopicName {
         true
     }
 
-    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        String::json_schema(generator)
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        json_schema!({
+            "type": "string",
+            "example": "some_topic_name",
+        })
     }
 }
 
@@ -221,8 +224,11 @@ impl JsonSchema for TopicPartition {
         true
     }
 
-    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        String::json_schema(generator)
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        json_schema!({
+            "type": "string",
+            "example": "some_topic_name~0",
+        })
     }
 }
 
@@ -271,8 +277,11 @@ impl JsonSchema for TopicIn {
         true
     }
 
-    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        String::json_schema(generator)
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        json_schema!({
+            "type": "string",
+            "example": "some_topic_name",
+        })
     }
 }
 
@@ -515,8 +524,11 @@ impl JsonSchema for ConsumerGroup {
         true
     }
 
-    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        String::json_schema(generator)
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        json_schema!({
+            "type": "string",
+            "example": "some_consumer_group",
+        })
     }
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -247,7 +247,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.cluster_admin()\n    .remove_node(\n        ClusterRemoveNodeIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.cluster_admin()\n    .remove_node(\n        ClusterRemoveNodeIn::new(\"a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -499,7 +499,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_token()\n    .create(\n        AdminAuthTokenCreateIn::new(\n            \"sample string\".to_owned(),\n            \"sample string\".to_owned(),\n        )\n            .with_expiry(Duration::from_secs(30))\n            .with_enabled(true),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_token()\n    .create(\n        AdminAuthTokenCreateIn::new(\n            \"some token name\".to_owned(),\n            \"some token role\".to_owned(),\n        )\n            .with_expiry(Duration::from_secs(30))\n            .with_enabled(true),\n    )\n    .await?;"
           }
         ]
       }
@@ -583,7 +583,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_token()\n    .expire(\n        AdminAuthTokenExpireIn::new(\"sample string\".to_owned())\n            .with_expiry(Duration::from_secs(30)),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_token()\n    .expire(\n        AdminAuthTokenExpireIn::new(\"key_06etngr201xwv7qj08mt4cs03w\".to_owned())\n            .with_expiry(Duration::from_secs(30)),\n    )\n    .await?;"
           }
         ]
       }
@@ -667,7 +667,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_token()\n    .rotate(\n        AdminAuthTokenRotateIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_token()\n    .rotate(\n        AdminAuthTokenRotateIn::new(\"key_06etngr201xwv7qj08mt4cs03w\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -751,7 +751,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_token()\n    .delete(\n        AdminAuthTokenDeleteIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_token()\n    .delete(\n        AdminAuthTokenDeleteIn::new(\"key_06etngr201xwv7qj08mt4cs03w\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -835,7 +835,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_token()\n    .list(\n        AdminAuthTokenListIn::new()\n            .with_limit(1)\n            .with_iterator(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_token()\n    .list(\n        AdminAuthTokenListIn::new()\n            .with_limit(1)\n            .with_iterator(\"key_06etngr201xwv7qj08mt4cs03w\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -919,7 +919,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_token()\n    .update(\n        AdminAuthTokenUpdateIn::new(\"sample string\".to_owned())\n            .with_name(\"sample string\".to_owned())\n            .with_expiry(Duration::from_secs(30))\n            .with_enabled(true),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_token()\n    .update(\n        AdminAuthTokenUpdateIn::new(\"key_06etngr201xwv7qj08mt4cs03w\".to_owned())\n            .with_name(\"some token name\".to_owned())\n            .with_expiry(Duration::from_secs(30))\n            .with_enabled(true),\n    )\n    .await?;"
           }
         ]
       }
@@ -1087,7 +1087,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_role()\n    .configure(\n        AdminRoleConfigureIn::new(\n            \"sample string\".to_owned(),\n            \"sample string\".to_owned(),\n        )\n            .with_rules(vec![])\n            .with_policies(vec![])\n            .with_context(HashMap::new()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_role()\n    .configure(\n        AdminRoleConfigureIn::new(\n            \"some_role_id\".to_owned(),\n            \"role description…\".to_owned(),\n        )\n            .with_rules(vec![])\n            .with_policies(vec![])\n            .with_context(HashMap::new()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1171,7 +1171,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_role()\n    .delete(\n        AdminRoleDeleteIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_role()\n    .delete(\n        AdminRoleDeleteIn::new(\"some_role_id\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1255,7 +1255,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_role()\n    .get(\n        AdminRoleGetIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_role()\n    .get(\n        AdminRoleGetIn::new(\"some_role_id\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1339,7 +1339,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_role()\n    .list(\n        AdminRoleListIn::new()\n            .with_limit(1)\n            .with_iterator(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_role()\n    .list(\n        AdminRoleListIn::new()\n            .with_limit(1)\n            .with_iterator(\"some_role_id\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1423,7 +1423,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_policy()\n    .configure(\n        AdminAccessPolicyConfigureIn::new(\n            \"sample string\".to_owned(),\n            \"sample string\".to_owned(),\n        )\n            .with_rules(vec![]),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_policy()\n    .configure(\n        AdminAccessPolicyConfigureIn::new(\n            \"some_access_policy\".to_owned(),\n            \"policy description…\".to_owned(),\n        )\n            .with_rules(vec![]),\n    )\n    .await?;"
           }
         ]
       }
@@ -1507,7 +1507,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_policy()\n    .delete(\n        AdminAccessPolicyDeleteIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_policy()\n    .delete(\n        AdminAccessPolicyDeleteIn::new(\"some_access_policy\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1591,7 +1591,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_policy()\n    .get(\n        AdminAccessPolicyGetIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_policy()\n    .get(\n        AdminAccessPolicyGetIn::new(\"some_access_policy\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -1675,7 +1675,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.admin()\n    .auth_policy()\n    .list(\n        AdminAccessPolicyListIn::new()\n            .with_limit(1)\n            .with_iterator(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.admin()\n    .auth_policy()\n    .list(\n        AdminAccessPolicyListIn::new()\n            .with_limit(1)\n            .with_iterator(\"some_access_policy\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -2461,7 +2461,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.cache()\n    .set(\n        \"sample string\".to_owned(),\n        vec![],\n        CacheSetIn::new(Duration::from_secs(30))\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.cache()\n    .set(\n        \"some_key\".to_owned(),\n        vec![],\n        CacheSetIn::new(Duration::from_secs(30))\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -2545,7 +2545,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.cache()\n    .get(\n        \"sample string\".to_owned(),\n        CacheGetIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_consistency(Consistency::Strong),\n    )\n    .await?;"
+            "source": "let response = diom.cache()\n    .get(\n        \"some_key\".to_owned(),\n        CacheGetIn::new()\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_consistency(Consistency::Strong),\n    )\n    .await?;"
           }
         ]
       }
@@ -2629,7 +2629,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.cache()\n    .namespace()\n    .configure(\n        CacheConfigureNamespaceIn::new(\"sample string\".to_owned())\n            .with_eviction_policy(EvictionPolicy::NoEviction),\n    )\n    .await?;"
+            "source": "let response = diom.cache()\n    .namespace()\n    .configure(\n        CacheConfigureNamespaceIn::new(\"some_namespace\".to_owned())\n            .with_eviction_policy(EvictionPolicy::NoEviction),\n    )\n    .await?;"
           }
         ]
       }
@@ -2713,7 +2713,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.cache()\n    .namespace()\n    .get(\n        CacheGetNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.cache()\n    .namespace()\n    .get(\n        CacheGetNamespaceIn::new(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -2797,7 +2797,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.cache()\n    .delete(\n        \"sample string\".to_owned(),\n        CacheDeleteIn::new()\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.cache()\n    .delete(\n        \"some_key\".to_owned(),\n        CacheDeleteIn::new()\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -2881,7 +2881,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.kv()\n    .set(\n        \"sample string\".to_owned(),\n        vec![],\n        KvSetIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_ttl(Duration::from_secs(30))\n            .with_behavior(OperationBehavior::Upsert)\n            .with_version(1),\n    )\n    .await?;"
+            "source": "let response = diom.kv()\n    .set(\n        \"some_key\".to_owned(),\n        vec![],\n        KvSetIn::new()\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_ttl(Duration::from_secs(30))\n            .with_behavior(OperationBehavior::Upsert)\n            .with_version(1),\n    )\n    .await?;"
           }
         ]
       }
@@ -2965,7 +2965,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.kv()\n    .get(\n        \"sample string\".to_owned(),\n        KvGetIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_consistency(Consistency::Strong),\n    )\n    .await?;"
+            "source": "let response = diom.kv()\n    .get(\n        \"some_key\".to_owned(),\n        KvGetIn::new()\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_consistency(Consistency::Strong),\n    )\n    .await?;"
           }
         ]
       }
@@ -3049,7 +3049,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.kv()\n    .namespace()\n    .configure(\n        KvConfigureNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.kv()\n    .namespace()\n    .configure(\n        KvConfigureNamespaceIn::new(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3133,7 +3133,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.kv()\n    .namespace()\n    .get(\n        KvGetNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.kv()\n    .namespace()\n    .get(\n        KvGetNamespaceIn::new(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3217,7 +3217,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.kv()\n    .delete(\n        \"sample string\".to_owned(),\n        KvDeleteIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_version(1),\n    )\n    .await?;"
+            "source": "let response = diom.kv()\n    .delete(\n        \"some_key\".to_owned(),\n        KvDeleteIn::new()\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_version(1),\n    )\n    .await?;"
           }
         ]
       }
@@ -3301,7 +3301,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.rate_limit()\n    .limit(\n        RateLimitCheckIn::new(\n            \"sample string\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"sample string\".to_owned())\n            .with_tokens(1),\n    )\n    .await?;"
+            "source": "let response = diom.rate_limit()\n    .limit(\n        RateLimitCheckIn::new(\n            \"some_key\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_tokens(1),\n    )\n    .await?;"
           }
         ]
       }
@@ -3385,7 +3385,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.rate_limit()\n    .get_remaining(\n        RateLimitGetRemainingIn::new(\n            \"sample string\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.rate_limit()\n    .get_remaining(\n        RateLimitGetRemainingIn::new(\n            \"some_key\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3469,7 +3469,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.rate_limit()\n    .reset(\n        RateLimitResetIn::new(\n            \"sample string\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.rate_limit()\n    .reset(\n        RateLimitResetIn::new(\n            \"some_key\".to_owned(),\n            RateLimitConfig::new(\n                1,\n                1,\n            )\n                .with_refill_interval(Duration::from_secs(30)),\n        )\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3553,7 +3553,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.rate_limit()\n    .namespace()\n    .configure(\n        RateLimitConfigureNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.rate_limit()\n    .namespace()\n    .configure(\n        RateLimitConfigureNamespaceIn::new(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3637,7 +3637,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.rate_limit()\n    .namespace()\n    .get(\n        RateLimitGetNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.rate_limit()\n    .namespace()\n    .get(\n        RateLimitGetNamespaceIn::new(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3721,7 +3721,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.idempotency()\n    .start(\n        \"sample string\".to_owned(),\n        IdempotencyStartIn::new(Duration::from_secs(30))\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.idempotency()\n    .start(\n        \"some_key\".to_owned(),\n        IdempotencyStartIn::new(Duration::from_secs(30))\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3805,7 +3805,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.idempotency()\n    .complete(\n        \"sample string\".to_owned(),\n        IdempotencyCompleteIn::new(\n            vec![],\n            Duration::from_secs(30),\n        )\n            .with_namespace(\"sample string\".to_owned())\n            .with_context(HashMap::new()),\n    )\n    .await?;"
+            "source": "let response = diom.idempotency()\n    .complete(\n        \"some_key\".to_owned(),\n        IdempotencyCompleteIn::new(\n            vec![],\n            Duration::from_secs(30),\n        )\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_context(HashMap::new()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3889,7 +3889,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.idempotency()\n    .abort(\n        \"sample string\".to_owned(),\n        IdempotencyAbortIn::new()\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.idempotency()\n    .abort(\n        \"some_key\".to_owned(),\n        IdempotencyAbortIn::new()\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -3973,7 +3973,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.idempotency()\n    .namespace()\n    .configure(\n        IdempotencyConfigureNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.idempotency()\n    .namespace()\n    .configure(\n        IdempotencyConfigureNamespaceIn::new(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -4057,7 +4057,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.idempotency()\n    .namespace()\n    .get(\n        IdempotencyGetNamespaceIn::new(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.idempotency()\n    .namespace()\n    .get(\n        IdempotencyGetNamespaceIn::new(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -4141,7 +4141,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .namespace()\n    .configure(\n        \"sample string\".to_owned(),\n        MsgNamespaceConfigureIn::new()\n            .with_retention(Retention::new()\n                .with_period(Duration::from_secs(30))),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .namespace()\n    .configure(\n        \"some_namespace\".to_owned(),\n        MsgNamespaceConfigureIn::new()\n            .with_retention(Retention::new()\n                .with_period(Duration::from_secs(30))),\n    )\n    .await?;"
           }
         ]
       }
@@ -4225,7 +4225,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .namespace()\n    .get(\n        \"sample string\".to_owned(),\n        MsgNamespaceGetIn::new(),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .namespace()\n    .get(\n        \"some_namespace\".to_owned(),\n        MsgNamespaceGetIn::new(),\n    )\n    .await?;"
           }
         ]
       }
@@ -4309,7 +4309,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .publish(\n        \"sample string\".to_owned(),\n        MsgPublishIn::new(vec![])\n            .with_namespace(\"sample string\".to_owned())\n            .with_idempotency_key(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .publish(\n        \"some_topic_name\".to_owned(),\n        MsgPublishIn::new(vec![])\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_idempotency_key(\"my_idempotency_key\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -4393,7 +4393,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .stream()\n    .receive(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgStreamReceiveIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_batch_size(1)\n            .with_lease_duration(Duration::from_secs(30))\n            .with_default_starting_position(SeekPosition::Earliest)\n            .with_batch_wait(Duration::from_secs(30)),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .stream()\n    .receive(\n        \"some_topic_name\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgStreamReceiveIn::new()\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_batch_size(1)\n            .with_lease_duration(Duration::from_secs(30))\n            .with_default_starting_position(SeekPosition::Earliest)\n            .with_batch_wait(Duration::from_secs(30)),\n    )\n    .await?;"
           }
         ]
       }
@@ -4477,7 +4477,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .stream()\n    .commit(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgStreamCommitIn::new(1)\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .stream()\n    .commit(\n        \"some_topic_name~0\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgStreamCommitIn::new(1)\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -4561,7 +4561,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .stream()\n    .seek(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgStreamSeekIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_offset(1)\n            .with_position(SeekPosition::Earliest)\n            .with_timestamp(\"2026-04-20 12:00:00\".parse()?),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .stream()\n    .seek(\n        \"some_topic_name\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgStreamSeekIn::new()\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_offset(1)\n            .with_position(SeekPosition::Earliest)\n            .with_timestamp(\"2026-04-20 12:00:00\".parse()?),\n    )\n    .await?;"
           }
         ]
       }
@@ -4645,7 +4645,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .stream()\n    .cancel_lease(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgStreamCancelLeaseIn::new()\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .stream()\n    .cancel_lease(\n        \"some_topic_name~0\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgStreamCancelLeaseIn::new()\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -4729,7 +4729,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .queue()\n    .receive(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueReceiveIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_batch_size(1)\n            .with_lease_duration(Duration::from_secs(30))\n            .with_batch_wait(Duration::from_secs(30)),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .queue()\n    .receive(\n        \"some_topic_name\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgQueueReceiveIn::new()\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_batch_size(1)\n            .with_lease_duration(Duration::from_secs(30))\n            .with_batch_wait(Duration::from_secs(30)),\n    )\n    .await?;"
           }
         ]
       }
@@ -4813,7 +4813,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .queue()\n    .ack(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueAckIn::new(vec![])\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .queue()\n    .ack(\n        \"some_topic_name\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgQueueAckIn::new(vec![])\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -4897,7 +4897,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .queue()\n    .extend_lease(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueExtendLeaseIn::new(vec![])\n            .with_namespace(\"sample string\".to_owned())\n            .with_lease_duration(Duration::from_secs(30)),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .queue()\n    .extend_lease(\n        \"some_topic_name\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgQueueExtendLeaseIn::new(vec![])\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_lease_duration(Duration::from_secs(30)),\n    )\n    .await?;"
           }
         ]
       }
@@ -4981,7 +4981,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .queue()\n    .configure(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueConfigureIn::new()\n            .with_namespace(\"sample string\".to_owned())\n            .with_retry_schedule(vec![])\n            .with_dlq_topic(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .queue()\n    .configure(\n        \"some_topic_name\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgQueueConfigureIn::new()\n            .with_namespace(\"some_namespace\".to_owned())\n            .with_retry_schedule(vec![])\n            .with_dlq_topic(\"some_topic_name\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -5065,7 +5065,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .queue()\n    .nack(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueNackIn::new(vec![])\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .queue()\n    .nack(\n        \"some_topic_name\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgQueueNackIn::new(vec![])\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -5149,7 +5149,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .queue()\n    .redrive_dlq(\n        \"sample string\".to_owned(),\n        \"sample string\".to_owned(),\n        MsgQueueRedriveDlqIn::new()\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .queue()\n    .redrive_dlq(\n        \"some_topic_name\".to_owned(),\n        \"some_consumer_group\".to_owned(),\n        MsgQueueRedriveDlqIn::new()\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -5233,7 +5233,7 @@
           {
             "lang": "Rust",
             "label": "Rust",
-            "source": "let response = diom.msgs()\n    .topic()\n    .configure(\n        \"sample string\".to_owned(),\n        MsgTopicConfigureIn::new(1)\n            .with_namespace(\"sample string\".to_owned()),\n    )\n    .await?;"
+            "source": "let response = diom.msgs()\n    .topic()\n    .configure(\n        \"some_topic_name\".to_owned(),\n        MsgTopicConfigureIn::new(1)\n            .with_namespace(\"some_namespace\".to_owned()),\n    )\n    .await?;"
           }
         ]
       }
@@ -5422,10 +5422,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_access_policy"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "example": "policy description…"
           },
           "rules": {
             "type": "array",
@@ -5444,7 +5446,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_access_policy"
           },
           "created": {
             "type": "integer",
@@ -5469,7 +5472,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_access_policy"
           }
         },
         "required": [
@@ -5491,7 +5495,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_access_policy"
           }
         },
         "required": [
@@ -5512,6 +5517,7 @@
           "iterator": {
             "description": "The iterator returned from a prior invocation",
             "type": "string",
+            "example": "some_access_policy",
             "nullable": true
           }
         }
@@ -5520,7 +5526,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_access_policy"
           },
           "description": {
             "type": "string"
@@ -5556,10 +5563,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "example": "some token name"
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "example": "some token role"
           },
           "expiry_ms": {
             "description": "Milliseconds from now until the token expires.",
@@ -5584,7 +5593,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "token": {
             "type": "string"
@@ -5613,7 +5623,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           }
         },
         "required": [
@@ -5635,7 +5646,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "expiry_ms": {
             "description": "Milliseconds from now until the token expires. `None` means expire immediately.",
@@ -5667,6 +5679,7 @@
           "iterator": {
             "description": "The iterator returned from a prior invocation",
             "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w",
             "nullable": true
           }
         }
@@ -5675,7 +5688,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "name": {
             "type": "string"
@@ -5725,7 +5739,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           }
         },
         "required": [
@@ -5736,7 +5751,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "token": {
             "type": "string"
@@ -5765,11 +5781,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "name": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "example": "some token name"
           },
           "expiry_ms": {
             "type": "integer",
@@ -5797,7 +5815,8 @@
         "type": "object",
         "properties": {
           "role": {
-            "type": "string"
+            "type": "string",
+            "example": "some_role_id"
           }
         },
         "required": [
@@ -5808,10 +5827,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_role_id"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "example": "role description…"
           },
           "rules": {
             "type": "array",
@@ -5823,7 +5844,8 @@
           "policies": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "example": "some_access_policy"
             },
             "default": []
           },
@@ -5844,7 +5866,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_role_id"
           },
           "created": {
             "type": "integer",
@@ -5869,7 +5892,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_role_id"
           }
         },
         "required": [
@@ -5891,7 +5915,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_role_id"
           }
         },
         "required": [
@@ -5912,6 +5937,7 @@
           "iterator": {
             "description": "The iterator returned from a prior invocation",
             "type": "string",
+            "example": "some_role_id",
             "nullable": true
           }
         }
@@ -5920,7 +5946,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "some_role_id"
           },
           "description": {
             "type": "string"
@@ -5934,7 +5961,8 @@
           "policies": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "example": "some_access_policy"
             }
           },
           "context": {
@@ -6022,7 +6050,8 @@
             "nullable": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "example": "some token name"
           },
           "prefix": {
             "type": "string",
@@ -6048,7 +6077,8 @@
             }
           },
           "owner_id": {
-            "type": "string"
+            "type": "string",
+            "example": "owner ID"
           },
           "scopes": {
             "type": "array",
@@ -6072,7 +6102,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "created": {
             "type": "integer",
@@ -6109,7 +6140,8 @@
             "nullable": true
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           }
         },
         "required": [
@@ -6139,7 +6171,8 @@
             "nullable": true
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "expiry_ms": {
             "description": "Milliseconds from now until the token expires. `None` means expire immediately.",
@@ -6226,6 +6259,7 @@
           "iterator": {
             "description": "The iterator returned from a prior invocation",
             "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w",
             "nullable": true
           }
         },
@@ -6237,7 +6271,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "name": {
             "type": "string"
@@ -6304,7 +6339,8 @@
             "nullable": true
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "prefix": {
             "type": "string",
@@ -6331,7 +6367,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "created": {
             "type": "integer",
@@ -6368,7 +6405,8 @@
             "nullable": true
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "example": "key_06etngr201xwv7qj08mt4cs03w"
           },
           "name": {
             "type": "string",
@@ -6684,10 +6722,12 @@
         "properties": {
           "previous_leader_id": {
             "type": "string",
+            "example": "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8",
             "nullable": true
           },
           "new_leader_id": {
             "type": "string",
+            "example": "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8",
             "nullable": true
           }
         }
@@ -6740,7 +6780,8 @@
         "type": "object",
         "properties": {
           "node_id": {
-            "type": "string"
+            "type": "string",
+            "example": "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8"
           }
         },
         "required": [
@@ -6751,7 +6792,8 @@
         "type": "object",
         "properties": {
           "node_id": {
-            "type": "string"
+            "type": "string",
+            "example": "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8"
           }
         },
         "required": [
@@ -6773,7 +6815,8 @@
           },
           "this_node_id": {
             "description": "The unique ID of the node servicing this request",
-            "type": "string"
+            "type": "string",
+            "example": "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8"
           },
           "this_node_state": {
             "description": "The cluster state of the node servicing this request",
@@ -7670,7 +7713,8 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "msgs": {
             "type": "array",
@@ -7680,8 +7724,9 @@
           },
           "idempotency_key": {
             "type": "string",
+            "nullable": true,
             "default": null,
-            "nullable": true
+            "example": "my_idempotency_key"
           }
         },
         "required": [
@@ -7710,7 +7755,8 @@
         "type": "object",
         "properties": {
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name~0"
           },
           "start_offset": {
             "type": "integer",
@@ -7742,10 +7788,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           },
           "msg_ids": {
             "type": "array",
@@ -7780,10 +7828,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           },
           "retry_schedule": {
             "type": "array",
@@ -7796,6 +7846,7 @@
           },
           "dlq_topic": {
             "type": "string",
+            "example": "some_topic_name",
             "nullable": true
           }
         },
@@ -7821,6 +7872,7 @@
           },
           "dlq_topic": {
             "type": "string",
+            "example": "some_topic_name",
             "nullable": true
           }
         },
@@ -7841,10 +7893,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           },
           "msg_ids": {
             "type": "array",
@@ -7886,10 +7940,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           },
           "msg_ids": {
             "type": "array",
@@ -7924,10 +7980,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           },
           "batch_size": {
             "type": "integer",
@@ -7989,10 +8047,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           }
         },
         "required": [
@@ -8020,10 +8080,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name~0"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           }
         },
         "required": [
@@ -8051,10 +8113,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name~0"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           },
           "offset": {
             "type": "integer",
@@ -8088,10 +8152,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           },
           "batch_size": {
             "type": "integer",
@@ -8157,10 +8223,12 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "consumer_group": {
-            "type": "string"
+            "type": "string",
+            "example": "some_consumer_group"
           },
           "offset": {
             "type": "integer",
@@ -8205,7 +8273,8 @@
             "nullable": true
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name"
           },
           "partitions": {
             "type": "integer",
@@ -8241,7 +8310,8 @@
         "properties": {
           "node_id": {
             "description": "A unique ID representing this node.\n\nThis will never change unless the node is erased and reset",
-            "type": "string"
+            "type": "string",
+            "example": "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8"
           },
           "address": {
             "description": "The advertised inter-server (cluster) address of this node.",
@@ -8635,7 +8705,8 @@
             "minimum": 0
           },
           "topic": {
-            "type": "string"
+            "type": "string",
+            "example": "some_topic_name~0"
           },
           "value": {
             "type": "array",

--- a/src/core/cluster/node.rs
+++ b/src/core/cluster/node.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use http::HeaderValue;
 use opentelemetry::{KeyValue, Value};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, json_schema};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use tap::Pipe;
@@ -112,8 +112,15 @@ impl JsonSchema for NodeId {
         true
     }
 
-    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        String::json_schema(generator)
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let example = NodeId {
+            inner: Uuid::from_u128(0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8),
+        };
+
+        json_schema!({
+            "type": "string",
+            "example": example,
+        })
     }
 }
 

--- a/src/v1/endpoints/admin/auth/policy.rs
+++ b/src/v1/endpoints/admin/auth/policy.rs
@@ -77,6 +77,7 @@ impl From<AccessPolicyModel> for AdminAccessPolicyOut {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct AdminAccessPolicyConfigureIn {
     pub id: AccessPolicyId,
+    #[schemars(example = "policy description…")]
     pub description: String,
     #[serde(default)]
     pub rules: Vec<AccessRule>,

--- a/src/v1/endpoints/admin/auth/role.rs
+++ b/src/v1/endpoints/admin/auth/role.rs
@@ -83,6 +83,7 @@ impl From<RoleModel> for AdminRoleOut {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct AdminRoleConfigureIn {
     pub id: RoleId,
+    #[schemars(example = "role description…")]
     pub description: String,
     #[serde(default)]
     pub rules: Vec<AccessRule>,

--- a/src/v1/endpoints/admin/auth/token.rs
+++ b/src/v1/endpoints/admin/auth/token.rs
@@ -66,7 +66,9 @@ pub struct AdminAuthTokenOut {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct AdminAuthTokenCreateIn {
+    #[schemars(example = "some token name")]
     pub name: String,
+    #[schemars(example = "some token role")]
     pub role: String,
     /// Milliseconds from now until the token expires.
     #[serde(rename = "expiry_ms")]
@@ -309,6 +311,7 @@ async fn auth_token_list(
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct AdminAuthTokenUpdateIn {
     pub id: Public<AuthTokenId>,
+    #[schemars(example = "some token name")]
     pub name: Option<String>,
     #[serde(rename = "expiry_ms")]
     pub expiry: Option<DurationMs>,

--- a/src/v1/endpoints/auth_token.rs
+++ b/src/v1/endpoints/auth_token.rs
@@ -91,6 +91,7 @@ impl From<AuthTokenModel> for AuthTokenOut {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct AuthTokenCreateIn {
     pub namespace: Option<NamespaceName>,
+    #[schemars(example = "some token name")]
     pub name: String,
     #[serde(default = "default_prefix")]
     pub prefix: String,
@@ -100,6 +101,7 @@ pub struct AuthTokenCreateIn {
     pub expiry: Option<DurationMs>,
     #[serde(default)]
     pub metadata: Metadata,
+    #[schemars(example = "owner ID")]
     pub owner_id: String,
     #[serde(default)]
     pub scopes: Vec<String>,

--- a/src/v1/endpoints/msgs.rs
+++ b/src/v1/endpoints/msgs.rs
@@ -145,6 +145,7 @@ struct MsgPublishIn {
     pub topic: TopicIn,
     pub msgs: Vec<diom_msgs::entities::MsgIn>,
     #[serde(default)]
+    #[schemars(example = &"my_idempotency_key")]
     pub idempotency_key: Option<String>,
 }
 

--- a/z-clients/cli/src/cmds/api/admin_auth_policy.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_policy.rs
@@ -26,12 +26,12 @@ pub enum AdminAuthPolicyCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\",
-  \"description\": \"...\",
+  \"id\": \"some_access_policy\",
+  \"description\": \"policy description…\",
   \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}]
 }\n\nExample response:
 {
-  \"id\": \"...\",
+  \"id\": \"some_access_policy\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
 }\n")]
@@ -50,7 +50,7 @@ pub enum AdminAuthPolicyCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\"
+  \"id\": \"some_access_policy\"
 }\n\nExample response:
 {
   \"success\": true
@@ -69,10 +69,10 @@ pub enum AdminAuthPolicyCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\"
+  \"id\": \"some_access_policy\"
 }\n\nExample response:
 {
-  \"id\": \"...\",
+  \"id\": \"some_access_policy\",
   \"description\": \"...\",
   \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}],
   \"created\": 1234567890123,
@@ -93,10 +93,10 @@ pub enum AdminAuthPolicyCommands {
     #[command(after_help = "Example body:
 {
   \"limit\": 123,
-  \"iterator\": \"...\"
+  \"iterator\": \"some_access_policy\"
 }\n\nExample response:
 {
-  \"data\": [{\"id\": \"...\", \"description\": \"...\", \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}], \"created\": 1234567890123, \"updated\": 1234567890123}],
+  \"data\": [{\"id\": \"some_access_policy\", \"description\": \"...\", \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}], \"created\": 1234567890123, \"updated\": 1234567890123}],
   \"iterator\": \"...\",
   \"prev_iterator\": \"...\",
   \"done\": true

--- a/z-clients/cli/src/cmds/api/admin_auth_role.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_role.rs
@@ -26,14 +26,14 @@ pub enum AdminAuthRoleCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\",
-  \"description\": \"...\",
+  \"id\": \"some_role_id\",
+  \"description\": \"role description…\",
   \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}],
   \"policies\": [\"...\"],
   \"context\": {\"key\": \"...\"}
 }\n\nExample response:
 {
-  \"id\": \"...\",
+  \"id\": \"some_role_id\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
 }\n")]
@@ -51,7 +51,7 @@ pub enum AdminAuthRoleCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\"
+  \"id\": \"some_role_id\"
 }\n\nExample response:
 {
   \"success\": true
@@ -70,10 +70,10 @@ pub enum AdminAuthRoleCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\"
+  \"id\": \"some_role_id\"
 }\n\nExample response:
 {
-  \"id\": \"...\",
+  \"id\": \"some_role_id\",
   \"description\": \"...\",
   \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}],
   \"policies\": [\"...\"],
@@ -96,10 +96,10 @@ pub enum AdminAuthRoleCommands {
     #[command(after_help = "Example body:
 {
   \"limit\": 123,
-  \"iterator\": \"...\"
+  \"iterator\": \"some_role_id\"
 }\n\nExample response:
 {
-  \"data\": [{\"id\": \"...\", \"description\": \"...\", \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}], \"policies\": [\"...\"], \"context\": {\"key\": \"...\"}, \"created\": 1234567890123, \"updated\": 1234567890123}],
+  \"data\": [{\"id\": \"some_role_id\", \"description\": \"...\", \"rules\": [{\"effect\": \"allow\", \"resource\": \"...\", \"actions\": [\"...\"]}], \"policies\": [\"...\"], \"context\": {\"key\": \"...\"}, \"created\": 1234567890123, \"updated\": 1234567890123}],
   \"iterator\": \"...\",
   \"prev_iterator\": \"...\",
   \"done\": true

--- a/z-clients/cli/src/cmds/api/admin_auth_token.rs
+++ b/z-clients/cli/src/cmds/api/admin_auth_token.rs
@@ -26,13 +26,13 @@ pub enum AdminAuthTokenCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"name\": \"...\",
-  \"role\": \"...\",
+  \"name\": \"some token name\",
+  \"role\": \"some token role\",
   \"expiry_ms\": 60000,
   \"enabled\": true
 }\n\nExample response:
 {
-  \"id\": \"...\",
+  \"id\": \"key_06etngr201xwv7qj08mt4cs03w\",
   \"token\": \"...\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
@@ -51,7 +51,7 @@ pub enum AdminAuthTokenCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\",
+  \"id\": \"key_06etngr201xwv7qj08mt4cs03w\",
   \"expiry_ms\": 60000
 }\n\nExample response:
 {
@@ -70,10 +70,10 @@ pub enum AdminAuthTokenCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\"
+  \"id\": \"key_06etngr201xwv7qj08mt4cs03w\"
 }\n\nExample response:
 {
-  \"id\": \"...\",
+  \"id\": \"key_06etngr201xwv7qj08mt4cs03w\",
   \"token\": \"...\",
   \"created\": 1234567890123,
   \"updated\": 1234567890123
@@ -92,7 +92,7 @@ pub enum AdminAuthTokenCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\"
+  \"id\": \"key_06etngr201xwv7qj08mt4cs03w\"
 }\n\nExample response:
 {
   \"success\": true
@@ -112,10 +112,10 @@ pub enum AdminAuthTokenCommands {
     #[command(after_help = "Example body:
 {
   \"limit\": 123,
-  \"iterator\": \"...\"
+  \"iterator\": \"key_06etngr201xwv7qj08mt4cs03w\"
 }\n\nExample response:
 {
-  \"data\": [{\"id\": \"...\", \"name\": \"...\", \"created\": 1234567890123, \"updated\": 1234567890123, \"expiry\": 1234567890123, \"role\": \"...\", \"enabled\": true, \"expired\": true}],
+  \"data\": [{\"id\": \"key_06etngr201xwv7qj08mt4cs03w\", \"name\": \"...\", \"created\": 1234567890123, \"updated\": 1234567890123, \"expiry\": 1234567890123, \"role\": \"...\", \"enabled\": true, \"expired\": true}],
   \"iterator\": \"...\",
   \"prev_iterator\": \"...\",
   \"done\": true
@@ -134,8 +134,8 @@ pub enum AdminAuthTokenCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"id\": \"...\",
-  \"name\": \"...\",
+  \"id\": \"key_06etngr201xwv7qj08mt4cs03w\",
+  \"name\": \"some token name\",
   \"expiry_ms\": 60000,
   \"enabled\": true
 }\n\nExample response:
@@ -157,7 +157,7 @@ pub enum AdminAuthTokenCommands {
 {
 }\n\nExample response:
 {
-  \"role\": \"...\"
+  \"role\": \"some_role_id\"
 }\n")]
     Whoami {
         admin_auth_token_whoami_in:

--- a/z-clients/cli/src/cmds/api/cluster_admin.rs
+++ b/z-clients/cli/src/cmds/api/cluster_admin.rs
@@ -28,11 +28,11 @@ pub enum ClusterAdminCommands {
 {
   \"cluster_id\": \"...\",
   \"cluster_name\": \"...\",
-  \"this_node_id\": \"...\",
+  \"this_node_id\": \"a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8\",
   \"this_node_state\": \"leader\",
   \"this_node_last_committed_timestamp\": 1234567890123,
   \"this_node_last_snapshot_id\": \"...\",
-  \"nodes\": [{\"node_id\": \"...\", \"address\": \"...\", \"state\": \"leader\", \"last_committed_log_index\": 123, \"last_committed_term\": 123}]
+  \"nodes\": [{\"node_id\": \"a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8\", \"address\": \"...\", \"state\": \"leader\", \"last_committed_log_index\": 123, \"last_committed_term\": 123}]
 }\n")]
     Status {},
     /// Initialize this node as the leader of a new cluster
@@ -70,10 +70,10 @@ pub enum ClusterAdminCommands {
         ))]
     #[command(after_help = "Example body:
 {
-  \"node_id\": \"...\"
+  \"node_id\": \"a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8\"
 }\n\nExample response:
 {
-  \"node_id\": \"...\"
+  \"node_id\": \"a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8\"
 }\n")]
     RemoveNode {
         cluster_remove_node_in: crate::json::JsonOf<diom::models::ClusterRemoveNodeIn>,
@@ -112,8 +112,8 @@ pub enum ClusterAdminCommands {
 {
 }\n\nExample response:
 {
-  \"previous_leader_id\": \"...\",
-  \"new_leader_id\": \"...\"
+  \"previous_leader_id\": \"a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8\",
+  \"new_leader_id\": \"a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8\"
 }\n")]
     ForceElection {
         cluster_force_election_in:

--- a/z-clients/cli/src/cmds/api/msgs.rs
+++ b/z-clients/cli/src/cmds/api/msgs.rs
@@ -33,10 +33,10 @@ pub enum MsgsCommands {
 {
   \"namespace\": \"some_namespace\",
   \"msgs\": [{\"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"key\": \"...\", \"delay_ms\": 60000}],
-  \"idempotency_key\": \"...\"
+  \"idempotency_key\": \"my_idempotency_key\"
 }\n\nExample response:
 {
-  \"topics\": [{\"topic\": \"...\", \"start_offset\": 123, \"offset\": 123}]
+  \"topics\": [{\"topic\": \"some_topic_name~0\", \"start_offset\": 123, \"offset\": 123}]
 }\n")]
     Publish {
         topic: String,

--- a/z-clients/cli/src/cmds/api/msgs_queue.rs
+++ b/z-clients/cli/src/cmds/api/msgs_queue.rs
@@ -107,11 +107,11 @@ pub enum MsgsQueueCommands {
 {
   \"namespace\": \"some_namespace\",
   \"retry_schedule\": [123],
-  \"dlq_topic\": \"...\"
+  \"dlq_topic\": \"some_topic_name\"
 }\n\nExample response:
 {
   \"retry_schedule\": [123],
-  \"dlq_topic\": \"...\"
+  \"dlq_topic\": \"some_topic_name\"
 }\n")]
     Configure {
         topic: String,

--- a/z-clients/cli/src/cmds/api/msgs_stream.rs
+++ b/z-clients/cli/src/cmds/api/msgs_stream.rs
@@ -36,7 +36,7 @@ pub enum MsgsStreamCommands {
   \"batch_wait_ms\": 60000
 }\n\nExample response:
 {
-  \"msgs\": [{\"offset\": 123, \"topic\": \"...\", \"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"timestamp\": 1234567890123, \"scheduled_at\": 1234567890123}]
+  \"msgs\": [{\"offset\": 123, \"topic\": \"some_topic_name~0\", \"value\": \"...\", \"headers\": {\"key\": \"...\"}, \"timestamp\": 1234567890123, \"scheduled_at\": 1234567890123}]
 }\n")]
     Receive {
         topic: String,


### PR DESCRIPTION
No more `"sample string"`s! (for now)

Part of https://github.com/svix/monorepo-private/issues/12997.