### PR TITLE
[CI] Manually Install crun 1.28 before codegen to fix podman OCI v1.2.1 error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,13 @@ jobs:
       - uses: ubicloud/rust-cache@65b3ff06b9bcc69d88c25e212f1ae3d14a0953c3 # v2.7.5
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install crun >= 1.14.3 (podman OCI v1.2.1 compat)
+        run: |
+          CRUN_VERSION=1.28
+          sudo curl -fsSL -o /usr/bin/crun \
+            "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+          sudo chmod +x /usr/bin/crun
+          crun --version
       - name: Regerate openapi.json and SDKs
         run: cargo codegen
       - name: Regerate config.defaults.toml


### PR DESCRIPTION
In response to this lovely failure: https://github.com/svix/diom/actions/runs/31027382776/job/92380933891?pr=1313

The check-codegen job's containerized formatters (goimports, ruff) were
failing with "crun: unknown version specified".

Based on https://github.com/podman-container-tools/podman/issues/27272, it seems like a version mismatch with what Ubuntu 24.04 ships and what the OCI runtime spec requires, or something like that.

Installing a recent static crun before running cargo codegen seems to fix this.