### PR TITLE
server: add a dedicated, documented readiness endpoint

### DIFF
--- a/crates/test-utils/src/json.rs
+++ b/crates/test-utils/src/json.rs
@@ -5,6 +5,7 @@ pub trait JsonFastAndLoose {
     fn assert_str(&self) -> &str;
     fn assert_array(&self) -> &[serde_json::Value];
     fn assert_bytes(&self) -> Vec<u8>;
+    fn assert_bool(&self) -> bool;
 }
 
 impl JsonFastAndLoose for serde_json::Value {
@@ -29,5 +30,10 @@ impl JsonFastAndLoose for serde_json::Value {
     #[track_caller]
     fn assert_array(&self) -> &[serde_json::Value] {
         self.as_array().unwrap()
+    }
+
+    #[track_caller]
+    fn assert_bool(&self) -> bool {
+        self.as_bool().unwrap()
     }
 }

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -48,6 +48,7 @@ pub struct TestServerBuilder {
     listener: Option<TcpListener>,
     repl_listener: Option<TcpListener>,
     workdir: Option<TempDir>,
+    wait_for_initialization: bool,
 }
 
 impl TestServerBuilder {
@@ -60,7 +61,13 @@ impl TestServerBuilder {
             token: None,
             listener: None,
             repl_listener: None,
+            wait_for_initialization: true,
         }
+    }
+
+    pub fn set_wait_for_initialization(mut self, value: bool) -> Self {
+        self.wait_for_initialization = value;
+        self
     }
 
     /// Mutate the current configuration.
@@ -149,10 +156,12 @@ impl TestServerBuilder {
         };
         let client = TestClient::new(base_uri, &token);
 
-        initialized
-            .wait()
-            .await
-            .expect("initialization should finish");
+        if self.wait_for_initialization {
+            initialized
+                .wait()
+                .await
+                .expect("initialization should finish");
+        }
 
         let (node_id, cluster_id) = wait_for_initialized(addr, repl_addr, Duration::from_secs(8))
             .await
@@ -350,6 +359,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         bootstrap_cfg: None,
         bootstrap_cfg_paths: vec![],
         bootstrap_cfg_path: None,
+        bootstrap_delay: None,
         sync_mode: SyncMode::Buffer,
         fsync_mode: FsyncMode::SyncData,
         admin_token: Some(TEST_ADMIN_TOKEN.to_string()),

--- a/infra/operator/src/resources/statefulset.rs
+++ b/infra/operator/src/resources/statefulset.rs
@@ -273,7 +273,7 @@ fn build_container(
 ) -> Container {
     let intracluster_port = INTRACLUSTER_PORT;
     const API_HEALTH_ENDPOINT: &str = "/api/v1.health.ping";
-    const CLUSTER_HEALTH_ENDPOINT: &str = "/repl/health";
+    const API_READINESS_ENDPOINT: &str = "/api/v1.health.ready";
 
     Container {
         name: "diom".into(),
@@ -301,13 +301,13 @@ fn build_container(
             ..Default::default()
         })),
         readiness_probe: Some(spec.probes.readiness.as_probe_with_http_get(HTTPGetAction {
-            path: Some(CLUSTER_HEALTH_ENDPOINT.into()),
-            port: IntOrString::Int(intracluster_port as _),
+            path: Some(API_READINESS_ENDPOINT.into()),
+            port: IntOrString::Int(spec.diom.api_port as _),
             ..Default::default()
         })),
         startup_probe: Some(spec.probes.startup.as_probe_with_http_get(HTTPGetAction {
-            path: Some(CLUSTER_HEALTH_ENDPOINT.into()),
-            port: IntOrString::Int(intracluster_port as _),
+            path: Some(API_READINESS_ENDPOINT.into()),
+            port: IntOrString::Int(spec.diom.api_port as _),
             ..Default::default()
         })),
         ..Default::default()

--- a/openapi.json
+++ b/openapi.json
@@ -7347,7 +7347,7 @@
           "Health"
         ],
         "summary": "Ping",
