### PR TITLE
server: do not fail /api/v1.health.ping on boot

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -317,12 +317,14 @@ fn load_commands(
 async fn wait_for_up(config: &AppConfig, raft_state: &RaftState) -> anyhow::Result<()> {
     let shutdown = crate::shutting_down_token();
     let value = if let Some(time) = config.bootstrap_max_wait_time {
+        tracing::debug!(max_wait_time=?time, "waiting for node to come up before bootstrapping...");
         shutdown
             .run_until_cancelled(tokio::time::timeout(time.into(), raft_state.wait_for_up()))
             .await
             .transpose()
             .context("waiting for node to be up for bootstrapping")?
     } else {
+        tracing::debug!("waiting indefinitely for node to come up before bootstrapping...");
         shutdown.run_until_cancelled(raft_state.wait_for_up()).await
     }
     .ok_or_else(|| anyhow::anyhow!("node shut down before bootstrapping finished"))?;

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -100,6 +100,9 @@ impl RaftStateWatcher {
 
     pub(crate) fn record_first_applied_log(&self) {
         let mut inner = self.inner.write();
+        if !inner.has_applied_log {
+            tracing::debug!("first raft log applied to node");
+        }
         inner.has_applied_log = true;
         inner.recompute_ready();
     }
@@ -110,7 +113,11 @@ impl RaftStateWatcher {
             let inner_h = Arc::clone(&inner_h);
             async move {
                 let mut guard = inner_h.write();
-                guard.leader = Some((new_leader_id.node_id, new_leader_id.term));
+                let new_leader = Some((new_leader_id.node_id, new_leader_id.term));
+                if new_leader != guard.leader {
+                    tracing::debug!(node_id=?new_leader_id.node_id, term=?new_leader_id.term, "leader has changed");
+                }
+                guard.leader = new_leader;
                 guard.recompute_ready();
             }
         });
@@ -123,6 +130,7 @@ impl RaftStateWatcher {
             .unwrap_or(false);
         let mut guard = self.inner.write();
         guard.handle = Some(handle);
+        tracing::debug!(is_single_node, "connected to raft state log");
         guard.is_single_node = is_single_node;
         guard.recompute_ready();
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,7 +58,8 @@ pub(crate) async fn fail_until_bootstrapped(
     request: axum::extract::Request,
     next: middleware::Next,
 ) -> axum::response::Response {
-    let is_admin_route = path.as_str().starts_with("/api/v1.admin.cluster.");
+    let is_admin_route = path.as_str().starts_with("/api/v1.admin.cluster.")
+        || path.as_str() == "/api/v1.health.ping";
     if !(is_admin_route || bootstrapped.load(Ordering::Relaxed)) {
         return Error::not_ready("this node has not yet finished bootstrapping").into_response();
     }


### PR DESCRIPTION
This is making the liveness check from kubernetes fail because bootstrapping in prod takes longer than 5 seconds. We have a separate readiness check that looks at the cluster status.

Also add some logs around bootstrapping.