### PR TITLE
Operator: Make tests wait for cluster ready status

### DIFF
--- a/infra/operator/tests/it/common.rs
+++ b/infra/operator/tests/it/common.rs
@@ -7,10 +7,7 @@ use k8s_openapi::{
     },
     apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
 };
-use kube::{
-    Api, Client, CustomResourceExt,
-    api::{ListParams, PostParams},
-};
+use kube::{Api, Client, CustomResourceExt, api::PostParams};
 use std::{
     process::Command,
     sync::{
@@ -98,37 +95,30 @@ impl TestContext {
         run_with_retries(async || Ok(self.sts_api().get(self.name()).await?)).await
     }
 
-    pub(crate) async fn wait_for_ready_pods(&self, expected: i32) -> anyhow::Result<()> {
-        self.wait_for_ready_pods_timeout(expected, Duration::from_secs(60))
+    pub(crate) async fn wait_for_cluster_ready(&self) -> anyhow::Result<DiomCluster> {
+        self.wait_for_cluster_ready_timeout(Duration::from_secs(60))
             .await
     }
 
-    pub(crate) async fn wait_for_ready_pods_timeout(
+    pub(crate) async fn wait_for_cluster_ready_timeout(
         &self,
-        expected: i32,
         timeout: Duration,
-    ) -> anyhow::Result<()> {
-        let lp = ListParams::default().labels(&format!("diom.svix.com/cluster={}", self.name()));
+    ) -> anyhow::Result<DiomCluster> {
         run_with_timeout(
             async || {
-                let pods = self.pod_api().list(&lp).await?;
-                let ready = pods.items.iter().filter(|p| pod_is_ready(p)).count() as i32;
-                anyhow::ensure!(ready >= expected, "{ready}/{expected} pods ready");
-                Ok(())
+                let cluster = self.cluster_api().get(self.name()).await?;
+                let status = cluster
+                    .status
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("no status"))?;
+                let ready = status.conditions.iter().find(|c| c.type_ == "Ready");
+                anyhow::ensure!(ready.is_some_and(|c| c.status == "True" && c.reason == "Running"));
+                Ok(cluster)
             },
             timeout,
         )
         .await
     }
-}
-
-fn pod_is_ready(pod: &Pod) -> bool {
-    pod.status
-        .as_ref()
-        .and_then(|s| s.conditions.as_deref())
-        .unwrap_or(&[])
-        .iter()
-        .any(|c| c.type_ == "Ready" && c.status == "True")
 }
 
 pub(crate) struct TestContextBuilder {

--- a/infra/operator/tests/it/e2e.rs
+++ b/infra/operator/tests/it/e2e.rs
@@ -38,7 +38,7 @@ async fn test_basic_creation() -> TestResult {
         uid
     ));
 
-    env.wait_for_ready_pods(1).await?;
+    env.wait_for_cluster_ready().await?;
 
     run_with_retries(async || {
         let cluster = env.cluster_api().get(env.name()).await?;
@@ -109,10 +109,9 @@ async fn test_replica_update() -> TestResult {
 async fn test_degraded_on_bad_image() -> TestResult {
     let env = TestContextBuilder::new().replicas(3).build().await;
 
-    env.wait_for_ready_pods_timeout(3, Duration::from_secs(180))
+    let mut cluster = env
+        .wait_for_cluster_ready_timeout(Duration::from_secs(180))
         .await?;
-
-    let mut cluster = env.cluster_api().get(env.name()).await?;
     cluster.spec.image = format!("{}:nonexistent", crate::common::E2E_IMAGE);
     env.cluster_api()
         .replace(env.name(), &PostParams::default(), &cluster)
@@ -224,9 +223,7 @@ async fn test_stalled_on_invalid_storage_spec() -> TestResult {
         .build()
         .await;
 
-    env.wait_for_ready_pods(1).await?;
-
-    let mut cluster = env.cluster_api().get(env.name()).await?;
+    let mut cluster = env.wait_for_cluster_ready().await?;
     cluster.spec.diom.storage.persistent.size = Quantity("not-a-quantity".to_string());
     env.cluster_api()
         .replace(env.name(), &PostParams::default(), &cluster)


### PR DESCRIPTION
Now that we have a proper `Ready` condition, the tests should actually use that instead of waiting on pods directly.