### PR TITLE
implement more-graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -40,6 +40,7 @@ The diom server accepts the following environment variables:
 | `$DIOM_EPHEMERAL_DB_PATH` | Directory in which this database is stored |
 | `$DIOM_EPHEMERAL_DB_WORKER_THREADS` | Number of worker threads<br/><br/>If not passed, defaults to min(# CPU cores, 4) |
 | `$DIOM_FSYNC_MODE` | When fsyncing, should we use fsync(2) or fdatasync(2) |
+| `$DIOM_GRACEFUL_SHUTDOWN_TIME_MS` | How long to wait before shutting down once a shutdown signal is received |
 | `$DIOM_JWT_ALGORITHM` | JWT signature algorithm |
 | `$DIOM_JWT_AUDIENCE` | Expected `aud` values. When set, the token must contain one of these values in its `aud` claim. When absent, `aud` is not validated. |
 | `$DIOM_JWT_ISSUER` | Expected `iss` values. When set, the token's `iss` claim must match one of these values. When absent, `iss` is not validated. |

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -31,6 +31,9 @@ environment = "dev"
 # When fsyncing, should we use fsync(2) or fdatasync(2)
 fsync_mode = "sync-data"
 
+# How long to wait before shutting down once a shutdown signal is received
+graceful_shutdown_time_ms = 15000
+
 # The address to listen on
 listen_address = "[::]:8624"
 

--- a/crates/diom-core/src/shutdown.rs
+++ b/crates/diom-core/src/shutdown.rs
@@ -1,11 +1,13 @@
-use std::sync::LazyLock;
+use std::{sync::LazyLock, time::Duration};
 use tokio_util::sync::CancellationToken;
 
 static SHUTTING_DOWN_TOKEN: LazyLock<CancellationToken> = LazyLock::new(CancellationToken::new);
+static GRACEFUL_SHUTTING_DOWN_TOKEN: LazyLock<CancellationToken> =
+    LazyLock::new(CancellationToken::new);
 
 /// Has someone requested shutdown?
 pub fn is_shutting_down() -> bool {
-    SHUTTING_DOWN_TOKEN.is_cancelled()
+    SHUTTING_DOWN_TOKEN.is_cancelled() || GRACEFUL_SHUTTING_DOWN_TOKEN.is_cancelled()
 }
 
 /// Request a CancellationToken for the application shut down
@@ -13,7 +15,32 @@ pub fn shutting_down_token() -> CancellationToken {
     SHUTTING_DOWN_TOKEN.clone()
 }
 
-/// Shut down the application
+/// Request a CancellationToken for the application entering pre-shutdown
+pub fn graceful_shutting_down_token() -> CancellationToken {
+    GRACEFUL_SHUTTING_DOWN_TOKEN.clone()
+}
+
+/// Shut down the application immediately
 pub fn start_shut_down() {
+    if GRACEFUL_SHUTTING_DOWN_TOKEN.is_cancelled() {
+        tracing::trace!("shutdown already started");
+        return;
+    };
+    GRACEFUL_SHUTTING_DOWN_TOKEN.cancel();
+    SHUTTING_DOWN_TOKEN.cancel();
+}
+
+/// Shut down the application with a grace period
+pub async fn start_shut_down_gracefully(timeout: Duration) {
+    if GRACEFUL_SHUTTING_DOWN_TOKEN.is_cancelled() {
+        tracing::debug!("shutdown already started");
+        return;
+    }
+    GRACEFUL_SHUTTING_DOWN_TOKEN.cancel();
+    tracing::info!(
+        "graceful shutdown requested; waiting {:?} before shutting down",
+        timeout
+    );
+    tokio::time::sleep(timeout).await;
     SHUTTING_DOWN_TOKEN.cancel();
 }

--- a/crates/test-utils/src/server.rs
+++ b/crates/test-utils/src/server.rs
@@ -372,6 +372,7 @@ pub fn default_server_config(workdir: &Path) -> ConfigurationInner {
         admin_token: Some(TEST_ADMIN_TOKEN.to_string()),
         jwt: Default::default(),
         max_body_size: 2_000_000,
+        graceful_shutdown_time: NonZeroDurationMs::from_millis(10).unwrap(),
     }
 }
 

--- a/src/cfg/defaults.rs
+++ b/src/cfg/defaults.rs
@@ -141,3 +141,7 @@ pub(super) const fn default_max_body_size() -> usize {
     // 2 MB
     2 * 1000 * 1000
 }
