### PR TITLE
NOMERGE: versioning example

### DIFF
--- a/crates/diom-admin-auth/src/controller.rs
+++ b/crates/diom-admin-auth/src/controller.rs
@@ -43,6 +43,7 @@ pub struct UpsertRoleInput {
     pub policies: Vec<AccessPolicyId>,
     pub context: HashMap<String, String>,
     pub now: UnixTimestampMs,
+    pub last_configured: Option<UnixTimestampMs>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,6 +134,7 @@ impl AdminAuthController {
                 context: input.context,
                 created,
                 updated: input.now,
+                last_configured: input.last_configured,
             };
             keyspace.insert(RoleKey::build_key(row.id.as_str()), row.to_fjall_value()?)?;
             Ok(RoleModel::from(row))

--- a/crates/diom-admin-auth/src/operations/configure_role.rs
+++ b/crates/diom-admin-auth/src/operations/configure_role.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use diom_authorization::api::{AccessPolicyId, AccessRule, RoleId};
 use diom_core::{PersistableValue, types::UnixTimestampMs};
 use diom_error::Result;
-use diom_operations::OpContext;
+use diom_operations::{OpContext, VERSIONS};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -47,6 +47,7 @@ impl ConfigureRoleOperation {
         self,
         state: &State,
         now: UnixTimestampMs,
+        last_configured: Option<UnixTimestampMs>,
     ) -> Result<ConfigureRoleResponseData> {
         let model = state
             .controller
@@ -57,6 +58,7 @@ impl ConfigureRoleOperation {
                 policies: self.policies,
                 context: self.context,
                 now,
+                last_configured,
             })
             .await?;
         Ok(ConfigureRoleResponseData { model })
@@ -65,6 +67,12 @@ impl ConfigureRoleOperation {
 
 impl AdminAuthRequest for ConfigureRoleOperation {
     async fn apply(self, state: AdminAuthRaftState<'_>, ctx: &OpContext) -> ConfigureRoleResponse {
-        ConfigureRoleResponse::new(self.apply_real(state.state, ctx.timestamp).await)
+        // Gate the new column on the committed feature version, read deterministically from the
+        // apply context. Until every node has advanced to feature version VERSIONS[1] this stays None.
+        let last_configured = (ctx.feature_version >= VERSIONS[1]).then_some(ctx.timestamp);
+        ConfigureRoleResponse::new(
+            self.apply_real(state.state, ctx.timestamp, last_configured)
+                .await,
+        )
     }
 }

--- a/crates/diom-admin-auth/src/storage.rs
+++ b/crates/diom-admin-auth/src/storage.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use diom_authorization::api::{AccessPolicyId, AccessRule, RoleId};
 use diom_core::{PersistableVersioned, types::UnixTimestampMs};
+use diom_operations::VERSIONS;
 use fjall_utils::FjallKey;
 
 /// These values can never change. Only additions are allowed.
@@ -23,6 +24,11 @@ pub struct RoleRow {
     pub context: HashMap<String, String>,
     pub created: UnixTimestampMs,
     pub updated: UnixTimestampMs,
+    /// Demonstrates a feature-version-gated column. It is written only once the whole cluster has
+    /// advanced to feature version VERSIONS[1], so older nodes never have to understand it and a
+    /// rollback before the cluster advances loses nothing. Older rows read back as None.
+    #[since(VERSIONS[1])]
+    pub last_configured: Option<UnixTimestampMs>,
 }
 
 #[derive(FjallKey)]

--- a/crates/diom-derive/src/versioned.rs
+++ b/crates/diom-derive/src/versioned.rs
@@ -1,21 +1,20 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    DeriveInput, Expr, Ident, LitInt, Token,
+    DeriveInput, Expr, Ident, Token,
     parse::{Parse, ParseStream},
     spanned::Spanned,
 };
 
-/// Parsed `#[since(N)]` or `#[since(N, default = EXPR)]` field attribute.
+/// Parsed `#[since(EXPR)]` or `#[since(EXPR, default = EXPR)]` field attribute.
 struct SinceAttr {
-    version: u32,
+    version: Expr,
     default: Option<Expr>,
 }
 
 impl Parse for SinceAttr {
     fn parse(input: ParseStream<'_>) -> Result<Self, syn::Error> {
-        let lit: LitInt = input.parse()?;
-        let version = lit.base10_parse()?;
+        let version: Expr = input.parse()?;
         let mut default = None;
         if input.peek(Token![,]) {
             let _: Token![,] = input.parse()?;
@@ -33,9 +32,16 @@ impl Parse for SinceAttr {
 struct VersionedField {
     ident: Ident,
     ty: syn::Type,
-    since: u32,
+    since: Option<Expr>,
     default: Option<Expr>,
     nested: bool,
+}
+
+fn since_value(field: &VersionedField) -> TokenStream {
+    match &field.since {
+        Some(expr) => quote! { (#expr) as u32 },
+        None => quote! { 0u32 },
+    }
 }
 
 fn parse_since(field: &syn::Field) -> Result<Option<SinceAttr>, syn::Error> {
@@ -98,8 +104,8 @@ fn collect_fields(input: &DeriveInput) -> Result<Vec<VersionedField>, syn::Error
     for field in fields.named.iter() {
         let ident = field.ident.clone().expect("named field");
         let (since, default) = match parse_since(field)? {
-            Some(a) => (a.version, a.default),
-            None => (0, None),
+            Some(a) => (Some(a.version), a.default),
+            None => (None, None),
         };
         out.push(VersionedField {
             ident,
@@ -108,22 +114,6 @@ fn collect_fields(input: &DeriveInput) -> Result<Vec<VersionedField>, syn::Error
             default,
             nested: parse_nested(field),
         });
-    }
-
-    // Fields are read positionally, so a version-`v` reader must be able to stop right after the
-    // last field with `since <= v`. That only works if fields are declared in non-decreasing
-    // `since` order.
-    for w in out.windows(2) {
-        if w[1].since < w[0].since {
-            return Err(syn::Error::new(
-                w[1].ident.span(),
-                format!(
-                    "field `{}` (since {}) must not precede a field with a higher `since` ({}); \
-                     declare fields in non-decreasing `since` order",
-                    w[1].ident, w[1].since, w[0].since
-                ),
-            ));
-        }
     }
 
     Ok(out)
@@ -136,7 +126,35 @@ pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
     let name = &input.ident;
     let field_count = fields.len();
     let tuple_len = field_count + 1;
-    let write_version = fields.iter().map(|f| f.since).max().unwrap_or(0);
+
+    // The written schema version is the highest `since` across the fields. Fields must be declared
+    // in non-decreasing `since` order (asserted below at const-eval), so that is the last field's
+    // value. This is computed at const-eval rather than macro time so `since` can be a const
+    // expression rather than a literal.
+    let write_version = fields
+        .last()
+        .map(since_value)
+        .unwrap_or_else(|| quote! { 0u32 });
+
+    // Fields are read positionally, so a version-`v` reader must be able to stop right after the last
+    // field with `since <= v`. That only works if fields are declared in non-decreasing `since`
+    // order. Because `since` may now be an opaque const expression, we cannot compare the values at
+    // macro time, so we enforce the ordering with a const assertion instead.
+    let order_assert = {
+        let checks = fields.windows(2).map(|w| {
+            let a = since_value(&w[0]);
+            let b = since_value(&w[1]);
+            let msg = format!(
+                "field `{}` must not precede a field with a higher `since`; declare fields in \
+                 non-decreasing `since` order",
+                w[1].ident
+            );
+            quote! { ::core::assert!(#a <= #b, #msg); }
+        });
+        quote! {
+            const _: () = { #(#checks)* };
+        }
+    };
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
@@ -216,20 +234,23 @@ pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
                     .ok_or_else(|| <A::Error as ::serde::de::Error>::custom(#missing))?
             }
         };
-        if f.since == 0 {
-            quote! { let #ident: #ty = #read_expr; }
-        } else {
-            let since = f.since;
-            let default_expr = match &f.default {
-                Some(expr) => quote! { #expr },
-                None => quote! { ::core::default::Default::default() },
-            };
-            quote! {
-                let #ident: #ty = if __version >= #since {
-                    #read_expr
-                } else {
-                    #default_expr
+        match &f.since {
+            // Version-0 fields are always present, so read them unconditionally.
+            None => quote! { let #ident: #ty = #read_expr; },
+            // Later fields are present only when the record was written at or above their `since`;
+            // otherwise fall back to the default.
+            Some(since) => {
+                let default_expr = match &f.default {
+                    Some(expr) => quote! { #expr },
+                    None => quote! { ::core::default::Default::default() },
                 };
+                quote! {
+                    let #ident: #ty = if __version >= ((#since) as u32) {
+                        #read_expr
+                    } else {
+                        #default_expr
+                    };
+                }
             }
         }
     });
@@ -247,7 +268,7 @@ pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
             let member_name = f.ident.to_string();
             let ty = &f.ty;
             let ty_str = quote!(#ty).to_string();
-            let since = f.since;
+            let since = since_value(f);
             let nested = f.nested;
             quote! {
                 diom_core::schema_shape::MemberShape {
@@ -273,6 +294,8 @@ pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
     };
 
     Ok(quote! {
+        #order_assert
+
         #[automatically_derived]
         impl #impl_generics ::serde::Serialize for #name #ty_generics #where_clause {
             fn serialize<__S: ::serde::Serializer>(
@@ -281,7 +304,7 @@ pub(crate) fn derive(input: TokenStream) -> Result<TokenStream, syn::Error> {
             ) -> ::core::result::Result<__S::Ok, __S::Error> {
                 use ::serde::ser::SerializeTuple as _;
                 let mut __tup = __serializer.serialize_tuple(#tuple_len)?;
-                __tup.serialize_element(&(#write_version as u32))?;
+                __tup.serialize_element(&Self::WRITE_VERSION)?;
                 #(#serialize_elems)*
                 __tup.end()
             }

--- a/crates/diom-operations/src/context.rs
+++ b/crates/diom-operations/src/context.rs
@@ -4,6 +4,11 @@ use diom_core::types::UnixTimestampMs;
 /// the writing of certain data across nodes that may have a different version during an upgrade.
 pub type FeatureVersion = u32;
 
+/// Every feature version this codebase knows about, in increasing order. Code gates new behavior by
+/// comparing against a named entry here (for example `VERSIONS[1]`) rather than a bare number, so the
+/// set of versions lives in one place.
+pub const VERSIONS: [FeatureVersion; 2] = [0, 1];
+
 #[derive(Debug, Clone)]
 pub struct OpContext {
     /// The (monotonic) timestamp at which this object was enqueued for application.

--- a/crates/diom-operations/src/lib.rs
+++ b/crates/diom-operations/src/lib.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio::task::JoinError;
 
 mod context;
-pub use context::{FeatureVersion, OpContext};
+pub use context::{FeatureVersion, OpContext, VERSIONS};
 pub mod workers;
 
 #[derive(Debug)]

--- a/src/core/cluster/version.rs
+++ b/src/core/cluster/version.rs
@@ -3,11 +3,14 @@
 //! Each build supports a contiguous range of feature versions. Nodes advertise their range during
 //! discovery and health checks so an incompatible node parks instead of joining a cluster it cannot
 //! interoperate with.
-use diom_operations::FeatureVersion;
+use diom_operations::{FeatureVersion, VERSIONS};
 use serde::{Deserialize, Serialize};
 
 /// The range of feature versions this build can operate at.
-pub(crate) const SUPPORTED_VERSION_RANGE: VersionRange = VersionRange { min: 0, max: 0 };
+pub(crate) const SUPPORTED_VERSION_RANGE: VersionRange = VersionRange {
+    min: VERSIONS[0],
+    max: VERSIONS.last().copied().unwrap(),
+};
 
 /// An inclusive range of feature versions a node supports.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/tests/it/static/schema-snapshot.txt
+++ b/tests/it/static/schema-snapshot.txt
@@ -30,6 +30,7 @@ diom_admin_auth::storage::RoleRow (versioned)
     context: HashMap<String, String>
     created: UnixTimestampMs
     updated: UnixTimestampMs
+    last_configured: Option<UnixTimestampMs> since=1
 diom_auth_token::entities::TokenHashed (value-struct)
     0: [u8; 32]
 diom_auth_token::operations::AuthTokenOperation (value-enum)


### PR DESCRIPTION
This shows what the final "result" is, when it comes to adding a versioned column. This isn't intended to be merged, or a meaningful functional change. But just to demo how versioning works with all the prior PRs in the stack in place.

I had to update the macro a bit so that we could do `#[since(VERSIONS[0]])` instead of `#[since(1)]`. We could also make `VERSIONS` an enum, so it reads closer to `#[since(Versions::One)]` instead? I'm open to bikeshedding here.