### PR TITLE
deps: bump fjall/lsm-tree to 3.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,9 +2184,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fjall"
-version = "3.1.6"
+version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fcdc69609906151dff9b534e30eaf8515082055d36f628e382bd0b5d6a1d362"
+checksum = "cd201c93927cdf4712e8f7d4c9c8d34d68c7534380c05d4a58864a309f91c33f"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -3460,9 +3460,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
-version = "3.1.6"
+version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca67401338b98d58447387dd5230552d2241bc388206e491d137b18dfea9d6"
+checksum = "5498808f4d41cf785079d3ef3f28716f1b4364af1b512f3097bfb651bded1b3e"
 dependencies = [
  "byteorder-lite",
  "byteview",

--- a/src/core/cluster/serialized_state_machine.rs
+++ b/src/core/cluster/serialized_state_machine.rs
@@ -299,10 +299,11 @@ pub(crate) fn load_from_file<F: Read + Seek>(
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
+    use std::{collections::BTreeSet, io::Cursor};
 
     use fjall::{Database, KeyspaceCreateOptions, Slice};
     use fjall_utils::{Databases, SchemaManifest, SerializableKeyspaceCreateOptions};
+    use maplit::btreeset;
 
     use super::{ClusterId, load_from_file, serialize_to_file};
     use fjall_utils::StorageType;
@@ -436,8 +437,11 @@ mod tests {
             .list_keyspace_names()
             .into_iter()
             .map(|s| s.to_string())
-            .collect::<Vec<_>>();
-        assert_eq!(&found_keyspaces, &["keyspace1", "_schema"]);
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            found_keyspaces,
+            btreeset!["keyspace1".to_owned(), "_schema".to_owned()]
+        );
 
         // even though we initialize it here with ::default, it should already have been
         // initialized as kv-separated in the `load_from_file` call.


### PR DESCRIPTION
This supposedly fixes the `.clear()` corruption we saw in #796