### PR TITLE
deps: bump chacha20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,9 +745,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
See https://github.com/RustCrypto/stream-ciphers/pull/580; they yanked 0.10.1.

It makes me a little anxious to bump this without a RUSTSEC advisory or any official posting about why they did the yank outside of that github thread, but @tarcieri is the right person to make that call, so hopefully 0.10.2 isn't secretly malware.