### PR TITLE
cluster: do not crash if snapshot_id is invalid

### DIFF
--- a/src/core/cluster/state_machine.rs
+++ b/src/core/cluster/state_machine.rs
@@ -418,7 +418,8 @@ impl Store {
         self.last_membership = last_membership;
         self.snapshot_idx = last_snapshot
             .as_ref()
-            .map_or(Ok(0), |s| s.meta.snapshot_idx())?;
+            .and_then(|s| s.meta.snapshot_idx().ok())
+            .unwrap_or(0);
         self.cluster_id = cluster_id;
         if let Some(cluster_id) = &cluster_id {
             tracing::info!(%cluster_id, "starting up with existing cluster membership");
@@ -434,7 +435,7 @@ impl Store {
     ) -> anyhow::Result<()> {
         let handle = self.stores.clone();
         let keyspace = self.meta_keyspace.clone();
-        self.snapshot_idx = std::cmp::max(self.snapshot_idx + 1, meta.snapshot_idx()?);
+        self.snapshot_idx = std::cmp::max(self.snapshot_idx + 1, meta.snapshot_idx().unwrap_or(0));
         let data = LastSnapshot {
             meta,
             path: snapshot_path.clone(),


### PR DESCRIPTION
openraft 0.10.0.alpha33 removes snapshot IDs. They are only used today to disambiguate multiple snapshots taken at the same term & log index, which is a pretty edge case (and is handled better in alpha33).

This makes it so that if the snapshot ID is empty, we don't panic. This will allow nodes to downgrade from 0.10.0.alpha33 in the future.

Part of #1316