### PR TITLE
Try to fix new PR comments workflow

### DIFF
--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -25,15 +25,17 @@ jobs:
             const response = await github.rest.actions.listWorkflowRunArtifacts({
               owner,
               repo,
-              run_id: "${{ github.event.workflow_run.id }}",
+              run_id: ${{ github.event.workflow_run.id }},
             });
-            return response.artifacts[0].id.toString()
+            console.log(response);
+            return response?.artifacts?.[0]?.id?.toString()
 
       - name: Download Test Report
         uses: actions/download-artifact@v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
-          artifact-ids: ${{ steps.get_test_report_artifact_id.outputs.result }}
+          name: test-report # use this for now, though the below should avoid an extra API roundtrip
+          #artifact-ids: ${{ steps.get_test_report_artifact_id.outputs.result }}
           github-token: ${{ github.token }}
 
       - name: Publish Test Report Comment


### PR DESCRIPTION
First try resulted in the gh-script I added getting an empty list of artifacts.

Since I doubt the run ID being string instead of number is the actual issue, also add a bit of logging and don't make the download-test-report step depend on the gh-script.