### PR TITLE
deps: bump hickory to 0.26.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2619,9 +2619,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+checksum = "084e7bd6a377435d568f652153e571b50970d7ccc1d1eeec0519f834632287e1"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2643,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+checksum = "7e2da0694c15b44c6f68a6b05e0233617008c54080e31d6eb848d858a9c5b38d"
 dependencies = [
  "data-encoding",
  "idna",
@@ -2663,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+checksum = "0e4f9f4603319422d482738f3f6fe5aac03157fdbfed1cd85a3ff45adb09072f"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5715,7 +5715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
Resolves GHSA-2vgh-3wfw-qj7c, GHSA-57pw-897j-v4j6, GHSA-wjgj-fvg9-65w9, GHSA-588m-chg6-8jqj, GHSA-qw83-5pm2-ggp5, GHSA-3jvh-8vj5-65rq, GHSA-3r6v-f3jh-vvqm, GHSA-624w-vvww-xvpw, GHSA-7php-9j59-g3ch, GHSA-vrv5-968r-5ggm, GHSA-p2jv-r3m3-7wf4, GHSA-86vr-jm6c-7cpg, GHSA-8hq4-5836-w6q4, GHSA-5j98-2g5x-46v6, GHSA-929p-gjf6-5hqj, GHSA-j2rc-wxwh-62g9, GHSA-rx82-4p2j-j5cv, GHSA-2hxp-x833-73f7, GHSA-x962-5xwx-fr8x, GHSA-wgfr-mphw-j5g4, GHSA-hx8c-fjhc-hmf5, GHSA-4rph-pmrw-mwpw, GHSA-3w89-7rx5-hpwx, GHSA-vcjp-57rr-mpfw, GHSA-6w6g-hm98-mhgm, GHSA-cx5j-p54p-q756, GHSA-6h5c-jjg5-wj59, GHSA-v44v-c8m4-gc43, GHSA-67wc-6jq8-ghrc, GHSA-2f4m-fq7w-mrgx, GHSA-g8wg-4mwh-fjfv, GHSA-5r56-v84h-c3w5, GHSA-6f2x-v7q7-m7m5, GHSA-xv7c-h5g9-x25x, GHSA-9px7-7m25-f6q2, GHSA-29q9-p769-j8gq, GHSA-4jwp-xjwm-333g