### PR TITLE
Add support for versioning rows in DB

### DIFF
--- a/crates/diom-core/src/lib.rs
+++ b/crates/diom-core/src/lib.rs
@@ -28,5 +28,5 @@ pub mod __reexport {
     pub use serde_json;
 }
 
-pub use diom_derive::PersistableValue;
+pub use diom_derive::{PersistableValue, PersistableVersioned};
 pub use persistable_value::PersistableValue;

--- a/crates/diom-derive/src/lib.rs
+++ b/crates/diom-derive/src/lib.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 mod fjall_key;
 mod fjall_key_component;
+mod versioned;
 
 use self::aide::{AideAnnotateArgumentList, expand_aide_annotate};
 
@@ -84,4 +85,21 @@ pub fn macro_derive_dumpable_config(input: TokenStream) -> TokenStream {
 pub fn macro_derive_persistable_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     derive_persistable_value(input).into()
+}
+
+/// Derive `Serialize`/`Deserialize` with a leading schema-version tag so trailing fields can be
+/// added over time without breaking reads of existing postcard data.
+///
+/// Use this **instead of** `#[derive(Serialize, Deserialize, PersistableValue)]`. Mark fields added
+/// after the initial layout with `#[since(n)]` (unmarked fields are version 0). A non-`Option` field
+/// added later must supply a default via `#[since(n, default = EXPR)]`. Fields must be declared in
+/// non-decreasing `since` order.
+///
+/// Add `#[versioned(row_type = EXPR)]` on the struct to also generate a `TableRow` impl.
+/// Omit it for versioned types used only as nested (non-row) values.
+#[proc_macro_derive(PersistableVersioned, attributes(since, versioned))]
+pub fn macro_derive_persistable_versioned(input: TokenStream) -> TokenStream {
+    versioned::derive(input.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }

--- a/crates/diom-derive/src/versioned.rs
+++ b/crates/diom-derive/src/versioned.rs
@@ -1,0 +1,250 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    DeriveInput, Expr, Ident, LitInt, Token,
+    parse::{Parse, ParseStream},
+    spanned::Spanned,
+};
+
+/// Parsed `#[since(N)]` or `#[since(N, default = EXPR)]` field attribute.
+struct SinceAttr {
+    version: u32,
+    default: Option<Expr>,
+}
+
+impl Parse for SinceAttr {
+    fn parse(input: ParseStream<'_>) -> Result<Self, syn::Error> {
+        let lit: LitInt = input.parse()?;
+        let version = lit.base10_parse()?;
+        let mut default = None;
+        if input.peek(Token![,]) {
+            let _: Token![,] = input.parse()?;
+            let key: Ident = input.parse()?;
+            if key != "default" {
+                return Err(syn::Error::new(key.span(), "expected `default`"));
+            }
+            let _: Token![=] = input.parse()?;
+            default = Some(input.parse()?);
+        }
+        Ok(SinceAttr { version, default })
+    }
+}
+
+struct VersionedField {
+    ident: Ident,
+    ty: syn::Type,
+    since: u32,
+    default: Option<Expr>,
+}
+
+fn parse_since(field: &syn::Field) -> Result<Option<SinceAttr>, syn::Error> {
+    for attr in &field.attrs {
+        if attr.path().is_ident("since") {
+            return Ok(Some(attr.parse_args::<SinceAttr>()?));
+        }
+    }
+    Ok(None)
+}
+
+/// Parses an optional `#[versioned(row_type = EXPR)]` container attribute. When present, the derive
+/// also generates a `TableRow` impl wired to the versioned storage envelope.
+fn parse_row_type(input: &DeriveInput) -> Result<Option<Expr>, syn::Error> {
+    for attr in &input.attrs {
+        if attr.path().is_ident("versioned") {
+            let mut row_type = None;
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("row_type") {
+                    row_type = Some(meta.value()?.parse::<Expr>()?);
+                    Ok(())
+                } else {
+                    Err(meta.error("expected `row_type`"))
+                }
+            })?;
+            return row_type
+                .ok_or_else(|| {
+                    syn::Error::new(attr.span(), "missing `row_type` in #[versioned(...)]")
+                })
+                .map(Some);
+        }
+    }
+    Ok(None)
+}
+
+fn collect_fields(input: &DeriveInput) -> Result<Vec<VersionedField>, syn::Error> {
+    let syn::Data::Struct(data) = &input.data else {
+        return Err(syn::Error::new(
+            input.ident.span(),
+            "PersistableVersioned can only be derived for structs",
+        ));
+    };
+    let syn::Fields::Named(fields) = &data.fields else {
+        return Err(syn::Error::new(
+            input.ident.span(),
+            "PersistableVersioned requires named fields",
+        ));
+    };
+    if !input.generics.params.is_empty() {
+        return Err(syn::Error::new(
+            input.generics.span(),
+            "PersistableVersioned does not support generic types",
+        ));
+    }
+
+    let mut out = Vec::with_capacity(fields.named.len());
+    for field in fields.named.iter() {
+        let ident = field.ident.clone().expect("named field");
+        let (since, default) = match parse_since(field)? {
+            Some(a) => (a.version, a.default),
+            None => (0, None),
+        };
+        out.push(VersionedField {
+            ident,
+            ty: field.ty.clone(),
+            since,
+            default,
+        });
+    }
+
+    // Fields are read positionally, so a version-`v` reader must be able to stop right after the
+    // last field with `since <= v`. That only works if fields are declared in non-decreasing
+    // `since` order.
+    for w in out.windows(2) {
+        if w[1].since < w[0].since {
+            return Err(syn::Error::new(
+                w[1].ident.span(),
+                format!(
+                    "field `{}` (since {}) must not precede a field with a higher `since` ({}); \
+                     declare fields in non-decreasing `since` order",
+                    w[1].ident, w[1].since, w[0].since
+                ),
+            ));
+        }
+    }
+
+    Ok(out)
+}
+
+pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
+    let input: DeriveInput = syn::parse2(input)?;
+    let fields = collect_fields(&input)?;
+    let row_type = parse_row_type(&input)?;
+    let name = &input.ident;
+    let field_count = fields.len();
+    let tuple_len = field_count + 1;
+    let write_version = fields.iter().map(|f| f.since).max().unwrap_or(0);
+
+    // When `#[versioned(row_type = ...)]` is present, generate the TableRow impl so the row uses the
+    // versioned envelope (its own leading version tag) instead of V0Wrapper. Types without the
+    // attribute get only the serde impls, for use as nested (non-row) values.
+    let table_row_impl = row_type.map(|row_type| {
+        quote! {
+            #[automatically_derived]
+            impl ::fjall_utils::TableRow for #name {
+                const ROW_TYPE: u8 = (#row_type) as u8;
+                const VERSIONED: bool = true;
+            }
+        }
+    });
+
+    let serialize_elems = fields.iter().map(|f| {
+        let ident = &f.ident;
+        quote! { __tup.serialize_element(&self.#ident)?; }
+    });
+
+    let deserialize_bindings = fields.iter().map(|f| {
+        let ident = &f.ident;
+        let ty = &f.ty;
+        let missing = format!("missing field `{ident}`");
+        if f.since == 0 {
+            quote! {
+                let #ident: #ty = __seq
+                    .next_element()?
+                    .ok_or_else(|| <A::Error as ::serde::de::Error>::custom(#missing))?;
+            }
+        } else {
+            let since = f.since;
+            let default_expr = match &f.default {
+                Some(expr) => quote! { #expr },
+                None => quote! { ::core::default::Default::default() },
+            };
+            quote! {
+                let #ident: #ty = if __version >= #since {
+                    __seq
+                        .next_element()?
+                        .ok_or_else(|| <A::Error as ::serde::de::Error>::custom(#missing))?
+                } else {
+                    #default_expr
+                };
+            }
+        }
+    });
+
+    let field_idents = fields.iter().map(|f| &f.ident);
+    let inner_types = fields.iter().map(|f| &f.ty);
+    let expecting = format!("{name} versioned tuple");
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl ::serde::Serialize for #name {
+            fn serialize<__S: ::serde::Serializer>(
+                &self,
+                __serializer: __S,
+            ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                use ::serde::ser::SerializeTuple as _;
+                let mut __tup = __serializer.serialize_tuple(#tuple_len)?;
+                __tup.serialize_element(&(#write_version as u32))?;
+                #(#serialize_elems)*
+                __tup.end()
+            }
+        }
+
+        #[automatically_derived]
+        impl<'de> ::serde::Deserialize<'de> for #name {
+            fn deserialize<__D: ::serde::Deserializer<'de>>(
+                __deserializer: __D,
+            ) -> ::core::result::Result<Self, __D::Error> {
+                struct __Visitor;
+                impl<'de> ::serde::de::Visitor<'de> for __Visitor {
+                    type Value = #name;
+
+                    fn expecting(
+                        &self,
+                        __f: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        __f.write_str(#expecting)
+                    }
+
+                    fn visit_seq<A: ::serde::de::SeqAccess<'de>>(
+                        self,
+                        mut __seq: A,
+                    ) -> ::core::result::Result<Self::Value, A::Error> {
+                        let __version: u32 = __seq
+                            .next_element()?
+                            .ok_or_else(|| {
+                                <A::Error as ::serde::de::Error>::custom("missing schema version")
+                            })?;
+                        #(#deserialize_bindings)*
+                        ::core::result::Result::Ok(#name { #(#field_idents),* })
+                    }
+                }
+                __deserializer.deserialize_tuple(#tuple_len, __Visitor)
+            }
+        }
+
+        #[automatically_derived]
+        impl #name {
+            /// Schema version this build writes as the leading tag on new records.
+            ///
+            /// Reads accept any version from 0 up to this value. Bumped automatically by adding a
+            /// field with a higher `#[since(n)]`.
+            pub const WRITE_VERSION: u32 = #write_version;
+        }
+
+        #[automatically_derived]
+        impl diom_core::persistable_value::PersistableStruct for #name {
+            type INNER = ( #(#inner_types,)* );
+        }
+
+        #table_row_impl
+    })
+}

--- a/crates/fjall-utils/src/lib.rs
+++ b/crates/fjall-utils/src/lib.rs
@@ -133,4 +133,174 @@ mod tests {
         let via_vec = postcard::to_allocvec(&V0Wrapper::V0(original)).unwrap();
         assert_eq!(&*via_slice, via_vec.as_slice());
     }
+
+    // `Fixture` and `FixtureOld` model a row serialized in the db prior to this addition
+    // of `PersistableVersioned`, and then being swapped to use PersistableVersioned
+    // later on, so we can prove backwards compatibility.
+
+    #[derive(diom_core::PersistableVersioned, PartialEq, Debug)]
+    #[versioned(row_type = 0)]
+    struct Fixture {
+        a: u32,
+        b: u32,
+        #[since(1)]
+        c: Option<u32>,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, diom_core::PersistableValue)]
+    struct FixtureOld {
+        a: u32,
+        b: u32,
+    }
+
+    impl TableRow for FixtureOld {
+        const ROW_TYPE: u8 = 0;
+    }
+
+    #[test]
+    fn versioned_round_trips_current_version() {
+        assert_eq!(Fixture::WRITE_VERSION, 1);
+
+        let value = Fixture {
+            a: 1,
+            b: 2,
+            c: Some(3),
+        };
+        let bytes = value.to_fjall_value().unwrap();
+        let decoded = Fixture::from_fjall_value(bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn versioned_decodes_legacy_v0_with_defaulted_field() {
+        let legacy = FixtureOld { a: 10, b: 20 }.to_fjall_value().unwrap();
+        let decoded = Fixture::from_fjall_value(legacy).unwrap();
+        assert_eq!(
+            decoded,
+            Fixture {
+                a: 10,
+                b: 20,
+                c: None,
+            }
+        );
+    }
+
+    #[test]
+    fn versioned_all_v0_matches_old_encoding() {
+        #[derive(diom_core::PersistableVersioned)]
+        #[versioned(row_type = 3)]
+        struct FixtureAllV0 {
+            a: u32,
+            b: u32,
+        }
+        assert_eq!(FixtureAllV0::WRITE_VERSION, 0);
+
+        let old = FixtureOld { a: 10, b: 20 }.to_fjall_value().unwrap();
+        let versioned = FixtureAllV0 { a: 10, b: 20 }.to_fjall_value().unwrap();
+        assert_eq!(old, versioned);
+    }
+
+    /// A non-Option field added in a later version falls back to its `#[since(.., default = ..)]`
+    /// expression when reading data that predates the field.
+    #[test]
+    fn versioned_uses_explicit_default_for_legacy_field() {
+        #[derive(diom_core::PersistableVersioned, PartialEq, Debug)]
+        #[versioned(row_type = 4)]
+        struct WithDefault {
+            a: u32,
+            #[since(1, default = 99)]
+            b: u32,
+        }
+
+        // The same row before `b` existed.
+        #[derive(serde::Serialize, serde::Deserialize, diom_core::PersistableValue)]
+        struct WithDefaultOld {
+            a: u32,
+        }
+        impl TableRow for WithDefaultOld {
+            const ROW_TYPE: u8 = 4;
+        }
+
+        let legacy = WithDefaultOld { a: 10 }.to_fjall_value().unwrap();
+        let decoded = WithDefault::from_fjall_value(legacy).unwrap();
+        assert_eq!(decoded, WithDefault { a: 10, b: 99 });
+
+        // A value written at the current version keeps its real `b`.
+        let current = WithDefault { a: 10, b: 7 }.to_fjall_value().unwrap();
+        assert_eq!(
+            WithDefault::from_fjall_value(current).unwrap(),
+            WithDefault { a: 10, b: 7 }
+        );
+    }
+
+    #[test]
+    fn versioned_reads_all_prior_versions_at_v2() {
+        // The row before any fields were added.
+        #[derive(serde::Serialize, serde::Deserialize, diom_core::PersistableValue)]
+        struct RowV0 {
+            a: u32,
+        }
+        impl TableRow for RowV0 {
+            const ROW_TYPE: u8 = 5;
+        }
+
+        // The row after `b` was added in version 1.
+        #[derive(diom_core::PersistableVersioned)]
+        #[versioned(row_type = 5)]
+        struct RowV1 {
+            a: u32,
+            #[since(1)]
+            b: Option<u32>,
+        }
+
+        // The current row, with `c` added in version 2.
+        #[derive(diom_core::PersistableVersioned, PartialEq, Debug)]
+        #[versioned(row_type = 5)]
+        struct RowV2 {
+            a: u32,
+            #[since(1)]
+            b: Option<u32>,
+            #[since(2)]
+            c: Option<u32>,
+        }
+
+        assert_eq!(RowV1::WRITE_VERSION, 1);
+        assert_eq!(RowV2::WRITE_VERSION, 2);
+
+        let v0 = RowV0 { a: 1 }.to_fjall_value().unwrap();
+        assert_eq!(
+            RowV2::from_fjall_value(v0).unwrap(),
+            RowV2 {
+                a: 1,
+                b: None,
+                c: None,
+            }
+        );
+
+        let v1 = RowV1 { a: 1, b: Some(2) }.to_fjall_value().unwrap();
+        assert_eq!(
+            RowV2::from_fjall_value(v1).unwrap(),
+            RowV2 {
+                a: 1,
+                b: Some(2),
+                c: None,
+            }
+        );
+
+        let v2 = RowV2 {
+            a: 1,
+            b: Some(2),
+            c: Some(3),
+        }
+        .to_fjall_value()
+        .unwrap();
+        assert_eq!(
+            RowV2::from_fjall_value(v2).unwrap(),
+            RowV2 {
+                a: 1,
+                b: Some(2),
+                c: Some(3),
+            }
+        );
+    }
 }

--- a/crates/fjall-utils/src/table_row.rs
+++ b/crates/fjall-utils/src/table_row.rs
@@ -17,16 +17,28 @@ pub trait TableRow:
     // FIXME: can probably get rid of this, and encode it in the type system.
     const ROW_TYPE: u8;
 
+    /// Whether this row carries its own leading schema-version tag (a `PersistableVersioned` type)
+    /// rather than the `V0Wrapper` envelope. Set automatically by the `PersistableVersioned` derive
+    /// when given `#[versioned(row_type = ...)]`.
+    const VERSIONED: bool = false;
+
     fn to_fjall_value(&self) -> Result<fjall::UserValue> {
-        crate::postcard_to_byteview(&crate::V0Wrapper::V0(self))
-            .map(fjall::Slice::from)
-            .or_internal_error()
+        let bytes = if Self::VERSIONED {
+            crate::postcard_to_byteview(self)
+        } else {
+            crate::postcard_to_byteview(&crate::V0Wrapper::V0(self))
+        };
+        bytes.map(fjall::Slice::from).or_internal_error()
     }
 
     fn from_fjall_value(value: fjall::UserValue) -> Result<Self> {
-        postcard::from_bytes::<crate::V0Wrapper<Self>>(&value)
-            .map(|crate::V0Wrapper::V0(inner)| inner)
-            .or_internal_error()
+        if Self::VERSIONED {
+            postcard::from_bytes::<Self>(&value).or_internal_error()
+        } else {
+            postcard::from_bytes::<crate::V0Wrapper<Self>>(&value)
+                .map(|crate::V0Wrapper::V0(inner)| inner)
+                .or_internal_error()
+        }
     }
 
     fn fetch<K: ReadableKeyspace, TK: Into<TableKey<Self>>>(


### PR DESCRIPTION
This adds a `PersistibleVersion` trait and derive macro, so we can actually start versioning rows in the DB.

That's basically it. I think derive macro implementations are always hard to parse, but hopefully the [tests](https://github.com/svix/diom/pull/1327/changes#diff-0febf36721079eb4064cb109f41750619b17ad6f3ee4336ce6e0f57f6d251c56R136) are convincing enough.