### PR TITLE
Prepare Helm 0.2.0 / Operator 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "diom-operator"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "diom-backend",

--- a/infra/helm-diom/ChangeLog.md
+++ b/infra/helm-diom/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased Changes
 
+## Version 0.2.0
+* **Breaking** Default operator version 0.3.0
+
 ## Version 0.1.1
 * Consistently name operator pod `<release>-operator`
 * Add `operator.logFormat` and `operator.extraEnv` values

--- a/infra/helm-diom/Chart.yaml
+++ b/infra/helm-diom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diom
 description: Helm chart for Diom clusters
 type: application
-version: 0.1.1
+version: 0.2.0
 
 dependencies:
   - name: crds

--- a/infra/helm-diom/values.yaml
+++ b/infra/helm-diom/values.yaml
@@ -13,7 +13,7 @@ operator:
   image:
     repository: svix/diom-operator
     pullPolicy: IfNotPresent
-    tag: "0.2.1"
+    tag: "0.3.0"
 
   imagePullSecrets: []
 

--- a/infra/operator/Cargo.toml
+++ b/infra/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diom-operator"
-version = "0.2.1"
+version = "0.3.0"
 license.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/infra/operator/ChangeLog.md
+++ b/infra/operator/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased Changes
+
+## Version 0.3.0
 * **Breaking** Replace `status.phase` with `status.conditions` and add `status.observedGeneration`
 
 ## Version 0.2.1


### PR DESCRIPTION
Since the Operator API changes, I'm treating the Helm
version as breaking as well to be safe. 