### PR TITLE
gha: set verbose_summary to false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
           check_retries: true
           job_summary: true
           detailed_summary: true
+          verbose_summary: false
           fail_on_parse_error: true
           include_time_in_summary: true
           group_suite: true


### PR DESCRIPTION
This removes the "No test annotations available" message if all tests pass