### PR TITLE
Improve Diom Operator Status reporting

### DIFF
--- a/infra/helm-diom/charts/crds/crds/diomclusters.json
+++ b/infra/helm-diom/charts/crds/crds/diomclusters.json
@@ -25,14 +25,14 @@
             "type": "integer"
           },
           {
-            "jsonPath": ".status.phase",
-            "name": "Phase",
-            "type": "string"
-          },
-          {
             "jsonPath": ".status.readyReplicas",
             "name": "Ready",
             "type": "integer"
+          },
+          {
+            "jsonPath": ".status.conditions[?(@.type=='Ready')].reason",
+            "name": "Status",
+            "type": "string"
           }
         ],
         "name": "v1alpha1",
@@ -1626,14 +1626,53 @@
                 "description": "Status of a DiomCluster.",
                 "nullable": true,
                 "properties": {
-                  "phase": {
-                    "default": "Initializing",
-                    "enum": [
-                      "Initializing",
-                      "Running",
-                      "Degraded"
-                    ],
-                    "type": "string"
+                  "conditions": {
+                    "default": [],
+                    "items": {
+                      "description": "Condition contains details for one aspect of the current state of this API Resource.",
+                      "properties": {
+                        "lastTransitionTime": {
+                          "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                          "type": "string"
+                        },
+                        "observedGeneration": {
+                          "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "reason": {
+                          "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                          "type": "string"
+                        },
+                        "status": {
+                          "description": "status of the condition, one of True, False, Unknown.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "lastTransitionTime",
+                        "message",
+                        "reason",
+                        "status",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "observedGeneration": {
+                    "default": 0,
+                    "format": "int64",
+                    "type": "integer"
                   },
                   "readyReplicas": {
                     "default": 0,

--- a/infra/operator/ChangeLog.md
+++ b/infra/operator/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased Changes
+* **Breaking** Replace `status.phase` with `status.conditions` and add `status.observedGeneration`
 
 ## Version 0.2.1
 * Add default crypto provider

--- a/infra/operator/src/crd.rs
+++ b/infra/operator/src/crd.rs
@@ -6,7 +6,7 @@ use k8s_openapi::{
         Affinity, EmptyDirVolumeSource, EnvVar, EnvVarSource, HTTPGetAction, Probe,
         ResourceRequirements, SecretKeySelector, Toleration, TopologySpreadConstraint,
     },
-    apimachinery::pkg::api::resource::Quantity,
+    apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::Condition},
 };
 use kube::CustomResource;
 use schemars::JsonSchema;
@@ -35,8 +35,8 @@ fn default_replicas() -> i32 {
     status = "DiomClusterStatus",
     shortname = "cc",
     printcolumn = r#"{"name":"Replicas","type":"integer","jsonPath":".spec.replicas"}"#,
-    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
-    printcolumn = r#"{"name":"Ready","type":"integer","jsonPath":".status.readyReplicas"}"#
+    printcolumn = r#"{"name":"Ready","type":"integer","jsonPath":".status.readyReplicas"}"#,
+    printcolumn = r#"{"name":"Status","type":"string","jsonPath":".status.conditions[?(@.type=='Ready')].reason"}"#
 )]
 pub struct DiomClusterSpec {
     /// Cluster/replication configuration.
@@ -381,18 +381,13 @@ impl ProbeSpec {
 #[serde(rename_all = "camelCase")]
 pub struct DiomClusterStatus {
     #[serde(default)]
-    pub phase: Phase,
+    pub ready_replicas: i32,
 
     #[serde(default)]
-    pub ready_replicas: i32,
-}
+    pub observed_generation: i64,
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema, PartialEq)]
-pub enum Phase {
-    #[default]
-    Initializing,
-    Running,
-    Degraded,
+    #[serde(default)]
+    pub conditions: Vec<Condition>,
 }
 
 /// Source for the admin token.

--- a/infra/operator/src/error.rs
+++ b/infra/operator/src/error.rs
@@ -11,8 +11,11 @@ pub(crate) enum Error {
     #[error("Timeout: {0}")]
     Timeout(String),
 
-    #[error("Storage error: {0}")]
-    Storage(String),
+    #[error("Invalid storage size: {0}")]
+    InvalidStorageSize(String),
+
+    #[error("Unexpected PVC storage state: {0}")]
+    PvcStorageState(String),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/infra/operator/src/lib.rs
+++ b/infra/operator/src/lib.rs
@@ -4,7 +4,7 @@ use futures_util::StreamExt;
 use k8s_openapi::api::apps::v1::StatefulSet;
 use kube::{
     Api, Client,
-    runtime::{Controller, watcher},
+    runtime::{Controller, controller::Error as ControllerError, watcher},
 };
 use tracing::*;
 
@@ -16,13 +16,21 @@ pub mod reconciler;
 pub mod resources;
 
 use crd::DiomCluster;
-use reconciler::{Context, error_policy, reconcile};
+use reconciler::{Context, STALL_THRESHOLD, error_policy, reconcile};
 
 pub async fn run(client: Client) -> anyhow::Result<()> {
     run_with_requeue(client, Duration::from_secs(60)).await
 }
 
 pub async fn run_with_requeue(client: Client, requeue_interval: Duration) -> anyhow::Result<()> {
+    run_with_config(client, requeue_interval, STALL_THRESHOLD).await
+}
+
+pub async fn run_with_config(
+    client: Client,
+    requeue_interval: Duration,
+    stall_threshold: Duration,
+) -> anyhow::Result<()> {
     let clusters: Api<DiomCluster> = Api::all(client.clone());
     let statefulsets: Api<StatefulSet> = Api::all(client.clone());
 
@@ -31,6 +39,7 @@ pub async fn run_with_requeue(client: Client, requeue_interval: Duration) -> any
     let ctx = Arc::new(Context {
         client,
         requeue_interval,
+        stall_threshold,
     });
 
     Controller::new(clusters, watcher::Config::default())
@@ -44,6 +53,11 @@ pub async fn run_with_requeue(client: Client, requeue_interval: Duration) -> any
                     obj.0.namespace.as_deref().unwrap_or(""),
                     obj.0.name
                 ),
+                Err(ControllerError::QueueError(watcher::Error::WatchError(status)))
+                    if status.code == 410 =>
+                {
+                    warn!("Watch expired, relisting: {status:?}");
+                }
                 Err(err) => error!("Reconcile error: {err:?}"),
             }
         })

--- a/infra/operator/src/reconciler.rs
+++ b/infra/operator/src/reconciler.rs
@@ -1,33 +1,190 @@
+#![allow(clippy::disallowed_methods)]
+
 use std::{sync::Arc, time::Duration};
 
+use k8s_openapi::{
+    apimachinery::pkg::apis::meta::v1::{Condition, Time},
+    jiff::{SignedDuration, Timestamp},
+};
 use kube::{Client, Resource, api::Patch, runtime::controller::Action};
 
 use crate::{
     context::ClusterCtx,
-    crd::{DiomCluster, Phase},
+    crd::{DiomCluster, DiomClusterStatus},
     error::{Error, Result},
     resources::{pdb, pvcs, services, statefulset},
 };
 
+const READY_CONDITION: &str = "Ready";
+const RECONCILING_CONDITION: &str = "Reconciling";
+const STALLED_CONDITION: &str = "Stalled";
+
+// Duration at which a "Reconciling" error condition becomes "Stalled"
+pub const STALL_THRESHOLD: Duration = Duration::from_secs(300);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConditionStatus {
+    True,
+    False,
+    Unknown,
+}
+
+impl ConditionStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::True => "True",
+            Self::False => "False",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum ReadyState {
+    Running,
+    Initializing,
+    Degraded { ready_replicas: i32, desired: i32 },
+    Failed,
+}
+
+impl ReadyState {
+    fn compute(
+        ready_replicas: i32,
+        desired: i32,
+        previous_ready_replicas: i32,
+        was_degraded: bool,
+    ) -> Self {
+        if ready_replicas == desired {
+            Self::Running
+        } else if previous_ready_replicas == desired || was_degraded {
+            Self::Degraded {
+                ready_replicas,
+                desired,
+            }
+        } else {
+            Self::Initializing
+        }
+    }
+
+    fn status(&self) -> ConditionStatus {
+        match self {
+            Self::Running => ConditionStatus::True,
+            Self::Initializing => ConditionStatus::Unknown,
+            Self::Degraded { .. } | Self::Failed => ConditionStatus::False,
+        }
+    }
+
+    fn reason(&self) -> &'static str {
+        match self {
+            Self::Running => "Running",
+            Self::Initializing => "Initializing",
+            Self::Degraded { .. } => "Degraded",
+            Self::Failed => "Failed",
+        }
+    }
+
+    fn message(&self) -> String {
+        match self {
+            Self::Running => "All replicas ready".to_string(),
+            Self::Initializing => "Waiting for replicas to become ready".to_string(),
+            Self::Degraded {
+                ready_replicas,
+                desired,
+            } => format!("{ready_replicas}/{desired} replicas ready"),
+            Self::Failed => "Reconcile failing".to_string(),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+enum FailureState {
+    Reconciling(String),
+    StalledInternalError(String),
+    StalledInvalidSpec(String),
+    StalledTimeout { err: String, threshold: Duration },
+}
+
+impl FailureState {
+    fn compute(err: &Error, failing_for: SignedDuration, stall_threshold: Duration) -> Self {
+        if matches!(err, Error::MissingField(_)) {
+            return Self::StalledInternalError(err.to_string());
+        }
+
+        if matches!(err, Error::InvalidStorageSize(_)) {
+            return Self::StalledInvalidSpec(err.to_string());
+        }
+
+        if failing_for.as_secs() >= stall_threshold.as_secs() as i64 {
+            Self::StalledTimeout {
+                err: err.to_string(),
+                threshold: stall_threshold,
+            }
+        } else {
+            Self::Reconciling(err.to_string())
+        }
+    }
+
+    fn type_(&self) -> &'static str {
+        match self {
+            Self::Reconciling(_) => RECONCILING_CONDITION,
+            Self::StalledInternalError(_)
+            | Self::StalledInvalidSpec(_)
+            | Self::StalledTimeout { .. } => STALLED_CONDITION,
+        }
+    }
+
+    fn status(&self) -> ConditionStatus {
+        ConditionStatus::True
+    }
+
+    fn reason(&self) -> &'static str {
+        match self {
+            Self::Reconciling(_) => "ReconcileError",
+            Self::StalledInternalError(_) => "InternalError",
+            Self::StalledInvalidSpec(_) => "InvalidSpec",
+            Self::StalledTimeout { .. } => "Timeout",
+        }
+    }
+
+    fn message(&self) -> String {
+        match self {
+            Self::Reconciling(err)
+            | Self::StalledInternalError(err)
+            | Self::StalledInvalidSpec(err) => err.clone(),
+            Self::StalledTimeout { err, threshold } => format!(
+                "Reconciliation has been failing for over {}s: {err}",
+                threshold.as_secs()
+            ),
+        }
+    }
+}
 pub(crate) struct Context {
     pub client: Client,
     pub requeue_interval: Duration,
+    pub stall_threshold: Duration,
 }
 
 struct Reconciler {
     ctx: ClusterCtx,
     requeue_interval: Duration,
+    stall_threshold: Duration,
 }
 
 impl Reconciler {
-    fn new(cluster: Arc<DiomCluster>, client: Client, requeue_interval: Duration) -> Result<Self> {
+    fn new(
+        cluster: Arc<DiomCluster>,
+        client: Client,
+        requeue_interval: Duration,
+        stall_threshold: Duration,
+    ) -> Result<Self> {
         Ok(Self {
             ctx: ClusterCtx::new(cluster, client)?,
             requeue_interval,
+            stall_threshold,
         })
     }
 
-    async fn run(self) -> Result<Action> {
+    async fn run(&self) -> Result<Action> {
         services::reconcile(&self.ctx).await?;
         statefulset::reconcile(&self.ctx).await?;
         pvcs::reconcile(&self.ctx).await?;
@@ -40,53 +197,122 @@ impl Reconciler {
 
     async fn update_status(&self) -> Result<()> {
         let name = &self.ctx.name;
-        let current_status = self.ctx.cluster.status.as_ref();
-        let current_phase = current_status.map(|s| s.phase.clone()).unwrap_or_default();
-        let current_ready = current_status.map(|s| s.ready_replicas).unwrap_or(0);
+        let previous_status = self.ctx.cluster.status.clone().unwrap_or_default();
+        let generation = self.ctx.cluster.meta().generation.unwrap_or(0);
+        let desired = self.ctx.cluster.spec.diom.replicas;
 
-        let (ready_replicas, phase) = match self.ctx.sts_api().get_opt(name).await? {
-            Some(sts) => {
-                let ready = sts
-                    .status
-                    .as_ref()
-                    .and_then(|s| s.ready_replicas)
-                    .unwrap_or(0);
-                let desired = self.ctx.cluster.spec.diom.replicas;
-                let phase = compute_phase(ready, desired, &current_phase);
-                (ready, phase)
-            }
-            None => (0, Phase::Initializing),
+        let ready_replicas = match self.ctx.sts_api().get_opt(name).await? {
+            Some(sts) => sts
+                .status
+                .as_ref()
+                .and_then(|s| s.ready_replicas)
+                .unwrap_or(0),
+            None => 0,
         };
 
-        if phase == current_phase && ready_replicas == current_ready {
+        let prev_ready_condition = find_condition(&previous_status.conditions, READY_CONDITION);
+        let was_degraded = prev_ready_condition.is_some_and(|c| c.reason == "Degraded");
+
+        let state = ReadyState::compute(
+            ready_replicas,
+            desired,
+            previous_status.ready_replicas,
+            was_degraded,
+        );
+
+        let new_ready_condition = ready_condition(state, generation, prev_ready_condition);
+
+        let ready_cond_changed = prev_ready_condition.is_none_or(|c| {
+            c.status != new_ready_condition.status || c.reason != new_ready_condition.reason
+        });
+
+        if ready_cond_changed {
+            tracing::info!(
+                name = %self.ctx.name,
+                ns = %self.ctx.ns,
+                previous_reason = prev_ready_condition.map_or("None", |c| c.reason.as_str()),
+                new_reason = %new_ready_condition.reason,
+                message = %new_ready_condition.message,
+                "Ready condition changed"
+            );
+        }
+
+        let prior_error_conditions = previous_status
+            .conditions
+            .iter()
+            .any(|c| c.type_ == RECONCILING_CONDITION || c.type_ == STALLED_CONDITION);
+
+        if ready_replicas == previous_status.ready_replicas
+            && generation == previous_status.observed_generation
+            && !ready_cond_changed
+            && !prior_error_conditions
+        {
             return Ok(());
         }
 
+        self.apply_status(DiomClusterStatus {
+            ready_replicas,
+            observed_generation: generation,
+            conditions: vec![new_ready_condition],
+        })
+        .await
+    }
+
+    /// Mark the resource not-ready after a failed reconcile
+    async fn mark_failed(&self, err: &Error) {
+        let previous_status = self.ctx.cluster.status.clone().unwrap_or_default();
+        let generation = self.ctx.cluster.meta().generation.unwrap_or(0);
+
+        let previous_ready = find_condition(&previous_status.conditions, READY_CONDITION);
+        let ready = ready_condition(ReadyState::Failed, generation, previous_ready);
+
+        let failure_condition = compute_failure_condition(
+            err,
+            generation,
+            &previous_status.conditions,
+            Timestamp::now(),
+            self.stall_threshold,
+        );
+
+        let previous_failure =
+            find_condition(&previous_status.conditions, &failure_condition.type_);
+
+        let unchanged = previous_status.observed_generation == generation
+            && condition_unchanged(previous_ready, &ready)
+            && condition_unchanged(previous_failure, &failure_condition);
+
+        if unchanged {
+            return;
+        }
+
+        let status = DiomClusterStatus {
+            observed_generation: generation,
+            conditions: vec![ready, failure_condition],
+            ..previous_status
+        };
+
+        if let Err(patch_err) = self.apply_status(status).await {
+            tracing::error!(name = %self.ctx.name, ns = %self.ctx.ns, "Failed to patch status after reconcile error: {patch_err:?}");
+        }
+    }
+
+    async fn apply_status(&self, status: DiomClusterStatus) -> Result<()> {
         let status_patch = serde_json::json!({
             "apiVersion": "diom.svix.com/v1alpha1",
             "kind": "DiomCluster",
-            "status": {
-                "readyReplicas": ready_replicas,
-                "phase": phase,
-            }
+            "status": status,
         });
 
         self.ctx
             .cluster_api()
-            .patch_status(name, &self.ctx.status_pp(), &Patch::Apply(status_patch))
+            .patch_status(
+                &self.ctx.name,
+                &self.ctx.status_pp(),
+                &Patch::Apply(status_patch),
+            )
             .await?;
 
         Ok(())
-    }
-}
-
-fn compute_phase(ready: i32, desired: i32, current_phase: &Phase) -> Phase {
-    if ready == desired {
-        Phase::Running
-    } else if matches!(current_phase, Phase::Initializing) {
-        Phase::Initializing
-    } else {
-        Phase::Degraded
     }
 }
 
@@ -95,14 +321,102 @@ pub(crate) async fn reconcile(cluster: Arc<DiomCluster>, ctx: Arc<Context>) -> R
         return Ok(Action::await_change());
     }
 
-    let r = Reconciler::new(cluster, ctx.client.clone(), ctx.requeue_interval)?;
+    let r = Reconciler::new(
+        cluster,
+        ctx.client.clone(),
+        ctx.requeue_interval,
+        ctx.stall_threshold,
+    )?;
     tracing::info!(name = %r.ctx.name, ns = %r.ctx.ns, "Reconciling DiomCluster");
-    r.run().await
+    match r.run().await {
+        Ok(action) => Ok(action),
+        Err(err) => {
+            r.mark_failed(&err).await;
+            Err(err)
+        }
+    }
 }
 
-pub(crate) fn error_policy(_cluster: Arc<DiomCluster>, err: &Error, _ctx: Arc<Context>) -> Action {
+pub(crate) fn error_policy(_cluster: Arc<DiomCluster>, err: &Error, ctx: Arc<Context>) -> Action {
     tracing::warn!("Reconcile error: {err:?}");
-    Action::requeue(Duration::from_secs(30))
+    Action::requeue(ctx.requeue_interval)
+}
+
+fn find_condition<'a>(conditions: &'a [Condition], type_: &str) -> Option<&'a Condition> {
+    conditions.iter().find(|c| c.type_ == type_)
+}
+
+fn condition_unchanged(previous: Option<&Condition>, new: &Condition) -> bool {
+    previous.is_some_and(|c| {
+        c.status == new.status && c.reason == new.reason && c.message == new.message
+    })
+}
+
+fn build_condition(
+    type_: &str,
+    status: ConditionStatus,
+    reason: &str,
+    message: String,
+    observed_generation: i64,
+    previous: Option<&Condition>,
+) -> Condition {
+    let last_transition_time = previous
+        .filter(|c| c.status == status.as_str())
+        .map(|c| c.last_transition_time.clone())
+        .unwrap_or_else(|| Time(Timestamp::now()));
+
+    Condition {
+        type_: type_.to_string(),
+        status: status.as_str().to_string(),
+        reason: reason.to_string(),
+        message,
+        observed_generation: Some(observed_generation),
+        last_transition_time,
+    }
+}
+
+fn ready_condition(state: ReadyState, generation: i64, previous: Option<&Condition>) -> Condition {
+    build_condition(
+        READY_CONDITION,
+        state.status(),
+        state.reason(),
+        state.message(),
+        generation,
+        previous,
+    )
+}
+
+fn compute_failure_condition(
+    err: &Error,
+    generation: i64,
+    previous_conditions: &[Condition],
+    now: Timestamp,
+    stall_threshold: Duration,
+) -> Condition {
+    let already_stalled = find_condition(previous_conditions, STALLED_CONDITION)
+        .is_some_and(|c| c.status == ConditionStatus::True.as_str());
+
+    let failing_for = if already_stalled {
+        SignedDuration::from_secs(stall_threshold.as_secs() as i64)
+    } else {
+        let previous_reconciling = find_condition(previous_conditions, RECONCILING_CONDITION);
+        let reconciling_started = previous_reconciling
+            .filter(|c| c.status == ConditionStatus::True.as_str())
+            .map_or(now, |c: &Condition| c.last_transition_time.0);
+        now.duration_since(reconciling_started)
+    };
+
+    let state = FailureState::compute(err, failing_for, stall_threshold);
+    let previous = find_condition(previous_conditions, state.type_());
+
+    build_condition(
+        state.type_(),
+        state.status(),
+        state.reason(),
+        state.message(),
+        generation,
+        previous,
+    )
 }
 
 #[cfg(test)]
@@ -110,24 +424,195 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_compute_phase() {
-        assert_eq!(compute_phase(3, 3, &Phase::Initializing), Phase::Running);
-        assert_eq!(compute_phase(3, 3, &Phase::Degraded), Phase::Running);
-        assert_eq!(compute_phase(3, 3, &Phase::Running), Phase::Running);
+    fn test_ready_state_compute() {
+        assert_eq!(ReadyState::compute(3, 3, 0, false), ReadyState::Running);
+        assert_eq!(ReadyState::compute(3, 3, 3, false), ReadyState::Running);
         assert_eq!(
-            compute_phase(0, 3, &Phase::Initializing),
-            Phase::Initializing
-        );
-        assert_eq!(compute_phase(0, 3, &Phase::Running), Phase::Degraded);
-        assert_eq!(compute_phase(0, 3, &Phase::Degraded), Phase::Degraded);
-        assert_eq!(
-            compute_phase(1, 3, &Phase::Initializing),
-            Phase::Initializing
+            ReadyState::compute(0, 3, 0, false),
+            ReadyState::Initializing
         );
         assert_eq!(
-            compute_phase(2, 3, &Phase::Initializing),
-            Phase::Initializing
+            ReadyState::compute(2, 3, 1, false),
+            ReadyState::Initializing
         );
-        assert_eq!(compute_phase(1, 3, &Phase::Running), Phase::Degraded);
+        assert_eq!(
+            ReadyState::compute(0, 3, 3, false),
+            ReadyState::Degraded {
+                ready_replicas: 0,
+                desired: 3
+            }
+        );
+        assert_eq!(
+            ReadyState::compute(1, 3, 3, false),
+            ReadyState::Degraded {
+                ready_replicas: 1,
+                desired: 3
+            }
+        );
+        assert_eq!(
+            ReadyState::compute(1, 3, 1, true),
+            ReadyState::Degraded {
+                ready_replicas: 1,
+                desired: 3
+            }
+        );
+        assert_eq!(
+            ReadyState::compute(1, 3, 1, false),
+            ReadyState::Initializing
+        );
+    }
+
+    fn fake_condition(type_: &str, status: &str, last_transition_time: Timestamp) -> Condition {
+        Condition {
+            type_: type_.to_string(),
+            status: status.to_string(),
+            reason: "PreviousReason".to_string(),
+            message: "previous message".to_string(),
+            observed_generation: Some(1),
+            last_transition_time: Time(last_transition_time),
+        }
+    }
+
+    #[test]
+    fn test_compute_failure_condition_missing_field_stalls_immediately() {
+        let now = Timestamp::now();
+        let err = Error::MissingField("adminToken");
+
+        let condition = compute_failure_condition(&err, 1, &[], now, STALL_THRESHOLD);
+
+        assert_eq!(condition.type_, STALLED_CONDITION);
+        assert_eq!(condition.status, "True");
+    }
+
+    #[test]
+    fn test_compute_failure_condition_bad_storage_spec_stalls_immediately() {
+        let now = Timestamp::now();
+        let err = Error::InvalidStorageSize("invalid quantity".to_string());
+
+        let condition = compute_failure_condition(&err, 1, &[], now, STALL_THRESHOLD);
+
+        assert_eq!(condition.type_, STALLED_CONDITION);
+        assert_eq!(condition.status, "True");
+    }
+
+    #[test]
+    fn test_compute_failure_condition_first_failure_reconciles() {
+        let now = Timestamp::now();
+        let err = Error::Timeout("statefulset not ready".to_string());
+
+        let condition = compute_failure_condition(&err, 1, &[], now, STALL_THRESHOLD);
+
+        assert_eq!(condition.type_, RECONCILING_CONDITION);
+        assert_eq!(condition.status, "True");
+        assert!(
+            condition
+                .last_transition_time
+                .0
+                .duration_since(now)
+                .as_secs()
+                < 1
+        );
+    }
+
+    #[test]
+    fn test_compute_failure_condition_stays_reconciling_below_threshold() {
+        let now = Timestamp::now();
+        let started = now - (STALL_THRESHOLD - Duration::from_secs(1));
+        let previous = [fake_condition(RECONCILING_CONDITION, "True", started)];
+        let err = Error::Timeout("statefulset not ready".to_string());
+
+        let condition = compute_failure_condition(&err, 1, &previous, now, STALL_THRESHOLD);
+
+        assert_eq!(condition.type_, RECONCILING_CONDITION);
+        assert_eq!(condition.last_transition_time.0, started);
+    }
+
+    #[test]
+    fn test_compute_failure_condition_escalates_past_threshold() {
+        let now = Timestamp::now();
+        let started = now - (STALL_THRESHOLD + Duration::from_secs(1));
+        let previous = [fake_condition(RECONCILING_CONDITION, "True", started)];
+        let err = Error::Timeout("statefulset not ready".to_string());
+
+        let condition = compute_failure_condition(&err, 1, &previous, now, STALL_THRESHOLD);
+
+        assert_eq!(condition.type_, STALLED_CONDITION);
+        assert_eq!(condition.status, "True");
+    }
+
+    #[test]
+    fn test_compute_failure_condition_respects_custom_threshold() {
+        let now = Timestamp::now();
+        let short_threshold = Duration::from_secs(5);
+        let started = now - Duration::from_secs(6);
+        let previous = [fake_condition(RECONCILING_CONDITION, "True", started)];
+        let err = Error::Timeout("statefulset not ready".to_string());
+
+        let condition = compute_failure_condition(&err, 1, &previous, now, short_threshold);
+
+        assert_eq!(condition.type_, STALLED_CONDITION);
+    }
+
+    #[test]
+    fn test_compute_failure_condition_stays_stalled_across_ticks() {
+        let now = Timestamp::now();
+        let err = Error::Timeout("statefulset not ready".to_string());
+
+        let started = now - (STALL_THRESHOLD + Duration::from_secs(1));
+        let previous = [fake_condition(RECONCILING_CONDITION, "True", started)];
+        let stalled = compute_failure_condition(&err, 1, &previous, now, STALL_THRESHOLD);
+        assert_eq!(stalled.type_, STALLED_CONDITION);
+
+        let previous = [stalled.clone()];
+        let next_tick = now + Duration::from_secs(5);
+        let condition = compute_failure_condition(&err, 1, &previous, next_tick, STALL_THRESHOLD);
+
+        assert_eq!(condition.type_, STALLED_CONDITION);
+        assert_eq!(condition.status, "True");
+        assert_eq!(
+            condition.last_transition_time.0,
+            stalled.last_transition_time.0
+        );
+    }
+
+    #[test]
+    fn test_failure_state_decide() {
+        let zero = SignedDuration::ZERO;
+        let threshold = STALL_THRESHOLD;
+
+        assert!(matches!(
+            FailureState::compute(&Error::MissingField("adminToken"), zero, threshold),
+            FailureState::StalledInternalError(_)
+        ));
+        assert!(matches!(
+            FailureState::compute(
+                &Error::InvalidStorageSize("bad".to_string()),
+                zero,
+                threshold
+            ),
+            FailureState::StalledInvalidSpec(_)
+        ));
+
+        let other = Error::PvcStorageState("unexpected".to_string());
+        assert!(matches!(
+            FailureState::compute(&other, zero, threshold),
+            FailureState::Reconciling(_)
+        ));
+        assert!(matches!(
+            FailureState::compute(
+                &other,
+                SignedDuration::from_secs(threshold.as_secs() as i64 - 1),
+                threshold
+            ),
+            FailureState::Reconciling(_)
+        ));
+        assert!(matches!(
+            FailureState::compute(
+                &other,
+                SignedDuration::from_secs(threshold.as_secs() as i64),
+                threshold
+            ),
+            FailureState::StalledTimeout { .. }
+        ));
     }
 }

--- a/infra/operator/src/resources/pvcs.rs
+++ b/infra/operator/src/resources/pvcs.rs
@@ -78,7 +78,7 @@ async fn reconcile_volume(
 
         let desired_size: ParsedQuantity = desired_size
             .try_into()
-            .map_err(|e: ParseQuantityError| Error::Storage(e.to_string()))?;
+            .map_err(|e: ParseQuantityError| Error::InvalidStorageSize(e.to_string()))?;
         let current_size = pvc_requested_size(&pvc)?;
 
         if desired_size <= current_size {
@@ -166,9 +166,9 @@ fn pvc_requested_size(pvc: &PersistentVolumeClaim) -> Result<ParsedQuantity> {
         .as_ref()
         .and_then(|s| s.resources.as_ref()?.requests.as_ref()?.get("storage"))
         .cloned()
-        .ok_or_else(|| Error::Storage("Storage not found".to_owned()))?
+        .ok_or_else(|| Error::PvcStorageState("Storage not found".to_owned()))?
         .try_into()
-        .map_err(|e: ParseQuantityError| Error::Storage(e.to_string()))
+        .map_err(|e: ParseQuantityError| Error::PvcStorageState(e.to_string()))
 }
 
 pub(crate) fn pvc_name(volume_name: &str, cluster_name: &str, ordinal: i32) -> String {

--- a/infra/operator/tests/it/common.rs
+++ b/infra/operator/tests/it/common.rs
@@ -135,6 +135,7 @@ pub(crate) struct TestContextBuilder {
     replicas: i32,
     image: String,
     storage_size: String,
+    stall_threshold: Duration,
     #[allow(clippy::disallowed_types)]
     extra_spec: serde_json::Map<String, serde_json::Value>,
 }
@@ -145,6 +146,7 @@ impl Default for TestContextBuilder {
             replicas: 1,
             image: E2E_IMAGE.to_string(),
             storage_size: "10M".to_string(),
+            stall_threshold: diom_operator::reconciler::STALL_THRESHOLD,
             extra_spec: serde_json::Map::new(),
         }
     }
@@ -168,6 +170,11 @@ impl TestContextBuilder {
 
     pub(crate) fn storage_size(mut self, size: impl Into<String>) -> Self {
         self.storage_size = size.into();
+        self
+    }
+
+    pub(crate) fn stall_threshold(mut self, threshold: Duration) -> Self {
+        self.stall_threshold = threshold;
         self
     }
 
@@ -256,7 +263,11 @@ impl TestContextBuilder {
 
         let _handle = tokio::spawn({
             let client = client.clone();
-            async move { diom_operator::run_with_requeue(client, Duration::from_secs(2)).await }
+            let stall_threshold = self.stall_threshold;
+            async move {
+                diom_operator::run_with_config(client, Duration::from_secs(2), stall_threshold)
+                    .await
+            }
         });
 
         let cluster_api: Api<DiomCluster> = Api::namespaced(client.clone(), "default");

--- a/infra/operator/tests/it/e2e.rs
+++ b/infra/operator/tests/it/e2e.rs
@@ -43,7 +43,9 @@ async fn test_basic_creation() -> TestResult {
     run_with_retries(async || {
         let cluster = env.cluster_api().get(env.name()).await?;
         let cluster_json = serde_json::to_value(&cluster).unwrap();
-        anyhow::ensure!(cluster_json["status"]["phase"] == "Running");
+        let conditions = cluster_json["status"]["conditions"].assert_array();
+        let ready = conditions.iter().find(|c| c["type"] == "Ready");
+        anyhow::ensure!(ready.is_some_and(|c| c["status"] == "True" && c["reason"] == "Running"));
         Ok(())
     })
     .await?;
@@ -58,11 +60,25 @@ async fn test_replica_update() -> TestResult {
     // No PDB at 1 replica.
     assert!(env.pdb_api().get(env.name()).await.is_err());
 
-    let mut cluster = env.cluster_api().get(env.name()).await?;
-    cluster.spec.diom.replicas = 3;
-    env.cluster_api()
-        .replace(env.name(), &PostParams::default(), &cluster)
-        .await?;
+    let initial_generation = env
+        .cluster_api()
+        .get(env.name())
+        .await?
+        .metadata
+        .generation
+        .unwrap();
+
+    let updated_generation = run_with_retries(async || {
+        let mut cluster = env.cluster_api().get(env.name()).await?;
+        cluster.spec.diom.replicas = 3;
+        let cluster = env
+            .cluster_api()
+            .replace(env.name(), &PostParams::default(), &cluster)
+            .await?;
+        Ok(cluster.metadata.generation.unwrap())
+    })
+    .await?;
+    assert_eq!(updated_generation, initial_generation + 1);
 
     run_with_retries(async || {
         let sts = env.sts_api().get(env.name()).await?;
@@ -74,6 +90,14 @@ async fn test_replica_update() -> TestResult {
     run_with_retries(async || {
         let pdb = env.pdb_api().get(env.name()).await?;
         anyhow::ensure!(pdb.spec.as_ref().unwrap().min_available == Some(IntOrString::Int(2)));
+        Ok(())
+    })
+    .await?;
+
+    run_with_retries(async || {
+        let cluster = env.cluster_api().get(env.name()).await?;
+        let status = cluster.status.ok_or_else(|| anyhow::anyhow!("no status"))?;
+        anyhow::ensure!(status.observed_generation == updated_generation);
         Ok(())
     })
     .await?;
@@ -98,7 +122,11 @@ async fn test_degraded_on_bad_image() -> TestResult {
         async || {
             let cluster = env.cluster_api().get(env.name()).await?;
             let cluster_json = serde_json::to_value(&cluster).unwrap();
-            anyhow::ensure!(cluster_json["status"]["phase"] == "Degraded");
+            let conditions = cluster_json["status"]["conditions"].assert_array();
+            let ready = conditions.iter().find(|c| c["type"] == "Ready");
+            anyhow::ensure!(
+                ready.is_some_and(|c| c["status"] == "False" && c["reason"] == "Degraded")
+            );
             Ok(())
         },
         Duration::from_secs(60),
@@ -184,6 +212,41 @@ async fn test_storage_resize() -> TestResult {
         anyhow::ensure!(size == "20M");
         Ok(())
     })
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stalled_on_invalid_storage_spec() -> TestResult {
+    let env = TestContextBuilder::new()
+        .stall_threshold(Duration::from_secs(1))
+        .build()
+        .await;
+
+    env.wait_for_ready_pods(1).await?;
+
+    let mut cluster = env.cluster_api().get(env.name()).await?;
+    cluster.spec.diom.storage.persistent.size = Quantity("not-a-quantity".to_string());
+    env.cluster_api()
+        .replace(env.name(), &PostParams::default(), &cluster)
+        .await?;
+
+    run_with_timeout(
+        async || {
+            let cluster = env.cluster_api().get(env.name()).await?;
+            let cluster_json = serde_json::to_value(&cluster).unwrap();
+            let conditions = cluster_json["status"]["conditions"].assert_array();
+            let stalled = conditions.iter().find(|c| c["type"] == "Stalled");
+            anyhow::ensure!(stalled.is_some_and(|c| c["status"] == "True"));
+            let ready = conditions.iter().find(|c| c["type"] == "Ready");
+            anyhow::ensure!(
+                ready.is_some_and(|c| c["status"] == "False" && c["reason"] == "Failed")
+            );
+            Ok(())
+        },
+        Duration::from_secs(30),
+    )
     .await?;
 
     Ok(())


### PR DESCRIPTION
In line with API recommendations outlined in K8s architecture
documents, this changeset adds `Condition`s to the Diom cluster's 
reported status. These will include a `Ready` condition, which should 
always be present, along with possible failure conditions of 
`Reconciling` or `Stalled`. The practical effect of these changes
are that monitoring successful/failed deployments should be much
easier now since the status conditions can be directly watched
during the deployment process.

The `observed_generation` of the cluster resource has also been added 
and is incremented whenever the cluster resource is updated.

`Phase` has been removed entirely from status reporting, as it's now
redundant. (Also note that the K8s API Conventions document states that 
"the pattern of using `phase` is deprecated.")

References:
* https://github.com/kubernetes/community/blob/main/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
* https://github.com/kubernetes-sigs/cli-utils/blob/master/pkg/kstatus/README.md
