### PR TITLE
Add Tokio runtime metrics

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -134,8 +134,18 @@ fn dump_variables(path: Option<PathBuf>) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // Build the runtime by hand rather than via `#[tokio::main]` so we can enable
+    // the poll-time histogram, which feeds the `diom.tokio.poll_histogram` metric.
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .enable_metrics_poll_time_histogram()
+        .build()
+        .context("building Tokio runtime")?
+        .block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     if let Some(env_file) = &args.env_file {

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -1,11 +1,12 @@
 use std::time::Duration;
 
+use diom_core::shutdown::shutting_down_token;
 use http::StatusCode;
 use opentelemetry::{
     KeyValue, Value,
     metrics::{Counter, Gauge, Histogram, Meter},
 };
-use tokio::runtime::RuntimeMetrics;
+use tokio::runtime::{Handle, RuntimeMetrics};
 
 use super::cluster::NodeId;
 
@@ -692,10 +693,28 @@ impl ClusterNetworkMetrics {
     }
 }
 
+trait GaugeExt {
+    fn record_if_nonzero(&self, value: u64, attributes: &[KeyValue]);
+}
+
+impl GaugeExt for Gauge<u64> {
+    fn record_if_nonzero(&self, value: u64, attributes: &[KeyValue]) {
+        if value > 0 {
+            self.record(value, attributes);
+        }
+    }
+}
+
 /// Number of poll-time histogram buckets reported per worker, from the slowest end.
 const NUM_REPORTED_POLL_HISTOGRAM_BUCKETS: usize = 10;
 
-const QUEUE_DEPTH_REPORT_THRESHOLD: u64 = 2;
+/// Runtime saturation values at or below this are not reported.
+///
+/// Queue depths and the number of active blocking threads sit low almost all of
+/// the time, and only become interesting when they spike or stay elevated.
+/// Skipping the uninteresting values keeps the volume of reported metrics, and
+/// the cost of storing them, down.
+const SATURATION_REPORT_THRESHOLD: u64 = 2;
 
 /// Previous poll-time histogram bucket values, kept so each collection can report
 /// the per-interval difference of the runtime's monotonic bucket counters.
