### PR TITLE
Fix new nightly future-compat warning

### DIFF
--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::fmt::{Debug, Display};
 
 pub use reqwest::StatusCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![warn(clippy::all)]
 
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
The old trait solver has a recursion tracking bug that's fixed in new solver, and we're relying on this bug to not hit the default recursion limit.