### PR TITLE
update output of cargo +nightly fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,10 @@ mod docs {
             debug_assertions => {
                 use tower_http::services::ServeFile;
 
-                let docs_route = ServeFile::new(concat!(env!("CARGO_MANIFEST_DIR"), "/src/static/docs.html"));
-                let openapi_json_route = ServeFile::new(concat!(env!("CARGO_MANIFEST_DIR"), "/openapi.json"));
+                let docs_route =
+                    ServeFile::new(concat!(env!("CARGO_MANIFEST_DIR"), "/src/static/docs.html"));
+                let openapi_json_route =
+                    ServeFile::new(concat!(env!("CARGO_MANIFEST_DIR"), "/openapi.json"));
             }
             // For release builds, embed both files in the binary for ease of deployment
             _ => {


### PR DESCRIPTION
unbreaks the build since we run `cargo +nightly fmt` in CI