+
+pub(super) const fn graceful_shutdown_time() -> NonZeroDurationMs {
+    NonZeroDurationMs::from_secs(15).unwrap()
+}

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -601,6 +601,13 @@ pub struct ConfigurationInner {
     #[serde(rename = "bootstrap_delay_ms", default)]
     pub bootstrap_delay: Option<NonZeroDurationMs>,
 
+    /// How long to wait before shutting down once a shutdown signal is received
+    #[serde(
+        rename = "graceful_shutdown_time_ms",
+        default = "defaults::graceful_shutdown_time"
+    )]
+    pub graceful_shutdown_time: NonZeroDurationMs,
+
     /// How often to run background cleanup/garbage collection jobs
     ///
     /// Correctness should never be affected by this, just wasted memory/disk.

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -15,7 +15,7 @@ use headers::{Authorization, authorization::Bearer};
 use http::StatusCode;
 use openraft::{
     ChangeMembers,
-    raft::{AppendEntriesRequest, InstallSnapshotRequest, VoteRequest},
+    raft::{AppendEntriesRequest, InstallSnapshotRequest, TransferLeaderRequest, VoteRequest},
 };
 use serde::Serialize;
 use tap::{Pipe, TapFallible};
@@ -59,6 +59,7 @@ pub fn router(cfg: &Configuration) -> axum::Router<AppState> {
         .route("/repl/discover", get(discover))
         .route("/repl/raft/append_entries", post(append_entries))
         .route("/repl/raft/vote", post(vote))
+        .route("/repl/raft/transfer_leader", post(transfer_leader))
         .route("/repl/raft/stream-snapshot", post(stream_snapshot))
         .route(
             "/repl/raft/handle-forwarded-write",
@@ -160,6 +161,19 @@ async fn vote(
         "recording a vote",
     );
     state.raft.vote(body).await.pipe(rpc_response)
+}
+
+#[tracing::instrument(skip_all)]
+async fn transfer_leader(
+    Extension(state): Extension<RaftState>,
+    MsgPack(body): MsgPack<TransferLeaderRequest<TypeConfig>>,
+) -> impl IntoResponse {
+    tracing::trace!("recording leadership-transfer request",);
+    state
+        .raft
+        .handle_transfer_leader(body)
+        .await
+        .pipe(rpc_response)
 }
 
 #[tracing::instrument(skip_all)]

--- a/src/core/cluster/app.rs
+++ b/src/core/cluster/app.rs
@@ -168,7 +168,7 @@ async fn transfer_leader(
     Extension(state): Extension<RaftState>,
     MsgPack(body): MsgPack<TransferLeaderRequest<TypeConfig>>,
 ) -> impl IntoResponse {
-    tracing::trace!("recording leadership-transfer request",);
+    tracing::trace!("recording leadership-transfer request");
     state
         .raft
         .handle_transfer_leader(body)

--- a/src/core/cluster/network.rs
+++ b/src/core/cluster/network.rs
@@ -343,6 +343,16 @@ impl RaftNetworkV2<TypeConfig> for NetworkClient {
     > {
         super::streaming_snapshot::Sender::send_snapshot(self, vote, snapshot, cancel, option).await
     }
+
+    #[tracing::instrument(skip_all)]
+    async fn transfer_leader(
+        &mut self,
+        rpc: openraft::raft::TransferLeaderRequest<TypeConfig>,
+        option: RPCOption,
+    ) -> Result<openraft::raft::TransferLeaderResponse<TypeConfig>, RPCError> {
+        self.send_request_with_timeout("/repl/raft/transfer_leader", rpc, option.soft_ttl())
+            .await
+    }
 }
 
 impl RaftNetworkFactory<TypeConfig> for NetworkFactory {

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Instant};
 
 use anyhow::Context;
 use diom_core::Monotime;
+use diom_error::CanFailExt;
 use eyeball::Observable;
 use openraft::error::{InitializeError, RaftError};
 use tap::TapFallible;
@@ -287,6 +288,52 @@ pub async fn initialize_raft(
                 );
                 crate::start_shut_down()
             }
+        }
+    });
+    tokio::spawn({
+        let handle = handle.clone();
+        let initialized = initialized.clone();
+        let my_node_id = handle.node_id;
+        let token = diom_core::shutdown::graceful_shutting_down_token();
+        async move {
+            if initialized.wait().await.is_err() {
+                return;
+            }
+            token.cancelled().await;
+            tracing::debug!("graceful shutdown started, can I transfer leadership?");
+            let Ok(other_peer) = handle
+                .raft
+                .with_raft_state(move |f| {
+                    if !f.server_state.is_leader() {
+                        return None;
+                    }
+                    f.membership_state
+                        .effective()
+                        .nodes()
+                        .find_map(|(node_id, _node)| {
+                            if *node_id != my_node_id {
+                                Some(*node_id)
+                            } else {
+                                None
+                            }
+                        })
+                })
+                .await
+            else {
+                tracing::warn!("error looking up other peers at shutdown; ignoring");
+                return;
+            };
+            let Some(other_node_id) = other_peer else {
+                tracing::debug!("no other node to hand off leadership to");
+                return;
+            };
+            tracing::info!(my_node_id = %handle.node_id, %other_node_id, "transferring leadership to other node at shutdown");
+            handle
+                .raft
+                .trigger()
+                .transfer_leader(other_node_id)
+                .await
+                .can_fail("transferring leadership to other node");
         }
     });
     Ok(handle)

