### PR TITLE
deps: bump openraft to alpha24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -175,7 +175,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1412,7 +1412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2094,7 +2094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2998,7 +2998,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3021,6 +3021,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -3627,7 +3636,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3739,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.19"
+version = "0.10.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be61988143b295becb312ba3aa87180fab9cede5034e71cdfc56b67307e527ce"
+checksum = "71c9994f816c3b71255e2b5e1c53c8feed5a8a5d5deca74f3f4e318a72615684"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -3751,7 +3760,7 @@ dependencies = [
  "derive_more",
  "display-more",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "maplit",
  "openraft-macros",
  "openraft-rt",
@@ -3768,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.20"
+version = "0.10.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880853cd85c2dd7883122134abcc5483005dd175d6027e9e00c1eede8fd2a956"
+checksum = "c8b12005e854b4bbd471dcd27e98288a921b6e57c96f0ceb5e689e9e0ab04c7b"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -3781,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.20"
+version = "0.10.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba87cea8e45601807f2537fd9e657e02c9ee2fdaa9be4ece013b296b03b2c97"
+checksum = "e33af8e5c55654111ea638c683ae6d953d98758c83d810249e4bece6ae242803"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3794,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.20"
+version = "0.10.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a539ef5ef89d4da720c56300aeb702d6ddf2a9fa653b029b79d30e5f8cf68fa"
+checksum = "38b2718987a0b9fc347aaf8583f4b61726aa670e715999f63609ca883edacaf5"
 dependencies = [
  "futures-util",
  "openraft-rt",
@@ -4929,7 +4938,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4988,7 +4997,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5403,7 +5412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5576,7 +5585,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6479,7 +6488,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,7 @@ maplit = "1"
 mimalloc = { version = "0.1.48", features = ["v3"] }
 mime = "0.3"
 openapi-codegen = { git = "https://github.com/svix/openapi-codegen", rev = "fecc6dc607c19cb9247f35849288725514cb4675" }
-openraft = { version = "=0.10.0-alpha.19", default-features = false, features = ["tracing-log", "anyhow", "serde", "tokio-rt"] }
+openraft = { version = "=0.10.0-alpha.24", default-features = false, features = ["tracing-log", "anyhow", "serde", "tokio-rt"] }
 opentelemetry = { version = "0.32.0", features = ["metrics"] }
 opentelemetry-http = "0.32.0"
 opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["internal-logs", "metrics", "grpc-tonic", "http-proto"] }

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -209,7 +209,7 @@ async fn discover(
     let cluster = raft_state
         .raft
         .with_raft_state(move |state| DiscoverClusterResponse {
-            last_committed_log_id: state.committed().copied(),
+            last_committed_log_id: state.local_committed().copied(),
             cluster_name,
             state: state.server_state,
             cluster_id,
@@ -292,7 +292,7 @@ async fn last_id(Extension(state): Extension<RaftState>) -> impl IntoResponse {
     state
         .raft
         .with_raft_state(move |s| LastIdResponse {
-            last_committed_log_id: s.committed().copied(),
+            last_committed_log_id: s.local_committed().copied(),
         })
         .await
         .pipe(rpc_response)
@@ -310,7 +310,7 @@ async fn health(Extension(state): Extension<RaftState>) -> impl IntoResponse {
         .with_raft_state(move |s| {
             let response = HealthResponse {
                 node_id: me,
-                last_committed_log_index: s.committed().map(|l| l.index),
+                last_committed_log_index: s.local_committed().map(|l| l.index),
                 server_state: s.server_state,
                 cluster_id,
                 leader,

--- a/src/core/cluster/background.rs
+++ b/src/core/cluster/background.rs
@@ -347,7 +347,7 @@ pub(super) async fn run_background_jobs_on_all_nodes(
     let mut last_snapshot_time = std::time::Instant::now();
     let mut last_snapshot_index = handle
         .raft
-        .with_raft_state(|st| st.committed().copied())
+        .with_raft_state(|st| st.local_committed().copied())
         .await?;
     let mut ticker = tokio::time::interval(Duration::from_secs(60));
     let shutdown = crate::shutting_down_token();
@@ -366,7 +366,7 @@ pub(super) async fn run_background_jobs_on_all_nodes(
         };
         let (committed, state) = handle
             .raft
-            .with_raft_state(|st| (st.committed().copied(), st.server_state))
+            .with_raft_state(|st| (st.local_committed().copied(), st.server_state))
             .await?;
 
         let delta = match (committed, last_snapshot_index) {

--- a/src/core/cluster/handle.rs
+++ b/src/core/cluster/handle.rs
@@ -462,7 +462,7 @@ impl RaftState {
         let (has_cluster, server_state) = self
             .raft
             .with_raft_state(move |s| {
-                let has_committed_ids = s.committed().is_some();
+                let has_committed_ids = s.local_committed().is_some();
                 let has_nodes = s.membership_state.effective().nodes().count() > 0;
                 let self_in_nodes = s.membership_state.effective().get_node(&node_id).is_some();
                 let valid_state =

--- a/src/v1/endpoints/cluster_admin.rs
+++ b/src/v1/endpoints/cluster_admin.rs
@@ -121,7 +121,7 @@ async fn cluster_status(
         .raft
         .with_raft_state(move |s| {
             let this_node_state = s.server_state.into();
-            let committed = s.committed().copied();
+            let committed = s.local_committed().copied();
             let members = s.membership_state.effective().membership();
             let voters = members.voter_ids().collect::<BTreeSet<NodeId>>();
             let learners = members.voter_ids().collect::<BTreeSet<NodeId>>();
@@ -362,7 +362,7 @@ async fn cluster_force_election(
 ) -> Result<MsgPackOrJson<ClusterForceElectionOut>> {
     let previous_leader_id = repl.raft.current_leader().await;
 
-    repl.raft.trigger().elect().await.or_internal_error()?;
+    repl.raft.trigger().elect(true).await.or_internal_error()?;
 
     let new_leader_id = repl.raft.current_leader().await;
 


### PR DESCRIPTION
no major changes; passes the test suite and performs equivalently in local testing