### PR TITLE
sec: ignore "unmaintained crate" rustsec warning about build-time dep

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,8 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 ignore = [
+    # can't do anything about this until validator stops using proc-macro-error2
+    "RUSTSEC-2026-0173"
 ]
 
 [licenses]


### PR DESCRIPTION
[RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173.html) is a report that [proc-macro-error2](https://crates.io/crates/proc-macro-error2) is not actively maintained. Ok.