### PR TITLE
devex: less-aggressively clear diom vars from the environment

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,7 +50,7 @@ vacuum-openapi:
 # run `vacuum` to check operator CRD openapi schema
 [group('lint')]
 vacuum-operator-openapi:
-    {{HERE}}/scripts/vacuum-operator-openapi.sh
+    {{ HERE }}/scripts/vacuum-operator-openapi.sh
 
 # run `vacuum` to check openapi, showing the details of any failures/warnings
 [group('lint')]
@@ -97,8 +97,8 @@ codegen:
 
 # Dump out config.defaults.toml and ENVIRONMENT_VARIABLES.md
 default-config:
-    env -i PATH="$PATH" TERM="$TERM" COLORTERM="$COLORTERM" cargo run -- --skip-dot-env write-config config.defaults.toml
-    cargo run -- describe-environment-variables ENVIRONMENT_VARIABLES.md
+    ./scripts/clear-diom-env.sh cargo run -- --skip-dot-env write-config config.defaults.toml
+    ./scripts/clear-diom-env.sh cargo run -- describe-environment-variables ENVIRONMENT_VARIABLES.md
 
 # Run all the test commands
 test-all: test test-sdks

--- a/scripts/clear-diom-env.sh
+++ b/scripts/clear-diom-env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# invoke the given command with any environment variables whose name starts with `DIOM` unset
+
+while IFS='=' read -r -d '' n _v; do
+    if [[ "$n" = DIOM* ]]; then
+        unset -v "$n"
+    fi
+done < <(env -0)
+
+exec "$@"


### PR DESCRIPTION
We don't need to wipe the whole environment, just the `$DIOM_` variables.