### PR TITLE
cli: ignore EPIPE

### DIFF
--- a/z-clients/cli/src/json/mod.rs
+++ b/z-clients/cli/src/json/mod.rs
@@ -37,12 +37,12 @@ pub fn print_json_output<T>(val: &T) -> Result<()>
 where
     T: Serialize,
 {
-    let mut output = Vec::new();
+    let mut stdout = std::io::stdout().lock();
     let mut serializer =
-        serde_json::Serializer::with_formatter(&mut output, PrettyFormatter::default());
-    val.serialize(&mut serializer)?;
-    let s = String::from_utf8(output).expect("JSON is always valid utf-8");
-
-    println!("{s}");
-    Ok(())
+        serde_json::Serializer::with_formatter(&mut stdout, PrettyFormatter::default());
+    match val.serialize(&mut serializer) {
+        Ok(_) => Ok(()),
+        Err(e) if matches!(e.io_error_kind(), Some(std::io::ErrorKind::BrokenPipe)) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
 }


### PR DESCRIPTION
Fixes #1285

`diom admin metrics get | head -n 5` no longer has a big ugly panic on it

also avoids serializing everything in memory and then decoding to a string; that seemed silly to me