@@ -762,13 +781,11 @@ impl TokioMetrics {
     pub fn record(&self, metrics: &RuntimeMetrics, ctx: &mut RuntimeMetricsContext) {
         let node = std::slice::from_ref(&self.node_id_kv);
 
-        let alive_tasks = metrics.num_alive_tasks() as u64;
-        if alive_tasks != 0 {
-            self.alive_tasks.record(alive_tasks, node);
-        }
+        self.alive_tasks
+            .record_if_nonzero(metrics.num_alive_tasks() as u64, node);
 
         let global_queue_depth = metrics.global_queue_depth() as u64;
-        if global_queue_depth > QUEUE_DEPTH_REPORT_THRESHOLD {
+        if global_queue_depth > SATURATION_REPORT_THRESHOLD {
             self.global_queue_depth.record(global_queue_depth, node);
         }
 
@@ -778,13 +795,13 @@ impl TokioMetrics {
             .num_blocking_threads()
             .saturating_sub(metrics.num_idle_blocking_threads())
             as u64;
-        if active_blocking_threads > QUEUE_DEPTH_REPORT_THRESHOLD {
+        if active_blocking_threads > SATURATION_REPORT_THRESHOLD {
             self.active_blocking_threads
                 .record(active_blocking_threads, node);
         }
 
         let blocking_queue_depth = metrics.blocking_queue_depth() as u64;
-        if blocking_queue_depth > QUEUE_DEPTH_REPORT_THRESHOLD {
+        if blocking_queue_depth > SATURATION_REPORT_THRESHOLD {
             self.blocking_queue_depth.record(blocking_queue_depth, node);
         }
 
@@ -792,7 +809,7 @@ impl TokioMetrics {
 
         for worker in 0..metrics.num_workers() {
             let local_queue_depth = metrics.worker_local_queue_depth(worker) as u64;
-            if local_queue_depth > QUEUE_DEPTH_REPORT_THRESHOLD {
+            if local_queue_depth > SATURATION_REPORT_THRESHOLD {
                 self.worker_local_queue_depth.record(
                     local_queue_depth,
                     &[
@@ -820,10 +837,6 @@ impl TokioMetrics {
 
             for (bucket, prev) in prev_values.iter_mut().enumerate() {
                 let underlying_bucket = first_reported_bucket + bucket;
-                if underlying_bucket >= total_buckets {
-                    break;
-                }
-
                 let bucket_range = metrics.poll_time_histogram_bucket_range(underlying_bucket);
                 let full_count =
                     metrics.poll_time_histogram_bucket_count(worker, underlying_bucket);
@@ -831,19 +844,35 @@ impl TokioMetrics {
                 let count = full_count - *prev;
                 *prev = full_count;
 
-                // Skip zero counts to keep metric cardinality and billing down.
-                if count != 0 {
-                    self.poll_histogram.record(
-                        count,
-                        &[
-                            self.node_id_kv.clone(),
-                            KeyValue::new("bucket_start_us", bucket_range.start.as_micros() as i64),
-                            KeyValue::new("bucket_end_us", bucket_range.end.as_micros() as i64),
-                            KeyValue::new("worker_id", worker as i64),
-                        ],
-                    );
-                }
+                // Zero counts are skipped to keep metric cardinality and billing down.
+                self.poll_histogram.record_if_nonzero(
+                    count,
+                    &[
+                        self.node_id_kv.clone(),
+                        KeyValue::new("bucket_start_us", bucket_range.start.as_micros() as i64),
+                        KeyValue::new("bucket_end_us", bucket_range.end.as_micros() as i64),
+                        KeyValue::new("worker_id", worker as i64),
+                    ],
+                );
             }
         }
     }
+}
+
+/// Spawn a background task that periodically reports Tokio runtime metrics.
+pub(crate) fn spawn_tokio_metrics(meter: &Meter, node_id: NodeId) {
+    let metrics = TokioMetrics::new(meter, node_id);
+    let handle = Handle::current();
+    let num_workers = handle.metrics().num_workers();
+    let shutdown = shutting_down_token();
+
+    tokio::spawn(async move {
+        let runtime_metrics = handle.metrics();
+        let mut ctx = RuntimeMetricsContext::new(num_workers);
+        let mut ticker = tokio::time::interval(Duration::from_secs(10));
+
+        while shutdown.run_until_cancelled(ticker.tick()).await.is_some() {
+            metrics.record(&runtime_metrics, &mut ctx);
+        }
+    });
 }

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -5,6 +5,7 @@ use opentelemetry::{
     KeyValue, Value,
     metrics::{Counter, Gauge, Histogram, Meter},
 };
+use tokio::runtime::RuntimeMetrics;
 
 use super::cluster::NodeId;
 
@@ -688,5 +689,161 @@ impl ClusterNetworkMetrics {
         ];
         self.requests.add(1, dims);
         self.request_latency.record(duration.as_micros() as _, dims);
+    }
+}
+
+/// Number of poll-time histogram buckets reported per worker, from the slowest end.
+const NUM_REPORTED_POLL_HISTOGRAM_BUCKETS: usize = 10;
+
+const QUEUE_DEPTH_REPORT_THRESHOLD: u64 = 2;
+
+/// Previous poll-time histogram bucket values, kept so each collection can report
+/// the per-interval difference of the runtime's monotonic bucket counters.
+///
+/// Must be sized with [`RuntimeMetricsContext::new`] to match the runtime's worker
+/// count; there is deliberately no `Default`, as an empty context would panic.
+pub struct RuntimeMetricsContext {
+    previous_poll_histogram_bucket_values: Vec<[u64; NUM_REPORTED_POLL_HISTOGRAM_BUCKETS]>,
+}
+
+impl RuntimeMetricsContext {
+    pub fn new(num_workers: usize) -> Self {
+        Self {
+            previous_poll_histogram_bucket_values: vec![
+                [0; NUM_REPORTED_POLL_HISTOGRAM_BUCKETS];
+                num_workers
+            ],
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TokioMetrics {
+    alive_tasks: Gauge<u64>,
+    global_queue_depth: Gauge<u64>,
+    active_blocking_threads: Gauge<u64>,
+    blocking_queue_depth: Gauge<u64>,
+    poll_histogram: Gauge<u64>,
+    worker_local_queue_depth: Gauge<u64>,
+    node_id_kv: KeyValue,
+}
+
+impl TokioMetrics {
+    pub fn new(meter: &Meter, node_id: NodeId) -> Self {
+        Self {
+            alive_tasks: meter
+                .u64_gauge("diom.tokio.alive_tasks")
+                .with_description("Number of alive tasks in the runtime")
+                .build(),
+            global_queue_depth: meter
+                .u64_gauge("diom.tokio.global_queue_depth")
+                .with_description("Number of tasks in the runtime's global queue")
+                .build(),
+            active_blocking_threads: meter
+                .u64_gauge("diom.tokio.active_blocking_threads")
+                .with_description("Number of blocking threads currently running a task")
+                .build(),
+            blocking_queue_depth: meter
+                .u64_gauge("diom.tokio.blocking_queue_depth")
+                .with_description("Number of tasks queued to run on a blocking thread")
+                .build(),
+            poll_histogram: meter
+                .u64_gauge("diom.tokio.poll_histogram")
+                .with_description("Per-interval task poll-time histogram bucket counts")
+                .build(),
+            worker_local_queue_depth: meter
+                .u64_gauge("diom.tokio.worker.local_queue_depth")
+                .with_description("Number of tasks in a worker's local queue")
+                .build(),
+            node_id_kv: node_id.into(),
+        }
+    }
+
+    pub fn record(&self, metrics: &RuntimeMetrics, ctx: &mut RuntimeMetricsContext) {
+        let node = std::slice::from_ref(&self.node_id_kv);
+
+        let alive_tasks = metrics.num_alive_tasks() as u64;
+        if alive_tasks != 0 {
+            self.alive_tasks.record(alive_tasks, node);
+        }
+
+        let global_queue_depth = metrics.global_queue_depth() as u64;
+        if global_queue_depth > QUEUE_DEPTH_REPORT_THRESHOLD {
+            self.global_queue_depth.record(global_queue_depth, node);
+        }
+
+        // saturating: the two counters are independent atomics, so a reader can
+        // briefly observe more idle threads than total during pool teardown.
+        let active_blocking_threads = metrics
+            .num_blocking_threads()
+            .saturating_sub(metrics.num_idle_blocking_threads())
+            as u64;
+        if active_blocking_threads > QUEUE_DEPTH_REPORT_THRESHOLD {
+            self.active_blocking_threads
+                .record(active_blocking_threads, node);
+        }
+
+        let blocking_queue_depth = metrics.blocking_queue_depth() as u64;
+        if blocking_queue_depth > QUEUE_DEPTH_REPORT_THRESHOLD {
+            self.blocking_queue_depth.record(blocking_queue_depth, node);
+        }
+
+        self.record_poll_histogram(metrics, ctx);
+
+        for worker in 0..metrics.num_workers() {
+            let local_queue_depth = metrics.worker_local_queue_depth(worker) as u64;
+            if local_queue_depth > QUEUE_DEPTH_REPORT_THRESHOLD {
+                self.worker_local_queue_depth.record(
+                    local_queue_depth,
+                    &[
+                        self.node_id_kv.clone(),
+                        KeyValue::new("worker_id", worker as i64),
+                    ],
+                );
+            }
+        }
+    }
+
+    fn record_poll_histogram(&self, metrics: &RuntimeMetrics, ctx: &mut RuntimeMetricsContext) {
+        // Only populated when the runtime is built with the poll-time histogram
+        // enabled; skipped otherwise (e.g. the test harness).
+        if !metrics.poll_time_histogram_enabled() {
+            return;
+        }
+
+        let total_buckets = metrics.poll_time_histogram_num_buckets();
+        let first_reported_bucket =
+            total_buckets.saturating_sub(NUM_REPORTED_POLL_HISTOGRAM_BUCKETS);
+
+        for worker in 0..metrics.num_workers() {
+            let prev_values = &mut ctx.previous_poll_histogram_bucket_values[worker];
+
+            for (bucket, prev) in prev_values.iter_mut().enumerate() {
+                let underlying_bucket = first_reported_bucket + bucket;
+                if underlying_bucket >= total_buckets {
+                    break;
+                }
+
+                let bucket_range = metrics.poll_time_histogram_bucket_range(underlying_bucket);
+                let full_count =
+                    metrics.poll_time_histogram_bucket_count(worker, underlying_bucket);
+
+                let count = full_count - *prev;
+                *prev = full_count;
+
+                // Skip zero counts to keep metric cardinality and billing down.
+                if count != 0 {
+                    self.poll_histogram.record(
+                        count,
+                        &[
+                            self.node_id_kv.clone(),
+                            KeyValue::new("bucket_start_us", bucket_range.start.as_micros() as i64),
+                            KeyValue::new("bucket_end_us", bucket_range.end.as_micros() as i64),
+                            KeyValue::new("worker_id", worker as i64),
+                        ],
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -29,9 +29,7 @@ use crate::{
     core::{
         self,
         cluster::RaftState,
-        metrics::{
-            ConnectionMetrics, ConnectionType, RequestMetrics, RuntimeMetricsContext, TokioMetrics,
-        },
+        metrics::{ConnectionMetrics, ConnectionType, RequestMetrics, spawn_tokio_metrics},
         otel_spans::trace_layer,
     },
     docs,
@@ -85,7 +83,7 @@ pub async fn run_with_listeners(
             .expect("failed to initialize cluster");
     let node_id = raft_state.node_id;
 
-    spawn_tokio_metrics(TokioMetrics::new(&app_state.meter, node_id));
+    spawn_tokio_metrics(&app_state.meter, node_id);
 
     let request_metrics = RequestMetrics::new(&app_state.meter, node_id);
 
@@ -222,23 +220,6 @@ pub async fn run_with_listeners(
         .persist(fjall::PersistMode::SyncAll)
         .expect("failed to fsync ephemeral db at shutdown");
     tracing::info!("shutdown complete");
-}
-
-/// Spawn a background task that periodically reports Tokio runtime metrics.
-fn spawn_tokio_metrics(metrics: TokioMetrics) {
-    let handle = tokio::runtime::Handle::current();
-    let num_workers = handle.metrics().num_workers();
-    let shutdown = shutting_down_token();
-
-    tokio::spawn(async move {
-        let runtime_metrics = handle.metrics();
-        let mut ctx = RuntimeMetricsContext::new(num_workers);
-        let mut ticker = tokio::time::interval(Duration::from_secs(10));
-
-        while shutdown.run_until_cancelled(ticker.tick()).await.is_some() {
-            metrics.record(&runtime_metrics, &mut ctx);
-        }
-    });
 }
 
 async fn run_interserver(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -29,7 +29,9 @@ use crate::{
     core::{
         self,
         cluster::RaftState,
-        metrics::{ConnectionMetrics, ConnectionType, RequestMetrics},
+        metrics::{
+            ConnectionMetrics, ConnectionType, RequestMetrics, RuntimeMetricsContext, TokioMetrics,
+        },
         otel_spans::trace_layer,
     },
     docs,
@@ -82,6 +84,8 @@ pub async fn run_with_listeners(
             .await
             .expect("failed to initialize cluster");
     let node_id = raft_state.node_id;
+
+    spawn_tokio_metrics(TokioMetrics::new(&app_state.meter, node_id));
 
     let request_metrics = RequestMetrics::new(&app_state.meter, node_id);
 
@@ -218,6 +222,23 @@ pub async fn run_with_listeners(
         .persist(fjall::PersistMode::SyncAll)
         .expect("failed to fsync ephemeral db at shutdown");
     tracing::info!("shutdown complete");
+}
+
+/// Spawn a background task that periodically reports Tokio runtime metrics.
+fn spawn_tokio_metrics(metrics: TokioMetrics) {
+    let handle = tokio::runtime::Handle::current();
+    let num_workers = handle.metrics().num_workers();
+    let shutdown = shutting_down_token();
+
+    tokio::spawn(async move {
+        let runtime_metrics = handle.metrics();
+        let mut ctx = RuntimeMetricsContext::new(num_workers);
+        let mut ticker = tokio::time::interval(Duration::from_secs(10));
+
+        while shutdown.run_until_cancelled(ticker.tick()).await.is_some() {
+            metrics.record(&runtime_metrics, &mut ctx);
+        }
+    });
 }
 
 async fn run_interserver(


### PR DESCRIPTION
Adds Tokio runtime metrics per #494, following the webhooks-private approach.

New **TokioMetrics** in **core::metrics** reports the runtime's health as **diom.tokio.*** gauges (alive tasks, queue depths, blocking threads, and the poll-time histogram), collected by a background task in the same shape as the
existing **DbMetrics** loop.

The poll-time histogram is only populated when the runtime is built with **enable_metrics_poll_time_histogram**, which **#[tokio::main]** cannot set, so **main** now builds the runtime explicitly. Reporting is guarded by
**poll_time_histogram_enabled**, so runtimes without it (the test harness) are unaffected.

## Testing

fmt, clippy, and the integration suite pass. Booted a single node locally (dummy admin token) and confirmed the diom.tokio.* series are emitted via the admin metrics endpoint:

    diom.tokio.alive_tasks    = 28
    diom.tokio.poll_histogram = 161   # worker_id=11
    ...                               # per-worker buckets across workers 0-15


<img width="966" height="341" alt="Screenshot from 2026-07-23 04-21-20" src="https://github.com/user-attachments/assets/d0b687e5-8070-4051-b45d-845242327132" />
<img width="1550" height="974" alt="Screenshot from 2026-07-23 04-20-56" src="https://github.com/user-attachments/assets/6c677f87-2b70-4da9-9965-af15999ec26b" />

