### PR TITLE
tests: remove startup timeout

### DIFF
--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -142,11 +142,9 @@ impl TestServerBuilder {
         };
         let client = TestClient::new(base_uri, &token);
 
-        const MAX_INITIALIZATION_TIME: Duration = Duration::from_secs(5);
-
-        tokio::time::timeout(MAX_INITIALIZATION_TIME, initialized.wait())
+        initialized
+            .wait()
             .await
-            .expect("initialization should not time out")
             .expect("initialization should finish");
 
         let (node_id, cluster_id) = wait_for_initialized(addr, repl_addr, Duration::from_secs(8))


### PR DESCRIPTION
Sometimes we hit this. I don't know why; when I've profiled it there's nothing interesting going on, but it just takes us 6 seconds to start up. It doesn't seem to lead to the test running slower.

We already have a max test timeout in nextest; let's remove this extra timeout for now.