### PR TITLE
server: improve body limit handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,7 @@ dependencies = [
  "axum",
  "bytes",
  "diom-authorization",
+ "futures-util",
  "http 1.4.2",
  "http-body-util",
  "mime",

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -48,7 +48,7 @@ The diom server accepts the following environment variables:
 | `$DIOM_LISTEN_ADDRESS` | The address to listen on |
 | `$DIOM_LOG_FORMAT` | The log format that all output will follow. Supported: default, json |
 | `$DIOM_LOG_LEVEL` | The log level to run the service with. Supported: info, debug, trace |
-| `$DIOM_MAX_BODY_SIZE` | Maximum size for a request body, in bytes.<br/><br/>This should be set to a large enough value to handle all real requests that you receive, but small enough not to consume all of your RAM. Requests more than 4x this size will be ungracefully terminated. |
+| `$DIOM_MAX_BODY_SIZE` | Maximum size for a request body, in bytes.<br/><br/>This should be set to a large enough value to handle all real requests that you receive, but small enough not to consume all of your RAM. Requests more than 2x this size will be ungracefully terminated. |
 | `$DIOM_OPENTELEMETRY_ADDRESS` | The OpenTelemetry address to send events to if given.<br/><br/>Currently only GRPC exports are supported. |
 | `$DIOM_OPENTELEMETRY_METRICS_ADDRESS` | The OpenTelemetry address to send metrics to if given.<br/><br/>If not specified, the server will attempt to fall back to `opentelemetry_address`. |
 | `$DIOM_OPENTELEMETRY_METRICS_PERIOD_MS` | How often to send metrics to opentelemetry receivers |

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -48,6 +48,7 @@ The diom server accepts the following environment variables:
 | `$DIOM_LISTEN_ADDRESS` | The address to listen on |
 | `$DIOM_LOG_FORMAT` | The log format that all output will follow. Supported: default, json |
 | `$DIOM_LOG_LEVEL` | The log level to run the service with. Supported: info, debug, trace |
+| `$DIOM_MAX_BODY_SIZE` | Maximum size for a request body, in bytes.<br/><br/>This should be set to a large enough value to handle all real requests that you receive, but small enough not to consume all of your RAM. Requests more than 4x this size will be ungracefully terminated. |
 | `$DIOM_OPENTELEMETRY_ADDRESS` | The OpenTelemetry address to send events to if given.<br/><br/>Currently only GRPC exports are supported. |
 | `$DIOM_OPENTELEMETRY_METRICS_ADDRESS` | The OpenTelemetry address to send metrics to if given.<br/><br/>If not specified, the server will attempt to fall back to `opentelemetry_address`. |
 | `$DIOM_OPENTELEMETRY_METRICS_PERIOD_MS` | How often to send metrics to opentelemetry receivers |

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -40,6 +40,13 @@ log_format = "default"
 # The log level to run the service with. Supported: info, debug, trace
 log_level = "info"
 
+# Maximum size for a request body, in bytes.
+#
+# This should be set to a large enough value to handle all real requests that you receive,
+# but small enough not to consume all of your RAM. Requests more than 4x this size will
+# be ungracefully terminated.
+max_body_size = 2000000
+
 # Maximum number of topic sinks that can be drained concurrently.
 #
 # Larger values allow for faster forwarding (when the number of sinks exceeds

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -43,7 +43,7 @@ log_level = "info"
 # Maximum size for a request body, in bytes.
 #
 # This should be set to a large enough value to handle all real requests that you receive,
-# but small enough not to consume all of your RAM. Requests more than 4x this size will
+# but small enough not to consume all of your RAM. Requests more than 2x this size will
 # be ungracefully terminated.
 max_body_size = 2000000
 

--- a/crates/diom-proto/Cargo.toml
+++ b/crates/diom-proto/Cargo.toml
@@ -14,6 +14,7 @@ aide.workspace = true
 axum.workspace = true
 bytes.workspace = true
 diom-authorization.workspace = true
+futures-util.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 mime.workspace = true

--- a/crates/diom-proto/src/body_limit.rs
+++ b/crates/diom-proto/src/body_limit.rs
@@ -6,6 +6,20 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use futures_util::stream::StreamExt;
+use std::time::Duration;
+
+const MAX_BODY_READ_TIME: Duration = Duration::from_secs(10);
+
+async fn read_body_forever(body: axum::body::Body, hard_body_limit: usize) {
+    let mut stream = body.into_data_stream();
+    let mut remaining = hard_body_limit;
+    while let Some(Ok(data)) = stream.next().await {
+        remaining = remaining.saturating_sub(data.len());
+        if remaining == 0 {
+            break;
+        }
+    }
+}
 
 /// Handler to ensure that large requests (but not huge) get a graceful 413
 ///
@@ -31,16 +45,12 @@ pub async fn limit_requests_body_gracefully(
         .and_then(|v| v.parse::<usize>().ok())
         && content_length > body_limit
     {
-        // consume up to hard_body_limit bytes and discard them
-        let body = request.into_body();
-        let mut stream = body.into_data_stream();
-        let mut remaining = hard_body_limit;
-        while let Some(Ok(data)) = stream.next().await {
-            remaining = remaining.saturating_sub(data.len());
-            if remaining == 0 {
-                break;
-            }
-        }
+        tokio::task::spawn(async move {
+            // consume up to hard_body_limit bytes and discard them; do this in
+            // a background task so that we can send the response right away
+            let body = request.into_body();
+            tokio::time::timeout(MAX_BODY_READ_TIME, read_body_forever(body, hard_body_limit)).await
+        });
         return (
             http::StatusCode::PAYLOAD_TOO_LARGE,
             MsgPackOrJson(ErrorBody::invalid_input(

--- a/crates/diom-proto/src/body_limit.rs
+++ b/crates/diom-proto/src/body_limit.rs
@@ -1,0 +1,55 @@
+use super::msgpack_or_json::MsgPackOrJson;
+use crate::ErrorBody;
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use futures_util::stream::StreamExt;
+
+/// Handler to ensure that large requests (but not huge) get a graceful 413
+///
+/// The axum BodyLimit middleware (and tower-http's RequestBodyLimitLayer) work
+/// by actually shutting down the read of the stream when the limit is hit; this causes
+/// clients to get an EPIPE, and (depending on whether the end-of-stream packet
+/// from the server is received before or after the last bytes are sent), can prevent
+/// clients from actually seeing the 413.
+///
+/// This middleware *only* looks at Content-Length, and emits a 413 without doing anything to the
+/// body. This can be tricked by HTTP/1.1 chunked-encoding or HTTP/1.0 connection-close or a whole
+/// variety of HTTP/2 things, so it's important to also use one of those other middlewares,
+/// configured for a higher value.
+pub async fn limit_requests_body_gracefully(
+    State((body_limit, hard_body_limit)): State<(usize, usize)>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if let Some(content_length) = request
+        .headers()
+        .get(http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<usize>().ok())
+        && content_length > body_limit
+    {
+        // consume up to hard_body_limit bytes and discard them
+        let body = request.into_body();
+        let mut stream = body.into_data_stream();
+        let mut remaining = hard_body_limit;
+        while let Some(Ok(data)) = stream.next().await {
+            remaining = remaining.saturating_sub(data.len());
+            if remaining == 0 {
+                break;
+            }
+        }
+        return (
+            http::StatusCode::PAYLOAD_TOO_LARGE,
+            MsgPackOrJson(ErrorBody::invalid_input(
+                "payload-too-large",
+                "Request payload is too large.",
+            )),
+        )
+            .into_response();
+    }
+
+    next.run(request).await
+}

--- a/crates/diom-proto/src/lib.rs
+++ b/crates/diom-proto/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::str_to_string)]
 
+mod body_limit;
 mod error;
 mod internal_client;
 mod msgpack;
@@ -9,6 +10,7 @@ pub mod prelude;
 mod request_input;
 
 pub use self::{
+    body_limit::limit_requests_body_gracefully,
     error::{ErrorBody, ErrorType},
     internal_client::{InternalClient, InternalRequest, InternalRequestError},
     msgpack::MsgPack,

--- a/crates/diom-proto/src/msgpack_or_json.rs
+++ b/crates/diom-proto/src/msgpack_or_json.rs
@@ -75,7 +75,7 @@ where
 
                 _ => {
                     tracing::error!("Error reading body as bytes: {e}");
-                    MsgPackOrJsonRejection::InternalServerError {
+                    MsgPackOrJsonRejection::BadRequestError {
                         msg: "Failed to read request body".to_owned(),
                     }
                 }
@@ -305,6 +305,9 @@ fn classify_content_type(
 
 pub enum MsgPackOrJsonRejection {
     PayloadTooLarge,
+    BadRequestError {
+        msg: String,
+    },
     InternalServerError {
         msg: String,
     },
@@ -339,6 +342,7 @@ impl IntoResponse for MsgPackOrJsonRejection {
                 "Request payload is too large.",
             ),
             Self::InternalServerError { msg } => internal_server_error(msg),
+            Self::BadRequestError { msg } => bad_request_error(msg),
             Self::ContentType { code } => invalid_input(
                 StatusCode::BAD_REQUEST,
                 code,
@@ -368,6 +372,13 @@ fn internal_server_error(msg: String) -> Response {
     error_response(
         StatusCode::INTERNAL_SERVER_ERROR,
         ErrorBody::server_error("internal", msg),
+    )
+}
+
+fn bad_request_error(msg: String) -> Response {
+    error_response(
+        StatusCode::BAD_REQUEST,
+        ErrorBody::server_error("request", msg),
     )
 }
 

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -193,6 +193,12 @@ pub struct TestContext {
     pub time: Monotime,
 }
 
+impl TestContext {
+    pub fn builder() -> TestServerBuilder {
+        TestServerBuilder::with_default_config()
+    }
+}
+
 async fn check_initialized(
     client: &reqwest::Client,
     url: &str,
@@ -365,6 +371,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         fsync_mode: FsyncMode::SyncData,
         admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
         jwt: Default::default(),
+        max_body_size: 2_000_000,
     }
 }
 

--- a/crates/test-utils/src/test_client.rs
+++ b/crates/test-utils/src/test_client.rs
@@ -170,6 +170,7 @@ impl<'a> IntoFuture for TestRequestBuilder<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct TestResponse(http::Response<Bytes>);
 
 impl TestResponse {

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -136,3 +136,8 @@ pub(super) const fn sink_max_task_duration() -> NonZeroDurationMs {
 pub(super) fn default_database_size() -> MemorySize {
     MemorySize::Percent(20)
 }
+
+pub(super) const fn default_max_body_size() -> usize {
+    // 2 MB
+    2 * 1000 * 1000
+}

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -683,6 +683,15 @@ pub struct ConfigurationInner {
     #[env_overridable(nest_with_prefix("OPENTELEMETRY"))]
     #[dumpable_config(nest)]
     pub opentelemetry: OpenTelemetryConfig,
+
+    /// Maximum size for a request body, in bytes.
+    ///
+    /// This should be set to a large enough value to handle all real requests that you receive,
+    /// but small enough not to consume all of your RAM. Requests more than 4x this size will
+    /// be ungracefully terminated.
+    #[serde(default = "defaults::default_max_body_size")]
+    #[validate(range(min = 10_000))]
+    pub max_body_size: usize,
 }
 
 impl ConfigurationInner {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -687,7 +687,7 @@ pub struct ConfigurationInner {
     /// Maximum size for a request body, in bytes.
     ///
     /// This should be set to a large enough value to handle all real requests that you receive,
-    /// but small enough not to consume all of your RAM. Requests more than 4x this size will
+    /// but small enough not to consume all of your RAM. Requests more than 2x this size will
     /// be ungracefully terminated.
     #[serde(default = "defaults::default_max_body_size")]
     #[validate(range(min = 10_000))]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -148,6 +148,11 @@ pub async fn run_with_listeners(
                 .allow_methods(Any)
                 .allow_headers(AllowHeaders::mirror_request())
                 .max_age(Duration::from_secs(600)),
+            DefaultBodyLimit::max(cfg.max_body_size * 4),
+            middleware::from_fn_with_state(
+                (cfg.max_body_size, cfg.max_body_size * 4),
+                diom_proto::limit_requests_body_gracefully,
+            ),
             CompressionLayer::new(),
         ))
         .into_make_service();
@@ -279,6 +284,7 @@ async fn run_internal(
             core::otel_spans::request_metrics_middleware,
         ),
         middleware::from_fn(diom_proto::capture_accept_hdr),
+        DefaultBodyLimit::disable(),
     ));
 
     // FIXME: Do we want to delay graceful shutdown of the internal API server

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -148,9 +148,9 @@ pub async fn run_with_listeners(
                 .allow_methods(Any)
                 .allow_headers(AllowHeaders::mirror_request())
                 .max_age(Duration::from_secs(600)),
-            DefaultBodyLimit::max(cfg.max_body_size * 4),
+            DefaultBodyLimit::max(cfg.max_body_size * 2),
             middleware::from_fn_with_state(
-                (cfg.max_body_size, cfg.max_body_size * 4),
+                (cfg.max_body_size, cfg.max_body_size * 2),
                 diom_proto::limit_requests_body_gracefully,
             ),
             CompressionLayer::new(),

--- a/tests/it/common.rs
+++ b/tests/it/common.rs
@@ -1,11 +1,13 @@
 use anyhow::Context;
 use serde_json::json;
+use std::io::Write;
 use tap::Pipe;
 use test_utils::{
     JsonFastAndLoose, StatusCode, TestClient, TestResponse, TestResult,
     retry::run_with_retries,
     server::{TestContext, start_cluster, start_server},
 };
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
 async fn kv_set(
     client: &TestClient,
@@ -15,7 +17,7 @@ async fn kv_set(
 ) -> anyhow::Result<TestResponse> {
     client
         .post("v1.kv.set")
-        .json(json!({
+        .msgpack(json!({
             "key": key,
             "value": value.as_bytes(),
             "behavior": behavior
@@ -130,5 +132,117 @@ async fn test_replication_end_to_end() -> TestResult {
     // it should eventually be visible on a follower
     run_with_retries(async || ensure_visible(follower_client, &key, value).await).await?;
 
+    Ok(())
+}
+
+async fn make_http11_kv_set(ctx: &TestContext, value: &str) -> TestResult<String> {
+    let url = url::Url::parse(&ctx.client.base_uri).unwrap();
+    let host = url.host_str().unwrap();
+    let port = url.port().unwrap_or(ctx.cfg.listen_address.port());
+    let mut conn = tokio::net::TcpStream::connect((host, port)).await?;
+    let (read, mut write) = conn.split();
+    let body = serde_json::json!({
+        "key": "key",
+        "value": value,
+        "behavior": "upsert",
+    });
+    let header_lines: &[&[u8]] = &[
+        b"POST /api/v1.kv.set HTTP/1.1",
+        b"Connection: keep-alive",
+        b"Transfer-Encoding: Chunked",
+        b"Content-Type: application/msgpack",
+        b"Accept: application/json",
+    ];
+    let mut http_request: Vec<u8> = vec![];
+    for line in header_lines {
+        http_request.extend(*line);
+        http_request.extend(b"\r\n");
+    }
+    if let Some(auth) = &ctx.client.auth_header {
+        write!(&mut http_request, "Authorization: {auth}\r\n")?;
+    };
+    http_request.extend(b"\r\n");
+    // send off the headers and wait for them to be flushed
+    write.write_all(&http_request).await?;
+    write.flush().await?;
+    let mut msgpack_body = rmp_serde::to_vec_named(&body)?;
+    let mut http_request_body = vec![];
+    // the chunk length
+    write!(&mut http_request_body, "{:x}\r\n", msgpack_body.len())?;
+    // the body
+    http_request_body.append(&mut msgpack_body);
+    // an empty chunk for the end of the stream
+    write!(&mut http_request_body, "\r\n0\r\n\r\n")?;
+    // now send the body (but ignore if we get an EPIPE)
+    if let Err(err) = write.write_all(&http_request_body).await {
+        tracing::debug!(?err, "got an error writing body; ignoring");
+    } else {
+        let _ = write.flush().await;
+    }
+    // read the response line
+    let mut buf = String::new();
+    let mut read = tokio::io::BufReader::new(read);
+    read.read_line(&mut buf).await?;
+    Ok(buf)
+}
+
+#[tokio::test]
+async fn test_body_limit() -> TestResult {
+    let ctx = TestContext::builder()
+        .tap_cfg(|cfg| {
+            cfg.max_body_size = 10000;
+        })
+        .build()
+        .await;
+    // a small request should succeed
+    kv_set(&ctx.client, "key", "a", "upsert")
+        .await?
+        .expect(StatusCode::OK);
+    // a large (normal) request should 413
+    let large_value = std::iter::repeat_n('n', 10001).collect::<String>();
+    kv_set(&ctx.client, "key", &large_value, "upsert")
+        .await?
+        .expect(StatusCode::PAYLOAD_TOO_LARGE);
+    // now make a chunked http1.1 request (no content-length)
+    let response_line = make_http11_kv_set(&ctx, &large_value).await?;
+    assert_eq!(response_line, "HTTP/1.1 200 OK\r\n");
+    // a very very large http/1.1 request should still fail
+    let huge_value = std::iter::repeat_n('n', 50001).collect::<String>();
+    let response_line = make_http11_kv_set(&ctx, &huge_value).await?;
+    assert_eq!(response_line, "HTTP/1.1 413 Payload Too Large\r\n");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_body_limit_allows_bigger_than_the_default() -> TestResult {
+    let ctx = TestContext::builder()
+        .tap_cfg(|cfg| {
+            cfg.max_body_size = 3_000_000;
+        })
+        .build()
+        .await;
+    // a larger than 2MB but smaller than max_body_size request should succeed
+    let huge_value = std::iter::repeat_n('n', 2_097_153).collect::<String>();
+    kv_set(&ctx.client, "key", &huge_value, "upsert")
+        .await?
+        .expect(StatusCode::OK);
+    // a larger than 3MB request should fail
+    let huger_value = std::iter::repeat_n('n', 3_000_001).collect::<String>();
+    kv_set(&ctx.client, "key", &huger_value, "upsert")
+        .await?
+        .expect(StatusCode::PAYLOAD_TOO_LARGE);
+    // as an HTTP/1.1 request, it should succeed
+    let response_line = make_http11_kv_set(&ctx, &huger_value).await?;
+    assert_eq!(response_line, "HTTP/1.1 200 OK\r\n");
+    let hugest_value = std::iter::repeat_n('n', 12_000_012).collect::<String>();
+    let response_line = make_http11_kv_set(&ctx, &hugest_value).await?;
+    assert_eq!(response_line, "HTTP/1.1 413 Payload Too Large\r\n");
+
+    // It would be good to test here a request *much* larger that hits that 4x
+    // body-reading limit and gets an EPIPE; however, that's totally dependent on
+    // OS scheduling (basically, whether we can write data faster than the server
+    // can do the SHUT_RD), so there's not a good way to test it. Maybe some kind
+    // of custom IO stream implementation?
     Ok(())
 }


### PR DESCRIPTION
See also @svix-james's svix/svix-webhooks-private#6995 for a workaround.

We have the Axum [`DefaultBodyLimit`](https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html) in Diom right now. The way this works is that it hooks into the actual body reading and, when the limit is hit, emits a [413](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/413) and (relatively quickly) drops the read end of the stream. If the client hasn't finished sending their request yet (which depends on any intermediate buffering load balancers, network latency, whether there are other substreams on the same HTTP/2 stream if HTTP/2 is used, and the phase of the moon), the client will end up seeing this as an EPIPE from trying to write to a half-closed socket.

This adds a new layer which **just** looks at the `Content-Length` and, if it's higher than the configured max body size (but only modestly so), first reads and discards the full request and then sends the 413. This means that clients more-often actually see the 413.

This also disables body limits on the internal/loopback client.