--- a/src/core/cluster/raft.rs
+++ b/src/core/cluster/raft.rs
@@ -5,7 +5,7 @@ use diom_core::Monotime;
 use diom_error::CanFailExt;
 use eyeball::Observable;
 use openraft::error::{InitializeError, RaftError};
-use tap::TapFallible;
+use tap::{TapFallible, TapOptional};
 
 use super::{
     handle::{RaftState, Request, RequestWithContext, Response},
@@ -297,14 +297,17 @@ pub async fn initialize_raft(
         let token = diom_core::shutdown::graceful_shutting_down_token();
         async move {
             if initialized.wait().await.is_err() {
+                // if we never initialized, it'd be pointless to do a leadership handoff
                 return;
             }
+            // wait until a graceful shutdown starts
             token.cancelled().await;
-            tracing::debug!("graceful shutdown started, can I transfer leadership?");
-            let Ok(other_peer) = handle
+            tracing::trace!("graceful shutdown started, can I transfer leadership?");
+            let other_node_id = match handle
                 .raft
                 .with_raft_state(move |f| {
                     if !f.server_state.is_leader() {
+                        tracing::debug!("not a leader; doing nothing");
                         return None;
                     }
                     f.membership_state
@@ -317,15 +320,20 @@ pub async fn initialize_raft(
                                 None
                             }
                         })
+                        .tap_none(|| {
+                            tracing::debug!(
+                                "no other node to hand off leadership to; this is a 1-node cluster right now"
+                            )
+                        })
                 })
                 .await
-            else {
-                tracing::warn!("error looking up other peers at shutdown; ignoring");
-                return;
-            };
-            let Some(other_node_id) = other_peer else {
-                tracing::debug!("no other node to hand off leadership to");
-                return;
+            {
+                Ok(Some(other_node_id)) => other_node_id,
+                Ok(None) => return,
+                Err(err) => {
+                    tracing::warn!(?err, "error looking up other peers at shutdown; ignoring");
+                    return;
+                }
             };
             tracing::info!(my_node_id = %handle.node_id, %other_node_id, "transferring leadership to other node at shutdown");
             handle

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -98,7 +98,7 @@ pub async fn run_with_listeners(
 
     let interserver_started_barrier = Arc::new(Barrier::new(2));
 
-    tokio::spawn(graceful_shutdown_handler());
+    tokio::spawn(graceful_shutdown_handler(cfg.clone()));
 
     let connection_metrics = ConnectionMetrics::new(&app_state.meter, node_id);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,11 +13,15 @@ use axum::{
     response::IntoResponse as _,
     serve::{Listener, ListenerExt as _},
 };
-use diom_core::shutdown::{shutting_down_token, start_shut_down};
+use diom_core::shutdown::{shutting_down_token, start_shut_down_gracefully};
+
 use diom_error::Error;
 use tokio::net::TcpListener;
 
-use crate::core::metrics::{ConnectionMetrics, ConnectionType};
+use crate::{
+    cfg::Configuration,
+    core::metrics::{ConnectionMetrics, ConnectionType},
+};
 
 #[derive(Debug, Clone)]
 pub struct Initialized {
@@ -68,7 +72,7 @@ pub(crate) async fn fail_until_bootstrapped(
     next.run(request).await
 }
 
-pub(crate) async fn graceful_shutdown_handler() {
+pub(crate) async fn graceful_shutdown_handler(cfg: Configuration) {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
             .await
@@ -92,7 +96,7 @@ pub(crate) async fn graceful_shutdown_handler() {
     }
 
     tracing::info!("Received shutdown signal. Shutting down gracefully...");
-    start_shut_down();
+    start_shut_down_gracefully(cfg.graceful_shutdown_time.into()).await;
 }
 
 pub(crate) fn handle_panic(

--- a/src/v1/endpoints/health.rs
+++ b/src/v1/endpoints/health.rs
@@ -5,6 +5,7 @@ use aide::axum::{
     routing::{get_with, post_with},
 };
 use axum::extract::Extension;
+use diom_core::shutdown::is_shutting_down;
 use diom_derive::aide_annotate;
 use diom_proto::MsgPackOrJson;
 use schemars::JsonSchema;
@@ -40,6 +41,11 @@ pub struct ReadyOut {
 /// Verify that this server is ready to serve customer traffic.
 #[aide_annotate(op_id = "v1.health.ready")]
 async fn ready(Extension(repl): Extension<RaftState>) -> Result<MsgPackOrJson<ReadyOut>> {
+    if is_shutting_down() {
+        return Err(Error::not_ready(
+            "This node is currently shutting down".to_owned(),
+        ));
+    }
     let state = repl.state().await.or_internal_error()?;
     if state.is_leader() || state.is_follower() || state.is_candidate() {
         Ok(MsgPackOrJson(ReadyOut {


### PR DESCRIPTION
This changes shutdown on signal to a two-phase process: first, we make the readiness check fail (so we stop getting traffic from the LB) and issue a TransferLeader request if we're the leader, *then* we actually shut down.