-        "description": "Verify the server is up and running.",
+        "description": "Verify the server is up and running.\n\nThis endpoint only checks the server itself, not the cluster mechanism, and should not be used\nas a readiness gate.",
         "operationId": "v1.health.ping",
         "responses": {
           "200": {
@@ -7436,6 +7436,105 @@
             "lang": "Rust",
             "label": "Rust",
             "source": "let response = diom.health()\n    .ping()\n    .await?;"
+          }
+        ]
+      }
+    },
+    "/api/v1.health.ready": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Ready",
+        "description": "Verify that this server is ready to serve customer traffic.",
+        "operationId": "v1.health.ready",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadyOut"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "Shell",
+            "label": "CLI",
+            "source": "diom health ready"
+          },
+          {
+            "lang": "Go",
+            "label": "Go",
+            "source": "response, err := diom.Health.Ready(ctx)"
+          },
+          {
+            "lang": "Java",
+            "label": "Java",
+            "source": "var response = diom.getHealth.ready();"
+          },
+          {
+            "lang": "TypeScript",
+            "label": "JavaScript",
+            "source": "const response = await diom.health.ready();"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "response = diom.health.ready();"
+          },
+          {
+            "lang": "Rust",
+            "label": "Rust",
+            "source": "let response = diom.health()\n    .ready()\n    .await?;"
           }
         ]
       }
