### PR TITLE
update rust to 1.96 and update debian image

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: '1.95'
+          toolchain: '1.96'
       - uses: ubicloud/rust-cache@65b3ff06b9bcc69d88c25e212f1ae3d14a0953c3 # v2.7.5
       - name: Install cargo-criterion
         run: cargo install cargo-criterion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   # Keep this in sync with Dockerfile
-  ci_toolchain_rust: '1.95'
+  ci_toolchain_rust: '1.96'
 
 jobs:
   check-fmt:

--- a/.github/workflows/sdk-integration.yml
+++ b/.github/workflows/sdk-integration.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: '1.95'
+          toolchain: '1.96'
       - uses: ubicloud/rust-cache@65b3ff06b9bcc69d88c25e212f1ae3d14a0953c3 # v2.7.5
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Using https://github.com/LukeMathWalker/cargo-chef for better layer caching
 
 # Base image for planner and build - keep in sync with .github/workflows/server-ci.yml
-FROM docker.io/rust:1.95-slim-trixie AS chef
+FROM docker.io/rust:1.96-slim-trixie AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 
@@ -17,7 +17,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Build environment
 FROM chef AS build-base
 
-ENV __BUST_DOCKER_BUILD_CACHE=2026-04-21
+ARG __BUST_DOCKER_BUILD_CACHE=2026-05-29
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
     #!/bin/bash
     set -euxo pipefail
@@ -65,9 +65,9 @@ ARG RELEASE_VERSION
 RUN cargo build --release --package diom-cli --bin diom --frozen
 
 # shared base image with dependencies
-FROM docker.io/debian:trixie-slim AS base
+FROM docker.io/debian:trixie-20260518-slim AS base
 
-ENV __BUST_DOCKER_BUILD_CACHE=2026-05-18
+ARG __BUST_DOCKER_BUILD_CACHE=2026-05-18
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
     #!/bin/bash
     set -euxo pipefail
@@ -77,19 +77,6 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/
         ca-certificates=20250419 \
         --no-install-recommends
     update-ca-certificates
-EOF
-
-# Temporary: pin patched versions of CVE-2026-4437, CVE-2026-4046, CVE-2026-4878 until upstream image rebuilds
-RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
-    #!/bin/bash
-    set -euxo pipefail
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update -q
-    apt-get install -y \
-        libc-bin=2.41-12+deb13u3 \
-        libc6=2.41-12+deb13u3 \
-        libcap2=1:2.75-10+deb13u1+b1 \
-        --no-install-recommends
 EOF
 
 RUN <<EOF

--- a/infra/operator/Dockerfile
+++ b/infra/operator/Dockerfile
@@ -5,7 +5,7 @@
 # Using https://github.com/LukeMathWalker/cargo-chef for better layer caching
 
 # Base image for planner and build - keep in sync with root Dockerfile
-FROM docker.io/rust:1.95-slim-trixie AS chef
+FROM docker.io/rust:1.96-slim-trixie AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 
@@ -17,7 +17,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Build environment
 FROM chef AS build
 
-ENV __BUST_DOCKER_BUILD_CACHE=2026-05-18
+ARG __BUST_DOCKER_BUILD_CACHE=2026-05-29
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
     #!/bin/bash
     set -euxo pipefail
@@ -51,7 +51,7 @@ ARG RELEASE_VERSION
 RUN cargo build --release -p diom-operator --bin diom-operator --frozen
 
 # Production
-FROM docker.io/debian:trixie-slim AS prod
+FROM docker.io/debian:trixie-20260518-slim AS prod
 
 RUN <<EOF
     #!/bin/bash
@@ -61,7 +61,7 @@ RUN <<EOF
     chown -R appuser: /home/appuser
 EOF
 
-ENV __BUST_DOCKER_BUILD_CACHE=2026-05-18
+ARG __BUST_DOCKER_BUILD_CACHE=2026-05-29
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
     #!/bin/bash
     set -euxo pipefail
@@ -71,19 +71,6 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/
         ca-certificates=20250419 \
         --no-install-recommends
     update-ca-certificates
-EOF
-
-# Temporary: pin patched versions of CVE-2026-4437, CVE-2026-4046, CVE-2026-4878 until upstream image rebuilds
-RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
-    #!/bin/bash
-    set -euxo pipefail
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update -q
-    apt-get install -y \
-        libc-bin=2.41-12+deb13u3 \
-        libc6=2.41-12+deb13u3 \
-        libcap2=1:2.75-10+deb13u1+b1 \
-        --no-install-recommends
 EOF
 
 USER appuser


### PR DESCRIPTION
This bumps the Rust toolchain in CI to 1.96.0 and bumps the various images used in docker builds