### PR TITLE
Upgrade jackson to latest patch version of 2.21 (LTS)

### DIFF
--- a/z-clients/java/pom.xml
+++ b/z-clients/java/pom.xml
@@ -40,27 +40,27 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.21.1</version>
+            <version>2.21.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.19.4</version>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.4</version>
+            <version>2.21.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.19.4</version>
+            <version>2.21.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.19.4</version>
+            <version>2.21.4</version>
         </dependency>
         <dependency>
             <groupId>org.msgpack</groupId>


### PR DESCRIPTION
Replaces #1261, which failed CI with

```
Error:  Errors: 
Error:    IntegrationTest.setUp:33 » NoClassDefFound com/fasterxml/jackson/annotation/JsonSerializeAs
```

(maybe a v2.22 thing?)