@@ -10981,6 +11080,21 @@
       },
       "RateLimitResetOut": {
         "type": "object"
+      },
+      "ReadyOut": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok",
+          "message"
+        ]
       },
       "Retention": {
         "type": "object",

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -337,6 +337,11 @@ pub async fn run(app_config: AppConfig, raft_state: RaftState) -> anyhow::Result
 
     wait_for_up(&app_config, &raft_state).await?;
 
+    if let Some(delay) = app_config.bootstrap_delay {
+        tracing::debug!(?delay, "pausing before running bootstrap");
+        tokio::time::sleep(delay.into()).await;
+    }
+
     let mut paths = app_config.bootstrap_cfg_paths.clone();
     if let Some(path) = &app_config.bootstrap_cfg_path {
         tracing::warn!("`bootstrap_cfg_path` is deprecated; use `bootstrap_cfg_paths` instead");

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -588,6 +588,12 @@ pub struct ConfigurationInner {
     #[serde(rename = "bootstrap_max_wait_ms", default)]
     pub bootstrap_max_wait_time: Option<NonZeroDurationMs>,
 
+    /// Wait before bootstrapping (for use in tests)
+    #[env_overridable(skip)]
+    #[dumpable_config(skip)]
+    #[serde(rename = "bootstrap_delay_ms", default)]
+    pub bootstrap_delay: Option<NonZeroDurationMs>,
+
     /// How often to run background cleanup/garbage collection jobs
     ///
     /// Correctness should never be affected by this, just wasted memory/disk.

--- a/src/v1/endpoints/health.rs
+++ b/src/v1/endpoints/health.rs
@@ -4,12 +4,18 @@ use aide::axum::{
     ApiRouter,
     routing::{get_with, post_with},
 };
+use axum::extract::Extension;
 use diom_derive::aide_annotate;
 use diom_proto::MsgPackOrJson;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{AppState, error::Result, v1::utils::openapi_tag};
+use crate::{
+    AppState,
+    core::cluster::RaftState,
+    error::{Error, Result, ResultExt},
+    v1::utils::openapi_tag,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct PingOut {
@@ -17,17 +23,40 @@ pub struct PingOut {
 }
 
 /// Verify the server is up and running.
+///
+/// This endpoint only checks the server itself, not the cluster mechanism, and should not be used
+/// as a readiness gate.
 #[aide_annotate(op_id = "v1.health.ping")]
 async fn ping() -> Result<MsgPackOrJson<PingOut>> {
     Ok(MsgPackOrJson(PingOut { ok: true }))
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReadyOut {
+    pub ok: bool,
+    pub message: String,
+}
+
+/// Verify that this server is ready to serve customer traffic.
+#[aide_annotate(op_id = "v1.health.ready")]
+async fn ready(Extension(repl): Extension<RaftState>) -> Result<MsgPackOrJson<ReadyOut>> {
+    let state = repl.state().await.or_internal_error()?;
+    if state.is_leader() || state.is_follower() || state.is_candidate() {
+        Ok(MsgPackOrJson(ReadyOut {
+            ok: true,
+            message: format!("State: {state:?}"),
+        }))
+    } else {
+        Err(Error::not_ready(format!(
+            "Cluster is currently in state {state:?}"
+        )))
+    }
+}
+
 /// Intentionally return an error
 #[aide_annotate(op_id = "v1.health.error")]
 async fn error() -> Result<()> {
-    Err(diom_error::Error::internal(
-        "despite appearances, I am not an error",
-    ))
+    Err(Error::internal("despite appearances, I am not an error"))
 }
 
 /// Intentionally panic a thread
@@ -42,6 +71,7 @@ pub fn router() -> ApiRouter<AppState> {
 
     let router = ApiRouter::new()
         .api_route_with(ping_path, get_with(ping, ping_operation), &tag)
+        .api_route_with(ready_path, get_with(ready, ready_operation), &tag)
         .api_route_with(error_path, post_with(error, error_operation), &tag);
 
     #[cfg(debug_assertions)]

--- a/tests/it/health.rs
+++ b/tests/it/health.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use diom_core::types::NonZeroDurationMs;
-use test_utils::{JsonFastAndLoose as _, StatusCode, TestResult, server::TestServerBuilder};
+use test_utils::{StatusCode, TestResult, server::TestServerBuilder};
 
 #[tokio::test]
 async fn test_health_ping() -> TestResult {
@@ -15,7 +15,7 @@ async fn test_health_ping() -> TestResult {
     let response = ctx.client.get("v1.health.ping").await?;
     assert_eq!(response.status(), StatusCode::OK);
     let body = response.json();
-    assert!(body["ok"].assert_bool());
+    assert_eq!(body["ok"], true);
     Ok(())
 }
 
@@ -42,11 +42,8 @@ async fn test_error() -> TestResult {
     let response = ctx.client.post("v1.health.error").await?;
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     let body = response.json();
-    assert_eq!(body["code"].assert_str(), "internal");
-    assert_eq!(
-        body["detail"].assert_str(),
-        "despite appearances, I am not an error"
-    );
-    assert_eq!(body["type"].assert_str(), "server-error");
+    assert_eq!(body["code"], "internal");
+    assert_eq!(body["detail"], "despite appearances, I am not an error");
+    assert_eq!(body["type"], "server-error");
     Ok(())
 }

--- a/tests/it/health.rs
+++ b/tests/it/health.rs
@@ -1,0 +1,52 @@
+use std::time::Duration;
+
+use diom_core::types::NonZeroDurationMs;
+use test_utils::{JsonFastAndLoose as _, StatusCode, TestResult, server::TestServerBuilder};
+
+#[tokio::test]
+async fn test_health_ping() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .set_wait_for_initialization(false)
+        .tap_cfg(|c| {
+            c.bootstrap_delay = Some(NonZeroDurationMs::from_secs(1).unwrap());
+        })
+        .build()
+        .await;
+    let response = ctx.client.get("v1.health.ping").await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.json();
+    assert!(body["ok"].assert_bool());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_health_ready() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config()
+        .set_wait_for_initialization(false)
+        .tap_cfg(|c| {
+            c.bootstrap_delay = Some(NonZeroDurationMs::from_secs(1).unwrap());
+        })
+        .build()
+        .await;
+    let response = ctx.client.get("v1.health.ready").await?;
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let response = ctx.client.get("v1.health.ready").await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_error() -> TestResult {
+    let ctx = TestServerBuilder::with_default_config().build().await;
+    let response = ctx.client.post("v1.health.error").await?;
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = response.json();
+    assert_eq!(body["code"].assert_str(), "internal");
+    assert_eq!(
+        body["detail"].assert_str(),
+        "despite appearances, I am not an error"
+    );
+    assert_eq!(body["type"].assert_str(), "server-error");
+    Ok(())
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -4,6 +4,7 @@ mod bootstrap;
 mod cache;
 mod cluster_admin;
 mod common;
+mod health;
 mod idempotency;
 mod jwt_auth;
 mod kv;

--- a/z-clients/cli/src/cmds/api/health.rs
+++ b/z-clients/cli/src/cmds/api/health.rs
@@ -16,6 +16,9 @@ pub struct HealthArgs {
 #[derive(Subcommand)]
 pub enum HealthCommands {
     /// Verify the server is up and running.
+    ///
+    /// This endpoint only checks the server itself, not the cluster mechanism, and should not be used
+    /// as a readiness gate.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
             "{usage-heading} {usage}\n\n",
@@ -29,6 +32,21 @@ pub enum HealthCommands {
   \"ok\": true
 }\n")]
     Ping {},
+    /// Verify that this server is ready to serve customer traffic.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: diom health ready\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
+    #[command(after_help = "Example response:
+{
+  \"ok\": true,
+  \"message\": \"...\"
+}\n")]
+    Ready {},
     /// Intentionally return an error
     #[command(help_template = concat!(
             "{about-with-newline}\n",
@@ -46,6 +64,10 @@ impl HealthCommands {
         match self {
             Self::Ping {} => {
                 let resp = client.health().ping().await?;
+                crate::json::print_json_output(&resp)?;
+            }
+            Self::Ready {} => {
+                let resp = client.health().ready().await?;
                 crate::json::print_json_output(&resp)?;
             }
             Self::Error {} => {

--- a/z-clients/go/internal/apis/health.go
+++ b/z-clients/go/internal/apis/health.go
@@ -18,6 +18,9 @@ func NewHealth(client *diom_proto.HttpClient) Health {
 }
 
 // Verify the server is up and running.
+//
+// This endpoint only checks the server itself, not the cluster mechanism, and should not be used
+// as a readiness gate.
 func (health Health) Ping(
 	ctx context.Context,
 ) (*diom_models.PingOut, error) {
@@ -26,6 +29,19 @@ func (health Health) Ping(
 		health.client,
 		"GET",
 		"/api/v1.health.ping",
+		nil,
+	)
+}
+
+// Verify that this server is ready to serve customer traffic.
+func (health Health) Ready(
+	ctx context.Context,
+) (*diom_models.ReadyOut, error) {
+	return diom_proto.ExecuteRequest[any, diom_models.ReadyOut](
+		ctx,
+		health.client,
+		"GET",
+		"/api/v1.health.ready",
 		nil,
 	)
 }

--- a/z-clients/go/internal/models/ready_out.go
+++ b/z-clients/go/internal/models/ready_out.go
@@ -1,0 +1,8 @@
+package diom_models
+
+// This file is @generated DO NOT EDIT
+
+type ReadyOut struct {
+	Ok      bool   `msgpack:"ok"`
+	Message string `msgpack:"message"`
+}

--- a/z-clients/go/models.go
+++ b/z-clients/go/models.go
@@ -132,6 +132,7 @@ type (
 	RateLimitGetRemainingOut         = diom_models.RateLimitGetRemainingOut
 	RateLimitResetIn                 = diom_models.RateLimitResetIn
 	RateLimitResetOut                = diom_models.RateLimitResetOut
+	ReadyOut                         = diom_models.ReadyOut
 	Retention                        = diom_models.Retention
 	SeekPosition                     = diom_models.SeekPosition
 	ServerState                      = diom_models.ServerState

--- a/z-clients/java/src/main/java/com/svix/diom/apis/Health.java
+++ b/z-clients/java/src/main/java/com/svix/diom/apis/Health.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import com.svix.diom.models.PingOut;
+import com.svix.diom.models.ReadyOut;
 
 public class Health {
     private final HttpClient client;
@@ -19,7 +20,12 @@ public class Health {
         this.client = client;
     }
 
-    /** Verify the server is up and running. */
+    /**
+* Verify the server is up and running.
+* 
+* This endpoint only checks the server itself, not the cluster mechanism, and should not be used
+* as a readiness gate.
+*/
     public PingOut ping(
         
     ) throws DiomException {
@@ -30,6 +36,20 @@ public class Health {
             null,
             null,
             PingOut.class
+        );
+    }
+
+    /** Verify that this server is ready to serve customer traffic. */
+    public ReadyOut ready(
+        
+    ) throws DiomException {
+
+        return this.client.executeRequest(
+            "GET",
+            "/api/v1.health.ready",
+            null,
+            null,
+            ReadyOut.class
         );
     }
 

--- a/z-clients/java/src/main/java/com/svix/diom/models/ReadyOut.java
+++ b/z-clients/java/src/main/java/com/svix/diom/models/ReadyOut.java
@@ -1,0 +1,100 @@
+// this file is @generated
+package com.svix.diom.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.svix.diom.DurationMsSerializer;
+import com.svix.diom.DurationMsDeserializer;
+import com.svix.diom.UnixTimestampMsSerializer;
+import com.svix.diom.UnixTimestampMsDeserializer;
+import com.svix.diom.Utils;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.net.URI;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
+public class ReadyOut {
+    @JsonProperty private Boolean ok;
+    @JsonProperty private String message;
+    public ReadyOut() {}
+
+    public ReadyOut ok(Boolean ok) {
+        this.ok = ok;
+        return this;
+    }
+
+    /**
+    * Get ok
+    *
+     * @return ok
+     */
+    @javax.annotation.Nonnull
+    public Boolean getOk() {
+        return ok;
+    }
+
+    public void setOk(Boolean ok) {
+        this.ok = ok;
+    }
+
+    public ReadyOut message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    /**
+    * Get message
+    *
+     * @return message
+     */
+    @javax.annotation.Nonnull
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Create an instance of ReadyOut given a JSON string
+     *
+     * @param jsonString JSON string
+     * @return An instance of ReadyOut
+     * @throws JsonProcessingException if the JSON string is invalid with respect to ReadyOut
+     */
+    public static ReadyOut fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, ReadyOut.class);
+    }
+
+    /**
+     * Convert an instance of ReadyOut to a JSON string
+     *
+     * @return JSON string
+     */
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+}

--- a/z-clients/javascript/src/apis/health.ts
+++ b/z-clients/javascript/src/apis/health.ts
@@ -4,12 +4,21 @@ import {
     type PingOut,
     PingOutSerializer,
 } from '../models/pingOut';
+import {
+    type ReadyOut,
+    ReadyOutSerializer,
+} from '../models/readyOut';
 import { HttpMethod, DiomRequest, type DiomRequestContext } from "../request";
 
 export class Health {
     public constructor(private readonly requestCtx: DiomRequestContext) {}
 
-    /** Verify the server is up and running. */
+    /**
+* Verify the server is up and running.
+* 
+* This endpoint only checks the server itself, not the cluster mechanism, and should not be used
+* as a readiness gate.
+*/
     public ping(
     ): Promise<PingOut> {
         const request = new DiomRequest(HttpMethod.GET, "/api/v1.health.ping");
@@ -18,6 +27,16 @@ export class Health {
         return request.send(
             this.requestCtx,
             PingOutSerializer._fromJsonObject,
+        );
+    }/** Verify that this server is ready to serve customer traffic. */
+    public ready(
+    ): Promise<ReadyOut> {
+        const request = new DiomRequest(HttpMethod.GET, "/api/v1.health.ready");
+
+        
+        return request.send(
+            this.requestCtx,
+            ReadyOutSerializer._fromJsonObject,
         );
     }/** Intentionally return an error */
     public error(

--- a/z-clients/javascript/src/internal.ts
+++ b/z-clients/javascript/src/internal.ts
@@ -127,6 +127,7 @@ export { RateLimitGetRemainingInSerializer } from "./models/rateLimitGetRemainin
 export { RateLimitGetRemainingOutSerializer } from "./models/rateLimitGetRemainingOut";
 export { RateLimitResetInSerializer } from "./models/rateLimitResetIn";
 export { RateLimitResetOutSerializer } from "./models/rateLimitResetOut";
+export { ReadyOutSerializer } from "./models/readyOut";
 export { RetentionSerializer } from "./models/retention";
 export { SeekPositionSerializer } from "./models/seekPosition";
 export { ServerStateSerializer } from "./models/serverState";

--- a/z-clients/javascript/src/models/index.ts
+++ b/z-clients/javascript/src/models/index.ts
@@ -126,6 +126,7 @@ export type { RateLimitGetRemainingIn } from "./rateLimitGetRemainingIn";
 export type { RateLimitGetRemainingOut } from "./rateLimitGetRemainingOut";
 export type { RateLimitResetIn } from "./rateLimitResetIn";
 export type { RateLimitResetOut } from "./rateLimitResetOut";
+export type { ReadyOut } from "./readyOut";
 export type { Retention } from "./retention";
 export type { SeekPosition } from "./seekPosition";
 export type { ServerState } from "./serverState";

--- a/z-clients/javascript/src/models/readyOut.ts
+++ b/z-clients/javascript/src/models/readyOut.ts
@@ -1,0 +1,24 @@
+// this file is @generated
+
+export interface ReadyOut {
+    ok: boolean;
+    message: string;
+}
+
+export const ReadyOutSerializer = {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _fromJsonObject(object: any): ReadyOut {
+        return {
+            ok: object['ok'],
+            message: object['message'],
+        };
+    },
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional any
+    _toJsonObject(self: ReadyOut): any {
+        return {
+            'ok': self.ok,
+            'message': self.message,
+        };
+    }
+}

--- a/z-clients/python/diom/apis/health.py
+++ b/z-clients/python/diom/apis/health.py
@@ -3,6 +3,7 @@
 from ..internal.api_common import ApiBase
 from ..models import (
     PingOut,
+    ReadyOut,
 )
 
 
@@ -10,12 +11,26 @@ class HealthAsync(ApiBase):
     async def ping(
         self,
     ) -> PingOut:
-        """Verify the server is up and running."""
+        """Verify the server is up and running.
+
+        This endpoint only checks the server itself, not the cluster mechanism, and should not be used
+        as a readiness gate."""
 
         return await self._request_asyncio(
             method="get",
             path="/api/v1.health.ping",
             response_type=PingOut,
+        )
+
+    async def ready(
+        self,
+    ) -> ReadyOut:
+        """Verify that this server is ready to serve customer traffic."""
+
+        return await self._request_asyncio(
+            method="get",
+            path="/api/v1.health.ready",
+            response_type=ReadyOut,
         )
 
     async def error(
@@ -33,12 +48,26 @@ class Health(ApiBase):
     def ping(
         self,
     ) -> PingOut:
-        """Verify the server is up and running."""
+        """Verify the server is up and running.
+
+        This endpoint only checks the server itself, not the cluster mechanism, and should not be used
+        as a readiness gate."""
 
         return self._request_sync(
             method="get",
             path="/api/v1.health.ping",
             response_type=PingOut,
+        )
+
+    def ready(
+        self,
+    ) -> ReadyOut:
+        """Verify that this server is ready to serve customer traffic."""
+
+        return self._request_sync(
+            method="get",
+            path="/api/v1.health.ready",
+            response_type=ReadyOut,
         )
 
     def error(

--- a/z-clients/python/diom/models/__init__.py
+++ b/z-clients/python/diom/models/__init__.py
@@ -126,6 +126,7 @@ from .rate_limit_get_remaining_in import RateLimitGetRemainingIn
 from .rate_limit_get_remaining_out import RateLimitGetRemainingOut
 from .rate_limit_reset_in import RateLimitResetIn
 from .rate_limit_reset_out import RateLimitResetOut
+from .ready_out import ReadyOut
 from .retention import Retention
 from .seek_position import SeekPosition
 from .server_state import ServerState
@@ -273,6 +274,7 @@ __all__ = [
     "RateLimitGetRemainingOut",
     "RateLimitResetIn",
     "RateLimitResetOut",
+    "ReadyOut",
     "Retention",
     "SeekPosition",
     "ServerState",

--- a/z-clients/python/diom/models/ready_out.py
+++ b/z-clients/python/diom/models/ready_out.py
@@ -1,0 +1,9 @@
+# this file is @generated
+
+from ..internal.base_model import BaseModel
+
+
+class ReadyOut(BaseModel):
+    ok: bool
+
+    message: str

--- a/z-clients/rust/src/api/health.rs
+++ b/z-clients/rust/src/api/health.rs
@@ -11,8 +11,18 @@ impl<'a> Health<'a> {
     }
 
     /// Verify the server is up and running.
+    ///
+    /// This endpoint only checks the server itself, not the cluster mechanism, and should not be used
+    /// as a readiness gate.
     pub async fn ping(&self) -> Result<PingOut> {
         crate::request::Request::new(http::Method::GET, "/api/v1.health.ping")
+            .execute(self.cfg)
+            .await
+    }
+
+    /// Verify that this server is ready to serve customer traffic.
+    pub async fn ready(&self) -> Result<ReadyOut> {
+        crate::request::Request::new(http::Method::GET, "/api/v1.health.ready")
             .execute(self.cfg)
             .await
     }

--- a/z-clients/rust/src/models/mod.rs
+++ b/z-clients/rust/src/models/mod.rs
@@ -128,6 +128,7 @@ mod rate_limit_get_remaining_in;
 mod rate_limit_get_remaining_out;
 mod rate_limit_reset_in;
 mod rate_limit_reset_out;
+mod ready_out;
 mod retention;
 mod seek_position;
 mod server_state;
@@ -227,11 +228,11 @@ pub use self::{
     rate_limit_get_namespace_out::RateLimitGetNamespaceOut,
     rate_limit_get_remaining_in::RateLimitGetRemainingIn,
     rate_limit_get_remaining_out::RateLimitGetRemainingOut, rate_limit_reset_in::RateLimitResetIn,
-    rate_limit_reset_out::RateLimitResetOut, retention::Retention, seek_position::SeekPosition,
-    server_state::ServerState, sink_config::SinkConfig, sink_configure_in::SinkConfigureIn,
-    sink_configure_out::SinkConfigureOut, sink_delete_in::SinkDeleteIn,
-    sink_delete_out::SinkDeleteOut, sink_list_in::SinkListIn, sink_out::SinkOut,
-    stream_msg_out::StreamMsgOut, svix_poller_create_in::SvixPollerCreateIn,
+    rate_limit_reset_out::RateLimitResetOut, ready_out::ReadyOut, retention::Retention,
+    seek_position::SeekPosition, server_state::ServerState, sink_config::SinkConfig,
+    sink_configure_in::SinkConfigureIn, sink_configure_out::SinkConfigureOut,
+    sink_delete_in::SinkDeleteIn, sink_delete_out::SinkDeleteOut, sink_list_in::SinkListIn,
+    sink_out::SinkOut, stream_msg_out::StreamMsgOut, svix_poller_create_in::SvixPollerCreateIn,
     svix_poller_create_out::SvixPollerCreateOut, svix_poller_delete_in::SvixPollerDeleteIn,
     svix_poller_delete_out::SvixPollerDeleteOut, svix_poller_list_in::SvixPollerListIn,
     svix_poller_out::SvixPollerOut,

--- a/z-clients/rust/src/models/ready_out.rs
+++ b/z-clients/rust/src/models/ready_out.rs
@@ -1,0 +1,15 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ReadyOut {
+    pub ok: bool,
+
+    pub message: String,
+}
+
+impl ReadyOut {
+    pub fn new(ok: bool, message: String) -> Self {
+        Self { ok, message }
+    }
+}


### PR DESCRIPTION
Right now stuff is using the internal/undocumented `/repl/health` endpoint.

Fixes #1319